### PR TITLE
QSMxT: Added image-upload-cli

### DIFF
--- a/recipes/qsmxt/build.sh
+++ b/recipes/qsmxt/build.sh
@@ -69,7 +69,7 @@ neurodocker generate ${neurodocker_buildMode} \
    --miniconda version=4.7.12.1 conda_install='python=3.8' \
    --run="rm -rf /usr/bin/python3.8 \
        && ln -s /opt/miniconda-latest/bin/python /usr/bin/python3.8" \
-   --run="pip install psutil datetime networkx==2.8.8 numpy h5py nibabel nilearn scikit-sparse traits nipype scipy scikit-image pydicom pytest osfclient seaborn webdavclient3 \
+   --run="pip install psutil datetime networkx==2.8.8 numpy h5py nibabel nilearn scikit-sparse traits nipype scipy scikit-image pydicom pytest osfclient seaborn webdavclient3 images-upload-cli \
        && pip install cloudstor \
        && pip install niflow-nipype1-workflows \
        && pip install tensorflow packaging" \


### PR DESCRIPTION
image-upload-cli will allow the Python unit tests to upload images to freeimage.host so they can be inserted into the GitHub Actions GITHUB_STEP_SUMMARY for displaying in the browser.