### PR TITLE
QSMxT: require nextqsm>=1.0.5 for Keras 3 compatibility

### DIFF
--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -100,7 +100,7 @@ build:
         - run:
             - pip install dunamai
             - pip install git+https://github.com/astewartau/nii2dcm.git@v0.1.6c
-            - pip install nextqsm
+            - pip install nextqsm>=1.0.5
             - nextqsm --download_weights
         - deploy:
             bins:


### PR DESCRIPTION
## Summary
- Pin `nextqsm>=1.0.5` in qsmxt build recipe to ensure the Keras 3 compatible version is installed
- nextqsm v1.0.5 includes: h5 weight format, nibabel/numpy dependency declarations, and `training=False` default in model `call()` signatures

## Test plan
- [ ] Verify qsmxt container builds successfully on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)