### PR TITLE
Add generic webapp support for container recipes

### DIFF
--- a/.github/workflows/update-webapps-json.yml
+++ b/.github/workflows/update-webapps-json.yml
@@ -1,0 +1,102 @@
+name: Update webapps.json
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - "recipes/**/build.yaml"
+  workflow_dispatch:
+
+jobs:
+  update-webapps-json:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout neurocontainers repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Generate webapps.json
+        run: |
+          python3 tools/generate_webapps_json.py --output webapps.json
+
+      - name: Create pull request in neurocommand
+        env:
+          GH_TOKEN: ${{ secrets.NEURODESK_GITHUB_TOKEN_ISSUE_AUTOMATION }}
+        run: |
+          gh auth setup-git
+
+          gh repo clone neurodesk/neurocommand neurocommand -- --depth=1
+
+          cd neurocommand
+
+          # Configure git
+          git config user.name "neurocontainers-bot"
+          git config user.email "neurocontainers-bot@neurodesk.github.io"
+
+          # Create a new branch for the update
+          BRANCH_NAME="update-webapps-json-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+
+          # Copy the generated webapps.json
+          cp ../webapps.json neurodesk/webapps.json
+
+          # Stage the file first (handles both new files and updates)
+          git add neurodesk/webapps.json
+
+          # Check if there are any staged changes
+          if ! git diff --cached --quiet neurodesk/webapps.json; then
+            echo "Changes detected in webapps.json"
+            git commit -m "Update webapps.json from neurocontainers recipes
+
+            Auto-generated from webapp configurations in container recipes.
+
+            🤖 Generated with neurocontainers automation"
+
+            # Push the branch
+            git push origin "$BRANCH_NAME"
+
+            # Create pull request
+            gh pr create \
+              --title "Update webapps.json from neurocontainers recipes" \
+              --body "$(cat <<'EOF'
+          ## Summary
+
+          This PR updates webapps.json based on the latest webapp configurations from container recipes in the neurocontainers repository.
+
+          ## Changes
+
+          - Updated webapps.json with latest webapp configurations
+          - Generated automatically from deploy.webapp sections in recipe build.yaml files
+
+          ## Test Plan
+
+          - [ ] Verify webapps.json format is correct
+          - [ ] Check that all expected webapps are present
+          - [ ] Test webapp availability in neurodesktop after merge
+
+          🤖 Generated with neurocontainers automation
+          EOF
+          )" \
+              --head "$BRANCH_NAME" \
+              --base main
+
+            echo "Pull request created successfully"
+          else
+            echo "No changes detected in webapps.json"
+          fi

--- a/recipes/ezbids/build.yaml
+++ b/recipes/ezbids/build.yaml
@@ -163,6 +163,17 @@ deploy:
     - ezbids
     - dcm2niix
     - bids-validator
+  webapp:
+    title: "ezBIDS"
+    startup_command: "ezbids start"
+    start_page: "/ezbids/"
+    startup_timeout: 300
+    description: "Web-based DICOM to BIDS conversion tool"
+    ports:
+      main: 3000
+    additional_proxies:
+      - name: "api/ezbids"
+        port: 8082
 
 files:
   - name: start-ezbids.sh

--- a/tools/generate_webapps_json.py
+++ b/tools/generate_webapps_json.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Tool to generate webapps.json from container recipe build.yaml files.
+
+This tool scans all recipe directories for build.yaml files that contain
+a webapp configuration under deploy.webapp and creates a consolidated
+webapps.json file for use by neurodesktop.
+"""
+
+import json
+import argparse
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML is required. Install with: pip install pyyaml")
+    exit(1)
+
+
+def load_recipe(recipe_path: Path) -> Optional[Dict[str, Any]]:
+    """
+    Load a recipe's build.yaml file.
+
+    Args:
+        recipe_path: Path to the recipe directory
+
+    Returns:
+        Parsed YAML content or None if file doesn't exist/is invalid
+    """
+    build_yaml = recipe_path / "build.yaml"
+
+    if not build_yaml.exists():
+        return None
+
+    try:
+        with open(build_yaml, 'r') as f:
+            return yaml.safe_load(f)
+    except Exception as e:
+        print(f"  Warning: Error loading {build_yaml}: {e}")
+        return None
+
+
+def extract_webapp_config(recipe: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Extract webapp configuration from a recipe.
+
+    Args:
+        recipe: Parsed recipe YAML content
+
+    Returns:
+        Webapp configuration dict or None if not present
+    """
+    deploy = recipe.get("deploy", {})
+    if not deploy:
+        return None
+
+    webapp = deploy.get("webapp")
+    if not webapp:
+        return None
+
+    recipe_name = recipe.get("name")
+    recipe_version = recipe.get("version")
+
+    # Build webapp config with defaults from recipe
+    webapp_config = webapp.copy()
+
+    # Default module to recipe name if not specified
+    if "module" not in webapp_config:
+        webapp_config["module"] = recipe_name
+
+    # Add version from recipe (used for module loading: ml module/version)
+    webapp_config["version"] = recipe_version
+
+    return webapp_config
+
+
+def collect_webapp_configs(recipes_dir: Path) -> Dict[str, Dict[str, Any]]:
+    """
+    Collect all webapp configurations from recipes.
+
+    Args:
+        recipes_dir: Path to the recipes directory
+
+    Returns:
+        Dict mapping webapp name -> webapp configuration
+    """
+    webapps = {}
+
+    if not recipes_dir.exists():
+        print(f"Warning: Recipes directory {recipes_dir} does not exist")
+        return webapps
+
+    for recipe_dir in sorted(recipes_dir.iterdir()):
+        if not recipe_dir.is_dir():
+            continue
+
+        recipe = load_recipe(recipe_dir)
+        if not recipe:
+            continue
+
+        webapp_config = extract_webapp_config(recipe)
+        if webapp_config:
+            module = webapp_config.get("module")
+            if module:
+                print(f"  Found webapp: {module} (from {recipe_dir.name})")
+                webapps[module] = webapp_config
+            else:
+                print(f"  Warning: Webapp in {recipe_dir.name} missing 'module' field")
+
+    return webapps
+
+
+def generate_webapps_json(recipes_dir: str, output_file: str):
+    """
+    Generate webapps.json from all recipe build.yaml files.
+
+    Args:
+        recipes_dir: Directory containing recipe subdirectories
+        output_file: Path to write the generated webapps.json
+    """
+    recipes_path = Path(recipes_dir)
+    output_path = Path(output_file)
+
+    print(f"Scanning recipes in: {recipes_path}")
+
+    # Collect all webapp configurations
+    webapps = collect_webapp_configs(recipes_path)
+
+    if not webapps:
+        print("No webapp configurations found!")
+        # Still create an empty file for consistency
+        webapps_json = {"version": "1.0", "webapps": {}}
+    else:
+        webapps_json = {
+            "version": "1.0",
+            "webapps": webapps
+        }
+
+    # Write the generated webapps.json
+    print(f"\nWriting webapps.json to: {output_path}")
+
+    # Create parent directory if needed
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, 'w') as f:
+        json.dump(webapps_json, f, indent=2)
+
+    # Print summary
+    print(f"\nGenerated webapps.json successfully!")
+    print(f"  Webapps found: {len(webapps)}")
+    for name, config in webapps.items():
+        print(f"    - {name}: {config.get('title', 'No title')} (port {config.get('ports', {}).get('main', '?')})")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate webapps.json from container recipe build.yaml files"
+    )
+    parser.add_argument(
+        "--recipes-dir",
+        default="recipes",
+        help="Directory containing recipe subdirectories (default: recipes)"
+    )
+    parser.add_argument(
+        "--output",
+        default="webapps.json",
+        help="Output path for generated webapps.json (default: webapps.json)"
+    )
+
+    args = parser.parse_args()
+
+    # Resolve paths relative to script location if not absolute
+    script_dir = Path(__file__).parent.parent
+
+    recipes_dir = Path(args.recipes_dir)
+    if not recipes_dir.is_absolute():
+        recipes_dir = script_dir / recipes_dir
+
+    output_file = Path(args.output)
+    if not output_file.is_absolute():
+        output_file = Path.cwd() / output_file
+
+    generate_webapps_json(str(recipes_dir), str(output_file))
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
  Adds support for configuring web applications in container recipes via the `deploy.webapp` section in `build.yaml`.

  - Add `webapp` section to ezbids recipe as example
  - Add `tools/generate_webapps_json.py` to extract webapp configs from recipes
  - Add GitHub workflow to auto-update `webapps.json` in neurocommand when recipes change

 **Example webapp config**

  ```yaml
  deploy:
    webapp:
      title: "ezBIDS"
      startup_command: "ezbids start"
      start_page: "/ezbids/"
      startup_timeout: 300
      ports:
        main: 3000
```