### PR TITLE
Bidscoin add fsltools

### DIFF
--- a/recipes/bidscoin/README.md
+++ b/recipes/bidscoin/README.md
@@ -13,11 +13,14 @@ bidscoin: https://bidscoin.readthedocs.io/en/4.3.0
     bidseditor
     bidsmapper
     bidsparticipants
+    deface
     dicomsort
     echocombine
+    medeface
     physio2tsv
     plotphysio
     rawmapper
+    slicereport
 ```
 
 Example converting dicom to BIDS: 

--- a/recipes/bidscoin/README.md
+++ b/recipes/bidscoin/README.md
@@ -1,31 +1,23 @@
 
 ----------------------------------
-## bidscoin/4.2.0 ##
-Contains a collection of tools needed for DICOM to BIDS conversion, as well as MRS spectroscopy and physiological data to BIDS conversion
+## bidscoin/toolVersion ##
+Contains a GUI and CLI tools needed for DICOM to BIDS conversion, as well as MRS spectroscopy and physiological data to BIDS conversion
 
-Tools included:
+Tools included (NB: some tools that depend on FSL or FreeSurfer are not included):
 ```
-dcm2niix: v1.0.20230411 https://github.com/rordenlab/dcm2niix
-bidscoin: https://bidscoin.readthedocs.io/en/4.2.0
+dcm2niix: https://github.com/rordenlab/dcm2niix (v1.0.20240202)
+spec2nii: https://github.com/wtclarke/spec2nii (v0.7.2)
+bidscoin: https://bidscoin.readthedocs.io/en/toolVersion
     bidscoin
     bidscoiner
     bidseditor
     bidsmapper
     bidsparticipants
-    deface
     dicomsort
     echocombine
-    medeface
     physio2tsv
     plotphysio
     rawmapper
-    skullstrip
-    slicereport
-```
-
-Example reorganizing DICOM data:
-```
-dicomsort dicomfolder/sub-folder -r -e .IMA
 ```
 
 Example converting dicom to BIDS: 
@@ -39,7 +31,7 @@ bidscoiner dicomfolder bidsoutputfolder
 ```
 
 More documentation can be found here:
-https://bidscoin.readthedocs.io/en/4.2.0
+https://bidscoin.readthedocs.io/en/toolVersion
 
 
 Citation:
@@ -47,6 +39,6 @@ Citation:
 Zwiers MP, Moia S, Oostenveld R. BIDScoin: A User-Friendly Application to Convert Source Data to Brain Imaging Data Structure. Front Neuroinform. 2022 Jan 13;15:770608. doi: 10.3389/fninf.2021.770608. PMID: 35095452; PMCID: PMC8792932.
 ```
 
-To run container outside of this environment: ml bidscoin/4.2.0
+To run container outside of this environment: ml bidscoin/toolVersion
 
 ----------------------------------

--- a/recipes/bidscoin/README.md
+++ b/recipes/bidscoin/README.md
@@ -1,13 +1,13 @@
 
 ----------------------------------
-## bidscoin/toolVersion ##
+## bidscoin/4.3.0 ##
 Contains a GUI and CLI tools needed for DICOM to BIDS conversion, as well as MRS spectroscopy and physiological data to BIDS conversion
 
 Tools included (NB: some tools that depend on FSL or FreeSurfer are not included):
 ```
 dcm2niix: https://github.com/rordenlab/dcm2niix (v1.0.20240202)
 spec2nii: https://github.com/wtclarke/spec2nii (v0.7.2)
-bidscoin: https://bidscoin.readthedocs.io/en/toolVersion
+bidscoin: https://bidscoin.readthedocs.io/en/4.3.0
     bidscoin
     bidscoiner
     bidseditor
@@ -39,6 +39,6 @@ Citation:
 Zwiers MP, Moia S, Oostenveld R. BIDScoin: A User-Friendly Application to Convert Source Data to Brain Imaging Data Structure. Front Neuroinform. 2022 Jan 13;15:770608. doi: 10.3389/fninf.2021.770608. PMID: 35095452; PMCID: PMC8792932.
 ```
 
-To run container outside of this environment: ml bidscoin/toolVersion
+To run container outside of this environment: ml bidscoin/4.3.0
 
 ----------------------------------

--- a/recipes/bidscoin/README.md
+++ b/recipes/bidscoin/README.md
@@ -31,7 +31,7 @@ bidscoiner dicomfolder bidsoutputfolder
 ```
 
 More documentation can be found here:
-https://bidscoin.readthedocs.io/en/toolVersion
+https://bidscoin.readthedocs.io/
 
 
 Citation:

--- a/recipes/bidscoin/build.sh
+++ b/recipes/bidscoin/build.sh
@@ -33,9 +33,11 @@ neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file 
     `# NOTE: PyQt5 is installed as Debian package to solve dependencies issues occurring when installed with pip.` \
     --install python3-pyqt5 \
     --miniconda version=latest \
-		pip_install="bidscoin[spec2nii2bids]@git+https://github.com/Donders-Institute/bidscoin@v${toolVersion}+qt5" \
-   --env DEPLOY_BINS=bidscoin:bidscoiner:bidseditor:bidsmapper:bidsparticipants:dicomsort:echocombine:physio2tsv:plotphysio:rawmapper:dcm2niix:spec2nii \
-   --copy README.md /README.md \
+    conda_install="-c conda-forge -c https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/ fsl-libvis fsl-avwutils fsl-flirt" \
+		pip_install="bidscoin[spec2nii2bids,deface]@git+https://github.com/Donders-Institute/bidscoin@v${toolVersion}+qt5" \
+    --env FSLDIR=/opt/miniconda-latest FSLOUTPUTTYPE=NIFTI_GZ \
+    --env DEPLOY_BINS=bidscoin:bidscoiner:bidseditor:bidsmapper:bidsparticipants:deface:dicomsort:echocombine:medeface:physio2tsv:plotphysio:rawmapper:slicereport:dcm2niix:spec2nii \
+    --copy README.md /README.md \
   > ${toolName}_${toolVersion}.Dockerfile
 
 if [ "$1" != "" ]; then

--- a/recipes/bidscoin/build.sh
+++ b/recipes/bidscoin/build.sh
@@ -3,30 +3,27 @@ set -e
 
 # this template file builds tools required for dicom conversion to bids
 export toolName='bidscoin'
-export toolVersion='4.2.0'
-# Don't forget to update version change in README.md!!!!!
+export toolVersion='4.3.0'    # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
     echo "Entering Debug mode"
+    export BIDSCOIN_DEBUG=TRUE
     export debug=$1
 fi
 
 source ../main_setup.sh
 
-# Changes made to .def file:
-# 1. turned the apt-get install to neurodocker install
-# 2. put commands with cd with && in between
-# TODO: update these list items to better reflect the changes made
-neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file provided by bidscoin at https://github.com/Donders-Institute/bidscoin/blob/master/singularity.def` \
-    `# Install the latest dcm2niix from source` \
+# Changes made to .def file: turned the apt-get install to neurodocker install and use Ubuntu/Qt6
+neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file provided by bidscoin at https://github.com/Donders-Institute/bidscoin/blob/master/apptainer.def` \
     --pkg-manager apt \
     --base-image debian:stable \
     --env DEBIAN_FRONTEND=noninteractive \
     --run="printf '#!/bin/bash\nls -la' > /usr/bin/ll" \
     --run="chmod +x /usr/bin/ll" \
     --run="mkdir -p ${mountPointList}" \
+    `# Install the latest dcm2niix from source` \
     --install git build-essential cmake \
-    --run "export GIT_SSL_NO_VERIFY=1 && git clone https://github.com/rordenlab/dcm2niix.git" `# first command solves some issue with the close as explaine here: https://stackoverflow.com/questions/21181231/server-certificate-verification-failed-cafile-etc-ssl-certs-ca-certificates-c` \
+    --run "export GIT_SSL_NO_VERIFY=1 && git clone https://github.com/rordenlab/dcm2niix.git" `# first command solves some issue with the clone, see: https://stackoverflow.com/questions/21181231/server-certificate-verification-failed-cafile-etc-ssl-certs-ca-certificates-c` \
     --run "cd dcm2niix; mkdir build && cd build; cmake ..; make install" \
     `#  Install curl (sometimes needed by dcm2niix)` \
     --install curl \
@@ -36,11 +33,16 @@ neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file 
     `# NOTE: PyQt5 is installed as Debian package to solve dependencies issues occurring when installed with pip.` \
     --install python3-pyqt5 \
     --miniconda version=latest \
-		pip_install='bidscoin[spec2nii2bids,deface]@git+https://github.com/Donders-Institute/bidscoin@v4.2.0+qt5' \
-   --env DEPLOY_BINS=bidscoin:bidscoiner:bidseditor:bidsmapper:bidsparticipants:deface:dicomsort:echocombine:medeface:physio2tsv:plotphysio:rawmapper:skullstrip:slicereport:dcm2niix:pydeface  \
+		pip_install="bidscoin[spec2nii2bids]@git+https://github.com/Donders-Institute/bidscoin@v${toolVersion}+qt5" \
+   --env DEPLOY_BINS=bidscoin:bidscoiner:bidseditor:bidsmapper:bidsparticipants:dicomsort:echocombine:physio2tsv:plotphysio:rawmapper:dcm2niix:spec2nii \
    --copy README.md /README.md \
   > ${toolName}_${toolVersion}.Dockerfile
 
 if [ "$1" != "" ]; then
    ./../main_build.sh
 fi
+
+# Test image with:
+# sudo docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix bidscoin_${toolVersion}:TAG bidscoin -t
+# sudo docker run -it -v /root:/root --entrypoint /bin/bash -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix bidscoin_${toolVersion}:TAG
+# bidscoin -t

--- a/recipes/bidscoin/test.sh
+++ b/recipes/bidscoin/test.sh
@@ -1,3 +1,4 @@
  export QT_DEBUG_PLUGINS=1
  bidscoin -t
  bidseditor myproject/bids
+ # sudo docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix  bidscoin_4.3.0:20240219 bidscoin -t


### PR DESCRIPTION
This is the same bidscoin version (4.3.0) as before, but the container now has support for some fsl tools, so that bidscoin apps that depend on it now work as expected