### PR TITLE
Switch to self-hosted runner for container testing

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -66,7 +66,7 @@ jobs:
   test-containers:
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -88,15 +88,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Install container runtimes
+      - name: Verify container runtimes
         run: |
-          # Install Apptainer for .simg file support
-          wget -O apptainer.deb https://github.com/apptainer/apptainer/releases/download/v1.2.5/apptainer_1.2.5_amd64.deb
-          sudo dpkg -i apptainer.deb || sudo apt-get install -f -y
-          
-          # Verify installations
+          # Verify that container runtimes are available on self-hosted runner
           docker --version
-          apptainer --version
+          apptainer --version || singularity --version
 
       - name: Set up container cache
         uses: actions/cache@v4


### PR DESCRIPTION
- Change test-containers job to use self-hosted runner instead of ubuntu-latest
- Remove Apptainer installation step (pre-installed on self-hosted runner)
- Keep runtime verification to ensure Apptainer/Singularity is available
- This fixes user namespace permission issues with Apptainer on GitHub Actions

The self-hosted runner should have proper permissions for Apptainer container execution.

🤖 Generated with [Claude Code](https://claude.ai/code)