### PR TITLE
Fix run-fulltest dependency setup on GitHub Actions

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -28,12 +28,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install runtime and test dependencies
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.4.3
+
+      - name: Install test dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y apptainer python3-pip
-          python3 -m pip install --upgrade pip
-          python3 -m pip install datalad pyyaml rich nibabel
+          uv pip install --system datalad
 
       - name: Pull container and run fulltest
         env:
@@ -42,7 +52,7 @@ jobs:
           CONTAINERS_DIR: ${{ github.event.inputs.containers_dir }}
         run: |
           mkdir -p "$CONTAINERS_DIR"
-          python3 - <<'PY'
+          uv run python - <<'PY'
           import json
           import os
           import subprocess
@@ -110,7 +120,8 @@ jobs:
           output_log = workdir / f"{container}-fulltest.log"
 
           cmd = [
-              "python3",
+              "uv",
+              "run",
               "builder/run_tests.py",
               str(suite_path),
               "-c",


### PR DESCRIPTION
## Summary\n- replace apt-based Apptainer install in run-fulltest with eWaterCycle/setup-apptainer\n- set up Python 3.11 and uv in run-fulltest\n- execute inline prep and builder/run_tests.py via uv run\n- keep datalad CLI available by installing it explicitly\n\n## Why\nThe workflow failed in run 22163786311/job 64086476375 with:\n`E: Unable to locate package apptainer` on ubuntu-22.04.\n\nThis aligns run-fulltest with the repo's existing Apptainer setup pattern and uv-based execution model.