### PR TITLE
Update to the mfcsc container

### DIFF
--- a/recipes/mfcsc/README.md
+++ b/recipes/mfcsc/README.md
@@ -1,11 +1,12 @@
 
 ----------------------------------
-## mfcsc/1.0 ##
+## mfcsc/toolVersion ##
 Standalone (compiled) version of mfcsc with MATLAB runtime
 
 Example:
 ```
-mfcsc FC_SC_LIST FC_INPUT_DIR SC_INPUT_DIR OUTPUT_DIR
+mfcsc FC_SC_LIST FC_INPUT_DIR SC_INPUT_DIR OUTPUT_DIR not_in_mask_value is_contra is_keep_neg_fc is_symmetrical is_figures
+
 `
 ```
 
@@ -14,11 +15,13 @@ More documentation can be found here: https://github.com/civier/mfcsc
 mfcsc is released under the MIT license
 mfcsc includes the Brain Connectivity Toolbox (https://sites.google.com/site/bctnet/)
 
-Citation:
+Citations:
 ```
-Civier O, Sourty M, Calamante F (2023) MFCSC: Novel method to calculate mismatch between functional and structural brain connectomes, and its application for detecting hemispheric functional specialisations. Scientific Reports.
+Civier O, Sourty M, Calamante F (2023) MFCSC: Novel method to calculate mismatch between functional and structural brain connectomes, and its application for detecting hemispheric functional specialisations. Scientific Reports. https://doi.org/10.1038/s41598-022-17213-z
+
+Rubinov M, Sporns O (2010) Complex network measures of brain connectivity: Uses and interpretations. NeuroImage 52:1059-69.
 ```
 
-To run applications outside of this container: ml mfcsc/1.0
+To run mfcsc outside of this container, first type 'ml mfcsc/toolVersion' in the terminal and then follow the exmaple above
 
 ----------------------------------

--- a/recipes/mfcsc/build.sh
+++ b/recipes/mfcsc/build.sh
@@ -23,9 +23,8 @@ neurodocker generate ${neurodocker_buildMode} \
    --install curl unzip ca-certificates openjdk-8-jre dbus-x11 \
    --matlabmcr version=2020a install_path=/opt/MCR  \
    --workdir /opt/${toolName}-${toolVersion}/ \
-   --run="curl -fsSL --retry 5 https://swift.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/mfcsc1.0_mcr2020a.tar.gz \
-      | tar -xz -C /opt/${toolName}-${toolVersion}/" `# NOTICE: use access URL without pre-authorised token` \
-   `# --env XAPPLRESDIR=/opt/MCR/v98/x11/app-defaults` \
+   --run="curl -L -o mfcsc https://www.dropbox.com/s/qdz40cw7e9tjxc7/mfcsc?dl=0" `# download mfcsc executable from Oren's private Dropbox` \
+   --env XAPPLRESDIR=/opt/MCR/v98/x11/app-defaults \
    --run="chmod a+x /opt/${toolName}-${toolVersion}/*" `# give everybody permission to run because files are owned by rooot, and by default, only owner has execute permission` \
    --env PATH=/opt/${toolName}-${toolVersion}/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    --env DEPLOY_BINS=mfcsc \


### PR DESCRIPTION
Two notes:
1. I cloned my fork with "git clone --config pull.rebase https://github.com/civier/neurocontainers.git" as explained here:
https://www.neurodesk.org/developers/new_tools/cloning/
I hope it's sufficient for the rebasing to work properly. If not, let me know what extra commands I need to run.
2. I noticed that when I run "./build.sh -ds" as explained here: https://www.neurodesk.org/developers/new_tools/add_tool/#create-a-new-app
the build.sh script automatically changes the version numbers in the README.md file to the string 'toolVersion'.
Is it a feature or a bug? If it's supposed to be this way, please document it in the URL above, as it's a confusing behaviour.
If it's a bug, you're welcome to manually fix the version in the mfcsc container's README.md to "1.0".

The changes I introduced to mfcsc are:
- Added a new argument (not_in_mask_value)
- Fixed usage message
- Fixed various bugs
- Updated readme