### PR TITLE
QSMxT: Update qsm-forward version to support T1w files

### DIFF
--- a/recipes/qsmxt/build.sh
+++ b/recipes/qsmxt/build.sh
@@ -74,7 +74,7 @@ neurodocker generate ${neurodocker_buildMode} \
        && ln -s /opt/miniconda-latest/bin/python /usr/bin/python3.8" \
    --run="git clone --depth 1 --branch v0.4.9 https://github.com/scikit-sparse/scikit-sparse.git \
        && pip install scikit-sparse/" \
-   --run="pip install psutil datetime networkx==2.8.8 numpy h5py nibabel nilearn traits nipype scipy scikit-image pydicom pytest seaborn webdavclient3 images-upload-cli qsm-forward==0.14 \
+   --run="pip install psutil datetime networkx==2.8.8 numpy h5py nibabel nilearn traits nipype scipy scikit-image pydicom pytest seaborn webdavclient3 images-upload-cli qsm-forward==0.15 \
        && pip install cloudstor \
        && pip install niflow-nipype1-workflows \
        && pip install tensorflow packaging" \


### PR DESCRIPTION
Rather than fix the current QSMxT segmentation pipeline tests, I'm switching over to PyTest and using this opportunity to integrate the segmentation pipeline fully into `run_2_qsm.py`. The name may need to change later..

Part of this update requires qsm-forward==0.15, which allows me to specify different file suffixes such as _T1w, which will allow testing of the segmentation pipeline using simulated T1-weighted images. 