### PR TITLE
Fix GitHub Actions test report generation

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -162,37 +162,12 @@ jobs:
         run: |
           cd builder
           
-          # Generate markdown report from test results
-          python -c "
-          import json, sys
-          try:
-              with open('test-results-${{ matrix.release.name }}.json', 'r') as f:
-                  results = json.load(f)
-              
-              report = f'## Test Results for ${{ matrix.release.name }}:${{ matrix.release.version }}\n\n'
-              report += f'**Status:** {\"✅ PASSED\" if results[\"failed\"] == 0 else \"❌ FAILED\"}\n'
-              report += f'**Summary:** {results[\"passed\"]}/{results[\"total_tests\"]} tests passed\n\n'
-              
-              if results['failed'] > 0:
-                  report += '### Failed Tests:\n'
-                  for test in results['test_results']:
-                      if test['status'] == 'failed':
-                          report += f'- ❌ {test[\"name\"]}\n'
-                          if test['stderr']:
-                              report += f'  ```\n  {test[\"stderr\"]}\n  ```\n'
-              
-              if results['passed'] > 0:
-                  report += '### Passed Tests:\n'
-                  for test in results['test_results']:
-                      if test['status'] == 'passed':
-                          report += f'- ✅ {test[\"name\"]}\n'
-              
-              with open('test-report-${{ matrix.release.name }}.md', 'w') as f:
-                  f.write(report)
-          except Exception as e:
-              with open('test-report-${{ matrix.release.name }}.md', 'w') as f:
-                  f.write(f'## Test Results for ${{ matrix.release.name }}:${{ matrix.release.version }}\n\n❌ **ERROR**: Could not generate test report: {str(e)}\n')
-          "
+          # Generate markdown report from test results using dedicated script
+          python generate_test_report.py \
+            "test-results-${{ matrix.release.name }}.json" \
+            "${{ matrix.release.name }}" \
+            "${{ matrix.release.version }}" \
+            --output "test-report-${{ matrix.release.name }}.md"
         continue-on-error: true
 
       - name: Upload test results
@@ -284,7 +259,7 @@ jobs:
               TOTAL_RECIPES=$((TOTAL_RECIPES + 1))
               
               # Check if any tests failed
-              FAILED_TESTS=$(jq '.summary.failed' "$file" 2>/dev/null || echo "1")
+              FAILED_TESTS=$(jq '.failed' "$file" 2>/dev/null || echo "1")
               if [ "$FAILED_TESTS" -eq 0 ]; then
                 PASSED_RECIPES=$((PASSED_RECIPES + 1))
               else

--- a/builder/generate_test_report.py
+++ b/builder/generate_test_report.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Generate markdown test report from JSON test results.
+"""
+import argparse
+import json
+
+
+def generate_report(test_results_file: str, container_name: str, container_version: str) -> str:
+    """Generate a markdown report from test results JSON."""
+    try:
+        with open(test_results_file, 'r') as f:
+            results = json.load(f)
+        
+        report = f'## Test Results for {container_name}:{container_version}\n\n'
+        
+        # Status line
+        status = "✅ PASSED" if results["failed"] == 0 else "❌ FAILED"
+        report += f'**Status:** {status}\n'
+        report += f'**Summary:** {results["passed"]}/{results["total_tests"]} tests passed\n\n'
+        
+        # Failed tests section
+        if results['failed'] > 0:
+            report += '### Failed Tests:\n'
+            for test in results['test_results']:
+                if test['status'] == 'failed':
+                    report += f'- ❌ {test["name"]}\n'
+                    if test.get('stderr'):
+                        report += f'  ```\n  {test["stderr"]}\n  ```\n'
+        
+        # Passed tests section
+        if results['passed'] > 0:
+            report += '### Passed Tests:\n'
+            for test in results['test_results']:
+                if test['status'] == 'passed':
+                    report += f'- ✅ {test["name"]}\n'
+        
+        return report
+        
+    except Exception as e:
+        error_report = f'## Test Results for {container_name}:{container_version}\n\n'
+        error_report += f'❌ **ERROR**: Could not generate test report: {str(e)}\n'
+        return error_report
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate markdown test report from JSON results')
+    parser.add_argument('test_results_file', help='Path to JSON test results file')
+    parser.add_argument('container_name', help='Container name')
+    parser.add_argument('container_version', help='Container version')
+    parser.add_argument('--output', '-o', help='Output markdown file path')
+    
+    args = parser.parse_args()
+    
+    # Generate the report
+    report = generate_report(args.test_results_file, args.container_name, args.container_version)
+    
+    # Write to output file or stdout
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(report)
+        print(f"Test report written to {args.output}")
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The embedded Python script in the workflow was causing shell interpretation errors ("n: command not found"). This fix addresses the issue by:

1. Creating a dedicated `generate_test_report.py` script to handle markdown report generation from JSON test results
2. Updating the workflow to use the separate script instead of inline Python
3. Fixing JSON structure reference from `.summary.failed` to `.failed` to match the new container_tester.py output format

The new script provides better error handling and cleaner separation of concerns, making the workflow more maintainable and reliable.

🤖 Generated with [Claude Code](https://claude.ai/code)