### PR TITLE
Add library to mrtrix3 container

### DIFF
--- a/recipes/mrtrix3/build.sh
+++ b/recipes/mrtrix3/build.sh
@@ -19,7 +19,7 @@ neurodocker generate ${neurodocker_buildMode} \
    --${toolName} version=${toolVersion} method="source" build_processes=1 \
    --ants version="2.3.4" \
    --workdir /opt/${toolName}-${toolVersion} \
-   --install dbus-x11 less python3-distutils mesa-common-dev libglu1-mesa qt5-default libqt5svg5-dev wget libqt5opengl5-dev libqt5opengl5 libqt5gui5 libqt5core5a libtiff5-dev libtiff5 libfftw3-dev \
+   --install dbus-x11 less python3-distutils mesa-common-dev libglu1-mesa qt5-default libqt5svg5-dev wget libqt5opengl5-dev libqt5opengl5 libqt5gui5 libqt5core5a libtiff5-dev libtiff5 libfftw3-dev liblapack3 \
    --run "python3 configure" \
    --run "python3 build" \
    --run "ln -s /usr/bin/python3 /usr/bin/python" \


### PR DESCRIPTION
This pull request proposes the addition of the liblapack3 package to the mrtrix3 container. The liblapack3 library is crucial for providing LAPACK (Linear Algebra PACKage) functionality within the container environment. This is especially needed for the ART ACPCdetect program to ensure segmentation of the anterior commissure while running the 5ttgen command.