### PR TITLE
Fix openrecon macro

### DIFF
--- a/macros/openrecon/neurodocker.yaml
+++ b/macros/openrecon/neurodocker.yaml
@@ -32,7 +32,7 @@ directives:
       - cd siemens_to_ismrmrd
       - mkdir build
       - cd build
-      - cmake ..
+      - cmake -DBUILD_DYNAMIC=ON ..
       - make -j {{ parallel_jobs }}
       - make install
 
@@ -45,7 +45,7 @@ directives:
       - pip3 install --no-cache-dir .
 
   - run:
-      - git clone https://github.com/kspaceKelvin/python-ismrmrd-server
+      - git clone --branch fix/ismrmrd-compatibility https://github.com/astewartau/python-ismrmrd-server
       - find /opt/code/python-ismrmrd-server -name "*.sh" -exec chmod +x {} \;
       - find /opt/code/python-ismrmrd-server -name "*.sh" | xargs dos2unix
     # replace 'invertcontrast' in main.py with 'default_replace_with_valid_name' to avoid running 


### PR DESCRIPTION
Since September 2025, there has been a bug in the python-ismrmrd-server that the OpenRecon neurodocker macro installs. This bug is preventing building containers that use the macro (see https://github.com/neurodesk/neurocontainers/actions/runs/19156413381/job/54757930556). Further, there is now a bug in python-ismrmrd-server that has introduced an ImportError due to a change in its dependency python-ismrmrd.

I've fixed these issues in my own updated fork of python-ismrmrd-server and created a PR for the main repo (see https://github.com/kspaceKelvin/python-ismrmrd-server/pull/13). However, I need to update the macro immediately so I can build and make an OpenRecon container available for a clinical user. We can revert to using the main python-ismrmrd-server once the bug is fixed on their end.