### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/recipes-ci.yml
+++ b/.github/workflows/recipes-ci.yml
@@ -1,4 +1,6 @@
 name: Recipes CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurocontainers/security/code-scanning/17](https://github.com/neurodesk/neurocontainers/security/code-scanning/17)

To fix the issue, we need to explicitly set the `permissions:` key in the workflow for the jobs that do not require write access. This can be done at the root level (applies to all jobs unless overridden), or for individual jobs. In this case, the minimal permissions needed for the jobs appear to be `contents: read`, which allows the workflow to fetch code from the repository without granting write privileges.  
**Implementation:**  
- Add a top-level `permissions:` block immediately after the workflow `name:` and before the `on:` trigger, like so:  
  ```yaml
  permissions:
    contents: read
  ```
- This will enforce least privilege and is recommended for jobs that only need access to source code for checkout/build/test. If in future a job needs to do more (e.g., create PRs, modify issues) additional specific write privileges can be granted for just that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
