### PR TITLE
Upgrade pip and bump qsmxt to 8.3.1

### DIFF
--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -79,7 +79,7 @@ build:
             - rm -rf /usr/bin/python3.10
             - ln -s /opt/miniconda-latest/bin/python /usr/bin/python3.10
         - run:
-            - pip install setuptools==69.5.1
+            - pip install pip==26.0.1 setuptools==69.5.1
         - deploy:
             bins:
               - python3


### PR DESCRIPTION
## Summary
- Pin `pip==26.0.1` alongside existing `setuptools==69.5.1` to support PEP 660 editable installs, fixing `importlib.metadata` package discovery
- Bump qsmxt version from 8.3.0 to 8.3.1

## Test plan
- [ ] Container builds successfully
- [ ] `qsmxt --version` returns correct version inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)