### PR TITLE
julia 1.10.1

### DIFF
--- a/recipes/julia/README.md
+++ b/recipes/julia/README.md
@@ -1,6 +1,6 @@
 
 ----------------------------------
-## julia/1.6.1 ##
+## julia/toolVersion ##
 Julia was designed from the beginning for high performance. Julia programs compile to efficient native code for multiple platforms via LLVM.
 
 
@@ -11,6 +11,6 @@ julia
 
 More documentation can be found here: https://docs.julialang.org/en/v1/
 
-To run container outside of this environment: ml julia/1.6.1
+To run container outside of this environment: ml julia/toolVersion
 
 ----------------------------------

--- a/recipes/julia/build.sh
+++ b/recipes/julia/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 export toolName='julia'
-export toolVersion='1.6.1'
+export toolVersion='1.10.1'
 # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
@@ -13,20 +13,12 @@ fi
 source ../main_setup.sh
 
 neurodocker generate ${neurodocker_buildMode} \
-   --base-image ubuntu:20.04 \
+   --base-image julia:${toolVersion} \
    --pkg-manager apt \
    --run="mkdir -p ${mountPointList}" \
    --run="printf '#!/bin/bash\nls -la' > /usr/bin/ll" \
    --run="chmod +x /usr/bin/ll" \
-   --install zlib1g-dev libzstd1 wget \
-   --workdir /opt \
-   --run="wget https://julialang-s3.julialang.org/bin/linux/x64/${toolVersion:0:3}/julia-${toolVersion}-linux-x86_64.tar.gz" \
-   --run="tar zxvf julia-${toolVersion}-linux-x86_64.tar.gz" \
-   --run="rm -rf julia-${toolVersion}-linux-x86_64.tar.gz" \
-   --env PATH='$PATH':/opt/julia-${toolVersion}/bin \
-   --run="julia -e 'using Pkg; Pkg.add(\"MriResearchTools\")'" \
    --env DEPLOY_BINS=julia \
-   --entrypoint /opt/julia-${toolVersion}/bin \
    --copy README.md /README.md \
   > ${imageName}.${neurodocker_buildExt}
 

--- a/recipes/julia/build.sh
+++ b/recipes/julia/build.sh
@@ -3,24 +3,48 @@ set -e
 
 export toolName='julia'
 export toolVersion='1.10.1'
+export releaseVersion='1.10'
 # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
-    echo "Entering Debug mode"
-    export debug=$1
+   echo "Entering Debug mode"
+   export debug=$1
 fi
 
 source ../main_setup.sh
 
 neurodocker generate ${neurodocker_buildMode} \
-   --base-image julia:${toolVersion} \
+   --base-image debian \
    --pkg-manager apt \
-   --run="mkdir -p ${mountPointList}" \
+   --env DEBIAN_FRONTEND=noninteractive \
    --run="printf '#!/bin/bash\nls -la' > /usr/bin/ll" \
    --run="chmod +x /usr/bin/ll" \
-   --env DEPLOY_BINS=julia \
+   --run="mkdir -p ${mountPointList}" \
+   --install xdg-utils unzip git apt-transport-https ca-certificates coreutils \
+      curl gnome-keyring gnupg libnotify4 wget libnss3 libxkbfile1 libsecret-1-0 libgtk-3-0 libxss1 libgbm1 libxshmfence1 libasound2 \
+      lmod less nano tree \
+      gcc graphviz libzstd1 zlib1g-dev zip build-essential uuid-dev libgpgme-dev libseccomp-dev pkg-config \
+   --run="wget -O vscode.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64' \
+      && apt install ./vscode.deb  \
+      && rm -rf ./vscode.deb" \
+   --workdir /opt \
+   --run="wget https://julialang-s3.julialang.org/bin/linux/x64/${releaseVersion}/julia-${toolVersion}-linux-x86_64.tar.gz \
+      && tar zxvf julia-${toolVersion}-linux-x86_64.tar.gz \
+      && rm -rf julia-${toolVersion}-linux-x86_64.tar.gz \
+      && ln -s /opt/julia-${toolVersion} /opt/julia-latest" \
+   --run="code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension julialang.language-julia \
+      && code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension KorbinianEckstein.niivue \
+      && rm -rf /opt/vscode-data/CachedExtensionVSIXs/" \
+   --env PATH='$PATH':/opt/julia-${toolVersion}/bin \
    --copy README.md /README.md \
-  > ${imageName}.${neurodocker_buildExt}
+   --copy code /usr/local/sbin/ \
+   --run="chmod a+x /usr/local/sbin/code" \
+   --run="chmod a+rwx /opt/vscode-extensions/ -R" \
+   --run="chmod a+rwx /opt/vscode-data -R" \
+   --env DEPLOY_BINS=code \
+   --copy module.sh /usr/share/ \
+   --user neuro \
+   >${imageName}.${neurodocker_buildExt}
 
 if [ "$1" != "" ]; then
    ./../main_build.sh

--- a/recipes/julia/build.sh
+++ b/recipes/julia/build.sh
@@ -41,7 +41,7 @@ neurodocker generate ${neurodocker_buildMode} \
    --run="chmod a+x /usr/local/sbin/code" \
    --run="chmod a+rwx /opt/vscode-extensions/ -R" \
    --run="chmod a+rwx /opt/vscode-data -R" \
-   --env DEPLOY_BINS=code \
+   --env DEPLOY_BINS="code:julia" \
    --copy module.sh /usr/share/ \
    --user neuro \
    >${imageName}.${neurodocker_buildExt}

--- a/recipes/julia/code
+++ b/recipes/julia/code
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+/usr/bin/code --extensions-dir=/opt/vscode-extensions --no-sandbox

--- a/recipes/julia/module.sh
+++ b/recipes/julia/module.sh
@@ -1,0 +1,14 @@
+# system-wide profile.modules                                          #
+# Initialize modules for all sh-derivative shells                      #
+#----------------------------------------------------------------------#
+trap "" 1 2 3
+
+case "$0" in
+    -bash|bash|*/bash) . /usr/share/lmod/6.6/init/bash ;;
+       -ksh|ksh|*/ksh) . /usr/share/lmod/6.6/init/ksh ;;
+       -zsh|zsh|*/zsh) . /usr/share/lmod/6.6/init/zsh ;;
+          -sh|sh|*/sh) . /usr/share/lmod/6.6/init/sh ;;
+                    *) . /usr/share/lmod/6.6/init/sh ;;  # default for scripts
+esac
+
+trap - 1 2 3


### PR DESCRIPTION
@stebo85 
This PR uses the official julia docker image

A difference is that it directly drops the user into a running julia REPL (when testing it after an offline build, not sure if this happens in Neurodesk as well)

Another question about using julia, since there are multiple common ways to use julia:
1) REPL
2) vscode as IDE with julia extension
- vscode executes files or line-by-line in an interactive julia REPL in the vscode terminal. The path to the julia executable can be given to vscode
3) Jupyter or Pluto notebook

Can we create user-friendly ways to run julia for all these scenarios?

1) REPL is easy
2) I tried two things for vscode
- Opening the julia container and running vscode. This does not work as the command "code" is not found
- Starting vscode and setting the Executable Path for julia to "/cvmfs/neurodesk.ardc.edu.au/containers/julia_1.4.1_20210105/julia". This worked, but needs good documentation so that users can follow it.

