### PR TITLE
Implement automated apps.json maintenance system

### DIFF
--- a/.github/workflows/update-apps-json.yml
+++ b/.github/workflows/update-apps-json.yml
@@ -1,0 +1,98 @@
+name: Update apps.json
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'releases/**/*.json'
+  workflow_dispatch:
+
+jobs:
+  update-apps-json:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout neurocontainers repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    
+    - name: Generate apps.json
+      run: |
+        python3 tools/generate_apps_json.py --output apps.json
+    
+    - name: Checkout neurocommand repo
+      uses: actions/checkout@v4
+      with:
+        repository: neurodesk/neurocommand
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: neurocommand
+        fetch-depth: 0
+    
+    - name: Configure git
+      run: |
+        git config --global user.name "neurocontainers-bot"
+        git config --global user.email "neurocontainers-bot@neurodesk.github.io"
+    
+    - name: Create pull request
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd neurocommand
+        
+        # Create a new branch for the update
+        BRANCH_NAME="update-apps-json-$(date +%Y%m%d-%H%M%S)"
+        git checkout -b "$BRANCH_NAME"
+        
+        # Copy the generated apps.json
+        cp ../apps.json neurodesk/apps.json
+        
+        # Check if there are any changes
+        if ! git diff --quiet neurodesk/apps.json; then
+          echo "Changes detected in apps.json"
+          
+          # Add and commit changes
+          git add neurodesk/apps.json
+          git commit -m "Update apps.json from neurocontainers releases
+          
+          Auto-generated from release files in neurocontainers repo.
+          
+          🤖 Generated with neurocontainers automation"
+          
+          # Push the branch
+          git push origin "$BRANCH_NAME"
+          
+          # Create pull request
+          gh pr create \
+            --title "Update apps.json from neurocontainers releases" \
+            --body "$(cat <<'EOF'
+        ## Summary
+        
+        This PR updates apps.json based on the latest release files from the neurocontainers repository.
+        
+        ## Changes
+        
+        - Updated apps.json with latest container releases
+        - Generated automatically from individual release files
+        
+        ## Test Plan
+        
+        - [ ] Verify apps.json format is correct
+        - [ ] Check that all expected containers are present
+        - [ ] Test container availability after merge
+        
+        🤖 Generated with neurocontainers automation
+        EOF
+        )" \
+            --head "$BRANCH_NAME" \
+            --base master
+        
+          echo "Pull request created successfully"
+        else
+          echo "No changes detected in apps.json"
+        fi

--- a/recipes/fsl/build.yaml
+++ b/recipes/fsl/build.yaml
@@ -6,6 +6,17 @@ version: 6.0.7.16
 copyright:
   - name: fsl license
     url: https://fsl.fmrib.ox.ac.uk/fsl/docs/#/license
+
+categories:
+  - "functional imaging"
+  - "structural imaging" 
+  - "diffusion imaging"
+  - "image segmentation"
+  - "image registration"
+
+gui_apps:
+  - name: "fsleyesGUI"
+    exec: "fsleyes"
     
 options:
   workshop:

--- a/releases/afni/21.2.00.json
+++ b/releases/afni/21.2.00.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "afni 21.2.00": {
+      "version": "20210714",
+      "exec": ""
+    },
+    "sumaGUI-afni 21.2.00": {
+      "version": "20210714",
+      "exec": "suma"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/afni/22.3.07.json
+++ b/releases/afni/22.3.07.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "afni 22.3.07": {
+      "version": "20221206",
+      "exec": ""
+    },
+    "sumaGUI-afni 22.3.07": {
+      "version": "20221206",
+      "exec": "suma"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/afni/23.0.07.json
+++ b/releases/afni/23.0.07.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "afni 23.0.07": {
+      "version": "20230302",
+      "exec": ""
+    },
+    "sumaGUI-afni 23.0.07": {
+      "version": "20230302",
+      "exec": "suma"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/afni/23.3.02.json
+++ b/releases/afni/23.3.02.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "afni 23.3.02": {
+      "version": "20231024",
+      "exec": ""
+    },
+    "sumaGUI-afni 23.3.02": {
+      "version": "20231024",
+      "exec": "suma"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/afni/24.1.02.json
+++ b/releases/afni/24.1.02.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "afni 24.1.02": {
+      "version": "20240409",
+      "exec": ""
+    },
+    "sumaGUI-afni 24.1.02": {
+      "version": "20240409",
+      "exec": "suma"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/afni/24.3.00.json
+++ b/releases/afni/24.3.00.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "afni 24.3.00": {
+      "version": "20241003",
+      "exec": ""
+    },
+    "sumaGUI-afni 24.3.00": {
+      "version": "20241003",
+      "exec": "suma"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/aidamri/1.1.json
+++ b/releases/aidamri/1.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "aidamri 1.1": {
+      "version": "20210708",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "rodent imaging"
+  ]
+}

--- a/releases/ants/2.3.1.json
+++ b/releases/ants/2.3.1.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "ants 2.3.1": {
+      "version": "20211204",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration",
+    "structural imaging",
+    "image segmentation"
+  ]
+}

--- a/releases/ants/2.3.5.json
+++ b/releases/ants/2.3.5.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "ants 2.3.5": {
+      "version": "20211212",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration",
+    "structural imaging",
+    "image segmentation"
+  ]
+}

--- a/releases/ants/2.5.1.json
+++ b/releases/ants/2.5.1.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "ants 2.5.1": {
+      "version": "20240429",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration",
+    "structural imaging",
+    "image segmentation"
+  ]
+}

--- a/releases/ants/2.5.3.json
+++ b/releases/ants/2.5.3.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "ants 2.5.3": {
+      "version": "20240925",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration",
+    "structural imaging",
+    "image segmentation"
+  ]
+}

--- a/releases/ants/2.5.4.json
+++ b/releases/ants/2.5.4.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "ants 2.5.4": {
+      "version": "20250423",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration",
+    "structural imaging",
+    "image segmentation"
+  ]
+}

--- a/releases/ants/2.6.0.json
+++ b/releases/ants/2.6.0.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "ants 2.6.0": {
+      "version": "20250424",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration",
+    "structural imaging",
+    "image segmentation"
+  ]
+}

--- a/releases/ashs/2.0.0.json
+++ b/releases/ashs/2.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "ashs 2.0.0": {
+      "version": "20210105",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "hippocampus"
+  ]
+}

--- a/releases/aslprep/0.2.7.json
+++ b/releases/aslprep/0.2.7.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.2.7": {
+      "version": "20210323",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/aslprep/0.4.0.json
+++ b/releases/aslprep/0.4.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.4.0": {
+      "version": "20230728",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/aslprep/0.5.0.json
+++ b/releases/aslprep/0.5.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.5.0": {
+      "version": "20231116",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/aslprep/0.6.0.json
+++ b/releases/aslprep/0.6.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.6.0": {
+      "version": "20240318",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/aslprep/0.7.0.json
+++ b/releases/aslprep/0.7.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.7.0": {
+      "version": "20240530",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/aslprep/0.7.2.json
+++ b/releases/aslprep/0.7.2.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.7.2": {
+      "version": "20240917",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/aslprep/0.7.5.json
+++ b/releases/aslprep/0.7.5.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "aslprep 0.7.5": {
+      "version": "20250206",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "workflows"
+  ]
+}

--- a/releases/bart/0.7.00.json
+++ b/releases/bart/0.7.00.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bart 0.7.00": {
+      "version": "20210302",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image reconstruction"
+  ]
+}

--- a/releases/bart/0.9.00.json
+++ b/releases/bart/0.9.00.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bart 0.9.00": {
+      "version": "20240723",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image reconstruction"
+  ]
+}

--- a/releases/bidsappaa/0.2.0.json
+++ b/releases/bidsappaa/0.2.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsappaa 0.2.0": {
+      "version": "20230613",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidsappbaracus/1.1.4.json
+++ b/releases/bidsappbaracus/1.1.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsappbaracus 1.1.4": {
+      "version": "20230612",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidsappbrainsuite/21a.json
+++ b/releases/bidsappbrainsuite/21a.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsappbrainsuite 21a": {
+      "version": "20230618",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidsapphcppipelines/4.3.0.json
+++ b/releases/bidsapphcppipelines/4.3.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsapphcppipelines 4.3.0": {
+      "version": "20230524",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidsappmrtrix3connectome/0.5.3.json
+++ b/releases/bidsappmrtrix3connectome/0.5.3.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsappmrtrix3connectome 0.5.3": {
+      "version": "20230615",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidsapppymvpa/2.0.2.json
+++ b/releases/bidsapppymvpa/2.0.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsapppymvpa 2.0.2": {
+      "version": "20230629",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidsappspm/0.0.20.json
+++ b/releases/bidsappspm/0.0.20.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidsappspm 0.0.20": {
+      "version": "20230629",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "bids apps"
+  ]
+}

--- a/releases/bidscoin/3.7.0.json
+++ b/releases/bidscoin/3.7.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 3.7.0": {
+      "version": "20220329",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.2.0.json
+++ b/releases/bidscoin/4.2.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.2.0": {
+      "version": "20231017",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.2.1.json
+++ b/releases/bidscoin/4.2.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.2.1": {
+      "version": "20231030",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.3.0.json
+++ b/releases/bidscoin/4.3.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.3.0": {
+      "version": "20240221",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.3.2.json
+++ b/releases/bidscoin/4.3.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.3.2": {
+      "version": "20240329",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.3.3.json
+++ b/releases/bidscoin/4.3.3.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.3.3": {
+      "version": "20240716",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.4.0.json
+++ b/releases/bidscoin/4.4.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.4.0": {
+      "version": "20241003",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.5.0.json
+++ b/releases/bidscoin/4.5.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.5.0": {
+      "version": "20250205",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidscoin/4.6.1.json
+++ b/releases/bidscoin/4.6.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidscoin 4.6.1": {
+      "version": "20250328",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidstools/1.0.1.json
+++ b/releases/bidstools/1.0.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidstools 1.0.1": {
+      "version": "20230905",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidstools/1.0.2.json
+++ b/releases/bidstools/1.0.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidstools 1.0.2": {
+      "version": "20231017",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidstools/1.0.3.json
+++ b/releases/bidstools/1.0.3.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidstools 1.0.3": {
+      "version": "20231030",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/bidstools/1.0.4.json
+++ b/releases/bidstools/1.0.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "bidstools 1.0.4": {
+      "version": "20240221",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/brainlifecli/1.7.0.json
+++ b/releases/brainlifecli/1.7.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "brainlifecli 1.7.0": {
+      "version": "20241003",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "workflows"
+  ]
+}

--- a/releases/brainnetviewer/1.7.20191031.json
+++ b/releases/brainnetviewer/1.7.20191031.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "brainnetviewer 1.7.20191031": {
+      "version": "20240904",
+      "exec": ""
+    },
+    "brainnetviewerGUI-brainnetviewer 1.7.20191031": {
+      "version": "20240904",
+      "exec": "brainnetviewer"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "visualization"
+  ]
+}

--- a/releases/brainstorm/3.211130.json
+++ b/releases/brainstorm/3.211130.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "brainstorm 3.211130": {
+      "version": "20211207",
+      "exec": ""
+    },
+    "brainstormGUI-brainstorm 3.211130": {
+      "version": "20211207",
+      "exec": "brainstorm3.command /opt/MCR/v98/"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/brkraw/0.3.11.json
+++ b/releases/brkraw/0.3.11.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "brkraw 0.3.11": {
+      "version": "20240320",
+      "exec": ""
+    },
+    "brkrawGUI-brkraw 0.3.11": {
+      "version": "20240320",
+      "exec": "brkraw gui"
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/cat12/12.9.json
+++ b/releases/cat12/12.9.json
@@ -1,0 +1,17 @@
+{
+  "apps": {
+    "cat12GUI-cat12 12.9": {
+      "version": "20250307",
+      "exec": "bash run_spm12.sh /opt/mcr/v93/"
+    },
+    "cat12 12.9": {
+      "version": "20250307",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging"
+  ]
+}

--- a/releases/cat12/r1933.json
+++ b/releases/cat12/r1933.json
@@ -1,0 +1,17 @@
+{
+  "apps": {
+    "cat12GUI-cat12 r1933": {
+      "version": "20220128",
+      "exec": "bash run_spm12.sh /opt/mcr/v93/"
+    },
+    "cat12 r1933": {
+      "version": "20220128",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging"
+  ]
+}

--- a/releases/cat12/r2166.json
+++ b/releases/cat12/r2166.json
@@ -1,0 +1,17 @@
+{
+  "apps": {
+    "cat12GUI-cat12 r2166": {
+      "version": "20230601",
+      "exec": "bash run_spm12.sh /opt/mcr/v93/"
+    },
+    "cat12 r2166": {
+      "version": "20230601",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging"
+  ]
+}

--- a/releases/clearswi/1.0.0.json
+++ b/releases/clearswi/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "clearswi 1.0.0": {
+      "version": "20211018",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing"
+  ]
+}

--- a/releases/code/230315.json
+++ b/releases/code/230315.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "vscodeGUI-code 230315": {
+      "version": "20230315",
+      "exec": "code"
+    },
+    "code 230315": {
+      "version": "20230315",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "programming"
+  ]
+}

--- a/releases/conn/20b.json
+++ b/releases/conn/20b.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "connGUI-conn 20b": {
+      "version": "20210109",
+      "exec": "conn"
+    },
+    "conn 20b": {
+      "version": "20210109",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/conn/22a.json
+++ b/releases/conn/22a.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "connGUI-conn 22a": {
+      "version": "20231115",
+      "exec": "conn"
+    },
+    "conn 22a": {
+      "version": "20231115",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/connectomeworkbench/1.4.2.json
+++ b/releases/connectomeworkbench/1.4.2.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "connectomeworkbench 1.4.2": {
+      "version": "20201119",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "data organisation"
+  ]
+}

--- a/releases/connectomeworkbench/1.5.0.json
+++ b/releases/connectomeworkbench/1.5.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "connectomeworkbench 1.5.0": {
+      "version": "20220919",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "data organisation"
+  ]
+}

--- a/releases/convert3d/1.0.0.json
+++ b/releases/convert3d/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "convert3d 1.0.0": {
+      "version": "20210104",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/dcm2bids/3.2.0.json
+++ b/releases/dcm2bids/3.2.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "dcm2bids 3.2.0": {
+      "version": "20250402",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/dcm2niix/v1.0.20240202.json
+++ b/releases/dcm2niix/v1.0.20240202.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "dcm2niix v1.0.20240202": {
+      "version": "20241125",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/deepretinotopy/1.0.10.json
+++ b/releases/deepretinotopy/1.0.10.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "deepretinotopy 1.0.10": {
+      "version": "20250409",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "machine learning",
+    "functional imaging"
+  ]
+}

--- a/releases/deepretinotopy/1.0.5.json
+++ b/releases/deepretinotopy/1.0.5.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "deepretinotopy 1.0.5": {
+      "version": "20240609",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "machine learning",
+    "functional imaging"
+  ]
+}

--- a/releases/deepretinotopy/1.0.8.json
+++ b/releases/deepretinotopy/1.0.8.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "deepretinotopy 1.0.8": {
+      "version": "20250207",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "machine learning",
+    "functional imaging"
+  ]
+}

--- a/releases/dicomtools/1.0.0.json
+++ b/releases/dicomtools/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "dicomtools 1.0.0": {
+      "version": "20250204",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/diffusiontoolkit/0.6.4.1.json
+++ b/releases/diffusiontoolkit/0.6.4.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "diffusiontoolkit 0.6.4.1": {
+      "version": "20220303",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/dsistudio/2020.10.json
+++ b/releases/dsistudio/2020.10.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "dsistudio 2020.10": {
+      "version": "20210109",
+      "exec": ""
+    },
+    "dsistudioGUI-dsistudio 2020.10": {
+      "version": "20210109",
+      "exec": "dsi_studio"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/dsistudio/2024.06.12.json
+++ b/releases/dsistudio/2024.06.12.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "dsistudio 2024.06.12": {
+      "version": "20241010",
+      "exec": ""
+    },
+    "dsistudioGUI-dsistudio 2024.06.12": {
+      "version": "20241010",
+      "exec": "dsi_studio"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/dsistudio/chen.2024.04.19.json
+++ b/releases/dsistudio/chen.2024.04.19.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "dsistudio chen.2024.04.19": {
+      "version": "20240426",
+      "exec": ""
+    },
+    "dsistudioGUI-dsistudio chen.2024.04.19": {
+      "version": "20240426",
+      "exec": "dsi_studio"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/eeglab/2020.0.json
+++ b/releases/eeglab/2020.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "eeglab 2020.0": {
+      "version": "20211026",
+      "exec": ""
+    },
+    "eeglabGUI-eeglab 2020.0": {
+      "version": "20211026",
+      "exec": "EEGLAB"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/elastix/5.1.0.json
+++ b/releases/elastix/5.1.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "elastix 5.1.0": {
+      "version": "20230407",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration"
+  ]
+}

--- a/releases/fastcsr/1.0.json
+++ b/releases/fastcsr/1.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "fastcsr 1.0": {
+      "version": "20231213",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/fatsegnet/1.0.gpu.json
+++ b/releases/fatsegnet/1.0.gpu.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "fatsegnet 1.0.gpu": {
+      "version": "20201212",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "body"
+  ]
+}

--- a/releases/fieldtrip/20211114.json
+++ b/releases/fieldtrip/20211114.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "fieldtrip 20211114": {
+      "version": "20211206",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/fieldtrip/20220617.json
+++ b/releases/fieldtrip/20220617.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "fieldtrip 20220617": {
+      "version": "20220627",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/fmriprep/20.1.3.json
+++ b/releases/fmriprep/20.1.3.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 20.1.3": {
+      "version": "20201118",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/fmriprep/20.2.6.json
+++ b/releases/fmriprep/20.2.6.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 20.2.6": {
+      "version": "20211209",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/fmriprep/22.1.1.json
+++ b/releases/fmriprep/22.1.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 22.1.1": {
+      "version": "20230218",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/fmriprep/23.0.0.json
+++ b/releases/fmriprep/23.0.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 23.0.0": {
+      "version": "20230315",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/fmriprep/23.2.1.json
+++ b/releases/fmriprep/23.2.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 23.2.1": {
+      "version": "20240402",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/fmriprep/24.1.0.json
+++ b/releases/fmriprep/24.1.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 24.1.0": {
+      "version": "20241003",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/fmriprep/24.1.1.json
+++ b/releases/fmriprep/24.1.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "fmriprep 24.1.1": {
+      "version": "20250214",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/freesurfer/7.1.1.json
+++ b/releases/freesurfer/7.1.1.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "freesurfer 7.1.1": {
+      "version": "20211216",
+      "exec": ""
+    },
+    "freeviewGUI-freesurfer 7.1.1": {
+      "version": "20211216",
+      "exec": "freeview"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "structural imaging"
+  ]
+}

--- a/releases/freesurfer/7.2.0.json
+++ b/releases/freesurfer/7.2.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "freesurfer 7.2.0": {
+      "version": "20211206",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "structural imaging"
+  ]
+}

--- a/releases/freesurfer/7.3.2.json
+++ b/releases/freesurfer/7.3.2.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "freesurfer 7.3.2": {
+      "version": "20231214",
+      "exec": ""
+    },
+    "freeviewGUI-freesurfer 7.3.2": {
+      "version": "20231214",
+      "exec": "freeview"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "structural imaging"
+  ]
+}

--- a/releases/freesurfer/7.4.1.json
+++ b/releases/freesurfer/7.4.1.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "freesurfer 7.4.1": {
+      "version": "20231214",
+      "exec": ""
+    },
+    "freeviewGUI-freesurfer 7.4.1": {
+      "version": "20231214",
+      "exec": "freeview"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "structural imaging"
+  ]
+}

--- a/releases/freesurfer/8.0.0.json
+++ b/releases/freesurfer/8.0.0.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "freesurfer 8.0.0": {
+      "version": "20250210",
+      "exec": ""
+    },
+    "freeviewGUI-freesurfer 8.0.0": {
+      "version": "20250210",
+      "exec": "freeview"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "structural imaging"
+  ]
+}

--- a/releases/fsl/6.0.3.json
+++ b/releases/fsl/6.0.3.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.3": {
+      "version": "20200905",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.3": {
+      "version": "20200905",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.4.json
+++ b/releases/fsl/6.0.4.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.4": {
+      "version": "20210105",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.4": {
+      "version": "20210105",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.5.1.json
+++ b/releases/fsl/6.0.5.1.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.5.1": {
+      "version": "20221016",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.5.1": {
+      "version": "20221016",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.6.4.json
+++ b/releases/fsl/6.0.6.4.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.6.4": {
+      "version": "20230618",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.6.4": {
+      "version": "20230618",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.7.1.json
+++ b/releases/fsl/6.0.7.1.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.7.1": {
+      "version": "20230809",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.7.1": {
+      "version": "20230809",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.7.14.json
+++ b/releases/fsl/6.0.7.14.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.7.14": {
+      "version": "20241018",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.7.14": {
+      "version": "20241018",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.7.16.json
+++ b/releases/fsl/6.0.7.16.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.7.16": {
+      "version": "20250617",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.7.16": {
+      "version": "20250617",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.7.4.json
+++ b/releases/fsl/6.0.7.4.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.7.4": {
+      "version": "20231005",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.7.4": {
+      "version": "20231005",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/fsl/6.0.7.8.json
+++ b/releases/fsl/6.0.7.8.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "fsl 6.0.7.8": {
+      "version": "20240913",
+      "exec": ""
+    },
+    "fsleyesGUI-fsl 6.0.7.8": {
+      "version": "20240913",
+      "exec": "fsleyes"
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "structural imaging",
+    "diffusion imaging",
+    "image segmentation",
+    "image registration"
+  ]
+}

--- a/releases/gimp/2.10.18.json
+++ b/releases/gimp/2.10.18.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "gimpGUI-gimp 2.10.18": {
+      "version": "20210104",
+      "exec": "gimp"
+    },
+    "gimp 2.10.18": {
+      "version": "20210104",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "visualization"
+  ]
+}

--- a/releases/glmsingle/1.2.json
+++ b/releases/glmsingle/1.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "glmsingle 1.2": {
+      "version": "20240520",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/globus/3.2.2.json
+++ b/releases/globus/3.2.2.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "globusGUI-globus 3.2.2": {
+      "version": "20230620",
+      "exec": "globusconnectpersonal -gui"
+    },
+    "globus 3.2.2": {
+      "version": "20230620",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/hdbet/1.0.0.json
+++ b/releases/hdbet/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "hdbet 1.0.0": {
+      "version": "20210318",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/heudiconv/1.3.1.json
+++ b/releases/heudiconv/1.3.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "heudiconv 1.3.1": {
+      "version": "20241105",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/hmri/0.6.0.json
+++ b/releases/hmri/0.6.0.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "hmriGUI-hmri 0.6.0": {
+      "version": "20230901",
+      "exec": "bash run_spm12.sh /opt/mcr/R2023a fmri"
+    },
+    "hmri 0.6.0": {
+      "version": "20230901",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "structural imaging"
+  ]
+}

--- a/releases/hmri/0.6.1.json
+++ b/releases/hmri/0.6.1.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "hmriGUI-hmri 0.6.1": {
+      "version": "20231107",
+      "exec": "bash run_spm12.sh /opt/mcr/R2023a fmri"
+    },
+    "hmri 0.6.1": {
+      "version": "20231107",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "structural imaging"
+  ]
+}

--- a/releases/hnncore/0.3.json
+++ b/releases/hnncore/0.3.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "hnncore 0.3": {
+      "version": "20231112",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/ilastik/1.4.0.json
+++ b/releases/ilastik/1.4.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "ilastik 1.4.0": {
+      "version": "20230720",
+      "exec": ""
+    },
+    "ilastikGUI-ilastik 1.4.0": {
+      "version": "20230720",
+      "exec": "run_ilastik.sh"
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/itksnap/3.8.0.json
+++ b/releases/itksnap/3.8.0.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "itksnapGUI-itksnap 3.8.0": {
+      "version": "20201208",
+      "exec": "itksnap /MRIcrop-orig.gipl"
+    },
+    "itksnap 3.8.0": {
+      "version": "20201208",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "visualization"
+  ]
+}

--- a/releases/itksnap/4.0.1.json
+++ b/releases/itksnap/4.0.1.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "itksnapGUI-itksnap 4.0.1": {
+      "version": "20230609",
+      "exec": "itksnap /MRIcrop-orig.gipl"
+    },
+    "itksnap 4.0.1": {
+      "version": "20230609",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "visualization"
+  ]
+}

--- a/releases/itksnap/4.0.2.json
+++ b/releases/itksnap/4.0.2.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "itksnapGUI-itksnap 4.0.2": {
+      "version": "20240117",
+      "exec": "itksnap /MRIcrop-orig.gipl"
+    },
+    "itksnap 4.0.2": {
+      "version": "20240117",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "visualization"
+  ]
+}

--- a/releases/julia/1.10.1.json
+++ b/releases/julia/1.10.1.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "julia 1.10.1": {
+      "version": "20240321",
+      "exec": ""
+    },
+    "vscodeGUI-julia 1.10.1": {
+      "version": "20240321",
+      "exec": "code"
+    },
+    "REPLGUI-julia 1.10.1": {
+      "version": "20240321",
+      "exec": "julia"
+    }
+  },
+  "categories": [
+    "programming"
+  ]
+}

--- a/releases/julia/1.4.1.json
+++ b/releases/julia/1.4.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "julia 1.4.1": {
+      "version": "20210105",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "programming"
+  ]
+}

--- a/releases/julia/1.9.4.json
+++ b/releases/julia/1.9.4.json
@@ -1,0 +1,19 @@
+{
+  "apps": {
+    "julia 1.9.4": {
+      "version": "20240405",
+      "exec": ""
+    },
+    "vscodeGUI-julia 1.9.4": {
+      "version": "20240405",
+      "exec": "code"
+    },
+    "REPLGUI-julia 1.9.4": {
+      "version": "20240405",
+      "exec": "julia"
+    }
+  },
+  "categories": [
+    "programming"
+  ]
+}

--- a/releases/lashis/1.0.json
+++ b/releases/lashis/1.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "lashis 1.0": {
+      "version": "20210105",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "hippocampus"
+  ]
+}

--- a/releases/lashis/2.0.json
+++ b/releases/lashis/2.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "lashis 2.0": {
+      "version": "20210211",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "hippocampus"
+  ]
+}

--- a/releases/laynii/2.2.1.json
+++ b/releases/laynii/2.2.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "laynii 2.2.1": {
+      "version": "20220701",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/lcmodel/6.3.json
+++ b/releases/lcmodel/6.3.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "lcmodel 6.3": {
+      "version": "20220222",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spectroscopy"
+  ]
+}

--- a/releases/matlab/2022a.json
+++ b/releases/matlab/2022a.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "matlab 2022a": {
+      "version": "20231207",
+      "exec": ""
+    },
+    "matlabGUI-matlab 2022a": {
+      "version": "20231207",
+      "exec": "matlab"
+    }
+  },
+  "categories": [
+    "programming",
+    "visualization"
+  ]
+}

--- a/releases/matlab/2022b.json
+++ b/releases/matlab/2022b.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "matlab 2022b": {
+      "version": "20250124",
+      "exec": ""
+    },
+    "matlabGUI-matlab 2022b": {
+      "version": "20250124",
+      "exec": "matlab"
+    }
+  },
+  "categories": [
+    "programming",
+    "visualization"
+  ]
+}

--- a/releases/matlab/2023b.json
+++ b/releases/matlab/2023b.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "matlab 2023b": {
+      "version": "20250121",
+      "exec": ""
+    },
+    "matlabGUI-matlab 2023b": {
+      "version": "20250121",
+      "exec": "matlab"
+    }
+  },
+  "categories": [
+    "programming",
+    "visualization"
+  ]
+}

--- a/releases/matlab/2024b.json
+++ b/releases/matlab/2024b.json
@@ -1,0 +1,16 @@
+{
+  "apps": {
+    "matlab 2024b": {
+      "version": "20250117",
+      "exec": ""
+    },
+    "matlabGUI-matlab 2024b": {
+      "version": "20250117",
+      "exec": "matlab"
+    }
+  },
+  "categories": [
+    "programming",
+    "visualization"
+  ]
+}

--- a/releases/mfcsc/1.0.json
+++ b/releases/mfcsc/1.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "mfcsc 1.0": {
+      "version": "20230306",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "diffusion imaging"
+  ]
+}

--- a/releases/mfcsc/1.1.json
+++ b/releases/mfcsc/1.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "mfcsc 1.1": {
+      "version": "20230321",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "diffusion imaging"
+  ]
+}

--- a/releases/mgltools/1.5.7.json
+++ b/releases/mgltools/1.5.7.json
@@ -1,0 +1,23 @@
+{
+  "apps": {
+    "mgltools 1.5.7": {
+      "version": "20230313",
+      "exec": ""
+    },
+    "pmvGUI-mgltools 1.5.7": {
+      "version": "20230313",
+      "exec": "pmv"
+    },
+    "visionGUI-mgltools 1.5.7": {
+      "version": "20230313",
+      "exec": "vision"
+    },
+    "adtGUI-mgltools 1.5.7": {
+      "version": "20230313",
+      "exec": "adt"
+    }
+  },
+  "categories": [
+    "molecular biology"
+  ]
+}

--- a/releases/micapipe/v0.2.3.json
+++ b/releases/micapipe/v0.2.3.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "micapipe v0.2.3": {
+      "version": "20241030",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "structural imaging",
+    "diffusion imaging",
+    "functional imaging",
+    "workflows"
+  ]
+}

--- a/releases/minc/1.9.17.json
+++ b/releases/minc/1.9.17.json
@@ -1,0 +1,17 @@
+{
+  "apps": {
+    "minc 1.9.17": {
+      "version": "20210105",
+      "exec": ""
+    },
+    "registerGUI-minc 1.9.17": {
+      "version": "20210105",
+      "exec": "register"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging"
+  ]
+}

--- a/releases/minc/1.9.18.json
+++ b/releases/minc/1.9.18.json
@@ -1,0 +1,17 @@
+{
+  "apps": {
+    "minc 1.9.18": {
+      "version": "20230208",
+      "exec": ""
+    },
+    "registerGUI-minc 1.9.18": {
+      "version": "20230208",
+      "exec": "register"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging"
+  ]
+}

--- a/releases/mitkdiffusion/1.2.0.json
+++ b/releases/mitkdiffusion/1.2.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mitkdiffusion 1.2.0": {
+      "version": "20230720",
+      "exec": ""
+    },
+    "mitkdiffusionGUI-mitkdiffusion 1.2.0": {
+      "version": "20230720",
+      "exec": "MitkDiffusion.sh"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/mne/0.23.4.json
+++ b/releases/mne/0.23.4.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mne 0.23.4": {
+      "version": "20220121",
+      "exec": ""
+    },
+    "code-mne 0.23.4": {
+      "version": "20220121",
+      "exec": "code"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/mne/1.0.0.json
+++ b/releases/mne/1.0.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mne 1.0.0": {
+      "version": "20220325",
+      "exec": ""
+    },
+    "code-mne 1.0.0": {
+      "version": "20220325",
+      "exec": "code"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/mne/1.0.3.json
+++ b/releases/mne/1.0.3.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mne 1.0.3": {
+      "version": "20220607",
+      "exec": ""
+    },
+    "code-mne 1.0.3": {
+      "version": "20220607",
+      "exec": "code"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/mne/1.1.0.json
+++ b/releases/mne/1.1.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mneextended 1.1.0": {
+      "version": "20220819",
+      "exec": ""
+    },
+    "codemneextended-mneextended 1.1.0": {
+      "version": "20220819",
+      "exec": "code"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/mne/1.1.1.json
+++ b/releases/mne/1.1.1.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mne 1.1.1": {
+      "version": "20220912",
+      "exec": ""
+    },
+    "code-mne 1.1.1": {
+      "version": "20220912",
+      "exec": "code"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/mricrogl/1.2.20211006.json
+++ b/releases/mricrogl/1.2.20211006.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mricrogl 1.2.20211006": {
+      "version": "20220111",
+      "exec": ""
+    },
+    "mricroglGUI-mricrogl 1.2.20211006": {
+      "version": "20220111",
+      "exec": "MRIcroGL"
+    }
+  },
+  "categories": [
+    "visualization"
+  ]
+}

--- a/releases/mricron/1.0.20190902.json
+++ b/releases/mricron/1.0.20190902.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mricron 1.0.20190902": {
+      "version": "20220311",
+      "exec": ""
+    },
+    "mricronGUI-mricron 1.0.20190902": {
+      "version": "20220311",
+      "exec": "MRIcron"
+    }
+  },
+  "categories": [
+    "visualization"
+  ]
+}

--- a/releases/mriqc/0.16.1.json
+++ b/releases/mriqc/0.16.1.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "mriqc 0.16.1": {
+      "version": "20210917",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation",
+    "functional imaging",
+    "quality control",
+    "workflows"
+  ]
+}

--- a/releases/mriqc/22.0.6.json
+++ b/releases/mriqc/22.0.6.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "mriqc 22.0.6": {
+      "version": "20230215",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation",
+    "functional imaging",
+    "quality control",
+    "workflows"
+  ]
+}

--- a/releases/mriqc/24.0.2.json
+++ b/releases/mriqc/24.0.2.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "mriqc 24.0.2": {
+      "version": "20241108",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation",
+    "functional imaging",
+    "quality control",
+    "workflows"
+  ]
+}

--- a/releases/mritools/3.3.0.json
+++ b/releases/mritools/3.3.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "mritools 3.3.0": {
+      "version": "20220224",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing"
+  ]
+}

--- a/releases/mrsiproc/0.0.1.json
+++ b/releases/mrsiproc/0.0.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "mrsiproc 0.0.1": {
+      "version": "20230503",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spectroscopy"
+  ]
+}

--- a/releases/mrsiproc/0.1.0.json
+++ b/releases/mrsiproc/0.1.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "mrsiproc 0.1.0": {
+      "version": "20231211",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spectroscopy"
+  ]
+}

--- a/releases/mrtrix3/3.0.1.json
+++ b/releases/mrtrix3/3.0.1.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mrtrix3 3.0.1": {
+      "version": "20200908",
+      "exec": ""
+    },
+    "mrviewGUI-mrtrix3 3.0.1": {
+      "version": "20200908",
+      "exec": "mrview"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/mrtrix3/3.0.2.json
+++ b/releases/mrtrix3/3.0.2.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mrtrix3 3.0.2": {
+      "version": "20221108",
+      "exec": ""
+    },
+    "mrviewGUI-mrtrix3 3.0.2": {
+      "version": "20221108",
+      "exec": "mrview"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/mrtrix3/3.0.3.json
+++ b/releases/mrtrix3/3.0.3.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mrtrix3 3.0.3": {
+      "version": "20210917",
+      "exec": ""
+    },
+    "mrviewGUI-mrtrix3 3.0.3": {
+      "version": "20210917",
+      "exec": "mrview"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/mrtrix3/3.0.4.json
+++ b/releases/mrtrix3/3.0.4.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "mrtrix3 3.0.4": {
+      "version": "20240320",
+      "exec": ""
+    },
+    "mrviewGUI-mrtrix3 3.0.4": {
+      "version": "20240320",
+      "exec": "mrview"
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/mrtrix3/latest.json
+++ b/releases/mrtrix3/latest.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "mrtrix3src latest": {
+      "version": "latest",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/mrtrix3tissue/5.2.8.json
+++ b/releases/mrtrix3tissue/5.2.8.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "mrtrix3tissue 5.2.8": {
+      "version": "20201111",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/neurodock/1.0.0.json
+++ b/releases/neurodock/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "neurodock 1.0.0": {
+      "version": "20241122",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/niftyreg/1.4.0.json
+++ b/releases/niftyreg/1.4.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "niftyreg 1.4.0": {
+      "version": "20220317",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image registration"
+  ]
+}

--- a/releases/nighres/1.5.1.json
+++ b/releases/nighres/1.5.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "nighres 1.5.1": {
+      "version": "20240611",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "structural imaging"
+  ]
+}

--- a/releases/nighres/1.5.2.json
+++ b/releases/nighres/1.5.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "nighres 1.5.2": {
+      "version": "20250203",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "structural imaging"
+  ]
+}

--- a/releases/niimath/1.0.0.json
+++ b/releases/niimath/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "niimath 1.0.0": {
+      "version": "20240902",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/niistat/1.0.20191216.json
+++ b/releases/niistat/1.0.20191216.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "niistat 1.0.20191216": {
+      "version": "20220111",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/nipype/1.8.3.json
+++ b/releases/nipype/1.8.3.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "code-nipype 1.8.3": {
+      "version": "20220825",
+      "exec": "code"
+    },
+    "nipype 1.8.3": {
+      "version": "20220825",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "workflows"
+  ]
+}

--- a/releases/oshyx/0.4.json
+++ b/releases/oshyx/0.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "oshyx 0.4": {
+      "version": "20220620",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/palm/alpha119.json
+++ b/releases/palm/alpha119.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "palm alpha119": {
+      "version": "20211220",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/palmettobug/0.0.3.json
+++ b/releases/palmettobug/0.0.3.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "palmettobug 0.0.3": {
+      "version": "20250424",
+      "exec": ""
+    },
+    "palmettobugGUI-palmettobug 0.0.3": {
+      "version": "20250424",
+      "exec": "palmettobug"
+    }
+  },
+  "categories": [
+    "molecular biology"
+  ]
+}

--- a/releases/physio/r2021a.json
+++ b/releases/physio/r2021a.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "physioGUI-physio r2021a": {
+      "version": "20220220",
+      "exec": "bash run_spm12.sh /opt/mcr/v99/ fmri"
+    },
+    "physio r2021a": {
+      "version": "20220220",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/pydeface/2.0.2.json
+++ b/releases/pydeface/2.0.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "pydeface 2.0.2": {
+      "version": "20250206",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/qmrlab/2.4.2.json
+++ b/releases/qmrlab/2.4.2.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "qmrlab 2.4.2": {
+      "version": "20240828",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging"
+  ]
+}

--- a/releases/qsiprep/0.20.0.json
+++ b/releases/qsiprep/0.20.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "qsiprep 0.20.0": {
+      "version": "20240408",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/qsiprep/1.0.1.json
+++ b/releases/qsiprep/1.0.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "qsiprep 1.0.1": {
+      "version": "20250407",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/qsirecon/1.1.0.json
+++ b/releases/qsirecon/1.1.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "qsirecon 1.1.0": {
+      "version": "20250423",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/qsmxt/5.1.0.json
+++ b/releases/qsmxt/5.1.0.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "qsmxt 5.1.0": {
+      "version": "20230905",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing",
+    "quantitative imaging",
+    "structural imaging",
+    "workflows"
+  ]
+}

--- a/releases/qsmxt/6.3.2.json
+++ b/releases/qsmxt/6.3.2.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "qsmxt 6.3.2": {
+      "version": "20231101",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing",
+    "quantitative imaging",
+    "structural imaging",
+    "workflows"
+  ]
+}

--- a/releases/qsmxt/6.4.4.json
+++ b/releases/qsmxt/6.4.4.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "qsmxt 6.4.4": {
+      "version": "20240802",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing",
+    "quantitative imaging",
+    "structural imaging",
+    "workflows"
+  ]
+}

--- a/releases/qsmxt/7.3.3.json
+++ b/releases/qsmxt/7.3.3.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "qsmxt 7.3.3": {
+      "version": "20250311",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing",
+    "quantitative imaging",
+    "structural imaging",
+    "workflows"
+  ]
+}

--- a/releases/qsmxt/8.0.7.json
+++ b/releases/qsmxt/8.0.7.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "qsmxt 8.0.7": {
+      "version": "20250529",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing",
+    "quantitative imaging",
+    "structural imaging",
+    "workflows"
+  ]
+}

--- a/releases/quickshear/1.1.0.json
+++ b/releases/quickshear/1.1.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "quickshear 1.1.0": {
+      "version": "20240606",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/rabies/0.3.5.json
+++ b/releases/rabies/0.3.5.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "rabies 0.3.5": {
+      "version": "20220111",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "rodent imaging"
+  ]
+}

--- a/releases/relion/4.0.1.sm61.json
+++ b/releases/relion/4.0.1.sm61.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "relion 4.0.1.sm61": {
+      "version": "20240528",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "cryo EM"
+  ]
+}

--- a/releases/romeo/3.2.4.json
+++ b/releases/romeo/3.2.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "romeo 3.2.4": {
+      "version": "20211015",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing"
+  ]
+}

--- a/releases/romeo/3.2.8.json
+++ b/releases/romeo/3.2.8.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "romeo 3.2.8": {
+      "version": "20220224",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "phase processing"
+  ]
+}

--- a/releases/root/6.22.02.json
+++ b/releases/root/6.22.02.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "root 6.22.02": {
+      "version": "20201104",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "programming"
+  ]
+}

--- a/releases/rstudio/1.4.1106.json
+++ b/releases/rstudio/1.4.1106.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "rstudio 1.4.1106": {
+      "version": "20211014",
+      "exec": ""
+    },
+    "rstudioGUI-rstudio 1.4.1106": {
+      "version": "20211014",
+      "exec": "rstudio"
+    }
+  },
+  "categories": [
+    "statistics"
+  ]
+}

--- a/releases/rstudio/2022.07.2.json
+++ b/releases/rstudio/2022.07.2.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "rstudio 2022.07.2": {
+      "version": "20221129",
+      "exec": ""
+    },
+    "rstudioGUI-rstudio 2022.07.2": {
+      "version": "20221129",
+      "exec": "rstudio"
+    }
+  },
+  "categories": [
+    "statistics"
+  ]
+}

--- a/releases/rstudio/2023.09.1.json
+++ b/releases/rstudio/2023.09.1.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "rstudio 2023.09.1": {
+      "version": "20231207",
+      "exec": ""
+    },
+    "rstudioGUI-rstudio 2023.09.1": {
+      "version": "20231207",
+      "exec": "rstudio"
+    }
+  },
+  "categories": [
+    "statistics"
+  ]
+}

--- a/releases/rstudio/2023.12.1.json
+++ b/releases/rstudio/2023.12.1.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "rstudio 2023.12.1": {
+      "version": "20240209",
+      "exec": ""
+    },
+    "rstudioGUI-rstudio 2023.12.1": {
+      "version": "20240209",
+      "exec": "rstudio"
+    }
+  },
+  "categories": [
+    "statistics"
+  ]
+}

--- a/releases/samsrfx/v10.004.json
+++ b/releases/samsrfx/v10.004.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "samsrfx v10.004": {
+      "version": "20241127",
+      "exec": ""
+    },
+    "samsrfxGUI-samsrfx v10.004": {
+      "version": "20241127",
+      "exec": "samsrfx"
+    }
+  },
+  "categories": [
+    "functional imaging"
+  ]
+}

--- a/releases/sigviewer/0.6.4.json
+++ b/releases/sigviewer/0.6.4.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "sigviewer 0.6.4": {
+      "version": "20220315",
+      "exec": ""
+    },
+    "sigviewerGUI-sigviewer 0.6.4": {
+      "version": "20220315",
+      "exec": "sigviewer"
+    }
+  },
+  "categories": [
+    "electrophysiology"
+  ]
+}

--- a/releases/slicer/4.11.20200930.json
+++ b/releases/slicer/4.11.20200930.json
@@ -1,0 +1,18 @@
+{
+  "apps": {
+    "slicer 4.11.20200930": {
+      "version": "20201108",
+      "exec": ""
+    },
+    "3DSlicerGUI-slicer 4.11.20200930": {
+      "version": "20201108",
+      "exec": "Slicer"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging",
+    "visualization"
+  ]
+}

--- a/releases/slicer/5.0.3.json
+++ b/releases/slicer/5.0.3.json
@@ -1,0 +1,18 @@
+{
+  "apps": {
+    "slicer 5.0.3": {
+      "version": "20221025",
+      "exec": ""
+    },
+    "3DSlicerGUI-slicer 5.0.3": {
+      "version": "20221025",
+      "exec": "Slicer"
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "image registration",
+    "structural imaging",
+    "visualization"
+  ]
+}

--- a/releases/slicersalt/3.0.0.json
+++ b/releases/slicersalt/3.0.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "slicersalt 3.0.0": {
+      "version": "20210301",
+      "exec": ""
+    },
+    "3DSlicerGUI-slicersalt 3.0.0": {
+      "version": "20210301",
+      "exec": "SlicerSALTApp-real"
+    }
+  },
+  "categories": [
+    "shape analysis"
+  ]
+}

--- a/releases/sovabids/0.3.1a0.json
+++ b/releases/sovabids/0.3.1a0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "sovabids 0.3.1a0": {
+      "version": "20221202",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}

--- a/releases/spinalcordtoolbox/5.4.json
+++ b/releases/spinalcordtoolbox/5.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "spinalcordtoolbox 5.4": {
+      "version": "20211208",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spine"
+  ]
+}

--- a/releases/spinalcordtoolbox/5.5.json
+++ b/releases/spinalcordtoolbox/5.5.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "spinalcordtoolbox 5.5": {
+      "version": "20220419",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spine"
+  ]
+}

--- a/releases/spinalcordtoolbox/5.6.json
+++ b/releases/spinalcordtoolbox/5.6.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "spinalcordtoolbox 5.6": {
+      "version": "20220503",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spine"
+  ]
+}

--- a/releases/spinalcordtoolbox/5.7.json
+++ b/releases/spinalcordtoolbox/5.7.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "spinalcordtoolbox 5.7": {
+      "version": "20220803",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spine"
+  ]
+}

--- a/releases/spinalcordtoolbox/5.8.json
+++ b/releases/spinalcordtoolbox/5.8.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "spinalcordtoolbox 5.8": {
+      "version": "20230117",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spine"
+  ]
+}

--- a/releases/spinalcordtoolbox/6.4.json
+++ b/releases/spinalcordtoolbox/6.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "spinalcordtoolbox 6.4": {
+      "version": "20240925",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "spine"
+  ]
+}

--- a/releases/spm12/r7771.json
+++ b/releases/spm12/r7771.json
@@ -1,0 +1,18 @@
+{
+  "apps": {
+    "spm12GUI-spm12 r7771": {
+      "version": "20230609",
+      "exec": "bash run_spm12.sh /opt/mcr/v97/"
+    },
+    "spm12 r7771": {
+      "version": "20230609",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "functional imaging",
+    "image segmentation",
+    "image registration",
+    "structural imaging"
+  ]
+}

--- a/releases/surfice/1.0.20210730.json
+++ b/releases/surfice/1.0.20210730.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "surfice 1.0.20210730": {
+      "version": "20211218",
+      "exec": ""
+    },
+    "surficeGUI-surfice 1.0.20210730": {
+      "version": "20211218",
+      "exec": "surfice"
+    }
+  },
+  "categories": [
+    "visualization"
+  ]
+}

--- a/releases/synthstrip/7.4.1.json
+++ b/releases/synthstrip/7.4.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "synthstrip 7.4.1": {
+      "version": "20240913",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/tgvqsm/1.0.0.json
+++ b/releases/tgvqsm/1.0.0.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "tgvqsm 1.0.0": {
+      "version": "20210629",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "quantitative imaging",
+    "phase processing"
+  ]
+}

--- a/releases/topaz/0.2.5.json
+++ b/releases/topaz/0.2.5.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "topaz 0.2.5": {
+      "version": "20240313",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "cryo EM"
+  ]
+}

--- a/releases/trackvis/0.6.1.json
+++ b/releases/trackvis/0.6.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "trackvis 0.6.1": {
+      "version": "20220303",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "diffusion imaging"
+  ]
+}

--- a/releases/vesselapp/0.3.1.json
+++ b/releases/vesselapp/0.3.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "vesselapp 0.3.1": {
+      "version": "20211216",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/vesselboost/0.9.1.json
+++ b/releases/vesselboost/0.9.1.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "vesselboost 0.9.1": {
+      "version": "20231031",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/vesselboost/0.9.4.json
+++ b/releases/vesselboost/0.9.4.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "vesselboost 0.9.4": {
+      "version": "20240404",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/vesselboost/1.0.0.json
+++ b/releases/vesselboost/1.0.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "vesselboost 1.0.0": {
+      "version": "20240815",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/releases/vesselvio/1.1.2.json
+++ b/releases/vesselvio/1.1.2.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "vesselvio 1.1.2": {
+      "version": "20230428",
+      "exec": ""
+    },
+    "vesselvioGUI-vesselvio 1.1.2": {
+      "version": "20230428",
+      "exec": "vesselvio"
+    }
+  },
+  "categories": [
+    "visualization"
+  ]
+}

--- a/releases/vina/1.2.3.json
+++ b/releases/vina/1.2.3.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "vina 1.2.3": {
+      "version": "20230221",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "molecular biology"
+  ]
+}

--- a/releases/vmtk/1.5.0.json
+++ b/releases/vmtk/1.5.0.json
@@ -1,0 +1,11 @@
+{
+  "apps": {
+    "vmtk 1.5.0": {
+      "version": "20241004",
+      "exec": ""
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}

--- a/tools/generate_apps_json.py
+++ b/tools/generate_apps_json.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Tool to generate apps.json from individual release files.
+
+This tool reads all release files from the releases/ directory and creates
+a consolidated apps.json file that matches the original format.
+"""
+
+import json
+import os
+import argparse
+from pathlib import Path
+from typing import Dict, Any
+
+
+def collect_release_files(releases_dir: str) -> Dict[str, list]:
+    """
+    Collect all release files organized by container.
+    
+    Returns: Dict mapping container_name -> list of (version, file_path)
+    """
+    containers = {}
+    
+    if not os.path.exists(releases_dir):
+        print(f"Warning: Releases directory {releases_dir} does not exist")
+        return containers
+    
+    for container_dir in os.listdir(releases_dir):
+        container_path = os.path.join(releases_dir, container_dir)
+        
+        if not os.path.isdir(container_path):
+            continue
+        
+        containers[container_dir] = []
+        
+        for file_name in os.listdir(container_path):
+            if file_name.endswith('.json'):
+                version = file_name[:-5]  # Remove .json extension
+                file_path = os.path.join(container_path, file_name)
+                containers[container_dir].append((version, file_path))
+        
+        # Sort by version for consistent ordering
+        containers[container_dir].sort(key=lambda x: x[0])
+    
+    return containers
+
+
+def load_release_file(file_path: str) -> Dict[str, Any]:
+    """Load a single release file."""
+    try:
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"Error loading {file_path}: {e}")
+        return {"apps": {}, "categories": []}
+
+
+def merge_container_releases(container_name: str, release_files: list) -> Dict[str, Any]:
+    """
+    Merge all release files for a container into a single entry.
+    
+    Args:
+        container_name: Name of the container
+        release_files: List of (version, file_path) tuples
+    
+    Returns:
+        Container data in apps.json format
+    """
+    merged_apps = {}
+    merged_categories = set()
+    
+    for version, file_path in release_files:
+        print(f"  Processing {container_name} {version}")
+        
+        release_data = load_release_file(file_path)
+        
+        # Merge apps
+        apps = release_data.get('apps', {})
+        for app_name, app_data in apps.items():
+            merged_apps[app_name] = app_data
+        
+        # Merge categories
+        categories = release_data.get('categories', [])
+        merged_categories.update(categories)
+    
+    return {
+        "apps": merged_apps,
+        "categories": sorted(list(merged_categories))
+    }
+
+
+def generate_apps_json(releases_dir: str, output_file: str):
+    """
+    Generate apps.json from all release files.
+    
+    Args:
+        releases_dir: Directory containing release files
+        output_file: Path to write the generated apps.json
+    """
+    print(f"Collecting release files from: {releases_dir}")
+    
+    # Collect all release files
+    containers = collect_release_files(releases_dir)
+    
+    if not containers:
+        print("No release files found!")
+        return
+    
+    print(f"Found {len(containers)} containers")
+    
+    # Generate consolidated apps.json
+    apps_json = {}
+    
+    for container_name in sorted(containers.keys()):
+        print(f"Processing container: {container_name}")
+        release_files = containers[container_name]
+        
+        if not release_files:
+            print(f"  Warning: No release files for {container_name}")
+            continue
+        
+        print(f"  Found {len(release_files)} releases")
+        
+        # Merge all releases for this container
+        container_data = merge_container_releases(container_name, release_files)
+        apps_json[container_name] = container_data
+    
+    # Write the generated apps.json
+    print(f"Writing apps.json to: {output_file}")
+    
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    
+    with open(output_file, 'w') as f:
+        json.dump(apps_json, f, indent=4)
+    
+    # Print summary
+    total_apps = sum(len(container_data["apps"]) for container_data in apps_json.values())
+    print(f"Generated apps.json successfully!")
+    print(f"  Containers: {len(apps_json)}")
+    print(f"  Total apps: {total_apps}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate apps.json from release files")
+    parser.add_argument(
+        "--releases-dir",
+        default="releases",
+        help="Directory containing release files"
+    )
+    parser.add_argument(
+        "--output",
+        default="apps.json",
+        help="Output path for generated apps.json"
+    )
+    
+    args = parser.parse_args()
+    
+    # Resolve paths
+    releases_dir = os.path.abspath(args.releases_dir)
+    output_file = os.path.abspath(args.output)
+    
+    generate_apps_json(releases_dir, output_file)
+    
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
This commit introduces a complete automation system for maintaining apps.json by moving the source of truth to individual release files in the neurocontainers repository.

Key Features:
- Individual JSON release files per container version in releases/{container}/{version}.json
- Automatic release file generation during CI builds via enhanced builder
- GitHub workflow to regenerate apps.json and create PRs to neurocommand repo
- Migration tools to convert existing apps.json to release files
- Enhanced build.yaml format with categories and gui_apps definitions

Components Added:
- tools/migrate_apps_json.py: Convert existing apps.json to release files
- tools/generate_apps_json.py: Regenerate apps.json from release files
- tools/test_migration.py: Verify migration produces identical apps.json
- .github/workflows/update-apps-json.yml: Auto-create PRs when releases change
- Enhanced builder/build.py: Generate release files during CI builds
- 199 migrated release files for 104 containers with 279 total apps

Builder Enhancements:
- Added generate_release_file() function with CI detection
- Added --generate-release command line flag
- Enhanced build.yaml format to include categories and gui_apps
- Automatic release generation when CI environment variables detected

Verification:
- Migration test passes: regenerated apps.json identical to original
- All 104 containers successfully migrated with complete data preservation
- Release file generation tested and verified

🤖 Generated with [Claude Code](https://claude.ai/code)