### PR TITLE
Added qMRLab 2.4.2

### DIFF
--- a/recipes/qmrlab/README.md
+++ b/recipes/qmrlab/README.md
@@ -1,0 +1,35 @@
+
+----------------------------------
+## qmrlab/toolVersion##
+
+<b><h2 align="center">
+qMRLab is an open-source software for quantitative MR image analysis.</h2></b> 
+
+<p align="center">Our main goal is to provide the community with an intuitive tool for <b>data fitting</b>, <b>plotting</b>, <b>simulation</b> and <b>protocol optimization</b> for a myriad of different quantitative models.
+The modularity of the qMRLab framework makes it easy to add any additional modules and we encourage everyone to contribute their favorite recipe for qMR!</p>
+
+<p align="center">
+For <b>documentation 📖</b>, visit the <a href="http://qmrlab.readthedocs.io/">Documentation website</a>.</p>
+
+<p align="center">
+If you are a <b>developer 🛠</b>, please visit the <a href="https://github.com/neuropoly/qMRLab/wiki">Wiki page<a>.</p>
+
+<p align="center">
+Please report any <b>bug 🐛</b> or <b>suggestions 💭</b> in <a href="https://github.com/neuropoly/qMRLab/issues">GitHub</a>.</p>
+
+<p align="center">
+For <b>interactive tutorials 🎚</b>, <b>blog posts 🖋</b> and more, you can visit <a href="https://qmrlab.org">qMRLab portal</a>.</p>
+
+<p align="center">
+qMRLab is a fork from the initial project <a href="https://github.com/neuropoly/qMTLab">qMTLab</a>.</p>  
+
+Citation:
+
+* [Karakuzu et al. *qMRLab: Quantitative MRI analysis, under one umbrella.* Journal of Open Source Software (JOSS) 2020](https://joss.theoj.org/papers/10.21105/joss.02343)
+* [Karakuzu et al. *The qMRLab workflow: From acquisition to publication.* ISMRM 2019](https://www.ismrm.org/19/program_files/DP23.htm#005)
+* [Duval et al. *Quantitative MRI made easy with qMRLab.* ISMRM 2018](http://archive.ismrm.org/2018/2288.html)
+* [Cabana et al. *Quantitative magnetization transfer imaging made easy with qMTLab: Software for data simulation, analysis, and visualization.* Concepts in Magn Reson 2015](https://onlinelibrary.wiley.com/doi/abs/10.1002/cmr.a.21357)
+
+License: MIT License
+
+----------------------------------

--- a/recipes/qmrlab/build.sh
+++ b/recipes/qmrlab/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+export toolName='qMRLab'
+export toolVersion='2.4.2'
+
+if [ "$1" != "" ]; then
+    echo "Entering Debug mode"
+    export debug=$1
+fi
+
+source ../main_setup.sh
+
+# Use Singlrity/Apptainer to run TinyRange to generate the rootfs.
+singularity run docker://ghcr.io/tinyrange/tinyrange:stable build qMRLab.star:qmr_lab_root -o qmr_lab.tar
+
+# MAke sure the automaticcly included template doesn't add to the final layer.
+neurodocker generate docker \
+    --base-image ubuntu \
+    --pkg-manager apt \
+    --base-image scratch \
+    --add qmr_lab.tar . \
+    --run "/init -run-scripts /.pkg/scripts.json" \
+    --run "cd /qMRLab-2.4.2;octave --exec \"qMRLabVer\"" \
+    --copy qMRLab.sh /usr/bin/qMRLab \
+    --entrypoint "/usr/bin/qMRLab" \
+    > ${imageName}.${neurodocker_buildExt}
+
+if [ "$1" != "" ]; then
+   ./../main_build.sh
+fi

--- a/recipes/qmrlab/qMRLab.sh
+++ b/recipes/qmrlab/qMRLab.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /qMRLab-2.4.2
+exec octave $@

--- a/recipes/qmrlab/qMRLab.star
+++ b/recipes/qmrlab/qMRLab.star
@@ -1,0 +1,95 @@
+load("//lib/octave.star", "add_octave_packages", "build_octave_package")
+
+qmr_lab_url = "https://github.com/qMRLab/qMRLab/archive/v2.4.2.tar.gz"
+
+octave_forge = "https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/"
+
+pkg_image = build_octave_package(
+    octave_forge + "image-2.14.0.tar.gz",
+    "image-2.14.0",
+)
+
+pkg_io = build_octave_package(
+    octave_forge + "io-2.6.0.tar.gz",
+    "io-2.6.0",
+)
+
+pkg_struct = build_octave_package(
+    octave_forge + "struct-1.0.18.tar.gz",
+    "struct-1.0.18",
+)
+
+pkg_statistics = build_octave_package(
+    "https://github.com/gnu-octave/statistics/archive/refs/tags/release-1.6.7.tar.gz",
+    "statistics-1.6.7",
+)
+
+pkg_optim = build_octave_package(
+    octave_forge + "optim-1.6.2.tar.gz",
+    "optim-1.6.2",
+    depends = [pkg_struct, pkg_statistics],
+    additional_queries = [query("openblas-dev")],
+)
+
+vm_test = define.build_vm(
+    directives = [
+        define.plan(
+            builder = "alpine@3.20",
+            packages = [
+                query("octave"),
+                query("texinfo"),
+            ],
+            tags = ["level3", "defaults"],
+        ),
+    ] + add_octave_packages([
+        pkg_image,
+        pkg_io,
+        pkg_struct,
+        pkg_statistics,
+        pkg_optim,
+    ]) + [
+        directive.run_command("interactive"),
+    ],
+)
+
+qmr_lab = add_octave_packages([
+    pkg_image,
+    pkg_io,
+    pkg_struct,
+    pkg_statistics,
+    pkg_optim,
+]) + [
+    define.read_archive(define.fetch_http(qmr_lab_url), ".tar.gz"),
+]
+
+octave_deps = [
+    query("octave"),
+    query("octave-dev"),
+    query("build-base"),
+    query("texinfo"),
+    query("curl"),
+    query("mesa-dri-gallium"),
+    query("font-noto"),
+    query("adwaita-icon-theme"),
+    query("faenza-icon-theme"),
+]
+
+qmr_lab_root = define.build_fs([
+    define.plan(
+        builder = "alpine@3.20",
+        packages = octave_deps,
+        tags = ["level3", "defaults", "noScripts"],
+    ),
+] + qmr_lab + [
+    directive.builtin("init", "/init"),
+], "tar")
+
+qmr_lab_test = define.build_vm(
+    directives = [
+        define.plan(
+            builder = "alpine@3.20",
+            packages = octave_deps,
+            tags = ["level3", "defaults"],
+        ),
+    ] + qmr_lab + [directive.run_command("interactive")],
+)


### PR DESCRIPTION
Added qMRLab 2.4.2 using TinyRange for the build process.

The `qMRLab.star` file pulls all the required Octave packages and the source code from GitHub.

This container is Alpine Linux based.

Tested with https://qmrlab.readthedocs.io/en/master/batch_example.html (but it requires a GUI to test).

