### PR TITLE
Fix RStudio Server EOVERFLOW error when running from CVMFS

### DIFF
--- a/recipes/rstudio/build.yaml
+++ b/recipes/rstudio/build.yaml
@@ -163,11 +163,21 @@ files:
       # Works in both root and non-root contexts (e.g., Singularity/Apptainer)
 
       # Use /tmp for all runtime directories to avoid permission issues
-      # when running in containers without root access
+      # when running in containers without root access, and to avoid
+      # EOVERFLOW errors on CVMFS (large inode numbers cause issues with
+      # RStudio's SQLite database when stored on CVMFS filesystem)
       DATA_DIR="/tmp/rstudio-server-data"
       PID_FILE="/tmp/rstudio-server.pid"
+      DB_CONF="/tmp/rstudio-db.conf"
 
       mkdir -p "$DATA_DIR"
+
+      # Create database config to store SQLite database in /tmp
+      # This avoids EOVERFLOW errors when running from CVMFS
+      cat > "$DB_CONF" << EOF
+      provider=sqlite
+      directory=$DATA_DIR
+      EOF
 
       # Start RStudio Server in foreground mode with temp directories
       # Use current user since default 'rstudio-server' user doesn't exist in container
@@ -175,7 +185,8 @@ files:
           --server-daemonize=0 \
           --server-user="$(whoami)" \
           --server-data-dir="$DATA_DIR" \
-          --server-pid-file="$PID_FILE"
+          --server-pid-file="$PID_FILE" \
+          --database-config-file="$DB_CONF"
 
   - name: dependencies.R
     contents: |-


### PR DESCRIPTION
## Summary
- Fix RStudio Server failing to start when running from CVMFS due to EOVERFLOW (error 75)
- Root cause: CVMFS uses large inode numbers that overflow in stat() calls when RStudio creates its SQLite database in `/var/lib/rstudio-server/`
- Solution: Configure RStudio to store its SQLite database in `/tmp` via `--database-config-file`

## Details

When running RStudio Server from a CVMFS-mounted container, the default database path causes this error:
```
ERROR system error 75 (Value too large for defined data type) [path: /var/lib/rstudio-server/rstudio-os.sqlite]
```

This happens because CVMFS uses large inode numbers that can exceed the capacity of 32-bit stat structures. By redirecting the SQLite database to `/tmp`, we avoid the problematic filesystem.

## Test plan
- [x] Tested manually on play-america.neurodesk.org by running the modified startup script
- [x] Rebuild rstudio container with this fix
- [x] Verify RStudio Server webapp works on CVMFS-based deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)