### PR TITLE
tests: add implicit builtin deploy test by default

### DIFF
--- a/.github/workflows/recipes-ci.yml
+++ b/.github/workflows/recipes-ci.yml
@@ -7,6 +7,10 @@ on:
         description: "Debug mode (only run niimath test)"
         type: boolean
         default: true
+      run-tests:
+        description: "Run tests for each built container"
+        type: boolean
+        default: false
       architecture:
         description: "Target architecture (x86_64 or arm64)"
         type: choice
@@ -148,3 +152,46 @@ jobs:
             --bind "$PWD:/workspace" \
             "$BUILDER_SIF" \
             bash -lc "cd /workspace && sf-make \"${RECIPE}\" --ignore-architectures --architecture \"${ARCH}\""
+
+      - name: Set up Python for testing
+        if: ${{ inputs['run-tests'] == 'true' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install builder tooling (for tests)
+        if: ${{ inputs['run-tests'] == 'true' }}
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Determine recipe version
+        if: ${{ inputs['run-tests'] == 'true' }}
+        id: get-version
+        run: |
+          python - <<'PY'
+          import yaml, os
+          p = f"recipes/${{ matrix.recipe }}/build.yaml"
+          with open(p) as f:
+              d = yaml.safe_load(f)
+          version = d.get('version','latest')
+          print(f"Detected version: {version}")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
+              out.write(f"version={version}\n")
+          PY
+
+      - name: Run container tests (apptainer)
+        if: ${{ inputs['run-tests'] == 'true' }}
+        env:
+          RECIPE: ${{ matrix.recipe }}
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          set -euxo pipefail
+          echo "Testing ${RECIPE}:${VERSION} using local SIF"
+          python builder/container_tester.py \
+            "${RECIPE}:${VERSION}" \
+            --runtime apptainer \
+            --location local \
+            --test-config "recipes/${RECIPE}/build.yaml" \
+            --verbose

--- a/builder/build.py
+++ b/builder/build.py
@@ -2046,6 +2046,19 @@ def get_all_tests(description_file: typing.Any, recipe_path: str) -> list[dict]:
 
     walk_directives(directives)
 
+    # Ensure we always include the default builtin deploy test unless already present
+    has_builtin = any(
+        (isinstance(t, dict) and t.get("builtin") == "test_deploy.sh") for t in tests
+    )
+    if not has_builtin:
+        tests.insert(
+            0,
+            {
+                "name": "Simple Deploy Bins/Path Test",
+                "builtin": "test_deploy.sh",
+            },
+        )
+
     return tests
 
 

--- a/builder/container_tester.py
+++ b/builder/container_tester.py
@@ -292,6 +292,19 @@ class TestDefinitionExtractor:
         if "tests" in config:
             tests.extend(config["tests"])
 
+        # Ensure an implicit builtin deploy test is present unless already defined
+        has_builtin = any(
+            isinstance(t, dict) and t.get("builtin") == "test_deploy.sh" for t in tests
+        )
+        if not has_builtin:
+            tests.insert(
+                0,
+                {
+                    "name": "Simple Deploy Bins/Path Test",
+                    "builtin": "test_deploy.sh",
+                },
+            )
+
         return {
             "name": config.get("name", "unknown"),
             "version": config.get("version", "unknown"),

--- a/recipes/arfiproc/test.yaml
+++ b/recipes/arfiproc/test.yaml
@@ -1,7 +1,4 @@
 tests:
-  - name: Simple Deploy Bins/Path Test
-    builtin: test_deploy.sh
-
   - name: Test openreconexample
     script: |
       # Convert input DICOMs to ISMRMRD format

--- a/recipes/builder/build.yaml
+++ b/recipes/builder/build.yaml
@@ -50,9 +50,6 @@ build:
     # Override since starting a buildkit daemon is not useful.
     - entrypoint: bash
 
-    - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
 
 # Required for BuildKit.
 apptainer_args:

--- a/recipes/deepisles/build.yaml
+++ b/recipes/deepisles/build.yaml
@@ -102,9 +102,6 @@ build:
         path: []
         bins:
           - python
-    - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
 categories:
   - structural imaging
   - image segmentation

--- a/recipes/mricron/build.yaml
+++ b/recipes/mricron/build.yaml
@@ -30,9 +30,6 @@ build:
         bins:
           - MRIcron
           - dcm2niix
-    - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
     - boutique:
         name: mricron
         description: MRIcron is a cross-platform NIfTI format image viewer. It can load  multiple layers of images, generate volume renderings and draw regions  of interest. It also provides dcm2niix for converting DICOM images to  NIfTI format.

--- a/recipes/networkcorrespondancetoolkit/build.yaml
+++ b/recipes/networkcorrespondancetoolkit/build.yaml
@@ -142,9 +142,6 @@ build:
 
           print("NCT test ran successfully")
 
-    - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
 
 categories:
   - image registration

--- a/recipes/niftyreg/build.yaml
+++ b/recipes/niftyreg/build.yaml
@@ -56,9 +56,7 @@ build:
         path:
           - /opt/niftyreg-1.4.0/bin/
 
-    - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
+    
 
 readme: |
   ----------------------------------

--- a/recipes/niimath/build.yaml
+++ b/recipes/niimath/build.yaml
@@ -28,9 +28,6 @@ build:
         bins:
           - niimath
     - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
-    - test:
         name: Test NiiMath
         script: |
           #!/usr/bin/env bash

--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -311,9 +311,6 @@ build:
           - dicom-sort
           - dicom-convert
           - nifti-convert
-    - test:
-        name: Simple Deploy Bins/Path Test
-        builtin: test_deploy.sh
     - boutique:
         name: qsmxt
         description: >-


### PR DESCRIPTION
- builder: ensure "test_deploy.sh" is injected when absent
- container_tester: mirror implicit builtin handling
- recipes: remove duplicated builtin test entries
- CI: add optional 'run-tests' step to execute container tests