### PR TITLE
fix(clinica): downgrade base image to Ubuntu 20.04

### DIFF
--- a/recipes/clinica/build.yaml
+++ b/recipes/clinica/build.yaml
@@ -11,7 +11,7 @@ structured_readme:
   citation: 'Routier, A., Burgos, N., Díaz, M., Bacci, M., Bottani, S., El-Rifai O., Fontanella, S., Gori, P., Guillon, J., Guyot, A., Hassanaly, R., Jacquemont, T., Lu, P., Marcoux, A., Moreau, T., Samper-González, J., Teichmann, M., Thibeau-Sutre, E., Vaillant G., Wen, J., Wild, A., Habert, M.-O., Durrleman, S., and Colliot, O.: Clinica: An Open Source Software Platform for Reproducible Clinical Neuroscience Studies Frontiers in Neuroinformatics, 2021 doi:10.3389/fninf.2021.689675'
 build:
   kind: neurodocker
-  base-image: ubuntu:22.04
+  base-image: ubuntu:20.04
   pkg-manager: apt
   directives:
     - environment:


### PR DESCRIPTION
## Summary
- Downgrades clinica base image from Ubuntu 22.04 to Ubuntu 20.04
- Fixes build failure caused by missing `multiarch-support` package which was removed in Ubuntu 22.04+
- The neurodocker spm12 template requires this package

## Related
Fixes the build failure in https://github.com/neurodesk/neurocontainers/actions/runs/21385805811/job/61561949445

## Test plan
- [ ] CI build should pass with the new base image

🤖 Generated with [Claude Code](https://claude.com/claude-code)