### PR TITLE
Add release for osprey 2.9.0

### DIFF
--- a/releases/osprey/2.9.0.json
+++ b/releases/osprey/2.9.0.json
@@ -1,0 +1,15 @@
+{
+  "apps": {
+    "osprey 2.9.0": {
+      "version": "20250807",
+      "exec": ""
+    },
+    "ospreyGUI-osprey 2.9.0": {
+      "version": "20250807",
+      "exec": "Osprey"
+    }
+  },
+  "categories": [
+    "spectroscopy"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **osprey 2.9.0**.

## Changes

- Add `releases/osprey/2.9.0.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh osprey 2.9.0 20250807
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.org/osprey_2.9.0_20250807.simg -O
singularity shell --overlay /tmp/apptainer_overlay osprey_2.9.0_20250807.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @stebo85