### PR TITLE
Fix DataLad git identity in run-fulltest workflow

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           uv pip install --system datalad
 
+      - name: Configure git for DataLad
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Pull container and run fulltest
         env:
           CONTAINER: ${{ github.event.inputs.container }}


### PR DESCRIPTION
## Summary
- configure global git user.name and user.email before running fulltest
- keep existing uv + setup-apptainer workflow setup

## Why
The previous run progressed but failed during DataLad dataset preparation with:
`It is highly recommended to configure Git before using DataLad. Set both user.name and user.email configuration variables.`

This ensures DataLad clone/get operations succeed on GitHub-hosted runners.
