### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-apps-json.yml
+++ b/.github/workflows/update-apps-json.yml
@@ -1,5 +1,9 @@
 name: Update apps.json
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [closed]


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurocontainers/security/code-scanning/9](https://github.com/neurodesk/neurocontainers/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `pull-requests: write` for creating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`update-apps-json`) to limit its scope. In this case, adding it at the root level is sufficient and ensures consistency across the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
