### PR TITLE
Use NEURODESK_WEBAPP_PORT in webapps

### DIFF
--- a/recipes/dicompare/build.yaml
+++ b/recipes/dicompare/build.yaml
@@ -48,7 +48,7 @@ build:
     # Create startup script
     - run:
         - echo '#!/bin/bash' > /opt/dicompare/start.sh
-        - echo 'cd /opt/dicompare && exec serve -s dist -l 3001' >> /opt/dicompare/start.sh
+        - echo 'cd /opt/dicompare && exec serve -s dist -l ${NEURODESK_WEBAPP_PORT:-3001}' >> /opt/dicompare/start.sh
         - chmod +x /opt/dicompare/start.sh
 
     # Copy launcher script to PATH

--- a/recipes/ezbids/build.yaml
+++ b/recipes/ezbids/build.yaml
@@ -244,16 +244,17 @@ files:
       sleep 2
 
       # Start UI (serve pre-built production files with API proxy)
-      echo "Starting UI on port 3000..."
+      EZBIDS_UI_PORT="${NEURODESK_WEBAPP_PORT:-3000}"
+      echo "Starting UI on port ${EZBIDS_UI_PORT}..."
       cd /app/ezbids/ui
-      node server.js > "$LOG_DIR/ui.out.log" 2> "$LOG_DIR/ui.err.log" &
+      NEURODESK_WEBAPP_PORT="$EZBIDS_UI_PORT" node server.js > "$LOG_DIR/ui.out.log" 2> "$LOG_DIR/ui.err.log" &
       UI_PID=$!
 
       echo ""
       echo "=============================================="
       echo "ezBIDS is starting up!"
       echo ""
-      echo "  Web UI:  http://localhost:3000"
+      echo "  Web UI:  http://localhost:${EZBIDS_UI_PORT}"
       echo "  API:     http://localhost:8082"
       echo ""
       echo "  Logs:    $LOG_DIR/"
@@ -385,7 +386,7 @@ files:
       const fs = require('fs');
       const path = require('path');
 
-      const PORT = 3000;
+      const PORT = parseInt(process.env.NEURODESK_WEBAPP_PORT || '3000');
       const API_HOST = 'localhost';
       const API_PORT = 8082;
       const DIST_DIR = path.join(__dirname, 'dist');

--- a/recipes/qsmbly/build.yaml
+++ b/recipes/qsmbly/build.yaml
@@ -79,7 +79,7 @@ build:
     # Create startup script
     - run:
         - echo '#!/bin/bash' > /opt/qsmbly/start.sh
-        - echo 'cd /opt/qsmbly && exec serve -s dist -l 3002 --no-clipboard' >> /opt/qsmbly/start.sh
+        - echo 'cd /opt/qsmbly && exec serve -s dist -l ${NEURODESK_WEBAPP_PORT:-3001} --no-clipboard' >> /opt/qsmbly/start.sh
         - chmod +x /opt/qsmbly/start.sh
 
     # Copy launcher script to PATH
@@ -98,7 +98,7 @@ deploy:
     startup_command: "qsmbly start"
     startup_timeout: 120
     description: "Browser-based Quantitative Susceptibility Mapping using WebAssembly"
-    port: 3002
+    port: 3001
 
 files:
   - name: qsmbly

--- a/recipes/rstudio/build.yaml
+++ b/recipes/rstudio/build.yaml
@@ -189,6 +189,7 @@ files:
       # Note: --auth-none=1 must be on command line (not just config file) to work
       # reliably when running through Singularity with --cleanenv
       exec /usr/lib/rstudio-server/bin/rserver \
+          --www-port="${NEURODESK_WEBAPP_PORT:-8787}" \
           --server-daemonize=0 \
           --server-user="$(whoami)" \
           --server-data-dir="$DATA_DIR" \


### PR DESCRIPTION
This PR matches the feature added in https://github.com/neurodesk/neurodesktop/pull/401 in neurodesktop so that random ports can be assigned to webapps. The existing port field in the webapp is still used and is necessary for running the webapp when running standaloen (ie. outside of neurodesktop).  