### PR TITLE
Fix non-interactive git-annex install in run-fulltest

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install test dependencies
         run: |
           uv pip install --system datalad datalad-installer
-          datalad-installer git-annex -m datalad/packages
+          datalad-installer --sudo ok git-annex -m datalad/packages
           git-annex version
           datalad --version
 


### PR DESCRIPTION
## Summary
- make `datalad-installer` non-interactive in CI by adding `--sudo ok`

## Why
The latest `run-fulltest` run (`22164559312`) failed during dependency setup because `datalad-installer` prompted for confirmation before running `dpkg`:
`Proceed? [y/a/n]`

In GitHub Actions this prompt causes `EOFError`. Passing `--sudo ok` keeps the install unattended.
