### PR TITLE
Upgraded BIDScoin from 3.7.0 to 4.2.0 + cleanup

### DIFF
--- a/recipes/bidscoin/README.md
+++ b/recipes/bidscoin/README.md
@@ -1,30 +1,45 @@
 
 ----------------------------------
-## bidscoin/3.7.0 ##
+## bidscoin/4.2.0 ##
 Contains a collection of tools needed for DICOM to BIDS conversion, as well as MRS spectroscopy and physiological data to BIDS conversion
 
-Example:
+Tools included:
 ```
-dcm2niix
-bidsmapper
-bidscoiner
-bidseditor
-bidsparticipants
-deface
-medeface
-dicomsort
-rawmapper
+dcm2niix: v1.0.20230411 https://github.com/rordenlab/dcm2niix
+bidscoin: https://bidscoin.readthedocs.io/en/4.2.0
+    bidscoin
+    bidscoiner
+    bidseditor
+    bidsmapper
+    bidsparticipants
+    deface
+    dicomsort
+    echocombine
+    medeface
+    physio2tsv
+    plotphysio
+    rawmapper
+    skullstrip
+    slicereport
+```
 
-convert dicom to bids:
-dicomsort dicomfolder
+Example reorganizing DICOM data:
+```
+dicomsort dicomfolder/sub-folder -r -e .IMA
+```
+
+Example converting dicom to BIDS: 
+```
+Getting started:
+bidscoin -h
+
+Convert DICOM to BIDS:
 bidsmapper dicomfolder bidsoutputfolder
 bidscoiner dicomfolder bidsoutputfolder
-
 ```
 
 More documentation can be found here:
-https://bidscoin.readthedocs.io/en/latest/installation.html
-https://github.com/rordenlab/dcm2niix
+https://bidscoin.readthedocs.io/en/4.2.0
 
 
 Citation:
@@ -32,6 +47,6 @@ Citation:
 Zwiers MP, Moia S, Oostenveld R. BIDScoin: A User-Friendly Application to Convert Source Data to Brain Imaging Data Structure. Front Neuroinform. 2022 Jan 13;15:770608. doi: 10.3389/fninf.2021.770608. PMID: 35095452; PMCID: PMC8792932.
 ```
 
-To run container outside of this environment: ml bidscoin/3.7.0
+To run container outside of this environment: ml bidscoin/4.2.0
 
 ----------------------------------

--- a/recipes/bidscoin/build.sh
+++ b/recipes/bidscoin/build.sh
@@ -3,7 +3,7 @@ set -e
 
 # this template file builds tools required for dicom conversion to bids
 export toolName='bidscoin'
-export toolVersion='3.7.0'
+export toolVersion='4.2.0'
 # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
@@ -13,9 +13,10 @@ fi
 
 source ../main_setup.sh
 
-# Changes I made to .def file:
+# Changes made to .def file:
 # 1. turned the apt-get install to neurodocker install
 # 2. put commands with cd with && in between
+# TODO: update these list items to better reflect the changes made
 neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file provided by bidscoin at https://github.com/Donders-Institute/bidscoin/blob/master/singularity.def` \
     `# Install the latest dcm2niix from source` \
     --pkg-manager apt \
@@ -31,12 +32,12 @@ neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file 
     --install curl \
     `# Install pigz (to speed up dcm2niix)` \
     --install pigz \
-    `# Install the latest stable BIDScoin release from Python repository` \
+    `# Install the 4.2.0+Qt5 branch from Github` \
     `# NOTE: PyQt5 is installed as Debian package to solve dependencies issues occurring when installed with pip.` \
     --install python3-pyqt5 \
     --miniconda version=latest \
-		pip_install='bidscoin[spec2nii2bids,phys2bidscoin]' \
-   --env DEPLOY_BINS=bidsmapper:bidscoiner:dicomsort:rawmapper:echocombine:deface:medeface:bidseditor:bidsparticipants \
+		pip_install='bidscoin[spec2nii2bids,deface]@git+https://github.com/Donders-Institute/bidscoin@v4.2.0+qt5' \
+   --env DEPLOY_BINS=bidscoin:bidscoiner:bidseditor:bidsmapper:bidsparticipants:deface:dicomsort:echocombine:medeface:physio2tsv:plotphysio:rawmapper:skullstrip:slicereport:dcm2niix:pydeface  \
    --copy README.md /README.md \
   > ${toolName}_${toolVersion}.Dockerfile
 

--- a/recipes/bidscoin/test.sh
+++ b/recipes/bidscoin/test.sh
@@ -1,0 +1,3 @@
+ export QT_DEBUG_PLUGINS=1
+ bidscoin -t
+ bidseditor myproject/bids

--- a/recipes/bidstools/README.md
+++ b/recipes/bidstools/README.md
@@ -1,18 +1,26 @@
 
 ----------------------------------
-## bidstools/toolVersion ##
+## bidstools/1.0.2 ##
 Contains a collection of tools useful for DICOM to BIDS conversion
 
 Tools included:
 ```
 dcm2niix: v1.0.20230411 https://github.com/rordenlab/dcm2niix
-bidsmapper: https://bidscoin.readthedocs.io/en/latest/workflow.html#step-1a-running-the-bidsmapper
-bidseditor: https://bidscoin.readthedocs.io/en/latest/workflow.html#step-1b-running-the-bidseditor
-bidscoiner: https://bidscoin.readthedocs.io/en/latest/workflow.html#step-2-running-the-bidscoiner
-rawmapper: https://bidscoin.readthedocs.io/en/latest/installation.html
-deface: https://bidscoin.readthedocs.io/en/stable/bidsapps.html?highlight=deface#defacing
-bidsparticipants: https://bidscoin.readthedocs.io/en/latest/installation.html
-dicomsort: https://bidscoin.readthedocs.io/en/latest/installation.html
+bidscoin: https://bidscoin.readthedocs.io
+    bidscoin
+    bidscoiner
+    bidseditor
+    bidsmapper
+    bidsparticipants
+    deface
+    dicomsort
+    echocombine
+    medeface
+    physio2tsv
+    plotphysio
+    rawmapper
+    skullstrip
+    slicereport
 dcmtk: https://support.dcmtk.org/docs/pages.html
     dcmdump
     dump2dcm
@@ -27,9 +35,17 @@ heudiconv: https://heudiconv.readthedocs.io/en/latest/heuristics.html
 Bru2Nii: https://github.com/neurolabusc/Bru2Nii
 ```
 
-Example converting dicom to BIDS using bidscoin: 
+Example reorganizing DICOM data using BIDScoin:
 ```
 dicomsort dicomfolder/sub-folder -r -e .IMA
+```
+
+Example converting dicom to BIDS using BIDScoin: 
+```
+Getting started:
+bidscoin -h
+
+Convert DICOM to BIDS:
 bidsmapper dicomfolder bidsoutputfolder
 bidscoiner dicomfolder bidsoutputfolder
 ```

--- a/recipes/bidstools/build.sh
+++ b/recipes/bidstools/build.sh
@@ -3,7 +3,7 @@ set -e
 
 # this template file builds tools required for dicom conversion to bids
 export toolName='bidstools'
-export toolVersion='1.0.1'
+export toolVersion='1.0.2'
 # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
@@ -23,14 +23,14 @@ neurodocker generate ${neurodocker_buildMode} \
    --miniconda version=latest \
                mamba=true \
                conda_install='python=3.10 traits=6.3.2' \
-               pip_install='bidscoin heudiconv pydeface' \
+               pip_install='bidscoin[spec2nii2bids,deface] heudiconv' \
    --install opts="--quiet" wget zip qt6-base-dev libgl1 libgtk2.0-0 dcmtk xmedcon pigz libxcb-cursor0 \
    --workdir /opt/bru2 \
    --run="wget https://github.com/neurolabusc/Bru2Nii/releases/download/v1.0.20180303/Bru2_Linux.zip" \
    --run="unzip Bru2_Linux.zip" \
    --dcm2niix method=source version=latest \
    --env PATH='$PATH':/opt/bru2 \
-   --env DEPLOY_BINS=dcm2niix:bidsmapper:bidscoiner:bidseditor:bidsparticipants:bidstrainer:deface:dicomsort:pydeface:rawmapper:Bru2:Bru2Nii:heudiconv  \
+   --env DEPLOY_BINS=bidscoin:bidscoiner:bidseditor:bidsmapper:bidsparticipants:deface:dicomsort:echocombine:medeface:physio2tsv:plotphysio:rawmapper:skullstrip:slicereport:dcm2niix:pydeface:Bru2:Bru2Nii:heudiconv  \
    --copy README.md /README.md \
   > ${toolName}_${toolVersion}.Dockerfile
 


### PR DESCRIPTION
I updated the build scripts and README files to include BIDScoin 4.2.0 (as also described [here](https://github.com/orgs/NeuroDesk/discussions/371))

NB: I've upgraded BIDScoin in `bidscoin` and in `bidstools`, but these two have different base-images, and because of that `bidscoin` uses Qt5 but the `bidstools` version uses Qt6. This should not make any difference though (except for building). The `bidscoin` container is explicitly pinned to v4.2.0, but the `bidstools` recipe always takes the latest version (same is true for the other tools in there)
