### PR TITLE
Fix webapps.json to only include released apps

### DIFF
--- a/.github/workflows/update-webapps-json.yml
+++ b/.github/workflows/update-webapps-json.yml
@@ -9,7 +9,10 @@ on:
     types: [closed]
     branches: [main]
     paths:
-      - "recipes/**/build.yaml"
+      # Trigger when release files are merged, not when recipes are merged.
+      # This ensures webapps.json only includes apps that are actually released
+      # and available on CVMFS, preventing broken webapp entries.
+      - "releases/**/*.json"
   workflow_dispatch:
 
 jobs:

--- a/builder/validation.py
+++ b/builder/validation.py
@@ -103,6 +103,15 @@ def validate_url(instance, attribute, value):
         )
 
 
+def validate_webapp_icon(instance, attribute, value):
+    """Validate webapp icon is an SVG file"""
+    if value and not value.endswith(".svg"):
+        raise ValueError(
+            f"Webapp icon must be an SVG file (got '{value}'). "
+            "JupyterLab requires SVG format for launcher icons."
+        )
+
+
 # ============================================================================
 # Copyright Info
 # ============================================================================
@@ -169,7 +178,9 @@ class WebappInfo:
     description: Optional[str] = attrs.field(default=None)
     startup_timeout: Optional[int] = attrs.field(default=None)
     category: Optional[str] = attrs.field(default=None)
-    icon: Optional[str] = attrs.field(default=None)
+    icon: Optional[str] = attrs.field(
+        default=None, validator=attrs.validators.optional(validate_webapp_icon)
+    )
     additional_proxies: Optional[List[AdditionalProxy]] = attrs.field(default=None)
 
 


### PR DESCRIPTION
## Summary

- Trigger update-webapps-json workflow on release file merges instead of recipe merges
- Add check to skip webapps that don't have a corresponding release file
- Add SVG validation for webapp icons (JupyterLab requires SVG format)

## Problem

Previously, webapps.json could include apps before they were available on CVMFS. This happened because the workflow triggered when recipes were merged, not when releases were merged. Users would see the app in the launcher but get "command not found" errors.

## Changes

1. **update-webapps-json.yml**: Changed trigger from `recipes/**/build.yaml` to `releases/**/*.json`
2. **generate_webapps_json.py**: Added `has_release_file()` function and `--releases-dir` argument to filter out unreleased apps
3. **validation.py**: Added `validate_webapp_icon()` to enforce SVG format for icons