### PR TITLE
Fix afib1 bug in group image sending

### DIFF
--- a/recipes/afib1/build.yaml
+++ b/recipes/afib1/build.yaml
@@ -1,5 +1,5 @@
 name: afib1
-version: 1.5.0
+version: 1.6.0
 architectures:
     - x86_64
 


### PR DESCRIPTION
Remove exception raised when images processed as a group untriggered. Also fix temporary display of TR.