### PR TITLE
QSMxT: fix FastSurfer install script path for v2.4.2

### DIFF
--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -114,8 +114,7 @@ build:
             - apt-get update
             - apt-get install -y --no-install-recommends gawk libgomp1 libquadmath0 tcsh bc
             - rm -rf /var/lib/apt/lists/*
-            - /opt/FastSurfer/tools/build/install_fs_pruned.sh /opt --url https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.4.1/freesurfer-linux-ubuntu22_amd64-7.4.1.tar.gz
-            - /opt/FastSurfer/tools/build/link_fs.sh /opt/freesurfer
+            - /opt/FastSurfer/Docker/install_fs_pruned.sh /opt --url https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.4.1/freesurfer-linux-ubuntu22_amd64-7.4.1.tar.gz
           condition: arch=="x86_64"
         - run:
             - cd /opt/FastSurfer && python3 FastSurferCNN/download_checkpoints.py --all

--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -100,7 +100,7 @@ build:
         - run:
             - pip install dunamai
             - pip install git+https://github.com/astewartau/nii2dcm.git@v0.1.6c
-            - pip install nextqsm
+            - pip install nextqsm>=1.0.5
             - nextqsm --download_weights
         - deploy:
             bins:


### PR DESCRIPTION
## Summary
- Fix path to `install_fs_pruned.sh` — it's at `Docker/` in FastSurfer v2.4.2, not `tools/build/`
- Remove `link_fs.sh` call which doesn't exist in v2.4.2

## Test plan
- [ ] Verify qsmxt container builds successfully on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)