### PR TITLE
Added mrtrix3 source version for latest (non-release) mrtrix3.

### DIFF
--- a/recipes/mrtrix3src/README.md
+++ b/recipes/mrtrix3src/README.md
@@ -1,0 +1,22 @@
+
+----------------------------------
+## mrtrix3src/toolVersion ##
+MRtrix3 provides a set of tools to perform various types of diffusion MRI analyses, from various forms of tractography through to next-generation group-level analyses. It is designed with consistency, performance, and stability in mind, and is freely available under an open-source license. This is the current version, built from source (not a release).
+
+
+Example:
+```
+mrview
+```
+
+More documentation can be found here: https://mrtrix.readthedocs.io/en/toolVersion/
+
+Citation:
+```
+J.-D. Tournier, R. E. Smith, D. Raffelt, R. Tabbara, T. Dhollander, M. Pietsch, D. Christiaens, B. Jeurissen, C.-H. Yeh, and A. Connelly. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 202 (2019), pp. 116–37.
+```
+
+
+To run container outside of this environment: ml mrtrix3src/toolVersion
+
+----------------------------------

--- a/recipes/mrtrix3src/build.sh
+++ b/recipes/mrtrix3src/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+
+export toolName='mrtrix3src'
+export toolVersion='latest'
+# Don't forget to update version change in README.md!!!!!
+# https://github.com/MRtrix3/mrtrix3/releases/
+
+if [ "$1" != "" ]; then
+    echo "Entering Debug mode"
+    export debug=$1
+fi
+
+source ../main_setup.sh
+
+neurodocker generate ${neurodocker_buildMode} \
+   --base-image vnmd/fsl_6.0.5.1:20221016 \
+   --pkg-manager apt \
+   --ants version="2.3.4" \
+   --workdir /opt \
+   --install dbus-x11 less python3-distutils mesa-common-dev libglu1-mesa qt5-default libqt5svg5-dev wget libqt5opengl5-dev libqt5opengl5 libqt5gui5 libqt5core5a libtiff5-dev libtiff5 libfftw3-dev liblapack3 libeigen3-dev \
+   --run="wget https://github.com/MRtrix3/mrtrix3/archive/refs/heads/master.zip \
+      && unzip ./master.zip && mv mrtrix3-master mrtrix3-${toolVersion} && rm master.zip" \
+   --workdir /opt/mrtrix3-${toolVersion} \
+   --run "python3 configure" \
+   --run "python3 build" \
+   --run "ln -s /usr/bin/python3 /usr/bin/python" \
+   --workdir /opt/acpcdetect_V2.1 \
+   --run="wget https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/build/acpcdetect_V2.1_LinuxCentOS6.7.tar.gz \
+      && tar zxvf acpcdetect_V2.1_LinuxCentOS6.7.tar.gz \
+      && rm -rf acpcdetect_V2.1_LinuxCentOS6.7.tar.gz" \
+   --env ARTHOME=/opt/acpcdetect_V2.1/ \
+   --env PATH='$PATH':/opt/mrtrix3-${toolVersion}/bin:/opt/acpcdetect_V2.1/bin \
+   --env DEPLOY_PATH=/opt/mrtrix3-${toolVersion}/bin/:/opt/acpcdetect_V2.1/bin \
+   --copy README.md /README.md \
+   --user=neuro \
+  > ${imageName}.${neurodocker_buildExt}
+
+if [ "$1" != "" ]; then
+   ./../main_build.sh
+fi

--- a/recipes/mrtrix3src/test.sh
+++ b/recipes/mrtrix3src/test.sh
@@ -1,0 +1,5 @@
+dwifslpreproc
+# shouldn't through any errors (e.g. distutils, no python available ...)
+
+mrview
+# should open up ok -> needs QT and doesn't come from neurodocker -> we tried a pull request, but it didn't get merged.


### PR DESCRIPTION
Have created a new tool, mrtrix3src, to use the most recent (non-release) version of mrtrix3 (as the current release has some bugs that were fixed in later versions).

Because the other Neurocontainer version of mrtrix3 uses a neurodocker recipe, which itself requires a release version, a separate recipe has been created (mrtrix3src) rather than just integrating this into the main mrtrix3 tool.