### PR TITLE
Install git-annex for run-fulltest DataLad step

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -43,7 +43,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          uv pip install --system datalad
+          uv pip install --system datalad datalad-installer
+          datalad-installer git-annex -m datalad/packages
+          git-annex version
+          datalad --version
 
       - name: Configure git for DataLad
         run: |


### PR DESCRIPTION
## Summary
- install `datalad-installer` alongside `datalad` in `run-fulltest`
- install `git-annex` via `datalad-installer git-annex -m datalad/packages`
- print `git-annex version` and `datalad --version` for fast verification in logs

## Why
The latest `run-fulltest` run failed in Data preparation with:
`No working git-annex installation of version >= 10.20230126`

GitHub runner images do not provide a suitable git-annex by default, so DataLad clone/get fails unless we install it explicitly.
