### PR TITLE
Fix RStudio Server auth redirect loop on CVMFS

### DIFF
--- a/recipes/rstudio/build.yaml
+++ b/recipes/rstudio/build.yaml
@@ -162,6 +162,11 @@ files:
       # RStudio Server startup script for containerized single-user mode
       # Works in both root and non-root contexts (e.g., Singularity/Apptainer)
 
+      # Ensure USER is set - transparent-singularity runs with --cleanenv which
+      # strips environment variables. RStudio's auth-none handler needs USER to
+      # determine which user to auto-authenticate as.
+      export USER=${USER:-$(whoami)}
+
       # Use /tmp for all runtime directories to avoid permission issues
       # when running in containers without root access, and to avoid
       # EOVERFLOW errors on CVMFS (large inode numbers cause issues with


### PR DESCRIPTION
## Summary

- Fix infinite redirect loop between `/` and `/auth-sign-in` when running RStudio Server via CVMFS

## Problem

transparent-singularity runs containers with `--cleanenv`, which strips the `USER` environment variable. RStudio Server's `auth-none` handler needs `USER` to determine which user to auto-authenticate as. Without it, the auth-sign-in endpoint fails silently and redirects back, creating an infinite 302 loop.

## Fix

Set `USER` from `whoami` in the startup script before launching rserver. `whoami` reads from `/etc/passwd` based on UID (which Singularity/Apptainer maps from the host), so it returns the correct username regardless of `--cleanenv`.

## Test plan

- [ ] Container rebuilds successfully
- [ ] RStudio Server accessible via webapp on play-america without redirect loop
- [ ] `auth-none` correctly authenticates user without sign-in prompt