### PR TITLE
exposed python for remote debugging

### DIFF
--- a/recipes/qsmxt/README.md
+++ b/recipes/qsmxt/README.md
@@ -1,6 +1,6 @@
 
 ----------------------------------
-## qsmxt/1.1.10b ##
+## qsmxt/1.1.11 ##
 A full QSM processing pipeline from DICOM to segmentation to evaluation of results. 
 
 Usage:
@@ -57,6 +57,6 @@ This means there is not enough memory available. Troulbeshoot advice when runnin
 
 More documentation can be found here: https://github.com/QSMxT/QSMxT
 
-To run applications outside of this container: ml qsmxt/1.1.10b
+To run applications outside of this container: ml qsmxt/1.1.11
 
 ----------------------------------

--- a/recipes/qsmxt/README.md
+++ b/recipes/qsmxt/README.md
@@ -1,6 +1,6 @@
 
 ----------------------------------
-## qsmxt/1.1.10 ##
+## qsmxt/1.1.10b ##
 A full QSM processing pipeline from DICOM to segmentation to evaluation of results. 
 
 Usage:
@@ -57,6 +57,6 @@ This means there is not enough memory available. Troulbeshoot advice when runnin
 
 More documentation can be found here: https://github.com/QSMxT/QSMxT
 
-To run applications outside of this container: ml qsmxt/1.1.10
+To run applications outside of this container: ml qsmxt/1.1.10b
 
 ----------------------------------

--- a/recipes/qsmxt/build.sh
+++ b/recipes/qsmxt/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 export toolName='qsmxt'
-export toolVersion='1.1.10b'
+export toolVersion='1.1.11'
 # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then

--- a/recipes/qsmxt/build.sh
+++ b/recipes/qsmxt/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 export toolName='qsmxt'
-export toolVersion='1.1.10'
+export toolVersion='1.1.10b'
 # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
@@ -30,7 +30,7 @@ neurodocker generate ${neurodocker_buildMode} \
    --env PATH='$PATH':/opt/bru2 \
    --env PATH='$PATH':/opt/FastSurfer \
    --env DEPLOY_PATH=/opt/fsl-6.0.4/bin/:/opt/ants-2.3.4/:/opt/FastSurfer \
-   --env DEPLOY_BINS=dcm2niix:bidsmapper:bidscoiner:bidseditor:bidsparticipants:bidstrainer:deface:dicomsort:pydeface:rawmapper:Bru2:Bru2Nii:tgv_qsm:julia  \
+   --env DEPLOY_BINS=python:dcm2niix:bidsmapper:bidscoiner:bidseditor:bidsparticipants:bidstrainer:deface:dicomsort:pydeface:rawmapper:Bru2:Bru2Nii:tgv_qsm:julia  \
    --env PYTHONPATH=/opt/QSMxT:/TGVQSM-master-011045626121baa8bfdd6633929974c732ae35e3/TGV_QSM \
    --copy README.md /README.md \
   > ${imageName}.${neurodocker_buildExt}


### PR DESCRIPTION
The underlying container is unchanged (v1.1.10), but this new build (v1.1.10b) exposes the Python binary. This allows for remote debugging. 

For me, this will enable debugging of QSMxT through VS code while it is attached to my local neurodesktop container. I will use the post-launch command "ml load qsmxt/1.1.10b" to enable linting and debugging.