### PR TITLE
Upgrade to 4.3.1 - attempt 2

### DIFF
--- a/recipes/bidscoin/README.md
+++ b/recipes/bidscoin/README.md
@@ -1,20 +1,22 @@
 
 ----------------------------------
-## bidscoin/4.3.0 ##
+## bidscoin/4.3.1 ##
 Contains a GUI and CLI tools needed for DICOM to BIDS conversion, as well as MRS spectroscopy and physiological data to BIDS conversion
 
-Tools included (NB: some tools that depend on FSL or FreeSurfer are not included):
+Tools included:
 ```
 dcm2niix: https://github.com/rordenlab/dcm2niix (v1.0.20240202)
-spec2nii: https://github.com/wtclarke/spec2nii (v0.7.2)
-bidscoin: https://bidscoin.readthedocs.io/en/4.3.0
+spec2nii: https://github.com/wtclarke/spec2nii (v0.7.3)
+bidscoin: https://bidscoin.readthedocs.io/en/4.3.1
     bidscoin
     bidscoiner
     bidseditor
     bidsmapper
     bidsparticipants
+    deface
     dicomsort
     echocombine
+    medeface
     physio2tsv
     plotphysio
     rawmapper
@@ -39,6 +41,6 @@ Citation:
 Zwiers MP, Moia S, Oostenveld R. BIDScoin: A User-Friendly Application to Convert Source Data to Brain Imaging Data Structure. Front Neuroinform. 2022 Jan 13;15:770608. doi: 10.3389/fninf.2021.770608. PMID: 35095452; PMCID: PMC8792932.
 ```
 
-To run container outside of this environment: ml bidscoin/4.3.0
+To run container outside of this environment: ml bidscoin/4.3.1
 
 ----------------------------------

--- a/recipes/bidscoin/build.sh
+++ b/recipes/bidscoin/build.sh
@@ -3,7 +3,7 @@ set -e
 
 # this template file builds tools required for dicom conversion to bids
 export toolName='bidscoin'
-export toolVersion='4.3.0'    # Don't forget to update version change in README.md!!!!!
+export toolVersion='4.3.1'    # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
     echo "Entering Debug mode"
@@ -29,7 +29,7 @@ neurodocker generate ${neurodocker_buildMode} `# Based on Singularity .def file 
     --install curl \
     `# Install pigz (to speed up dcm2niix)` \
     --install pigz \
-    `# Install the 4.2.1+Qt5 branch from Github` \
+    `# Install the +qt5 branch from Github` \
     `# NOTE: PyQt5 is installed as Debian package to solve dependencies issues occurring when installed with pip.` \
     --install python3-pyqt5 \
     --miniconda version=latest \


### PR DESCRIPTION
This upgrades BIDScoin to v4.3.1 (this time without merge conflicts)