### PR TITLE
fix matlab PATH

### DIFF
--- a/recipes/matlab/build.sh
+++ b/recipes/matlab/build.sh
@@ -34,7 +34,7 @@ neurodocker generate ${neurodocker_buildMode} \
    --run="mkdir ${mountPointList}"                      `# create folders for singularity bind points` \
    --install wget git curl ca-certificates datalad unzip libfftw3-3 `# install apt-get packages` \
    --miniconda version=latest \
-   --env PATH='${PATH}:/opt/matlab/R${toolVersion}b/bin/'   	 `# set PATH; not required to run matlab, but required for other Matlab tools like mex` \
+   --env PATH='${PATH}'":/opt/matlab/R${toolVersion}/bin/"   	 `# set PATH; not required to run matlab, but required for other Matlab tools like mex` \
    --env DEPLOY_BINS=datalad:matlab:mex                 `# specify indiviual binaries (separated by :) on the PATH that should be exposed outside the container for the module system` \
    --env MLM_LICENSE_FILE='~/Downloads'		 `# tell Matlab to look for the license file in Downloads under the home directory. There is the default download folder in Neurodesktop` \
    --copy README.md /README.md                          `# include readme file in container` \
@@ -42,8 +42,8 @@ neurodocker generate ${neurodocker_buildMode} \
    --run="rm /usr/local/bin/matlab"			`# rm original matlab symbolic link` \
    --copy matlab /usr/local/bin/matlab `# replace original matlab with a script that sets MLM_LICENSE_FILE and then call matlab; license dir is set to ~/Downloads because there is where Firefox download the license to` \
    --run="chmod a+x /usr/local/bin/matlab"     		`# make matlab executables` \
-   --run="mkdir /opt/matlab/R2022a/licenses"     		`# create license directory - this will later be bind-mounted to the homedirectory download folder` \
-   --run="chmod a+rwx /opt/matlab/R2022a/licenses"     		`# make licenses folder writable - this will be used for an overlay test` \
+   --run="mkdir /opt/matlab/R${toolVersion}/licenses"     		`# create license directory - this will later be bind-mounted to the homedirectory download folder` \
+   --run="chmod a+rwx /opt/matlab/R${toolVersion}/licenses"     		`# make licenses folder writable - this will be used for an overlay test` \
   > ${imageName}.${neurodocker_buildExt}                `# LAST COMMENT; NOT FOLLOWED BY BACKSLASH!`
 
 


### PR DESCRIPTION
This line seems to produce wrong results:  
`37 --env PATH='${PATH}:/opt/matlab/R${toolVersion}b/bin/'` 
It avoids string interpolation in both cases of `${PATH}` and `${toolVersion}`, resulting in the path: `/opt/matlab/Rb/bin`. (I only tried this in the matlab 2019b container, but I guess it behaves similarly here)

This is fixed by separating the strings and interpolating the second one. (I didn't run a full build on this container to check if it actually is fixed)
