### PR TITLE
Upgrade to 4.5.0

### DIFF
--- a/recipes/bidscoin/build.sh
+++ b/recipes/bidscoin/build.sh
@@ -3,7 +3,7 @@ set -e
 
 # this template file builds tools required for dicom conversion to bids
 export toolName='bidscoin'
-export toolVersion='4.4.0'    # Don't forget to update version change in README.md!!!!!
+export toolVersion='4.5.0'    # Don't forget to update version change in README.md!!!!!
 
 if [ "$1" != "" ]; then
     echo "Entering Debug mode"


### PR DESCRIPTION
I tested the image and it worked fine:

```console
(neurodocker) ~/PycharmProjects/neurocontainers/recipes/bidscoin$ sudo docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix bidscoin_${VERSION}:20250205 bidscoin -t
INFO | --------- Testing the BIDScoin's core functionality ---------
INFO | Running bidsmap checks:
INFO | Reading: /root/.bidscoin/4.5.0/templates/bidsmap_dccn.yaml
INFO | generated new fontManager
INFO | Checking the bidsmap run-items:
VERBOSE | Could not validate every run-item in the bidsmap
VERBOSE | Checking the template bidsmap datatypes:
SUCCESS | All datatypes and options in the template bidsmap are valid
INFO | Testing the PyQt GUI setup:
SUCCESS | The GUI seems to work OK
INFO | Testing the DRMAA setup:
WARNING | The DRMAA library could not be imported. This is OK if you want to run pydeface locally and not use the option to distribute jobs on a compute cluster
Could not find drmaa library.  Please specify its full path using the environment variable DRMAA_LIBRARY_PATH
INFO | Executable BIDScoin tools:
INFO | - bidscoin
INFO | - bidscoiner
INFO | - bidseditor
INFO | - bidsmapper
INFO | - bidsparticipants
INFO | - deface
INFO | - dicomsort
INFO | - echocombine
INFO | - fixmeta
INFO | - medeface
INFO | - physio2tsv
INFO | - plotphysio
INFO | - rawmapper
INFO | - skullstrip
INFO | - slicereport
INFO | Installed template bidsmaps (/root/.bidscoin/4.5.0/templates):
INFO | - bidsmap_bids2bids
INFO | - bidsmap_dccn (default)
INFO | - bidsmap_sst
INFO | Installed plugins (/root/.bidscoin/4.5.0/plugins):
INFO | - dcm2niix2bids
INFO | - events2bids
INFO | - nibabel2bids
INFO | - spec2nii2bids
INFO | --------- Testing the 'dcm2niix2bids' plugin ---------
INFO | Testing the dcm2niix2bids installation:
VERBOSE | Command:
dcm2niix -v
VERBOSE | Output:
Chris Rorden's dcm2niiX version v1.0.20241211  (JP2:OpenJPEG) (JP-LS:CharLS) GCC12.2.0 x86-64 (64-bit Linux)
v1.0.20241211

SUCCESS | The 'dcm2niix2bids' plugin functioned correctly
INFO | --------- Testing the 'events2bids' plugin ---------
INFO | The bidscoin.plugins plugin test function is not implemented
SUCCESS | The 'events2bids' plugin functioned correctly
INFO | --------- Testing the 'nibabel2bids' plugin ---------
INFO | Testing the nibabel2bids installation:
INFO | Nibabel version: 5.3.2
SUCCESS | The 'nibabel2bids' plugin functioned correctly
INFO | --------- Testing the 'spec2nii2bids' plugin ---------
INFO | Testing the spec2nii2bids installation:
VERBOSE | Command:
spec2nii -v
VERBOSE | Output:
0.8.5

SUCCESS | The 'spec2nii2bids' plugin functioned correctly
SUCCESS | All tests finished successfully :-)
Creating BIDScoin user configuration:
-> /root/.bidscoin/4.5.0/config.toml
-> /root/.bidscoin/4.5.0/plugins/dcm2niix2bids.py
-> /root/.bidscoin/4.5.0/plugins/events2bids.py
-> /root/.bidscoin/4.5.0/plugins/nibabel2bids.py
-> /root/.bidscoin/4.5.0/plugins/spec2nii2bids.py
-> /root/.bidscoin/4.5.0/templates/bidsmap_bids2bids.yaml
-> /root/.bidscoin/4.5.0/templates/bidsmap_dccn.yaml
-> /root/.bidscoin/4.5.0/templates/bidsmap_sst.yaml
-> /root/.bidscoin/4.5.0/templates/schema.json
```