### PR TITLE
Added TractSeg recipe

### DIFF
--- a/recipes/tractseg/build.yaml
+++ b/recipes/tractseg/build.yaml
@@ -1,0 +1,17 @@
+name: tractseg
+version: '2.9'
+architectures:
+- x86_64
+copyright:
+- license: Apache-2.0
+  url: https://github.com/MIC-DKFZ/TractSeg/blob/master/LICENSE
+build:
+  kind: neurodocker
+  base-image: wasserth/tractseg_container:{{ context.version }}
+  pkg-manager: apt
+  directives: []
+deploy:
+  bins:
+   - tractseg
+readme: This is a recipe for Tractseg/{{ context.version }}
+readme_url: https://github.com/MIC-DKFZ/TractSeg/blob/master/Readme.md


### PR DESCRIPTION
TractSeg: Tool for fast and accurate white matter bundle segmentation from Diffusion MRI.
https://github.com/MIC-DKFZ/TractSeg/tree/master