### PR TITLE
Add an 'MNE extended' container

### DIFF
--- a/.github/workflows/mneextended.yml
+++ b/.github/workflows/mneextended.yml
@@ -1,0 +1,98 @@
+name: mneextended
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+  push:
+    paths:
+      - recipes/mneextended/*
+      - .github/workflows/mneextended.yml
+    branches:
+      - master
+
+env:
+  GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
+  DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_ORG }}
+  OS_PASSWORD: ${{ secrets.SWIFT_OS_PASSWORD }}
+  OS_PROJECT_ID: ${{ secrets.SWIFT_OS_PROJECT_ID }}
+  OS_USERNAME: ${{ secrets.SWIFT_OS_USERNAME }}
+  OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.SWIFT_OS_APPLICATION_CREDENTIAL_ID }}
+  OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.SWIFT_OS_APPLICATION_CREDENTIAL_SECRET }}
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    outputs:
+      BUILDDATE: ${{ steps.ENVVARS.outputs.BUILDDATE }}
+      IMAGELIST: ${{ steps.IMAGEVARS.outputs.IMAGELIST }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set environment variables
+        id: ENVVARS
+        run: |
+          APPLICATION=$(basename $GITHUB_WORKFLOW .yml)
+          SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
+          BUILDDATE=`date +%Y%m%d`
+          echo "APPLICATION=$APPLICATION" >> $GITHUB_ENV
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+          echo "BUILDDATE=$BUILDDATE" >> $GITHUB_ENV
+          echo "::set-output name=BUILDDATE::$BUILDDATE"
+      - name: Check free-up-space list
+        run: |
+          FREEUPSPACELIST=$(cat .github/workflows/free-up-space-list.txt)
+          if [[ $FREEUPSPACELIST == *"|$APPLICATION|"* ]]; then
+            rm -rf $GITHUB_WORKSPACE/*
+            FREEUPSPACE=true
+          fi
+          echo "FREEUPSPACE=$FREEUPSPACE" >> $GITHUB_ENV
+      - name: Free up space (optional)
+        if: env.FREEUPSPACE
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 40000
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          overprovision-lvm: 'true'
+      - name: Move docker installation (optional)
+        if: env.FREEUPSPACE
+        run: |
+          sudo mv /var/lib/docker /home/runner/work/docker
+          sudo ln -s /home/runner/work/docker /var/lib/docker
+          sudo systemctl restart docker
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name : Build recipes
+        run: |
+          echo "APPLICATION: $APPLICATION"
+          cd recipes/$APPLICATION
+          /bin/bash build.sh
+
+      - name: Set image variables
+        id: IMAGEVARS
+        run: |
+          IMAGELIST=()
+          for DOCKERFILE in recipes/$APPLICATION/*.Dockerfile; do
+            IMAGENAME=$(echo $(basename $DOCKERFILE .Dockerfile) | tr '[A-Z]' '[a-z]')
+            echo "IMAGENAME: $IMAGENAME"
+            echo "test command: bash /neurocommand/local/fetch_and_run.sh ${IMAGENAME//_/ } $BUILDDATE"
+            IMAGELIST+=$IMAGENAME
+          done
+          echo "IMAGELIST=$IMAGELIST" >> $GITHUB_ENV
+          echo "::set-output name=IMAGELIST::$IMAGELIST"
+      - name: Log into Github Package registry
+        if: env.GH_REGISTRY != ''
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Log into Dockerhub (optional)
+        if: env.DOCKERHUB_ORG != ''
+        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      - name : Run docker builder + Upload to docker and github registry
+        run: for IMAGENAME in "${IMAGELIST[@]}"; do /bin/bash .github/workflows/build-docker.sh $IMAGENAME; done
+      - name: Generate job output
+        run: |
+          echo "The container has been successfully build. To test the container, run this:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
+          for IMAGENAME in "${IMAGELIST[@]}"; do echo "bash /neurocommand/local/fetch_and_run.sh ${IMAGENAME//_/ } $BUILDDATE" >> $GITHUB_STEP_SUMMARY; done

--- a/recipes/mneextended/README.md
+++ b/recipes/mneextended/README.md
@@ -3,11 +3,12 @@
 ## mneextended/1.1.0 ##
 Python MNE environment with VScode 
 
-This environment contains MNE Python and additional dependencies (eg. for use with MNE BIDS Pipeline) and tools (eg. Neurokit2)   
+This environment contains MNE Python and some additional tools with dependencies (MNE BIDS Pipeline, MNE-connectivity, MNE-icalabel, Neurokit2)   
 
 Example:
 ```
-code 
+source /opt/miniconda-4.7.12/etc/profile.d/conda.sh
+conda activate mne-extended 
 ```
 
 More documentation can be found here: https://mne.tools/stable/index.html

--- a/recipes/mneextended/README.md
+++ b/recipes/mneextended/README.md
@@ -1,0 +1,25 @@
+
+----------------------------------
+## mneextended/1.1.0 ##
+Python MNE environment with VScode 
+
+This environment contains MNE Python and additional dependencies (eg. for use with MNE BIDS Pipeline) and tools (eg. Neurokit2)   
+
+Example:
+```
+code 
+```
+
+More documentation can be found here: https://mne.tools/stable/index.html
+To cite MNE Python see here: https://mne.tools/stable/overview/cite.html
+
+
+To use the MNE BIDS Pipeline (https://mne.tools/mne-bids-pipeline/)
+```
+python /opt/mne-bids-pipeline-main/run.py --config=/path/to/your/custom_config.py 
+```
+
+To run applications outside of this container: ml mneextended/1.1.0
+Note the use of the module system does not currently interface with MNE and conda environments in this container
+
+----------------------------------

--- a/recipes/mneextended/build.sh
+++ b/recipes/mneextended/build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+
+# this template file builds itksnap and is then used as a docker base image for layer caching
+export toolName='mneextended'
+export toolVersion='1.1.0'
+# Don't forget to update version change in condaenv.yml AND README.md!!!!!
+
+if [ "$1" != "" ]; then
+    echo "Entering Debug mode"
+    export debug=$1
+fi
+
+source ../main_setup.sh
+
+neurodocker generate ${neurodocker_buildMode} \
+   --base-image debian:9 \
+   --pkg-manager apt \
+   --env DEBIAN_FRONTEND=noninteractive \
+   --run="printf '#!/bin/bash\nls -la' > /usr/bin/ll" \
+   --run="chmod +x /usr/bin/ll" \
+   --run="mkdir ${mountPointList}" \
+   --install midori xdg-utils python-pyqt5 unzip git apt-transport-https ca-certificates coreutils curl gnome-keyring gnupg libnotify4 wget libnss3 libxkbfile1 libsecret-1-0 libgtk-3-0 libxss1 libgbm1 libxshmfence1 libasound2 libglu1-mesa libgl1-mesa-dri mesa-utils libgl1-mesa-glx spyder \
+   --copy mne-extended.yml /opt/mne-extended.yml \
+   --miniconda version=4.7.12 \
+      env_name=base \
+   --run="conda install -c conda-forge -n base mamba=0.24.0 "\
+   --run="mamba env create --file /opt/mne-extended.yml"\
+   --run="wget -O vscode.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64' \
+      && apt install ./vscode.deb  \
+      && rm -rf ./vscode.deb" \
+   --run=" code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-python.python \
+    && code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-python.vscode-pylance \
+    && code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-toolsai.jupyter \
+    && code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-toolsai.jupyter-keymap \
+    && code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-toolsai.jupyter-renderers" \
+   --env DONT_PROMPT_WSL_INSTALL=1 \
+   --workdir=/opt/ \
+   --run="curl -fsSL https://github.com/mne-tools/mne-bids-pipeline/archive/refs/heads/main.tar.gz | tar xz" \
+   --run="chmod a+rwx /opt/mne-bids-pipeline-main -R" \
+   --copy README.md /README.md \
+   --copy code /usr/local/sbin/ \
+   --run="chmod a+x /usr/local/sbin/code" \
+   --run="chmod a+rwx /opt/vscode-extensions -R" \
+   --env DEPLOY_BINS=code \
+   --env XDG_RUNTIME_DIR=/neurodesk-storage \
+   --env RUNLEVEL=3\
+   --user neuro \
+ > ${imageName}.${neurodocker_buildExt}
+
+
+if [ "$1" != "" ]; then
+   ./../main_build.sh
+fi
+
+# vscode needs /run bind mounted to work!!!!

--- a/recipes/mneextended/code
+++ b/recipes/mneextended/code
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+/usr/bin/code --extensions-dir=/opt/vscode-extensions

--- a/recipes/mneextended/mne-extended.yml
+++ b/recipes/mneextended/mne-extended.yml
@@ -1,0 +1,40 @@
+name: mne-extended
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3
+  - mne=1.1.0=ha770c72_0
+  - jupyter
+  - mne-bids
+  - mnelab
+  - nb_conda_kernels
+  - pytables
+  - h5py
+  - h5io
+  - pymatreader
+  - seaborn
+  - statsmodels
+  - pybv
+  - scikit-learn
+  - pyxdf
+  - pyEDFlib
+  - neurokit2
+  - autoreject
+  - coloredlogs
+  - pandas
+  - openpyxl
+  - json_tricks
+  - fire
+  - typing_extensions
+  - python-picard
+  - dask
+  - distributed
+  - psutil
+  - joblib
+  - jupyter-server-proxy
+  - pyqt
+  - pyvista
+  - pyvistaqt
+  - hdf5
+  - mne-icalabel


### PR DESCRIPTION
Following discussions around #117, this adds an MNE container with additional tools and dependencies. 

This MNE environment is an updated version (1.1.0) and includes the additional dependencies for the MNE BIDS Pipeline, and some extra MNE tools (MNE-connectivity, MNE-icalabel) and other psychophysiology (NeuroKit2).

Preliminary testing with the MNE python FLUX jupyter notebooks also indicate these run with this container (to be confirmed).  