### PR TITLE
itksnap: added curl libs to TinyRange build

### DIFF
--- a/recipes/itksnap/build.sh
+++ b/recipes/itksnap/build.sh
@@ -36,7 +36,7 @@ else
    $TINYRANGE login \
       --size xl \
       --pkg ubuntu \
-      --pkg pkg:unzip,mlocate,binutils,libqt5gui5,libopengl0 \
+      --pkg pkg:curl,ca-certificates,unzip,mlocate,binutils,libqt5gui5,libopengl0 \
       --file https://www.nitrc.org/frs/download.php/750/MRI-crop.zip \
       --file https://ixpeering.dl.sourceforge.net/project/itk-snap/itk-snap/${toolVersion}/itksnap-${toolVersion}-Linux-gcc64.tar.gz \
       --exec "set -ex; \


### PR DESCRIPTION
The itksnap container didn't work because it requires libcurl.

I re-added `curl` and `ca-certificates` to the `itksnap` build script. I initially removed them since TinyRange doesn't use them in the build process.