### PR TITLE
[codex] Fix fulltests for shell wrapper execution

### DIFF
--- a/recipes/afni/fulltest.yaml
+++ b/recipes/afni/fulltest.yaml
@@ -41,6 +41,7 @@ tests:
   - name: AFNI version check
     description: Verify AFNI installation and version
     command: afni -ver 2>&1 | head -5
+    timeout: 900
     expected_output_contains: "AFNI"
 
   - name: 3dinfo version check

--- a/recipes/aidamri/fulltest.yaml
+++ b/recipes/aidamri/fulltest.yaml
@@ -46,27 +46,27 @@ tests:
   # ==========================================================================
   - name: Python version check
     description: Verify miniconda Python is available
-    command: /opt/miniconda-latest/bin/python3 --version
+    command: bash -lc '/opt/miniconda-latest/bin/python3 --version'
     expected_output_contains: "Python 3"
 
   - name: Nipype availability
     description: Verify nipype module is installed
-    command: /opt/miniconda-latest/bin/python3 -c "import nipype; print('nipype version:', nipype.__version__)"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import nipype; print('\''nipype version:'\'', nipype.__version__)"'
     expected_output_contains: "nipype version"
 
   - name: Nibabel availability
     description: Verify nibabel module is installed
-    command: /opt/miniconda-latest/bin/python3 -c "import nibabel as nib; print('nibabel version:', nib.__version__)"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import nibabel as nib; print('\''nibabel version:'\'', nib.__version__)"'
     expected_output_contains: "nibabel version"
 
   - name: NumPy availability
     description: Verify numpy module is installed
-    command: /opt/miniconda-latest/bin/python3 -c "import numpy as np; print('numpy version:', np.__version__)"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import numpy as np; print('\''numpy version:'\'', np.__version__)"'
     expected_output_contains: "numpy version"
 
   - name: SciPy availability
     description: Verify scipy module is installed
-    command: /opt/miniconda-latest/bin/python3 -c "import scipy; print('scipy version:', scipy.__version__)"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import scipy; print('\''scipy version:'\'', scipy.__version__)"'
     expected_output_contains: "scipy version"
 
   # ==========================================================================
@@ -74,32 +74,32 @@ tests:
   # ==========================================================================
   - name: batchProc help
     description: Test batch processing script help
-    command: /opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/batchProc.py --help
+    command: bash -lc '/opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/batchProc.py --help'
     expected_output_contains: "Batch processing of all data"
 
   - name: T2 preprocessing help
     description: Test T2 preprocessing script help
-    command: /opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.1_T2PreProcessing/preProcessing_T2.py --help
+    command: bash -lc '/opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.1_T2PreProcessing/preProcessing_T2.py --help'
     expected_output_contains: "Preprocessing of T2 Data"
 
   - name: T2 registration help
     description: Test T2 registration script help
-    command: /opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.1_T2PreProcessing/registration_T2.py --help
+    command: bash -lc '/opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.1_T2PreProcessing/registration_T2.py --help'
     expected_output_contains: "Registration from ABA to T2 Data"
 
   - name: fMRI preprocessing help
     description: Test fMRI preprocessing script help
-    command: /opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.3_fMRIPreProcessing/preProcessing_fMRI.py --help
+    command: bash -lc '/opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.3_fMRIPreProcessing/preProcessing_fMRI.py --help'
     expected_output_contains: "Preprocessing of rsfMRI Data"
 
   - name: fMRI registration help
     description: Test fMRI registration script help
-    command: /opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.3_fMRIPreProcessing/registration_rsfMRI.py --help
+    command: bash -lc '/opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/2.3_fMRIPreProcessing/registration_rsfMRI.py --help'
     expected_output_contains: "Registration of Allen Brain Atlas to rsfMRI"
 
   - name: fMRI processing help
     description: Test fMRI activity processing script help
-    command: /opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/3.3_fMRIActivity/process_fMRI.py --help
+    command: bash -lc '/opt/miniconda-latest/bin/python3 /opt/aidamri-1.1/bin/3.3_fMRIActivity/process_fMRI.py --help'
     expected_output_contains: "Process fMRI data"
 
   # ==========================================================================
@@ -107,32 +107,32 @@ tests:
   # ==========================================================================
   - name: Allen Brain Atlas template exists
     description: Verify ABA template is present
-    command: /opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/average_template_50.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/average_template_50.nii.gz'
     expected_output_contains: "dim1"
 
   - name: Allen Brain Atlas annotation exists
     description: Verify ABA annotation file is present
-    command: /opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/annotation_50CHANGEDanno.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/annotation_50CHANGEDanno.nii.gz'
     expected_output_contains: "dim1"
 
   - name: Annotation volume exists
     description: Verify annotation volume file is present
-    command: /opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/annoVolume.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/annoVolume.nii.gz'
     expected_output_contains: "dim1"
 
   - name: rsfMRI annotation volume exists
     description: Verify rsfMRI annotation volume is present
-    command: /opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/annoVolume+2000_rsfMRI.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/annoVolume+2000_rsfMRI.nii.gz'
     expected_output_contains: "dim1"
 
   - name: ARA annotation exists
     description: Verify ARA annotation file is present
-    command: /opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/ARA_annotationR+2000.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/ARA_annotationR+2000.nii.gz'
     expected_output_contains: "dim1"
 
   - name: NP template exists
     description: Verify NP template file is present
-    command: /opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/NP_template_sc0.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo /opt/aidamri-1.1/lib/NP_template_sc0.nii.gz'
     expected_output_contains: "dim1"
 
   # ==========================================================================
@@ -140,31 +140,31 @@ tests:
   # ==========================================================================
   - name: BET help
     description: Test FSL bet brain extraction tool
-    command: /opt/fsl-5.0.11/bin/bet 2>&1 | head -20
+    command: bash -lc '/opt/fsl-5.0.11/bin/bet 2>&1 | head -20'
     expected_output_contains: "bet <input> <output>"
 
   - name: BET basic brain extraction
     description: Run brain extraction on T2 image
-    command: /opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/fsl_tests/t2_brain.nii.gz -f 0.3 -R
+    command: bash -lc '/opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/fsl_tests/t2_brain.nii.gz -f 0.3 -R'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_brain.nii.gz
 
   - name: BET with mask output
     description: Run brain extraction with binary mask
-    command: /opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/fsl_tests/t2_brain_mask -f 0.3 -m
+    command: bash -lc '/opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/fsl_tests/t2_brain_mask -f 0.3 -m'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_brain_mask.nii.gz
       - output_exists: ${output_dir}/fsl_tests/t2_brain_mask_mask.nii.gz
 
   - name: BET with skull output
     description: Run brain extraction with skull estimate
-    command: /opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/fsl_tests/t2_brain_skull -f 0.3 -s
+    command: bash -lc '/opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/fsl_tests/t2_brain_skull -f 0.3 -s'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_brain_skull.nii.gz
 
   - name: BET for 4D fMRI data
     description: Run brain extraction optimized for fMRI
-    command: /opt/fsl-5.0.11/bin/bet ${bold} test_output/aidamri/fsl_tests/bold_brain -F
+    command: bash -lc '/opt/fsl-5.0.11/bin/bet ${bold} test_output/aidamri/fsl_tests/bold_brain -F'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_brain.nii.gz
 
@@ -173,28 +173,28 @@ tests:
   # ==========================================================================
   - name: FLIRT help
     description: Test FSL flirt linear registration tool
-    command: /opt/fsl-5.0.11/bin/flirt 2>&1 | head -20
+    command: bash -lc '/opt/fsl-5.0.11/bin/flirt 2>&1 | head -20'
     expected_output_contains: "FLIRT version"
 
   - name: FLIRT basic registration
     description: Register T2 to mean BOLD
     command: |
-      /opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/fsl_tests/bold_mean.nii.gz && \
-      /opt/fsl-5.0.11/bin/flirt -in ${t2} -ref test_output/aidamri/fsl_tests/bold_mean.nii.gz -out test_output/aidamri/fsl_tests/t2_to_bold.nii.gz -omat test_output/aidamri/fsl_tests/t2_to_bold.mat -dof 6
+      bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/fsl_tests/bold_mean.nii.gz && \
+      /opt/fsl-5.0.11/bin/flirt -in ${t2} -ref test_output/aidamri/fsl_tests/bold_mean.nii.gz -out test_output/aidamri/fsl_tests/t2_to_bold.nii.gz -omat test_output/aidamri/fsl_tests/t2_to_bold.mat -dof 6'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_to_bold.nii.gz
       - output_exists: ${output_dir}/fsl_tests/t2_to_bold.mat
 
   - name: FLIRT affine registration
     description: Register with 12 DOF affine transformation
-    command: /opt/fsl-5.0.11/bin/flirt -in ${t2} -ref test_output/aidamri/fsl_tests/bold_mean.nii.gz -out test_output/aidamri/fsl_tests/t2_to_bold_affine.nii.gz -omat test_output/aidamri/fsl_tests/t2_to_bold_affine.mat -dof 12
+    command: bash -lc '/opt/fsl-5.0.11/bin/flirt -in ${t2} -ref test_output/aidamri/fsl_tests/bold_mean.nii.gz -out test_output/aidamri/fsl_tests/t2_to_bold_affine.nii.gz -omat test_output/aidamri/fsl_tests/t2_to_bold_affine.mat -dof 12'
     depends_on: FLIRT basic registration
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_to_bold_affine.nii.gz
 
   - name: FLIRT apply transform
     description: Apply pre-computed transformation matrix
-    command: /opt/fsl-5.0.11/bin/flirt -in ${t2} -ref test_output/aidamri/fsl_tests/bold_mean.nii.gz -out test_output/aidamri/fsl_tests/t2_applied.nii.gz -init test_output/aidamri/fsl_tests/t2_to_bold.mat -applyxfm
+    command: bash -lc '/opt/fsl-5.0.11/bin/flirt -in ${t2} -ref test_output/aidamri/fsl_tests/bold_mean.nii.gz -out test_output/aidamri/fsl_tests/t2_applied.nii.gz -init test_output/aidamri/fsl_tests/t2_to_bold.mat -applyxfm'
     depends_on: FLIRT basic registration
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_applied.nii.gz
@@ -204,76 +204,76 @@ tests:
   # ==========================================================================
   - name: fslmaths help
     description: Test FSL fslmaths image calculator
-    command: /opt/fsl-5.0.11/bin/fslmaths 2>&1 | head -20
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths 2>&1 | head -20'
     expected_output_contains: "fslmaths"
 
   - name: fslmaths temporal mean
     description: Calculate temporal mean of 4D data
-    command: /opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/fsl_tests/bold_Tmean.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/fsl_tests/bold_Tmean.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_Tmean.nii.gz
 
   - name: fslmaths temporal std
     description: Calculate temporal standard deviation
-    command: /opt/fsl-5.0.11/bin/fslmaths ${bold} -Tstd test_output/aidamri/fsl_tests/bold_Tstd.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${bold} -Tstd test_output/aidamri/fsl_tests/bold_Tstd.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_Tstd.nii.gz
 
   - name: fslmaths threshold
     description: Apply intensity threshold
-    command: /opt/fsl-5.0.11/bin/fslmaths ${t2} -thr 100 test_output/aidamri/fsl_tests/t2_thr100.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${t2} -thr 100 test_output/aidamri/fsl_tests/t2_thr100.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_thr100.nii.gz
 
   - name: fslmaths binarize
     description: Binarize image
-    command: /opt/fsl-5.0.11/bin/fslmaths ${t2} -thr 100 -bin test_output/aidamri/fsl_tests/t2_bin.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${t2} -thr 100 -bin test_output/aidamri/fsl_tests/t2_bin.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_bin.nii.gz
 
   - name: fslmaths masking
     description: Apply mask to image
-    command: /opt/fsl-5.0.11/bin/fslmaths ${t2} -mas test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz test_output/aidamri/fsl_tests/t2_masked.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${t2} -mas test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz test_output/aidamri/fsl_tests/t2_masked.nii.gz'
     depends_on: BET with mask output
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_masked.nii.gz
 
   - name: fslmaths smoothing
     description: Apply Gaussian smoothing
-    command: /opt/fsl-5.0.11/bin/fslmaths ${t2} -s 2 test_output/aidamri/fsl_tests/t2_smooth.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${t2} -s 2 test_output/aidamri/fsl_tests/t2_smooth.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_smooth.nii.gz
 
   - name: fslmaths erosion
     description: Morphological erosion on mask
-    command: /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz -ero test_output/aidamri/fsl_tests/mask_ero.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz -ero test_output/aidamri/fsl_tests/mask_ero.nii.gz'
     depends_on: BET with mask output
     validate:
       - output_exists: ${output_dir}/fsl_tests/mask_ero.nii.gz
 
   - name: fslmaths dilation
     description: Morphological dilation on mask
-    command: /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz -dilM test_output/aidamri/fsl_tests/mask_dilM.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz -dilM test_output/aidamri/fsl_tests/mask_dilM.nii.gz'
     depends_on: BET with mask output
     validate:
       - output_exists: ${output_dir}/fsl_tests/mask_dilM.nii.gz
 
   - name: fslmaths fill holes
     description: Fill holes in binary mask
-    command: /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz -fillh test_output/aidamri/fsl_tests/mask_fillh.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/t2_brain_mask_mask.nii.gz -fillh test_output/aidamri/fsl_tests/mask_fillh.nii.gz'
     depends_on: BET with mask output
     validate:
       - output_exists: ${output_dir}/fsl_tests/mask_fillh.nii.gz
 
   - name: fslmaths arithmetic operations
     description: Test arithmetic operations (add, sub, mul, div)
-    command: /opt/fsl-5.0.11/bin/fslmaths ${t2} -add 100 -sub 50 -mul 2 -div 2 test_output/aidamri/fsl_tests/t2_arith.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${t2} -add 100 -sub 50 -mul 2 -div 2 test_output/aidamri/fsl_tests/t2_arith.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_arith.nii.gz
 
   - name: fslmaths intensity normalization
     description: Normalize image intensity
-    command: /opt/fsl-5.0.11/bin/fslmaths ${t2} -inm 1000 test_output/aidamri/fsl_tests/t2_inm.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${t2} -inm 1000 test_output/aidamri/fsl_tests/t2_inm.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_inm.nii.gz
 
@@ -282,22 +282,22 @@ tests:
   # ==========================================================================
   - name: fslstats basic
     description: Get basic image statistics
-    command: /opt/fsl-5.0.11/bin/fslstats ${t2} -m -s -R
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslstats ${t2} -m -s -R'
     expected_output_contains: " "
 
   - name: fslstats volume
     description: Get volume of non-zero voxels
-    command: /opt/fsl-5.0.11/bin/fslstats ${t2} -V
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslstats ${t2} -V'
     expected_output_contains: " "
 
   - name: fslstats robust range
     description: Get robust min and max
-    command: /opt/fsl-5.0.11/bin/fslstats ${t2} -r
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslstats ${t2} -r'
     expected_output_contains: " "
 
   - name: fslstats COG
     description: Get center of gravity
-    command: /opt/fsl-5.0.11/bin/fslstats ${t2} -C
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslstats ${t2} -C'
     expected_output_contains: " "
 
   # ==========================================================================
@@ -305,13 +305,13 @@ tests:
   # ==========================================================================
   - name: fslroi spatial crop
     description: Extract spatial ROI from image
-    command: /opt/fsl-5.0.11/bin/fslroi ${t2} test_output/aidamri/fsl_tests/t2_roi.nii.gz 20 80 20 80 5 20
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslroi ${t2} test_output/aidamri/fsl_tests/t2_roi.nii.gz 20 80 20 80 5 20'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_roi.nii.gz
 
   - name: fslroi temporal crop
     description: Extract temporal subset from 4D
-    command: /opt/fsl-5.0.11/bin/fslroi ${bold} test_output/aidamri/fsl_tests/bold_roi.nii.gz 0 -1 0 -1 0 -1 10 50
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslroi ${bold} test_output/aidamri/fsl_tests/bold_roi.nii.gz 0 -1 0 -1 0 -1 10 50'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_roi.nii.gz
 
@@ -320,13 +320,13 @@ tests:
   # ==========================================================================
   - name: fslsplit temporal
     description: Split 4D into 3D volumes
-    command: /opt/fsl-5.0.11/bin/fslsplit ${bold} test_output/aidamri/fsl_tests/bold_split -t
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslsplit ${bold} test_output/aidamri/fsl_tests/bold_split -t'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_split0000.nii.gz
 
   - name: fslmerge temporal
     description: Merge 3D volumes into 4D
-    command: /opt/fsl-5.0.11/bin/fslmerge -t test_output/aidamri/fsl_tests/bold_merged.nii.gz test_output/aidamri/fsl_tests/bold_split0000.nii.gz test_output/aidamri/fsl_tests/bold_split0001.nii.gz test_output/aidamri/fsl_tests/bold_split0002.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslmerge -t test_output/aidamri/fsl_tests/bold_merged.nii.gz test_output/aidamri/fsl_tests/bold_split0000.nii.gz test_output/aidamri/fsl_tests/bold_split0001.nii.gz test_output/aidamri/fsl_tests/bold_split0002.nii.gz'
     depends_on: fslsplit temporal
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_merged.nii.gz
@@ -336,7 +336,7 @@ tests:
   # ==========================================================================
   - name: fslreorient2std
     description: Reorient image to standard orientation
-    command: /opt/fsl-5.0.11/bin/fslreorient2std ${t2} test_output/aidamri/fsl_tests/t2_reorient.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslreorient2std ${t2} test_output/aidamri/fsl_tests/t2_reorient.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_reorient.nii.gz
 
@@ -345,12 +345,12 @@ tests:
   # ==========================================================================
   - name: fslhd header info
     description: Display full NIfTI header
-    command: /opt/fsl-5.0.11/bin/fslhd ${t2} | head -30
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslhd ${t2} | head -30'
     expected_output_contains: "sizeof_hdr"
 
   - name: fslinfo summary
     description: Display image summary info
-    command: /opt/fsl-5.0.11/bin/fslinfo ${t2}
+    command: bash -lc '/opt/fsl-5.0.11/bin/fslinfo ${t2}'
     expected_output_contains: "dim1"
 
   # ==========================================================================
@@ -359,8 +359,8 @@ tests:
   - name: fslcpgeom copy geometry
     description: Copy geometry information between images
     command: |
-      cp test_output/aidamri/fsl_tests/t2_bin.nii.gz test_output/aidamri/fsl_tests/t2_bin_geom.nii.gz && \
-      /opt/fsl-5.0.11/bin/fslcpgeom ${t2} test_output/aidamri/fsl_tests/t2_bin_geom.nii.gz
+      bash -lc 'cp test_output/aidamri/fsl_tests/t2_bin.nii.gz test_output/aidamri/fsl_tests/t2_bin_geom.nii.gz && \
+      /opt/fsl-5.0.11/bin/fslcpgeom ${t2} test_output/aidamri/fsl_tests/t2_bin_geom.nii.gz'
     depends_on: fslmaths binarize
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_bin_geom.nii.gz
@@ -370,12 +370,12 @@ tests:
   # ==========================================================================
   - name: mcflirt help
     description: Test FSL mcflirt motion correction tool
-    command: /opt/fsl-5.0.11/bin/mcflirt 2>&1 | head -20
+    command: bash -lc '/opt/fsl-5.0.11/bin/mcflirt 2>&1 | head -20'
     expected_output_contains: "mcflirt"
 
   - name: mcflirt motion correction
     description: Run motion correction on fMRI
-    command: /opt/fsl-5.0.11/bin/mcflirt -in ${bold} -out test_output/aidamri/fsl_tests/bold_mcf -plots
+    command: bash -lc '/opt/fsl-5.0.11/bin/mcflirt -in ${bold} -out test_output/aidamri/fsl_tests/bold_mcf -plots'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_mcf.nii.gz
       - output_exists: ${output_dir}/fsl_tests/bold_mcf.par
@@ -385,7 +385,7 @@ tests:
   # ==========================================================================
   - name: susan smoothing
     description: Apply SUSAN noise reduction
-    command: /opt/fsl-5.0.11/bin/susan ${t2} 100 2 3 1 0 test_output/aidamri/fsl_tests/t2_susan.nii.gz
+    command: bash -lc '/opt/fsl-5.0.11/bin/susan ${t2} 100 2 3 1 0 test_output/aidamri/fsl_tests/t2_susan.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/t2_susan.nii.gz
 
@@ -394,7 +394,7 @@ tests:
   # ==========================================================================
   - name: slicetimer help
     description: Test FSL slicetimer tool
-    command: /opt/fsl-5.0.11/bin/slicetimer 2>&1 | head -20
+    command: bash -lc '/opt/fsl-5.0.11/bin/slicetimer 2>&1 | head -20'
     expected_output_contains: "slicetimer"
 
   # ==========================================================================
@@ -402,7 +402,7 @@ tests:
   # ==========================================================================
   - name: applywarp help
     description: Test FSL applywarp tool
-    command: /opt/fsl-5.0.11/bin/applywarp 2>&1 | head -20
+    command: bash -lc '/opt/fsl-5.0.11/bin/applywarp 2>&1 | head -20'
     expected_output_contains: "applywarp"
 
   # ==========================================================================
@@ -410,7 +410,7 @@ tests:
   # ==========================================================================
   - name: cluster help
     description: Test FSL cluster tool
-    command: /opt/fsl-5.0.11/bin/cluster --help 2>&1 | head -30
+    command: bash -lc '/opt/fsl-5.0.11/bin/cluster --help 2>&1 | head -30'
     expected_output_contains: "cluster"
 
   # ==========================================================================
@@ -418,32 +418,32 @@ tests:
   # ==========================================================================
   - name: NiftyReg reg_aladin exists
     description: Check NiftyReg reg_aladin binary exists
-    command: ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_aladin
+    command: "bash -lc 'ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_aladin'"
     expected_output_contains: "reg_aladin"
 
   - name: NiftyReg reg_f3d exists
     description: Check NiftyReg reg_f3d binary exists
-    command: ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_f3d
+    command: "bash -lc 'ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_f3d'"
     expected_output_contains: "reg_f3d"
 
   - name: NiftyReg reg_resample exists
     description: Check NiftyReg reg_resample binary exists
-    command: ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_resample
+    command: "bash -lc 'ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_resample'"
     expected_output_contains: "reg_resample"
 
   - name: NiftyReg reg_tools exists
     description: Check NiftyReg reg_tools binary exists
-    command: ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_tools
+    command: "bash -lc 'ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_tools'"
     expected_output_contains: "reg_tools"
 
   - name: NiftyReg reg_transform exists
     description: Check NiftyReg reg_transform binary exists
-    command: ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_transform
+    command: "bash -lc 'ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_transform'"
     expected_output_contains: "reg_transform"
 
   - name: NiftyReg reg_measure exists
     description: Check NiftyReg reg_measure binary exists
-    command: ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_measure
+    command: "bash -lc 'ls -la /opt/aidamri-1.1/NiftyReg/bin/reg_measure'"
     expected_output_contains: "reg_measure"
 
   # ==========================================================================
@@ -451,47 +451,47 @@ tests:
   # ==========================================================================
   - name: Script directory structure
     description: Verify AIDAmri script directories exist
-    command: ls /opt/aidamri-1.1/bin/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/'"
     expected_output_contains: "2.1_T2PreProcessing"
 
   - name: PV2NIfTi converter scripts exist
     description: Verify ParaVision to NIfTI converter scripts
-    command: ls /opt/aidamri-1.1/bin/1_PV2NIfTiConverter/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/1_PV2NIfTiConverter/'"
     expected_output_contains: "pv_conv2Nifti.py"
 
   - name: T2 preprocessing scripts exist
     description: Verify T2 preprocessing scripts are present
-    command: ls /opt/aidamri-1.1/bin/2.1_T2PreProcessing/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/2.1_T2PreProcessing/'"
     expected_output_contains: "preProcessing_T2.py"
 
   - name: DTI preprocessing scripts exist
     description: Verify DTI preprocessing scripts are present
-    command: ls /opt/aidamri-1.1/bin/2.2_DTIPreprocessing/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/2.2_DTIPreprocessing/'"
     expected_output_contains: "preProcessing_DTI.py"
 
   - name: fMRI preprocessing scripts exist
     description: Verify fMRI preprocessing scripts are present
-    command: ls /opt/aidamri-1.1/bin/2.3_fMRIPreProcessing/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/2.3_fMRIPreProcessing/'"
     expected_output_contains: "preProcessing_fMRI.py"
 
   - name: T2 processing scripts exist
     description: Verify T2 processing scripts are present
-    command: ls /opt/aidamri-1.1/bin/3.1_T2Processing/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/3.1_T2Processing/'"
     expected_output_contains: "getIncidenceMap.py"
 
   - name: DTI connectivity scripts exist
     description: Verify DTI connectivity scripts are present
-    command: ls /opt/aidamri-1.1/bin/3.2_DTIConnectivity/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/3.2_DTIConnectivity/'"
     expected_output_contains: "dsi_main.py"
 
   - name: fMRI activity scripts exist
     description: Verify fMRI activity scripts are present
-    command: ls /opt/aidamri-1.1/bin/3.3_fMRIActivity/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/3.3_fMRIActivity/'"
     expected_output_contains: "process_fMRI.py"
 
   - name: ROI analysis scripts exist
     description: Verify ROI analysis scripts are present
-    command: ls /opt/aidamri-1.1/bin/4.1_ROI_analysis/
+    command: "bash -lc 'ls /opt/aidamri-1.1/bin/4.1_ROI_analysis/'"
     expected_output_contains: "create_seed_rois.py"
 
   # ==========================================================================
@@ -499,49 +499,49 @@ tests:
   # ==========================================================================
   - name: Load NIfTI with nibabel
     description: Test loading NIfTI file with nibabel
-    command: /opt/miniconda-latest/bin/python3 -c "import nibabel as nib; img = nib.load('${t2}'); print('Shape:', img.shape); print('Affine:\\n', img.affine)"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import nibabel as nib; img = nib.load('\''${t2}'\''); print('\''Shape:'\'', img.shape); print('\''Affine:\\n'\'', img.affine)"'
     expected_output_contains: "Shape:"
 
   - name: Extract affine matrix
     description: Extract affine transformation matrix
-    command: /opt/miniconda-latest/bin/python3 -c "import nibabel as nib; import numpy as np; img = nib.load('${t2}'); np.savetxt('test_output/aidamri/t2_affine.txt', img.affine); print('Saved affine matrix')"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import nibabel as nib; import numpy as np; img = nib.load('\''${t2}'\''); np.savetxt('\''test_output/aidamri/t2_affine.txt'\'', img.affine); print('\''Saved affine matrix'\'')"'
     validate:
       - output_exists: ${output_dir}/t2_affine.txt
 
   - name: Calculate image statistics with Python
     description: Calculate mean, std, min, max using nibabel
-    command: /opt/miniconda-latest/bin/python3 -c "import nibabel as nib; import numpy as np; img = nib.load('${t2}'); data = img.get_fdata(); print('Mean:', np.mean(data)); print('Std:', np.std(data)); print('Min:', np.min(data)); print('Max:', np.max(data))"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import nibabel as nib; import numpy as np; img = nib.load('\''${t2}'\''); data = img.get_fdata(); print('\''Mean:'\'', np.mean(data)); print('\''Std:'\'', np.std(data)); print('\''Min:'\'', np.min(data)); print('\''Max:'\'', np.max(data))"'
     expected_output_contains: "Mean:"
 
   - name: Create binary mask with Python
     description: Create threshold-based binary mask
     command: |
-      /opt/miniconda-latest/bin/python3 << 'EOF'
+      bash -lc '/opt/miniconda-latest/bin/python3 << '\''EOF'\''
       import nibabel as nib
       import numpy as np
-      img = nib.load('${t2}')
+      img = nib.load('\''${t2}'\'')
       data = img.get_fdata()
       mask = (data > 100).astype(np.int16)
       mask_img = nib.Nifti1Image(mask, img.affine, img.header)
-      nib.save(mask_img, 'test_output/aidamri/t2_mask_py.nii.gz')
-      print('Mask saved')
-      EOF
+      nib.save(mask_img, '\''test_output/aidamri/t2_mask_py.nii.gz'\'')
+      print('\''Mask saved'\'')
+      EOF'
     validate:
       - output_exists: ${output_dir}/t2_mask_py.nii.gz
 
   - name: Extract 3D volume from 4D with Python
     description: Extract single volume from 4D fMRI
     command: |
-      /opt/miniconda-latest/bin/python3 << 'EOF'
+      bash -lc '/opt/miniconda-latest/bin/python3 << '\''EOF'\''
       import nibabel as nib
       import numpy as np
-      img = nib.load('${bold}')
+      img = nib.load('\''${bold}'\'')
       data = img.get_fdata()
       vol = data[:,:,:,0]
       vol_img = nib.Nifti1Image(vol, img.affine)
-      nib.save(vol_img, 'test_output/aidamri/bold_vol0.nii.gz')
-      print('Volume extracted')
-      EOF
+      nib.save(vol_img, '\''test_output/aidamri/bold_vol0.nii.gz'\'')
+      print('\''Volume extracted'\'')
+      EOF'
     validate:
       - output_exists: ${output_dir}/bold_vol0.nii.gz
 
@@ -550,39 +550,39 @@ tests:
   # ==========================================================================
   - name: Nipype FSL interface import
     description: Test nipype FSL interface import
-    command: /opt/miniconda-latest/bin/python3 -c "import nipype.interfaces.fsl as fsl; print('FSL interfaces available')"
+    command: bash -lc '/opt/miniconda-latest/bin/python3 -c "import nipype.interfaces.fsl as fsl; print('\''FSL interfaces available'\'')"'
     expected_output_contains: "FSL interfaces available"
 
   - name: Nipype BET interface
     description: Test nipype BET interface
     command: |
-      /opt/miniconda-latest/bin/python3 << 'EOF'
+      bash -lc '/opt/miniconda-latest/bin/python3 << '\''EOF'\''
       import nipype.interfaces.fsl as fsl
       bet = fsl.BET()
-      bet.inputs.in_file = '${t2}'
-      bet.inputs.out_file = 'test_output/aidamri/preprocessing/t2_nipype_bet.nii.gz'
+      bet.inputs.in_file = '\''${t2}'\''
+      bet.inputs.out_file = '\''test_output/aidamri/preprocessing/t2_nipype_bet.nii.gz'\''
       bet.inputs.frac = 0.3
       bet.inputs.robust = True
       result = bet.run()
-      print('BET completed:', result.outputs.out_file)
-      EOF
+      print('\''BET completed:'\'', result.outputs.out_file)
+      EOF'
     validate:
       - output_exists: ${output_dir}/preprocessing/t2_nipype_bet.nii.gz
 
   - name: Nipype FLIRT interface
     description: Test nipype FLIRT interface
     command: |
-      /opt/miniconda-latest/bin/python3 << 'EOF'
+      bash -lc '/opt/miniconda-latest/bin/python3 << '\''EOF'\''
       import nipype.interfaces.fsl as fsl
       flirt = fsl.FLIRT()
-      flirt.inputs.in_file = '${t2}'
-      flirt.inputs.reference = 'test_output/aidamri/fsl_tests/bold_mean.nii.gz'
-      flirt.inputs.out_file = 'test_output/aidamri/preprocessing/t2_nipype_flirt.nii.gz'
-      flirt.inputs.out_matrix_file = 'test_output/aidamri/preprocessing/t2_nipype_flirt.mat'
+      flirt.inputs.in_file = '\''${t2}'\''
+      flirt.inputs.reference = '\''test_output/aidamri/fsl_tests/bold_mean.nii.gz'\''
+      flirt.inputs.out_file = '\''test_output/aidamri/preprocessing/t2_nipype_flirt.nii.gz'\''
+      flirt.inputs.out_matrix_file = '\''test_output/aidamri/preprocessing/t2_nipype_flirt.mat'\''
       flirt.inputs.dof = 6
       result = flirt.run()
-      print('FLIRT completed:', result.outputs.out_file)
-      EOF
+      print('\''FLIRT completed:'\'', result.outputs.out_file)
+      EOF'
     depends_on: fslmaths temporal mean
     validate:
       - output_exists: ${output_dir}/preprocessing/t2_nipype_flirt.nii.gz
@@ -591,15 +591,15 @@ tests:
   - name: Nipype MCFLIRT interface
     description: Test nipype MCFLIRT interface
     command: |
-      /opt/miniconda-latest/bin/python3 << 'EOF'
+      bash -lc '/opt/miniconda-latest/bin/python3 << '\''EOF'\''
       import nipype.interfaces.fsl as fsl
       mcflirt = fsl.MCFLIRT()
-      mcflirt.inputs.in_file = '${bold}'
-      mcflirt.inputs.out_file = 'test_output/aidamri/preprocessing/bold_nipype_mcf.nii.gz'
+      mcflirt.inputs.in_file = '\''${bold}'\''
+      mcflirt.inputs.out_file = '\''test_output/aidamri/preprocessing/bold_nipype_mcf.nii.gz'\''
       mcflirt.inputs.save_plots = True
       result = mcflirt.run()
-      print('MCFLIRT completed')
-      EOF
+      print('\''MCFLIRT completed'\'')
+      EOF'
     validate:
       - output_exists: ${output_dir}/preprocessing/bold_nipype_mcf.nii.gz
 
@@ -608,12 +608,12 @@ tests:
   # ==========================================================================
   - name: DSI Studio directory exists
     description: Verify DSI Studio is installed
-    command: ls -la /opt/dsi-studio/
+    command: "bash -lc 'ls -la /opt/dsi-studio/'"
     expected_output_contains: "dsi_studio"
 
   - name: DSI Studio binary exists
     description: Verify DSI Studio binary is present
-    command: ls -la /opt/dsi-studio/dsi_studio_64/
+    command: "bash -lc 'ls -la /opt/dsi-studio/dsi_studio_64/'"
     expected_output_contains: "dsi_studio"
 
   # ==========================================================================
@@ -622,18 +622,18 @@ tests:
   - name: fMRI tSNR calculation
     description: Calculate temporal SNR for fMRI data
     command: |
-      /opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/fsl_tests/bold_mean_tsnr.nii.gz && \
+      bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/fsl_tests/bold_mean_tsnr.nii.gz && \
       /opt/fsl-5.0.11/bin/fslmaths ${bold} -Tstd test_output/aidamri/fsl_tests/bold_std_tsnr.nii.gz && \
-      /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/bold_mean_tsnr.nii.gz -div test_output/aidamri/fsl_tests/bold_std_tsnr.nii.gz test_output/aidamri/fsl_tests/bold_tsnr.nii.gz
+      /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/fsl_tests/bold_mean_tsnr.nii.gz -div test_output/aidamri/fsl_tests/bold_std_tsnr.nii.gz test_output/aidamri/fsl_tests/bold_tsnr.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl_tests/bold_tsnr.nii.gz
 
   - name: Brain extraction and masking pipeline
     description: Full brain extraction and masking workflow
     command: |
-      /opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/preprocessing/t2_bet_pipeline -f 0.3 -m -R && \
+      bash -lc '/opt/fsl-5.0.11/bin/bet ${t2} test_output/aidamri/preprocessing/t2_bet_pipeline -f 0.3 -m -R && \
       /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/preprocessing/t2_bet_pipeline_mask.nii.gz -dilM -fillh test_output/aidamri/preprocessing/t2_mask_clean.nii.gz && \
-      /opt/fsl-5.0.11/bin/fslmaths ${t2} -mas test_output/aidamri/preprocessing/t2_mask_clean.nii.gz test_output/aidamri/preprocessing/t2_brain_clean.nii.gz
+      /opt/fsl-5.0.11/bin/fslmaths ${t2} -mas test_output/aidamri/preprocessing/t2_mask_clean.nii.gz test_output/aidamri/preprocessing/t2_brain_clean.nii.gz'
     validate:
       - output_exists: ${output_dir}/preprocessing/t2_bet_pipeline.nii.gz
       - output_exists: ${output_dir}/preprocessing/t2_mask_clean.nii.gz
@@ -642,10 +642,10 @@ tests:
   - name: fMRI preprocessing pipeline
     description: Basic fMRI preprocessing workflow
     command: |
-      /opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/preprocessing/bold_mean_pipe.nii.gz && \
+      bash -lc '/opt/fsl-5.0.11/bin/fslmaths ${bold} -Tmean test_output/aidamri/preprocessing/bold_mean_pipe.nii.gz && \
       /opt/fsl-5.0.11/bin/bet test_output/aidamri/preprocessing/bold_mean_pipe.nii.gz test_output/aidamri/preprocessing/bold_brain_pipe -f 0.3 -m && \
       /opt/fsl-5.0.11/bin/fslmaths ${bold} -bptf 25 -1 test_output/aidamri/preprocessing/bold_hp.nii.gz && \
-      /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/preprocessing/bold_hp.nii.gz -mas test_output/aidamri/preprocessing/bold_brain_pipe_mask.nii.gz test_output/aidamri/preprocessing/bold_preproc.nii.gz
+      /opt/fsl-5.0.11/bin/fslmaths test_output/aidamri/preprocessing/bold_hp.nii.gz -mas test_output/aidamri/preprocessing/bold_brain_pipe_mask.nii.gz test_output/aidamri/preprocessing/bold_preproc.nii.gz'
     validate:
       - output_exists: ${output_dir}/preprocessing/bold_preproc.nii.gz
 

--- a/recipes/batchheudiconv/fulltest.yaml
+++ b/recipes/batchheudiconv/fulltest.yaml
@@ -114,17 +114,17 @@ tests:
   # ==========================================================================
   - name: bh_fix_intendedfor.py help
     description: Display help for IntendedFor fix utility
-    command: python3 /opt/batch-heudiconv/bh_fix_intendedfor.py --help 2>&1
+    command: "bash -lc 'python3 /opt/batch-heudiconv/bh_fix_intendedfor.py --help 2>&1'"
     expected_output_contains: "Fix IntendedFor field"
 
   - name: bh_dcm_sort_dir.py exists
     description: Verify DICOM sorting Python script exists
-    command: ls -la /opt/batch-heudiconv/bh_dcm_sort_dir.py
+    command: "bash -lc 'ls -la /opt/batch-heudiconv/bh_dcm_sort_dir.py'"
     expected_output_contains: "bh_dcm_sort_dir.py"
 
   - name: bh_reorganize_fieldmaps.py exists
     description: Verify fieldmap reorganization script exists
-    command: ls -la /opt/batch-heudiconv/bh_reorganize_fieldmaps.py
+    command: "bash -lc 'ls -la /opt/batch-heudiconv/bh_reorganize_fieldmaps.py'"
     expected_output_contains: "bh_reorganize_fieldmaps.py"
 
   # ==========================================================================
@@ -132,17 +132,17 @@ tests:
   # ==========================================================================
   - name: List heuristic templates
     description: List available heuristic template files
-    command: ls /opt/batch-heudiconv/code/
+    command: "bash -lc 'ls /opt/batch-heudiconv/code/'"
     expected_output_contains: "heuristic_template.py"
 
   - name: Verify heuristic template content
     description: Check that heuristic template contains proper BIDS keys
-    command: cat /opt/batch-heudiconv/code/heuristic_template.py | head -50
+    command: "bash -lc 'cat /opt/batch-heudiconv/code/heuristic_template.py | head -50'"
     expected_output_contains: "create_key"
 
   - name: Verify HARP heuristic
     description: Check HARP-specific heuristic file
-    command: ls /opt/batch-heudiconv/code/heuristic_HARP.py
+    command: "bash -lc 'ls /opt/batch-heudiconv/code/heuristic_HARP.py'"
     expected_output_contains: "heuristic_HARP.py"
 
   # ==========================================================================
@@ -711,7 +711,7 @@ tests:
 
   - name: List all batch-heudiconv scripts
     description: List all available batch-heudiconv scripts
-    command: ls -la /opt/batch-heudiconv/*.sh
+    command: bash -lc 'ls -la /opt/batch-heudiconv/*.sh'
     expected_output_contains: "bh01_prep_dir.sh"
 
 cleanup:

--- a/recipes/bidsappaa/fulltest.yaml
+++ b/recipes/bidsappaa/fulltest.yaml
@@ -61,34 +61,34 @@ tests:
   # ==========================================================================
   - name: AA version check
     description: Verify Automatic Analysis binary runs and reports version
-    command: /opt/bin/run.sh --version 2>&1 | head -20
+    command: bash -lc '/opt/bin/run.sh --version 2>&1 | head -20'
     container_options: "--writable-tmpfs"
     ignore_exit_code: true  # container bug: MATLAB Runtime has corrupted toolbox files
     expected_output_contains: "Setting up environment"
 
   - name: AA help via run.sh
     description: Display usage information from run.sh script
-    command: head -50 /opt/bin/run.sh
+    command: "bash -lc 'head -50 /opt/bin/run.sh'"
     expected_output_contains: "usage: run <bids_dir> <output_dir>"
 
   - name: AA default tasklist inspection
     description: Verify default BIDS tasklist exists and contains expected modules
-    command: cat /opt/BIDS_tasklist.xml
+    command: "bash -lc 'cat /opt/BIDS_tasklist.xml'"
     expected_output_contains: "aamod_structuralfromnifti"
 
   - name: AA default configuration inspection
     description: Verify default BIDS configuration exists
-    command: cat /opt/BIDS_aa.xml
+    command: "bash -lc 'cat /opt/BIDS_aa.xml'"
     expected_output_contains: "isBIDS"
 
   - name: AA parameters defaults
     description: Check aa parameters defaults file
-    command: cat /opt/aap_parameters_defaults_BIDS.xml | head -50
+    command: "bash -lc 'cat /opt/aap_parameters_defaults_BIDS.xml | head -50'"
     expected_output_contains: "aap_parameters_defaults.xml"
 
   - name: AA test configuration available
     description: Check test configuration files exist
-    command: ls -la /opt/test/
+    command: "bash -lc 'ls -la /opt/test/'"
     expected_output_contains: "BIDS114"
 
   # ==========================================================================
@@ -96,32 +96,32 @@ tests:
   # ==========================================================================
   - name: FSL directory structure
     description: Verify FSL installation directory
-    command: ls /opt/fsl/
+    command: "bash -lc 'ls /opt/fsl/'"
     expected_output_contains: "bin"
 
   - name: FSL bet availability
     description: Verify FSL bet (brain extraction) is available
-    command: /opt/fsl/bin/bet 2>&1 | head -10
+    command: bash -lc '/opt/fsl/bin/bet 2>&1 | head -10'
     expected_output_contains: "bet"
 
   - name: FSL fslmaths availability
     description: Verify FSL fslmaths is available
-    command: /opt/fsl/bin/fslmaths 2>&1 | head -15
+    command: bash -lc '/opt/fsl/bin/fslmaths 2>&1 | head -15'
     expected_output_contains: "fslmaths"
 
   - name: FSL flirt availability
     description: Verify FSL flirt (registration) is available
-    command: /opt/fsl/bin/flirt -help 2>&1 | head -15
+    command: bash -lc '/opt/fsl/bin/flirt -help 2>&1 | head -15'
     expected_output_contains: "FLIRT"
 
   - name: FSL mcflirt availability
     description: Verify FSL mcflirt (motion correction) is available
-    command: /opt/fsl/bin/mcflirt -help 2>&1 | head -15
+    command: bash -lc '/opt/fsl/bin/mcflirt -help 2>&1 | head -15'
     expected_output_contains: "mcflirt"
 
   - name: FSL fast availability
     description: Verify FSL fast (segmentation) is available
-    command: /opt/fsl/bin/fast -help 2>&1 | head -15
+    command: bash -lc '/opt/fsl/bin/fast -help 2>&1 | head -15'
     expected_output_contains: "FAST"
 
   # ==========================================================================
@@ -129,13 +129,13 @@ tests:
   # ==========================================================================
   - name: FSL bet basic brain extraction
     description: Run basic brain extraction on structural
-    command: /opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain -f 0.5 -g 0
+    command: bash -lc '/opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain -f 0.5 -g 0'
     validate:
       - output_exists: ${output_dir}/fsl/struct_brain.nii.gz
 
   - name: FSL bet with mask output
     description: Run brain extraction with binary mask output
-    command: /opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain_m -m -f 0.5
+    command: bash -lc '/opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain_m -m -f 0.5'
     depends_on: FSL bet basic brain extraction
     validate:
       - output_exists: ${output_dir}/fsl/struct_brain_m.nii.gz
@@ -143,7 +143,7 @@ tests:
 
   - name: FSL bet with skull output
     description: Run brain extraction with skull estimation
-    command: /opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain_s -s -f 0.5
+    command: bash -lc '/opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain_s -s -f 0.5'
     depends_on: FSL bet basic brain extraction
     validate:
       - output_exists: ${output_dir}/fsl/struct_brain_s.nii.gz
@@ -151,14 +151,14 @@ tests:
 
   - name: FSL bet robust mode
     description: Run robust brain extraction with eye cleanup
-    command: /opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain_robust -R -f 0.5
+    command: bash -lc '/opt/fsl/bin/bet ${structural} ${output_dir}/fsl/struct_brain_robust -R -f 0.5'
     depends_on: FSL bet basic brain extraction
     validate:
       - output_exists: ${output_dir}/fsl/struct_brain_robust.nii.gz
 
   - name: FSL bet on T2 image
     description: Run brain extraction on T2-weighted image
-    command: /opt/fsl/bin/bet ${t2} ${output_dir}/fsl/t2_brain -f 0.4
+    command: bash -lc '/opt/fsl/bin/bet ${t2} ${output_dir}/fsl/t2_brain -f 0.4'
     validate:
       - output_exists: ${output_dir}/fsl/t2_brain.nii.gz
 
@@ -167,7 +167,7 @@ tests:
   # ==========================================================================
   - name: FSL fast tissue segmentation
     description: Run FAST tissue segmentation on brain-extracted image
-    command: /opt/fsl/bin/fast -t 1 -n 3 -o ${output_dir}/fsl/struct_fast ${output_dir}/fsl/struct_brain.nii.gz
+    command: bash -lc '/opt/fsl/bin/fast -t 1 -n 3 -o ${output_dir}/fsl/struct_fast ${output_dir}/fsl/struct_brain.nii.gz'
     depends_on: FSL bet basic brain extraction
     validate:
       - output_exists: ${output_dir}/fsl/struct_fast_seg.nii.gz
@@ -177,7 +177,7 @@ tests:
 
   - name: FSL fast with bias correction
     description: Run FAST with bias field correction output
-    command: /opt/fsl/bin/fast -t 1 -n 3 -B -b -o ${output_dir}/fsl/struct_fast_bias ${output_dir}/fsl/struct_brain.nii.gz
+    command: bash -lc '/opt/fsl/bin/fast -t 1 -n 3 -B -b -o ${output_dir}/fsl/struct_fast_bias ${output_dir}/fsl/struct_brain.nii.gz'
     depends_on: FSL bet basic brain extraction
     validate:
       - output_exists: ${output_dir}/fsl/struct_fast_bias_restore.nii.gz
@@ -188,35 +188,35 @@ tests:
   # ==========================================================================
   - name: FSL flirt rigid registration
     description: Run rigid body (6 DOF) registration T2 to structural
-    command: /opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_rigid.nii.gz -omat ${output_dir}/fsl/t2_to_struct_rigid.mat -dof 6
+    command: bash -lc '/opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_rigid.nii.gz -omat ${output_dir}/fsl/t2_to_struct_rigid.mat -dof 6'
     validate:
       - output_exists: ${output_dir}/fsl/t2_to_struct_rigid.nii.gz
       - output_exists: ${output_dir}/fsl/t2_to_struct_rigid.mat
 
   - name: FSL flirt affine registration
     description: Run affine (12 DOF) registration
-    command: /opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_affine.nii.gz -omat ${output_dir}/fsl/t2_to_struct_affine.mat -dof 12
+    command: bash -lc '/opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_affine.nii.gz -omat ${output_dir}/fsl/t2_to_struct_affine.mat -dof 12'
     validate:
       - output_exists: ${output_dir}/fsl/t2_to_struct_affine.nii.gz
       - output_exists: ${output_dir}/fsl/t2_to_struct_affine.mat
 
   - name: FSL flirt apply transform
     description: Apply existing transform to image
-    command: /opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_applied.nii.gz -init ${output_dir}/fsl/t2_to_struct_rigid.mat -applyxfm
+    command: bash -lc '/opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_applied.nii.gz -init ${output_dir}/fsl/t2_to_struct_rigid.mat -applyxfm'
     depends_on: FSL flirt rigid registration
     validate:
       - output_exists: ${output_dir}/fsl/t2_to_struct_applied.nii.gz
 
   - name: FSL flirt mutual information cost
     description: Run registration with mutual information cost function
-    command: /opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_mi.nii.gz -omat ${output_dir}/fsl/t2_to_struct_mi.mat -cost mutualinfo -dof 6
+    command: bash -lc '/opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_mi.nii.gz -omat ${output_dir}/fsl/t2_to_struct_mi.mat -cost mutualinfo -dof 6'
     validate:
       - output_exists: ${output_dir}/fsl/t2_to_struct_mi.nii.gz
       - output_exists: ${output_dir}/fsl/t2_to_struct_mi.mat
 
   - name: FSL flirt schedule file
     description: Run registration with schedule file
-    command: /opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_sched.nii.gz -omat ${output_dir}/fsl/t2_to_struct_sched.mat -dof 6 -schedule /opt/fsl/etc/flirtsch/sch2D_3dof
+    command: bash -lc '/opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/t2_to_struct_sched.nii.gz -omat ${output_dir}/fsl/t2_to_struct_sched.mat -dof 6 -schedule /opt/fsl/etc/flirtsch/sch2D_3dof'
     validate:
       - output_exists: ${output_dir}/fsl/t2_to_struct_sched.nii.gz
 
@@ -225,28 +225,28 @@ tests:
   # ==========================================================================
   - name: FSL mcflirt basic motion correction
     description: Run basic motion correction on BOLD data
-    command: /opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf -plots
+    command: bash -lc '/opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf -plots'
     validate:
       - output_exists: ${output_dir}/fsl/bold_mcf.nii.gz
       - output_exists: ${output_dir}/fsl/bold_mcf.par
 
   - name: FSL mcflirt with mean volume reference
     description: Run motion correction registering to mean volume
-    command: /opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf_mean -meanvol -plots
+    command: bash -lc '/opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf_mean -meanvol -plots'
     validate:
       - output_exists: ${output_dir}/fsl/bold_mcf_mean.nii.gz
       - output_exists: ${output_dir}/fsl/bold_mcf_mean.par
 
   - name: FSL mcflirt with transformation matrices
     description: Run motion correction with transformation matrices output
-    command: /opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf_mats -mats -plots
+    command: bash -lc '/opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf_mats -mats -plots'
     validate:
       - output_exists: ${output_dir}/fsl/bold_mcf_mats.nii.gz
       - output_exists: ${output_dir}/fsl/bold_mcf_mats.mat
 
   - name: FSL mcflirt with statistics
     description: Run motion correction with statistics output
-    command: /opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf_stats -stats -plots
+    command: bash -lc '/opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/bold_mcf_stats -stats -plots'
     validate:
       - output_exists: ${output_dir}/fsl/bold_mcf_stats.nii.gz
 
@@ -255,58 +255,58 @@ tests:
   # ==========================================================================
   - name: FSL fslinfo on structural
     description: Get header information for structural
-    command: /opt/fsl/bin/fslinfo ${structural}
+    command: bash -lc '/opt/fsl/bin/fslinfo ${structural}'
     expected_output_contains: "dim1"
 
   - name: FSL fslinfo on BOLD
     description: Get header information for 4D BOLD
-    command: /opt/fsl/bin/fslinfo ${bold}
+    command: bash -lc '/opt/fsl/bin/fslinfo ${bold}'
     expected_output_contains: "dim4"
 
   - name: FSL fslstats basic
     description: Get basic statistics for structural image
-    command: /opt/fsl/bin/fslstats ${structural} -R -m -s
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -R -m -s'
     expected_exit_code: 0
 
   - name: FSL fslstats mean
     description: Get mean intensity
-    command: /opt/fsl/bin/fslstats ${structural} -M
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -M'
     expected_exit_code: 0
 
   - name: FSL fslstats volume
     description: Get voxel count and volume
-    command: /opt/fsl/bin/fslstats ${structural} -V
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -V'
     expected_exit_code: 0
 
   - name: FSL fslstats histogram
     description: Generate intensity histogram
-    command: /opt/fsl/bin/fslstats ${structural} -h 100
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -h 100'
     expected_exit_code: 0
 
   - name: FSL fslstats robust range
     description: Get robust min/max intensity
-    command: /opt/fsl/bin/fslstats ${structural} -r
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -r'
     expected_exit_code: 0
 
   - name: FSL fslstats with mask
     description: Get statistics within brain mask
-    command: /opt/fsl/bin/fslstats ${structural} -k ${output_dir}/fsl/struct_brain_m_mask.nii.gz -M -S
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -k ${output_dir}/fsl/struct_brain_m_mask.nii.gz -M -S'
     depends_on: FSL bet with mask output
     expected_exit_code: 0
 
   - name: FSL fslstats percentile
     description: Get 95th percentile value
-    command: /opt/fsl/bin/fslstats ${structural} -p 95
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -p 95'
     expected_exit_code: 0
 
   - name: FSL fslstats center of gravity
     description: Get center of gravity coordinates
-    command: /opt/fsl/bin/fslstats ${structural} -c
+    command: bash -lc '/opt/fsl/bin/fslstats ${structural} -c'
     expected_exit_code: 0
 
   - name: FSL fslstats 4D timeseries
     description: Get per-volume statistics for BOLD
-    command: /opt/fsl/bin/fslstats -t ${bold} -m | head -10
+    command: bash -lc '/opt/fsl/bin/fslstats -t ${bold} -m | head -10'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -314,126 +314,126 @@ tests:
   # ==========================================================================
   - name: FSL fslmaths threshold
     description: Apply intensity threshold
-    command: /opt/fsl/bin/fslmaths ${structural} -thr 100 ${output_dir}/fsl/struct_thr100.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -thr 100 ${output_dir}/fsl/struct_thr100.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_thr100.nii.gz
 
   - name: FSL fslmaths binarize
     description: Binarize image
-    command: /opt/fsl/bin/fslmaths ${structural} -bin ${output_dir}/fsl/struct_bin.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -bin ${output_dir}/fsl/struct_bin.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_bin.nii.gz
 
   - name: FSL fslmaths smooth
     description: Apply Gaussian smoothing (sigma=2mm)
-    command: /opt/fsl/bin/fslmaths ${structural} -s 2 ${output_dir}/fsl/struct_smooth.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -s 2 ${output_dir}/fsl/struct_smooth.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_smooth.nii.gz
 
   - name: FSL fslmaths temporal mean
     description: Calculate temporal mean of BOLD
-    command: /opt/fsl/bin/fslmaths ${bold} -Tmean ${output_dir}/fsl/bold_tmean.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${bold} -Tmean ${output_dir}/fsl/bold_tmean.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/bold_tmean.nii.gz
 
   - name: FSL fslmaths temporal std
     description: Calculate temporal standard deviation of BOLD
-    command: /opt/fsl/bin/fslmaths ${bold} -Tstd ${output_dir}/fsl/bold_tstd.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${bold} -Tstd ${output_dir}/fsl/bold_tstd.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/bold_tstd.nii.gz
 
   - name: FSL fslmaths temporal max
     description: Calculate temporal maximum of BOLD
-    command: /opt/fsl/bin/fslmaths ${bold} -Tmax ${output_dir}/fsl/bold_tmax.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${bold} -Tmax ${output_dir}/fsl/bold_tmax.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/bold_tmax.nii.gz
 
   - name: FSL fslmaths temporal min
     description: Calculate temporal minimum of BOLD
-    command: /opt/fsl/bin/fslmaths ${bold} -Tmin ${output_dir}/fsl/bold_tmin.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${bold} -Tmin ${output_dir}/fsl/bold_tmin.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/bold_tmin.nii.gz
 
   - name: FSL fslmaths masking
     description: Apply mask to image
-    command: /opt/fsl/bin/fslmaths ${structural} -mas ${output_dir}/fsl/struct_brain_m_mask.nii.gz ${output_dir}/fsl/struct_masked.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -mas ${output_dir}/fsl/struct_brain_m_mask.nii.gz ${output_dir}/fsl/struct_masked.nii.gz'
     depends_on: FSL bet with mask output
     validate:
       - output_exists: ${output_dir}/fsl/struct_masked.nii.gz
 
   - name: FSL fslmaths erosion
     description: Morphological erosion
-    command: /opt/fsl/bin/fslmaths ${output_dir}/fsl/struct_brain_m_mask.nii.gz -ero ${output_dir}/fsl/mask_eroded.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${output_dir}/fsl/struct_brain_m_mask.nii.gz -ero ${output_dir}/fsl/mask_eroded.nii.gz'
     depends_on: FSL bet with mask output
     validate:
       - output_exists: ${output_dir}/fsl/mask_eroded.nii.gz
 
   - name: FSL fslmaths dilation
     description: Morphological dilation
-    command: /opt/fsl/bin/fslmaths ${output_dir}/fsl/struct_brain_m_mask.nii.gz -dilM ${output_dir}/fsl/mask_dilated.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${output_dir}/fsl/struct_brain_m_mask.nii.gz -dilM ${output_dir}/fsl/mask_dilated.nii.gz'
     depends_on: FSL bet with mask output
     validate:
       - output_exists: ${output_dir}/fsl/mask_dilated.nii.gz
 
   - name: FSL fslmaths fillh
     description: Fill holes in mask
-    command: /opt/fsl/bin/fslmaths ${output_dir}/fsl/struct_brain_m_mask.nii.gz -fillh ${output_dir}/fsl/mask_fillh.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${output_dir}/fsl/struct_brain_m_mask.nii.gz -fillh ${output_dir}/fsl/mask_fillh.nii.gz'
     depends_on: FSL bet with mask output
     validate:
       - output_exists: ${output_dir}/fsl/mask_fillh.nii.gz
 
   - name: FSL fslmaths add constant
     description: Add constant to image
-    command: /opt/fsl/bin/fslmaths ${structural} -add 100 ${output_dir}/fsl/struct_add100.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -add 100 ${output_dir}/fsl/struct_add100.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_add100.nii.gz
 
   - name: FSL fslmaths subtract constant
     description: Subtract constant from image
-    command: /opt/fsl/bin/fslmaths ${structural} -sub 50 ${output_dir}/fsl/struct_sub50.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -sub 50 ${output_dir}/fsl/struct_sub50.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_sub50.nii.gz
 
   - name: FSL fslmaths multiply constant
     description: Multiply image by constant
-    command: /opt/fsl/bin/fslmaths ${structural} -mul 2 ${output_dir}/fsl/struct_mul2.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -mul 2 ${output_dir}/fsl/struct_mul2.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_mul2.nii.gz
 
   - name: FSL fslmaths divide constant
     description: Divide image by constant
-    command: /opt/fsl/bin/fslmaths ${structural} -div 2 ${output_dir}/fsl/struct_div2.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -div 2 ${output_dir}/fsl/struct_div2.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_div2.nii.gz
 
   - name: FSL fslmaths multiply images
     description: Multiply two images
-    command: /opt/fsl/bin/fslmaths ${structural} -mul ${output_dir}/fsl/struct_brain_m_mask.nii.gz ${output_dir}/fsl/struct_mul_mask.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -mul ${output_dir}/fsl/struct_brain_m_mask.nii.gz ${output_dir}/fsl/struct_mul_mask.nii.gz'
     depends_on: FSL bet with mask output
     validate:
       - output_exists: ${output_dir}/fsl/struct_mul_mask.nii.gz
 
   - name: FSL fslmaths absolute value
     description: Compute absolute value
-    command: /opt/fsl/bin/fslmaths ${structural} -abs ${output_dir}/fsl/struct_abs.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -abs ${output_dir}/fsl/struct_abs.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_abs.nii.gz
 
   - name: FSL fslmaths square root
     description: Compute square root
-    command: /opt/fsl/bin/fslmaths ${structural} -sqrt ${output_dir}/fsl/struct_sqrt.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -sqrt ${output_dir}/fsl/struct_sqrt.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_sqrt.nii.gz
 
   - name: FSL fslmaths square
     description: Compute square
-    command: /opt/fsl/bin/fslmaths ${structural} -sqr ${output_dir}/fsl/struct_sqr.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -sqr ${output_dir}/fsl/struct_sqr.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_sqr.nii.gz
 
   - name: FSL fslmaths reciprocal
     description: Compute reciprocal (1/x)
-    command: /opt/fsl/bin/fslmaths ${structural} -thr 1 -recip ${output_dir}/fsl/struct_recip.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmaths ${structural} -thr 1 -recip ${output_dir}/fsl/struct_recip.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_recip.nii.gz
 
@@ -442,12 +442,12 @@ tests:
   # ==========================================================================
   - name: FSL fslhd display header
     description: Display NIfTI header information
-    command: /opt/fsl/bin/fslhd ${structural} | head -30
+    command: bash -lc '/opt/fsl/bin/fslhd ${structural} | head -30'
     expected_output_contains: "sizeof_hdr"
 
   - name: FSL fslhd BOLD header
     description: Display BOLD NIfTI header
-    command: /opt/fsl/bin/fslhd ${bold} | head -30
+    command: bash -lc '/opt/fsl/bin/fslhd ${bold} | head -30'
     expected_output_contains: "dim4"
 
   # ==========================================================================
@@ -455,14 +455,14 @@ tests:
   # ==========================================================================
   - name: FSL fslsplit temporal
     description: Split 4D BOLD into individual volumes
-    command: mkdir -p ${output_dir}/fsl/bold_split && /opt/fsl/bin/fslsplit ${bold} ${output_dir}/fsl/bold_split/vol -t
+    command: bash -lc 'mkdir -p ${output_dir}/fsl/bold_split && /opt/fsl/bin/fslsplit ${bold} ${output_dir}/fsl/bold_split/vol -t'
     validate:
       - output_exists: ${output_dir}/fsl/bold_split/vol0000.nii.gz
       - output_exists: ${output_dir}/fsl/bold_split/vol0001.nii.gz
 
   - name: FSL fslmerge temporal
     description: Merge volumes back into 4D
-    command: /opt/fsl/bin/fslmerge -t ${output_dir}/fsl/bold_merged.nii.gz ${output_dir}/fsl/bold_split/vol0000.nii.gz ${output_dir}/fsl/bold_split/vol0001.nii.gz ${output_dir}/fsl/bold_split/vol0002.nii.gz
+    command: bash -lc '/opt/fsl/bin/fslmerge -t ${output_dir}/fsl/bold_merged.nii.gz ${output_dir}/fsl/bold_split/vol0000.nii.gz ${output_dir}/fsl/bold_split/vol0001.nii.gz ${output_dir}/fsl/bold_split/vol0002.nii.gz'
     depends_on: FSL fslsplit temporal
     validate:
       - output_exists: ${output_dir}/fsl/bold_merged.nii.gz
@@ -472,13 +472,13 @@ tests:
   # ==========================================================================
   - name: FSL fslroi temporal subset
     description: Extract temporal subset from BOLD
-    command: /opt/fsl/bin/fslroi ${bold} ${output_dir}/fsl/bold_roi_t.nii.gz 0 10
+    command: bash -lc '/opt/fsl/bin/fslroi ${bold} ${output_dir}/fsl/bold_roi_t.nii.gz 0 10'
     validate:
       - output_exists: ${output_dir}/fsl/bold_roi_t.nii.gz
 
   - name: FSL fslroi spatial crop
     description: Extract spatial ROI from structural image
-    command: /opt/fsl/bin/fslroi ${structural} ${output_dir}/fsl/struct_roi.nii.gz 40 80 40 80 40 80
+    command: bash -lc '/opt/fsl/bin/fslroi ${structural} ${output_dir}/fsl/struct_roi.nii.gz 40 80 40 80 40 80'
     validate:
       - output_exists: ${output_dir}/fsl/struct_roi.nii.gz
 
@@ -487,27 +487,27 @@ tests:
   # ==========================================================================
   - name: FSL avscale transform analysis
     description: Analyze transformation matrix
-    command: /opt/fsl/bin/avscale ${output_dir}/fsl/t2_to_struct_rigid.mat ${structural} 2>&1 | head -20
+    command: bash -lc '/opt/fsl/bin/avscale ${output_dir}/fsl/t2_to_struct_rigid.mat ${structural} 2>&1 | head -20'
     depends_on: FSL flirt rigid registration
     expected_exit_code: 0
 
   - name: FSL convert_xfm invert
     description: Invert transformation matrix
-    command: /opt/fsl/bin/convert_xfm -omat ${output_dir}/fsl/struct_to_t2_inv_rigid.mat -inverse ${output_dir}/fsl/t2_to_struct_rigid.mat
+    command: bash -lc '/opt/fsl/bin/convert_xfm -omat ${output_dir}/fsl/struct_to_t2_inv_rigid.mat -inverse ${output_dir}/fsl/t2_to_struct_rigid.mat'
     depends_on: FSL flirt rigid registration
     validate:
       - output_exists: ${output_dir}/fsl/struct_to_t2_inv_rigid.mat
 
   - name: FSL convert_xfm concat
     description: Concatenate transformation matrices
-    command: /opt/fsl/bin/convert_xfm -omat ${output_dir}/fsl/concat.mat -concat ${output_dir}/fsl/t2_to_struct_rigid.mat ${output_dir}/fsl/struct_to_t2_inv_rigid.mat
+    command: bash -lc '/opt/fsl/bin/convert_xfm -omat ${output_dir}/fsl/concat.mat -concat ${output_dir}/fsl/t2_to_struct_rigid.mat ${output_dir}/fsl/struct_to_t2_inv_rigid.mat'
     depends_on: FSL convert_xfm invert
     validate:
       - output_exists: ${output_dir}/fsl/concat.mat
 
   - name: FSL susan smoothing
     description: Run SUSAN non-linear smoothing
-    command: /opt/fsl/bin/susan ${structural} 100 2 3 1 0 ${output_dir}/fsl/struct_susan.nii.gz
+    command: bash -lc '/opt/fsl/bin/susan ${structural} 100 2 3 1 0 ${output_dir}/fsl/struct_susan.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/struct_susan.nii.gz
 
@@ -516,32 +516,32 @@ tests:
   # ==========================================================================
   - name: FreeSurfer directory structure
     description: Verify FreeSurfer installation directory
-    command: ls /opt/freesurfer/
+    command: "bash -lc 'ls /opt/freesurfer/'"
     expected_output_contains: "bin"
 
   - name: FreeSurfer version file
     description: Check FreeSurfer version
-    command: cat /opt/freesurfer/VERSION
+    command: "bash -lc 'cat /opt/freesurfer/VERSION'"
     expected_output_contains: "stable6"
 
   - name: FreeSurfer mri_convert availability
     description: Verify mri_convert is available
-    command: /opt/freesurfer/bin/mri_convert --help 2>&1 | head -20
+    command: bash -lc '/opt/freesurfer/bin/mri_convert --help 2>&1 | head -20'
     expected_output_contains: "mri_convert"
 
   - name: FreeSurfer mri_info availability
     description: Verify mri_info is available
-    command: /opt/freesurfer/bin/mri_info --help 2>&1 | head -20
+    command: bash -lc '/opt/freesurfer/bin/mri_info --help 2>&1 | head -20'
     expected_output_contains: "mri_info"
 
   - name: FreeSurfer recon-all availability
     description: Verify recon-all is available
-    command: /opt/freesurfer/bin/recon-all --help 2>&1 | head -20
+    command: bash -lc '/opt/freesurfer/bin/recon-all --help 2>&1 | head -20'
     expected_output_contains: "recon-all"
 
   - name: FreeSurfer mri_vol2vol availability
     description: Verify mri_vol2vol is available
-    command: /opt/freesurfer/bin/mri_vol2vol --help 2>&1 | head -20
+    command: bash -lc '/opt/freesurfer/bin/mri_vol2vol --help 2>&1 | head -20'
     expected_output_contains: "mri_vol2vol"
 
   # ==========================================================================
@@ -549,33 +549,33 @@ tests:
   # ==========================================================================
   - name: FreeSurfer mri_convert format info
     description: Get image format information
-    command: /opt/freesurfer/bin/mri_info ${structural} 2>&1 | head -30
+    command: bash -lc '/opt/freesurfer/bin/mri_info ${structural} 2>&1 | head -30'
     expected_output_contains: "dimensions"
 
   - name: FreeSurfer mri_convert to MGZ
     description: Convert NIfTI to MGZ format
-    command: /opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/t1w.mgz
+    command: bash -lc '/opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/t1w.mgz'
     ignore_exit_code: true  # container bug: missing FreeSurfer license file
 
   - name: FreeSurfer mri_convert back to NIfTI
     description: Convert MGZ back to NIfTI
-    command: /opt/freesurfer/bin/mri_convert ${output_dir}/freesurfer/t1w.mgz ${output_dir}/freesurfer/struct_from_mgz.nii.gz
+    command: bash -lc '/opt/freesurfer/bin/mri_convert ${output_dir}/freesurfer/t1w.mgz ${output_dir}/freesurfer/struct_from_mgz.nii.gz'
     depends_on: FreeSurfer mri_convert to MGZ
     ignore_exit_code: true  # container bug: missing FreeSurfer license file
 
   - name: FreeSurfer mri_convert reorient
     description: Reorient image to standard orientation
-    command: /opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/struct_reorient.nii.gz --out_orientation RAS
+    command: bash -lc '/opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/struct_reorient.nii.gz --out_orientation RAS'
     ignore_exit_code: true  # container bug: missing FreeSurfer license file
 
   - name: FreeSurfer mri_convert conform
     description: Conform image to 256x256x256 1mm isotropic
-    command: /opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/struct_conform.mgz --conform
+    command: bash -lc '/opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/struct_conform.mgz --conform'
     ignore_exit_code: true  # container bug: missing FreeSurfer license file
 
   - name: FreeSurfer mri_convert resample
     description: Resample image to different voxel size
-    command: /opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/struct_2mm.nii.gz --voxsize 2 2 2
+    command: bash -lc '/opt/freesurfer/bin/mri_convert ${structural} ${output_dir}/freesurfer/struct_2mm.nii.gz --voxsize 2 2 2'
     ignore_exit_code: true  # container bug: missing FreeSurfer license file
 
   # ==========================================================================
@@ -583,12 +583,12 @@ tests:
   # ==========================================================================
   - name: FreeSurfer mri_info detailed
     description: Get detailed image information
-    command: /opt/freesurfer/bin/mri_info ${structural}
+    command: bash -lc '/opt/freesurfer/bin/mri_info ${structural}'
     expected_output_contains: "voxel"
 
   - name: FreeSurfer mri_info BOLD
     description: Get BOLD image information
-    command: /opt/freesurfer/bin/mri_info ${bold}
+    command: bash -lc '/opt/freesurfer/bin/mri_info ${bold}'
     expected_output_contains: "dimensions"
 
   # ==========================================================================
@@ -597,8 +597,8 @@ tests:
   - name: Pipeline brain mask and stats
     description: Create brain mask and get statistics
     command: |
-      /opt/fsl/bin/bet ${structural} ${output_dir}/fsl/pipe_brain -m -f 0.5 && \
-      /opt/fsl/bin/fslstats ${structural} -k ${output_dir}/fsl/pipe_brain_mask.nii.gz -M -S -V
+      bash -lc '/opt/fsl/bin/bet ${structural} ${output_dir}/fsl/pipe_brain -m -f 0.5 && \
+      /opt/fsl/bin/fslstats ${structural} -k ${output_dir}/fsl/pipe_brain_mask.nii.gz -M -S -V'
     validate:
       - output_exists: ${output_dir}/fsl/pipe_brain.nii.gz
       - output_exists: ${output_dir}/fsl/pipe_brain_mask.nii.gz
@@ -606,9 +606,9 @@ tests:
   - name: Pipeline tSNR calculation
     description: Calculate temporal SNR from BOLD
     command: |
-      /opt/fsl/bin/fslmaths ${bold} -Tmean ${output_dir}/fsl/pipe_bold_mean.nii.gz && \
+      bash -lc '/opt/fsl/bin/fslmaths ${bold} -Tmean ${output_dir}/fsl/pipe_bold_mean.nii.gz && \
       /opt/fsl/bin/fslmaths ${bold} -Tstd ${output_dir}/fsl/pipe_bold_std.nii.gz && \
-      /opt/fsl/bin/fslmaths ${output_dir}/fsl/pipe_bold_mean.nii.gz -div ${output_dir}/fsl/pipe_bold_std.nii.gz ${output_dir}/fsl/pipe_bold_tsnr.nii.gz
+      /opt/fsl/bin/fslmaths ${output_dir}/fsl/pipe_bold_mean.nii.gz -div ${output_dir}/fsl/pipe_bold_std.nii.gz ${output_dir}/fsl/pipe_bold_tsnr.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/pipe_bold_mean.nii.gz
       - output_exists: ${output_dir}/fsl/pipe_bold_std.nii.gz
@@ -617,8 +617,8 @@ tests:
   - name: Pipeline motion correction with QC
     description: Motion correct BOLD and generate QC metrics
     command: |
-      /opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/pipe_bold_mcf -plots -stats && \
-      /opt/fsl/bin/fslmaths ${output_dir}/fsl/pipe_bold_mcf.nii.gz -Tmean ${output_dir}/fsl/pipe_bold_mcf_mean.nii.gz
+      bash -lc '/opt/fsl/bin/mcflirt -in ${bold} -out ${output_dir}/fsl/pipe_bold_mcf -plots -stats && \
+      /opt/fsl/bin/fslmaths ${output_dir}/fsl/pipe_bold_mcf.nii.gz -Tmean ${output_dir}/fsl/pipe_bold_mcf_mean.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/pipe_bold_mcf.nii.gz
       - output_exists: ${output_dir}/fsl/pipe_bold_mcf.par
@@ -627,8 +627,8 @@ tests:
   - name: Pipeline coregistration
     description: Register T2 to structural space
     command: |
-      /opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/pipe_t2_to_t1w.nii.gz -omat ${output_dir}/fsl/pipe_t2_to_t1w.mat -dof 6 -cost mutualinfo && \
-      /opt/fsl/bin/fslstats ${output_dir}/fsl/pipe_t2_to_t1w.nii.gz -R -m
+      bash -lc '/opt/fsl/bin/flirt -in ${t2} -ref ${structural} -out ${output_dir}/fsl/pipe_t2_to_t1w.nii.gz -omat ${output_dir}/fsl/pipe_t2_to_t1w.mat -dof 6 -cost mutualinfo && \
+      /opt/fsl/bin/fslstats ${output_dir}/fsl/pipe_t2_to_t1w.nii.gz -R -m'
     validate:
       - output_exists: ${output_dir}/fsl/pipe_t2_to_t1w.nii.gz
       - output_exists: ${output_dir}/fsl/pipe_t2_to_t1w.mat
@@ -636,8 +636,8 @@ tests:
   - name: Pipeline tissue segmentation
     description: Brain extraction followed by tissue segmentation
     command: |
-      /opt/fsl/bin/bet ${structural} ${output_dir}/fsl/pipe_struct_brain -f 0.5 && \
-      /opt/fsl/bin/fast -t 1 -n 3 -o ${output_dir}/fsl/pipe_struct_seg ${output_dir}/fsl/pipe_struct_brain.nii.gz
+      bash -lc '/opt/fsl/bin/bet ${structural} ${output_dir}/fsl/pipe_struct_brain -f 0.5 && \
+      /opt/fsl/bin/fast -t 1 -n 3 -o ${output_dir}/fsl/pipe_struct_seg ${output_dir}/fsl/pipe_struct_brain.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/pipe_struct_brain.nii.gz
       - output_exists: ${output_dir}/fsl/pipe_struct_seg_seg.nii.gz
@@ -645,8 +645,8 @@ tests:
   - name: Pipeline smoothing comparison
     description: Compare Gaussian and SUSAN smoothing
     command: |
-      /opt/fsl/bin/fslmaths ${structural} -s 3 ${output_dir}/fsl/pipe_struct_gauss3.nii.gz && \
-      /opt/fsl/bin/susan ${structural} 100 3 3 1 0 ${output_dir}/fsl/pipe_struct_susan3.nii.gz
+      bash -lc '/opt/fsl/bin/fslmaths ${structural} -s 3 ${output_dir}/fsl/pipe_struct_gauss3.nii.gz && \
+      /opt/fsl/bin/susan ${structural} 100 3 3 1 0 ${output_dir}/fsl/pipe_struct_susan3.nii.gz'
     validate:
       - output_exists: ${output_dir}/fsl/pipe_struct_gauss3.nii.gz
       - output_exists: ${output_dir}/fsl/pipe_struct_susan3.nii.gz
@@ -656,45 +656,31 @@ tests:
   # ==========================================================================
   - name: Validate structural dimensions preserved after smoothing
     description: Ensure smoothed output has same dimensions as input
-    command: |
-      orig_dims=$(/opt/fsl/bin/fslinfo ${structural} | grep -E "^dim[1-3]" | awk '{print $2}' | tr '\n' ' ') && \
-      smooth_dims=$(/opt/fsl/bin/fslinfo ${output_dir}/fsl/struct_smooth.nii.gz | grep -E "^dim[1-3]" | awk '{print $2}' | tr '\n' ' ') && \
-      [ "$orig_dims" = "$smooth_dims" ] && echo "Dimensions match: $orig_dims"
+    command: "bash -lc 'orig_dims=$(/opt/fsl/bin/fslinfo ${structural} | grep -E \"^dim[1-3]\" | awk '\"'\"'{print $2}'\"'\"' | tr '\"'\"'\\n'\"'\"' '\"'\"' '\"'\"') && \\\nsmooth_dims=$(/opt/fsl/bin/fslinfo ${output_dir}/fsl/struct_smooth.nii.gz | grep -E \"^dim[1-3]\" | awk '\"'\"'{print $2}'\"'\"' | tr '\"'\"'\\n'\"'\"' '\"'\"' '\"'\"') && \\\n[ \"$orig_dims\" = \"$smooth_dims\" ] && echo \"Dimensions match: $orig_dims\"'"
     depends_on: FSL fslmaths smooth
     expected_output_contains: "Dimensions match"
 
   - name: Validate motion correction preserves 4D structure
     description: Ensure motion corrected BOLD has same timepoints
-    command: |
-      orig_t=$(/opt/fsl/bin/fslinfo ${bold} | grep "^dim4" | awk '{print $2}') && \
-      mcf_t=$(/opt/fsl/bin/fslinfo ${output_dir}/fsl/bold_mcf.nii.gz | grep "^dim4" | awk '{print $2}') && \
-      [ "$orig_t" = "$mcf_t" ] && echo "Timepoints match: $orig_t"
+    command: "bash -lc 'orig_t=$(/opt/fsl/bin/fslinfo ${bold} | grep \"^dim4\" | awk '\"'\"'{print $2}'\"'\"') && \\\nmcf_t=$(/opt/fsl/bin/fslinfo ${output_dir}/fsl/bold_mcf.nii.gz | grep \"^dim4\" | awk '\"'\"'{print $2}'\"'\"') && \\\n[ \"$orig_t\" = \"$mcf_t\" ] && echo \"Timepoints match: $orig_t\"'"
     depends_on: FSL mcflirt basic motion correction
     expected_output_contains: "Timepoints match"
 
   - name: Validate brain mask is binary
     description: Ensure brain mask only contains 0 and 1
-    command: |
-      max_val=$(/opt/fsl/bin/fslstats ${output_dir}/fsl/struct_brain_m_mask.nii.gz -R | awk '{print $2}') && \
-      min_val=$(/opt/fsl/bin/fslstats ${output_dir}/fsl/struct_brain_m_mask.nii.gz -R | awk '{print $1}') && \
-      [ "$min_val" = "0.000000" ] && [ "$max_val" = "1.000000" ] && echo "Binary mask validated"
+    command: "bash -lc 'max_val=$(/opt/fsl/bin/fslstats ${output_dir}/fsl/struct_brain_m_mask.nii.gz -R | awk '\"'\"'{print $2}'\"'\"') && \\\nmin_val=$(/opt/fsl/bin/fslstats ${output_dir}/fsl/struct_brain_m_mask.nii.gz -R | awk '\"'\"'{print $1}'\"'\"') && \\\n[ \"$min_val\" = \"0.000000\" ] && [ \"$max_val\" = \"1.000000\" ] && echo \"Binary mask validated\"'"
     depends_on: FSL bet with mask output
     expected_output_contains: "Binary mask validated"
 
   - name: Validate temporal mean reduces dimensionality
     description: Ensure Tmean produces 3D output from 4D input
-    command: |
-      tmean_dim4=$(/opt/fsl/bin/fslinfo ${output_dir}/fsl/bold_tmean.nii.gz | grep "^dim4" | awk '{print $2}') && \
-      [ "$tmean_dim4" = "1" ] && echo "Temporal mean is 3D"
+    command: "bash -lc 'tmean_dim4=$(/opt/fsl/bin/fslinfo ${output_dir}/fsl/bold_tmean.nii.gz | grep \"^dim4\" | awk '\"'\"'{print $2}'\"'\"') && \\\n[ \"$tmean_dim4\" = \"1\" ] && echo \"Temporal mean is 3D\"'"
     depends_on: FSL fslmaths temporal mean
     expected_output_contains: "Temporal mean is 3D"
 
   - name: Validate FreeSurfer MGZ conversion roundtrip
     description: Ensure NIfTI-MGZ-NIfTI conversion preserves dimensions
-    command: |
-      orig_dims=$(/opt/fsl/bin/fslinfo ${structural} | grep -E "^dim[1-3]" | awk '{print $2}' | tr '\n' ' ') && \
-      rt_dims=$(/opt/fsl/bin/fslinfo ${output_dir}/freesurfer/struct_from_mgz.nii.gz | grep -E "^dim[1-3]" | awk '{print $2}' | tr '\n' ' ') && \
-      [ "$orig_dims" = "$rt_dims" ] && echo "Roundtrip dimensions match: $orig_dims"
+    command: "bash -lc 'orig_dims=$(/opt/fsl/bin/fslinfo ${structural} | grep -E \"^dim[1-3]\" | awk '\"'\"'{print $2}'\"'\"' | tr '\"'\"'\\n'\"'\"' '\"'\"' '\"'\"') && \\\nrt_dims=$(/opt/fsl/bin/fslinfo ${output_dir}/freesurfer/struct_from_mgz.nii.gz | grep -E \"^dim[1-3]\" | awk '\"'\"'{print $2}'\"'\"' | tr '\"'\"'\\n'\"'\"' '\"'\"' '\"'\"') && \\\n[ \"$orig_dims\" = \"$rt_dims\" ] && echo \"Roundtrip dimensions match: $orig_dims\"'"
     depends_on: FreeSurfer mri_convert back to NIfTI
     ignore_exit_code: true  # depends on mri_convert which needs license
 

--- a/recipes/bidsappbrainsuite/fulltest.yaml
+++ b/recipes/bidsappbrainsuite/fulltest.yaml
@@ -53,17 +53,17 @@ tests:
   # ==========================================================================
   - name: BIDS-App help
     description: Verify BrainSuite BIDS-App run.py shows help message
-    command: /BrainSuite/run.py --help 2>&1 | head -20
+    command: bash -lc '/BrainSuite/run.py --help 2>&1 | head -20'
     expected_output_contains: "BrainSuite"
 
   - name: BIDS-App version
     description: Check BrainSuite BIDS-App version
-    command: /BrainSuite/run.py --version 2>&1
+    command: bash -lc '/BrainSuite/run.py --version 2>&1'
     expected_output_contains: "21a"
 
   - name: BrainSuite installation check
     description: Verify BrainSuite21a is properly installed
-    command: ls /opt/BrainSuite21a/bin/bse && echo "BrainSuite installation verified"
+    command: "bash -lc 'ls /opt/BrainSuite21a/bin/bse && echo \"BrainSuite installation verified\"'"
     expected_output_contains: "BrainSuite installation verified"
 
   # ==========================================================================
@@ -71,12 +71,12 @@ tests:
   # ==========================================================================
   - name: BSE help
     description: Verify BSE (Brain Surface Extractor) shows usage
-    command: /opt/BrainSuite21a/bin/bse 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/bse 2>&1 | head -10'
     expected_output_contains: "brain surface extractor"
 
   - name: BSE basic extraction
     description: Run BSE on T1w image for skull stripping
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain.nii.gz --mask ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain.nii.gz --mask ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain.nii.gz
@@ -84,14 +84,14 @@ tests:
 
   - name: BSE with auto parameters
     description: Run BSE with automatic parameter tuning
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_auto.nii.gz --auto -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_auto.nii.gz --auto -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain_auto.nii.gz
 
   - name: BSE with edge detection output
     description: Run BSE with edge map output
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_edge.nii.gz --edge ${output_dir}/bse_output/t1w_edge.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_edge.nii.gz --edge ${output_dir}/bse_output/t1w_edge.nii.gz -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain_edge.nii.gz
@@ -99,7 +99,7 @@ tests:
 
   - name: BSE with diffusion filter output
     description: Run BSE with anisotropic diffusion filter output
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_adf.nii.gz --adf ${output_dir}/bse_output/t1w_adf.nii.gz -d 25 -n 3 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_adf.nii.gz --adf ${output_dir}/bse_output/t1w_adf.nii.gz -d 25 -n 3 -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain_adf.nii.gz
@@ -107,21 +107,21 @@ tests:
 
   - name: BSE with custom diffusion parameters
     description: Run BSE with custom diffusion constant and iterations
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_custom.nii.gz -d 30 -n 5 -s 0.7 -r 2 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_custom.nii.gz -d 30 -n 5 -s 0.7 -r 2 -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain_custom.nii.gz
 
   - name: BSE with brainstem trimming
     description: Run BSE with brainstem trimming option
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_trim.nii.gz --trim -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_trim.nii.gz --trim -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain_trim.nii.gz
 
   - name: BSE with high-resolution mask
     description: Run BSE with detailed brain mask output
-    command: /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_hires.nii.gz --hires ${output_dir}/bse_output/t1w_hires_mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/bse_output/t1w_brain_hires.nii.gz --hires ${output_dir}/bse_output/t1w_hires_mask.nii.gz -v 1'
     timeout: 300
     validate:
       - output_exists: ${output_dir}/bse_output/t1w_brain_hires.nii.gz
@@ -132,12 +132,12 @@ tests:
   # ==========================================================================
   - name: BFC help
     description: Verify BFC (Bias Field Corrector) shows usage
-    command: /opt/BrainSuite21a/bin/bfc 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc 2>&1 | head -10'
     expected_output_contains: "bias field corrector"
 
   - name: BFC basic correction
     description: Run BFC on skull-stripped image
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc.nii.gz -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -145,7 +145,7 @@ tests:
 
   - name: BFC with bias field output
     description: Run BFC and save bias field estimate
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_bias.nii.gz --bias ${output_dir}/bfc_output/t1w_bias.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_bias.nii.gz --bias ${output_dir}/bfc_output/t1w_bias.nii.gz -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -154,7 +154,7 @@ tests:
 
   - name: BFC with mask
     description: Run BFC with brain mask input
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_masked.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_masked.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -162,7 +162,7 @@ tests:
 
   - name: BFC iterative mode
     description: Run BFC in iterative mode for severe artifacts
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_iter.nii.gz --iterate -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_iter.nii.gz --iterate -v 1'
     depends_on: BSE basic extraction
     timeout: 600
     validate:
@@ -170,7 +170,7 @@ tests:
 
   - name: BFC with ellipsoid ROI
     description: Run BFC using ellipsoid for ROI histogram
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_ellipse.nii.gz --ellipse -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_ellipse.nii.gz --ellipse -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -178,7 +178,7 @@ tests:
 
   - name: BFC with custom parameters
     description: Run BFC with custom histogram and control point spacing
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_custom.nii.gz -r 10 -s 12 -c 48 -w 0.0005 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_custom.nii.gz -r 10 -s 12 -c 48 -w 0.0005 -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -186,7 +186,7 @@ tests:
 
   - name: BFC high bias model
     description: Run BFC with high bias model for strong artifacts
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_high.nii.gz --high -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_high.nii.gz --high -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -194,7 +194,7 @@ tests:
 
   - name: BFC with extrapolation
     description: Run BFC and extrapolate correction to entire volume
-    command: /opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_extrap.nii.gz --extrapolate -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/bfc -i ${output_dir}/bse_output/t1w_brain.nii.gz -o ${output_dir}/bfc_output/t1w_bfc_extrap.nii.gz --extrapolate -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -205,12 +205,12 @@ tests:
   # ==========================================================================
   - name: PVC help
     description: Verify PVC (Partial Volume Classifier) shows usage
-    command: /opt/BrainSuite21a/bin/pvc 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/pvc 2>&1 | head -10'
     expected_output_contains: "partial volume classifier"
 
   - name: PVC basic classification
     description: Run PVC on bias-corrected image
-    command: /opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc.label.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc.label.nii.gz -v 1'
     depends_on: BFC basic correction
     timeout: 300
     validate:
@@ -218,7 +218,7 @@ tests:
 
   - name: PVC with tissue fractions
     description: Run PVC with tissue fraction output
-    command: /opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_frac.label.nii.gz -f ${output_dir}/pvc_output/t1w_pvc.frac.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_frac.label.nii.gz -f ${output_dir}/pvc_output/t1w_pvc.frac.nii.gz -v 1'
     depends_on: BFC basic correction
     timeout: 300
     validate:
@@ -227,7 +227,7 @@ tests:
 
   - name: PVC with mask
     description: Run PVC with brain mask input
-    command: /opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_masked.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_masked.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1'
     depends_on: BFC basic correction
     timeout: 300
     validate:
@@ -235,7 +235,7 @@ tests:
 
   - name: PVC three-class labeling
     description: Run PVC with simplified three-class output (CSF/GM/WM)
-    command: /opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_3class.label.nii.gz -3 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_3class.label.nii.gz -3 -v 1'
     depends_on: BFC basic correction
     timeout: 300
     validate:
@@ -243,7 +243,7 @@ tests:
 
   - name: PVC with custom spatial prior
     description: Run PVC with modified spatial prior strength
-    command: /opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_lambda.label.nii.gz -l 0.2 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/pvc -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/pvc_output/t1w_pvc_lambda.label.nii.gz -l 0.2 -v 1'
     depends_on: BFC basic correction
     timeout: 300
     validate:
@@ -254,12 +254,12 @@ tests:
   # ==========================================================================
   - name: Skullfinder help
     description: Verify skullfinder shows usage
-    command: /opt/BrainSuite21a/bin/skullfinder 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/skullfinder 2>&1 | head -10'
     expected_output_contains: "Skull and scalp segmentation"
 
   - name: Skullfinder basic segmentation
     description: Run skullfinder for skull/scalp labeling
-    command: /opt/BrainSuite21a/bin/skullfinder -i ${t1w} -o ${output_dir}/mask_output/t1w_skull.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/skullfinder -i ${t1w} -o ${output_dir}/mask_output/t1w_skull.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -267,7 +267,7 @@ tests:
 
   - name: Skullfinder with custom thresholds
     description: Run skullfinder with custom intensity thresholds
-    command: /opt/BrainSuite21a/bin/skullfinder -i ${t1w} -o ${output_dir}/mask_output/t1w_skull_thresh.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -l 20 -u 200 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/skullfinder -i ${t1w} -o ${output_dir}/mask_output/t1w_skull_thresh.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz -l 20 -u 200 -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -275,7 +275,7 @@ tests:
 
   - name: Skullfinder with final opening
     description: Run skullfinder with final opening operation
-    command: /opt/BrainSuite21a/bin/skullfinder -i ${t1w} -o ${output_dir}/mask_output/t1w_skull_open.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz --finalOpening -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/skullfinder -i ${t1w} -o ${output_dir}/mask_output/t1w_skull_open.label.nii.gz -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz --finalOpening -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -286,12 +286,12 @@ tests:
   # ==========================================================================
   - name: TCA help
     description: Verify TCA (Topological Correction Algorithm) shows usage
-    command: /opt/BrainSuite21a/bin/tca 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/tca 2>&1 | head -10'
     expected_output_contains: "topological correction"
 
   - name: TCA basic correction
     description: Run TCA to remove topological handles from mask
-    command: /opt/BrainSuite21a/bin/tca -i ${output_dir}/bse_output/t1w_brain.mask.nii.gz -o ${output_dir}/mask_output/t1w_tca.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/tca -i ${output_dir}/bse_output/t1w_brain.mask.nii.gz -o ${output_dir}/mask_output/t1w_tca.mask.nii.gz -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -299,7 +299,7 @@ tests:
 
   - name: TCA with custom correction size
     description: Run TCA with custom maximum correction size
-    command: /opt/BrainSuite21a/bin/tca -i ${output_dir}/bse_output/t1w_brain.mask.nii.gz -o ${output_dir}/mask_output/t1w_tca_custom.mask.nii.gz -m 300 -n 2 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/tca -i ${output_dir}/bse_output/t1w_brain.mask.nii.gz -o ${output_dir}/mask_output/t1w_tca_custom.mask.nii.gz -m 300 -n 2 -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -307,7 +307,7 @@ tests:
 
   - name: TCA with delta
     description: Run TCA with foreground delta parameter
-    command: /opt/BrainSuite21a/bin/tca -i ${output_dir}/bse_output/t1w_brain.mask.nii.gz -o ${output_dir}/mask_output/t1w_tca_delta.mask.nii.gz --delta 1 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/tca -i ${output_dir}/bse_output/t1w_brain.mask.nii.gz -o ${output_dir}/mask_output/t1w_tca_delta.mask.nii.gz --delta 1 -v 1'
     depends_on: BSE basic extraction
     timeout: 300
     validate:
@@ -318,12 +318,12 @@ tests:
   # ==========================================================================
   - name: Dewisp help
     description: Verify dewisp shows usage
-    command: /opt/BrainSuite21a/bin/dewisp 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/dewisp 2>&1 | head -10'
     expected_output_contains: "removes wispy tendril structures"
 
   - name: Dewisp basic removal
     description: Run dewisp to remove wisps from cortex mask
-    command: /opt/BrainSuite21a/bin/dewisp -i ${output_dir}/mask_output/t1w_tca.mask.nii.gz -o ${output_dir}/mask_output/t1w_dewisp.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dewisp -i ${output_dir}/mask_output/t1w_tca.mask.nii.gz -o ${output_dir}/mask_output/t1w_dewisp.mask.nii.gz -v 1'
     depends_on: TCA basic correction
     timeout: 300
     validate:
@@ -331,7 +331,7 @@ tests:
 
   - name: Dewisp with custom threshold
     description: Run dewisp with custom size threshold
-    command: /opt/BrainSuite21a/bin/dewisp -i ${output_dir}/mask_output/t1w_tca.mask.nii.gz -o ${output_dir}/mask_output/t1w_dewisp_custom.mask.nii.gz -t 20 -n 15 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dewisp -i ${output_dir}/mask_output/t1w_tca.mask.nii.gz -o ${output_dir}/mask_output/t1w_dewisp_custom.mask.nii.gz -t 20 -n 15 -v 1'
     depends_on: TCA basic correction
     timeout: 300
     validate:
@@ -342,12 +342,12 @@ tests:
   # ==========================================================================
   - name: Scrubmask help
     description: Verify scrubmask shows usage
-    command: /opt/BrainSuite21a/bin/scrubmask 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/scrubmask 2>&1 | head -10'
     expected_output_contains: "mask"
 
   - name: Scrubmask basic filtering
     description: Run scrubmask to filter binary mask
-    command: /opt/BrainSuite21a/bin/scrubmask -i ${output_dir}/mask_output/t1w_dewisp.mask.nii.gz -o ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/scrubmask -i ${output_dir}/mask_output/t1w_dewisp.mask.nii.gz -o ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -v 1'
     depends_on: Dewisp basic removal
     timeout: 300
     validate:
@@ -355,7 +355,7 @@ tests:
 
   - name: Scrubmask with custom parameters
     description: Run scrubmask with custom thresholds and iterations
-    command: /opt/BrainSuite21a/bin/scrubmask -i ${output_dir}/mask_output/t1w_dewisp.mask.nii.gz -o ${output_dir}/mask_output/t1w_scrub_custom.mask.nii.gz -b 2 -f 2 -n 15 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/scrubmask -i ${output_dir}/mask_output/t1w_dewisp.mask.nii.gz -o ${output_dir}/mask_output/t1w_scrub_custom.mask.nii.gz -b 2 -f 2 -n 15 -v 1'
     depends_on: Dewisp basic removal
     timeout: 300
     validate:
@@ -366,12 +366,12 @@ tests:
   # ==========================================================================
   - name: DFS help
     description: Verify DFS (Surface Generator) shows usage
-    command: /opt/BrainSuite21a/bin/dfs 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs 2>&1 | head -10'
     expected_output_contains: "Surface Generator"
 
   - name: DFS basic surface generation
     description: Generate mesh surface from mask volume
-    command: /opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner.dfs -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner.dfs -v 1'
     depends_on: Scrubmask basic filtering
     timeout: 300
     validate:
@@ -379,7 +379,7 @@ tests:
 
   - name: DFS with smoothing
     description: Generate surface with custom smoothing parameters
-    command: /opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_smooth.dfs -n 20 -a 0.4 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_smooth.dfs -n 20 -a 0.4 -v 1'
     depends_on: Scrubmask basic filtering
     timeout: 300
     validate:
@@ -387,7 +387,7 @@ tests:
 
   - name: DFS with color mapping
     description: Generate surface with intensity coloring from volume
-    command: /opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_color.dfs -c ${output_dir}/bfc_output/t1w_bfc.nii.gz -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_color.dfs -c ${output_dir}/bfc_output/t1w_bfc.nii.gz -v 1'
     depends_on: Scrubmask basic filtering
     timeout: 300
     validate:
@@ -395,7 +395,7 @@ tests:
 
   - name: DFS with curvature weighting
     description: Generate surface with curvature-weighted smoothing
-    command: /opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_curv.dfs -w 0.5 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_curv.dfs -w 0.5 -v 1'
     depends_on: Scrubmask basic filtering
     timeout: 300
     validate:
@@ -403,7 +403,7 @@ tests:
 
   - name: DFS with zero padding
     description: Generate surface with zero-padded volume (avoid edge clipping)
-    command: /opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_zpad.dfs -z -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/mask_output/t1w_scrub.mask.nii.gz -o ${output_dir}/surface_output/t1w_inner_zpad.dfs -z -v 1'
     depends_on: Scrubmask basic filtering
     timeout: 300
     validate:
@@ -411,7 +411,7 @@ tests:
 
   - name: DFS with threshold
     description: Generate surface from thresholded volume
-    command: /opt/BrainSuite21a/bin/dfs -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/surface_output/t1w_thresh.dfs -gt 50 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/surface_output/t1w_thresh.dfs -gt 50 -v 1'
     depends_on: BFC basic correction
     timeout: 300
     validate:
@@ -422,7 +422,7 @@ tests:
   # ==========================================================================
   - name: Cortex help
     description: Verify cortex extractor shows usage
-    command: /opt/BrainSuite21a/bin/cortex 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/cortex 2>&1 | head -10'
     expected_output_contains: "cortex extractor"
 
   # ==========================================================================
@@ -430,7 +430,7 @@ tests:
   # ==========================================================================
   - name: Cerebro help
     description: Verify cerebro labeling tool shows usage
-    command: /opt/BrainSuite21a/bin/cerebro 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/cerebro 2>&1 | head -10'
     expected_output_contains: "Cerebrum/cerebellum labeling"
 
   # ==========================================================================
@@ -438,7 +438,7 @@ tests:
   # ==========================================================================
   - name: Pialmesh help
     description: Verify pialmesh shows usage
-    command: /opt/BrainSuite21a/bin/pialmesh 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/pialmesh 2>&1 | head -10'
     expected_output_contains: "pialmesh"
 
   # ==========================================================================
@@ -446,7 +446,7 @@ tests:
   # ==========================================================================
   - name: Hemisplit help
     description: Verify hemisplit shows usage
-    command: /opt/BrainSuite21a/bin/hemisplit 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/hemisplit 2>&1 | head -10'
     expected_output_contains: "Hemisphere splitter"
 
   # ==========================================================================
@@ -454,12 +454,12 @@ tests:
   # ==========================================================================
   - name: Clustermap help
     description: Verify clustermap shows usage
-    command: /opt/BrainSuite21a/bin/clustermap 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/clustermap 2>&1 | head -10'
     expected_output_contains: "identifies voxel clusters"
 
   - name: Clustermap basic clustering
     description: Run clustermap on PVC labels
-    command: /opt/BrainSuite21a/bin/clustermap -i ${output_dir}/pvc_output/t1w_pvc.frac.nii.gz -o ${output_dir}/pvc_output/t1w_cluster_stats.txt -t 1.5 -n 5 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/clustermap -i ${output_dir}/pvc_output/t1w_pvc.frac.nii.gz -o ${output_dir}/pvc_output/t1w_cluster_stats.txt -t 1.5 -n 5 -v 1'
     depends_on: PVC with tissue fractions
     timeout: 300
     validate:
@@ -467,7 +467,7 @@ tests:
 
   - name: Clustermap with label output
     description: Run clustermap with cluster label volume output
-    command: /opt/BrainSuite21a/bin/clustermap -i ${output_dir}/pvc_output/t1w_pvc.frac.nii.gz -o ${output_dir}/pvc_output/t1w_cluster_stats2.txt -l ${output_dir}/pvc_output/t1w_cluster.label.nii.gz -t 1.5 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/clustermap -i ${output_dir}/pvc_output/t1w_pvc.frac.nii.gz -o ${output_dir}/pvc_output/t1w_cluster_stats2.txt -l ${output_dir}/pvc_output/t1w_cluster.label.nii.gz -t 1.5 -v 1'
     depends_on: PVC with tissue fractions
     timeout: 300
     validate:
@@ -478,47 +478,47 @@ tests:
   # ==========================================================================
   - name: Volslice help
     description: Verify volslice shows usage
-    command: /opt/BrainSuite21a/bin/volslice 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice 2>&1 | head -10'
     expected_output_contains: "volslice"
 
   - name: Volslice axial slice
     description: Generate axial slice image from T1w
-    command: /opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_axial.png --view 1 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_axial.png --view 1 -v 1'
     timeout: 120
     validate:
       - output_exists: ${output_dir}/surface_output/t1w_axial.png
 
   - name: Volslice coronal slice
     description: Generate coronal slice image from T1w
-    command: /opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_coronal.png --view 2 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_coronal.png --view 2 -v 1'
     timeout: 120
     validate:
       - output_exists: ${output_dir}/surface_output/t1w_coronal.png
 
   - name: Volslice sagittal slice
     description: Generate sagittal slice image from T1w
-    command: /opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_sagittal.png --view 3 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_sagittal.png --view 3 -v 1'
     timeout: 120
     validate:
       - output_exists: ${output_dir}/surface_output/t1w_sagittal.png
 
   - name: Volslice with specific slice
     description: Generate slice at specific position
-    command: /opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_slice50.png --view 1 --slice 50 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_slice50.png --view 1 --slice 50 -v 1'
     timeout: 120
     validate:
       - output_exists: ${output_dir}/surface_output/t1w_slice50.png
 
   - name: Volslice with colormap
     description: Generate slice with hot colormap
-    command: /opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_hot.png --view 1 -c hot -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_hot.png --view 1 -c hot -v 1'
     timeout: 120
     validate:
       - output_exists: ${output_dir}/surface_output/t1w_hot.png
 
   - name: Volslice with label overlay
     description: Generate slice with label overlay
-    command: /opt/BrainSuite21a/bin/volslice -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/surface_output/t1w_label_overlay.png -l ${output_dir}/pvc_output/t1w_pvc.label.nii.gz --view 1 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${output_dir}/bfc_output/t1w_bfc.nii.gz -o ${output_dir}/surface_output/t1w_label_overlay.png -l ${output_dir}/pvc_output/t1w_pvc.label.nii.gz --view 1 -v 1'
     depends_on: PVC basic classification
     timeout: 120
     validate:
@@ -526,7 +526,7 @@ tests:
 
   - name: Volslice with mask overlay
     description: Generate slice with mask overlay
-    command: /opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_mask_overlay.png -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz --view 1 --alpha 128 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/volslice -i ${t1w} -o ${output_dir}/surface_output/t1w_mask_overlay.png -m ${output_dir}/bse_output/t1w_brain.mask.nii.gz --view 1 --alpha 128 -v 1'
     depends_on: BSE basic extraction
     timeout: 120
     validate:
@@ -537,12 +537,12 @@ tests:
   # ==========================================================================
   - name: Renderdfs help
     description: Verify renderdfs shows usage
-    command: /opt/BrainSuite21a/bin/renderdfs 2>&1 | head -10
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs 2>&1 | head -10'
     expected_output_contains: "renderdfs"
 
   - name: Renderdfs basic rendering
     description: Render surface to PNG image
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_render.png -s ${output_dir}/surface_output/t1w_inner.dfs -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_render.png -s ${output_dir}/surface_output/t1w_inner.dfs -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -550,7 +550,7 @@ tests:
 
   - name: Renderdfs anterior view
     description: Render surface from anterior viewpoint
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_ant.png -s ${output_dir}/surface_output/t1w_inner.dfs --ant -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_ant.png -s ${output_dir}/surface_output/t1w_inner.dfs --ant -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -558,7 +558,7 @@ tests:
 
   - name: Renderdfs superior view
     description: Render surface from superior viewpoint
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_sup.png -s ${output_dir}/surface_output/t1w_inner.dfs --sup -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_sup.png -s ${output_dir}/surface_output/t1w_inner.dfs --sup -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -566,7 +566,7 @@ tests:
 
   - name: Renderdfs left sagittal view
     description: Render surface from left sagittal viewpoint
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_left.png -s ${output_dir}/surface_output/t1w_inner.dfs --left -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_left.png -s ${output_dir}/surface_output/t1w_inner.dfs --left -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -574,7 +574,7 @@ tests:
 
   - name: Renderdfs with rotation
     description: Render surface with custom rotation angles
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_rot.png -s ${output_dir}/surface_output/t1w_inner.dfs --xrot 45 --yrot 30 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_rot.png -s ${output_dir}/surface_output/t1w_inner.dfs --xrot 45 --yrot 30 -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -582,7 +582,7 @@ tests:
 
   - name: Renderdfs with zoom
     description: Render surface with zoom factor
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_zoom.png -s ${output_dir}/surface_output/t1w_inner.dfs --zoom 1.5 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_zoom.png -s ${output_dir}/surface_output/t1w_inner.dfs --zoom 1.5 -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -590,7 +590,7 @@ tests:
 
   - name: Renderdfs with custom background
     description: Render surface with white background
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_white_bg.png -s ${output_dir}/surface_output/t1w_inner.dfs --bg 255 255 255 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_white_bg.png -s ${output_dir}/surface_output/t1w_inner.dfs --bg 255 255 255 -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -598,7 +598,7 @@ tests:
 
   - name: Renderdfs with custom resolution
     description: Render surface at higher resolution
-    command: /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_hires.png -s ${output_dir}/surface_output/t1w_inner.dfs -x 1024 -y 1024 -v 1
+    command: bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/surface_output/t1w_surface_hires.png -s ${output_dir}/surface_output/t1w_inner.dfs -x 1024 -y 1024 -v 1'
     depends_on: DFS basic surface generation
     timeout: 120
     validate:
@@ -609,12 +609,12 @@ tests:
   # ==========================================================================
   - name: SVReg help
     description: Verify SVReg shows usage information
-    command: /opt/BrainSuite21a/svreg/bin/svreg.sh 2>&1 | head -20
+    command: bash -lc '/opt/BrainSuite21a/svreg/bin/svreg.sh 2>&1 | head -20'
     expected_output_contains: "surface and volume registration"
 
   - name: SVReg file check
     description: Verify SVReg binaries are present
-    command: ls -la /opt/BrainSuite21a/svreg/bin/svreg && echo "SVReg binaries found"
+    command: "bash -lc 'ls -la /opt/BrainSuite21a/svreg/bin/svreg && echo \"SVReg binaries found\"'"
     expected_output_contains: "SVReg binaries found"
 
   # ==========================================================================
@@ -622,27 +622,27 @@ tests:
   # ==========================================================================
   - name: Htrack help
     description: Verify htrack (tractography) is available
-    command: /opt/BrainSuite21a/bin/htrack 2>&1 | head -5
+    command: bash -lc '/opt/BrainSuite21a/bin/htrack 2>&1 | head -5'
     expected_output_contains: "htrack"
 
   - name: Odfmax help
     description: Verify odfmax (ODF peak detection) is available
-    command: /opt/BrainSuite21a/bin/odfmax 2>&1 | head -5
+    command: bash -lc '/opt/BrainSuite21a/bin/odfmax 2>&1 | head -5'
     expected_output_contains: "odfmax"
 
   - name: Conmat help
     description: Verify conmat (connectivity matrix) is available
-    command: /opt/BrainSuite21a/bin/conmat 2>&1 | head -5
+    command: bash -lc '/opt/BrainSuite21a/bin/conmat 2>&1 | head -5'
     expected_output_contains: "conmat"
 
   - name: Statmap help
     description: Verify statmap is available
-    command: /opt/BrainSuite21a/bin/statmap 2>&1 | head -5
+    command: bash -lc '/opt/BrainSuite21a/bin/statmap 2>&1 | head -5'
     expected_output_contains: "statmap"
 
   - name: Dwisplit help
     description: Verify dwisplit (DWI splitting) is available
-    command: /opt/BrainSuite21a/bin/dwisplit 2>&1 | head -5
+    command: bash -lc '/opt/BrainSuite21a/bin/dwisplit 2>&1 | head -5'
     expected_output_contains: "dwisplit"
 
   # ==========================================================================
@@ -650,12 +650,12 @@ tests:
   # ==========================================================================
   - name: Anatomical pipeline script check
     description: Verify brainsuite_anatomical_pipeline.sh is present
-    command: ls -la /opt/BrainSuite21a/bin/brainsuite_anatomical_pipeline.sh && echo "Anatomical pipeline script found"
+    command: "bash -lc 'ls -la /opt/BrainSuite21a/bin/brainsuite_anatomical_pipeline.sh && echo \"Anatomical pipeline script found\"'"
     expected_output_contains: "Anatomical pipeline script found"
 
   - name: Cortical extraction script check
     description: Verify cortical_extraction.sh is present
-    command: ls -la /opt/BrainSuite21a/bin/cortical_extraction.sh && echo "Cortical extraction script found"
+    command: "bash -lc 'ls -la /opt/BrainSuite21a/bin/cortical_extraction.sh && echo \"Cortical extraction script found\"'"
     expected_output_contains: "Cortical extraction script found"
 
   # ==========================================================================
@@ -663,12 +663,12 @@ tests:
   # ==========================================================================
   - name: Atlas directory check
     description: Verify atlas files are present
-    command: ls /opt/BrainSuite21a/atlas/ | head -10
+    command: "bash -lc 'ls /opt/BrainSuite21a/atlas/ | head -10'"
     expected_output_contains: ""
 
   - name: SVReg atlas check
     description: Verify SVReg atlases are present
-    command: ls /opt/BrainSuite21a/svreg/BCI-DNI_brain_atlas/ 2>/dev/null | head -5 || ls /opt/BrainSuite21a/svreg/ | head -5
+    command: "bash -lc 'ls /opt/BrainSuite21a/svreg/BCI-DNI_brain_atlas/ 2>/dev/null | head -5 || ls /opt/BrainSuite21a/svreg/ | head -5'"
     expected_output_contains: ""
 
   # ==========================================================================
@@ -676,7 +676,7 @@ tests:
   # ==========================================================================
   - name: BSSR directory check
     description: Verify bssr files are present
-    command: ls /opt/BrainSuite21a/bssr/ | head -10
+    command: "bash -lc 'ls /opt/BrainSuite21a/bssr/ | head -10'"
     expected_output_contains: ""
 
   # ==========================================================================
@@ -685,9 +685,9 @@ tests:
   - name: Full CSE pipeline (BSE + BFC + PVC)
     description: Run complete Cortical Surface Extractor sequence
     command: |
-      /opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/pipeline/t1w.bse.nii.gz --mask ${output_dir}/pipeline/t1w.mask.nii.gz --auto -v 1 && \
+      bash -lc '/opt/BrainSuite21a/bin/bse -i ${t1w} -o ${output_dir}/pipeline/t1w.bse.nii.gz --mask ${output_dir}/pipeline/t1w.mask.nii.gz --auto -v 1 && \
       /opt/BrainSuite21a/bin/bfc -i ${output_dir}/pipeline/t1w.bse.nii.gz -o ${output_dir}/pipeline/t1w.bfc.nii.gz -m ${output_dir}/pipeline/t1w.mask.nii.gz -v 1 && \
-      /opt/BrainSuite21a/bin/pvc -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/t1w.pvc.label.nii.gz -f ${output_dir}/pipeline/t1w.pvc.frac.nii.gz -v 1
+      /opt/BrainSuite21a/bin/pvc -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/t1w.pvc.label.nii.gz -f ${output_dir}/pipeline/t1w.pvc.frac.nii.gz -v 1'
     timeout: 600
     setup_command: mkdir -p ${output_dir}/pipeline
     validate:
@@ -699,9 +699,9 @@ tests:
   - name: Full mask cleanup pipeline (TCA + Dewisp + Scrubmask)
     description: Run complete mask cleanup sequence
     command: |
-      /opt/BrainSuite21a/bin/tca -i ${output_dir}/pipeline/t1w.mask.nii.gz -o ${output_dir}/pipeline/t1w.tca.mask.nii.gz -v 1 && \
+      bash -lc '/opt/BrainSuite21a/bin/tca -i ${output_dir}/pipeline/t1w.mask.nii.gz -o ${output_dir}/pipeline/t1w.tca.mask.nii.gz -v 1 && \
       /opt/BrainSuite21a/bin/dewisp -i ${output_dir}/pipeline/t1w.tca.mask.nii.gz -o ${output_dir}/pipeline/t1w.dewisp.mask.nii.gz -v 1 && \
-      /opt/BrainSuite21a/bin/scrubmask -i ${output_dir}/pipeline/t1w.dewisp.mask.nii.gz -o ${output_dir}/pipeline/t1w.cortex.mask.nii.gz -v 1
+      /opt/BrainSuite21a/bin/scrubmask -i ${output_dir}/pipeline/t1w.dewisp.mask.nii.gz -o ${output_dir}/pipeline/t1w.cortex.mask.nii.gz -v 1'
     depends_on: Full CSE pipeline (BSE + BFC + PVC)
     timeout: 300
     validate:
@@ -712,8 +712,8 @@ tests:
   - name: Surface generation pipeline
     description: Generate inner cortical surface from cleaned mask
     command: |
-      /opt/BrainSuite21a/bin/dfs -i ${output_dir}/pipeline/t1w.cortex.mask.nii.gz -o ${output_dir}/pipeline/t1w.inner.cortex.dfs -n 15 -a 0.5 -v 1 && \
-      /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/t1w.inner.cortex.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --left -v 1
+      bash -lc '/opt/BrainSuite21a/bin/dfs -i ${output_dir}/pipeline/t1w.cortex.mask.nii.gz -o ${output_dir}/pipeline/t1w.inner.cortex.dfs -n 15 -a 0.5 -v 1 && \
+      /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/t1w.inner.cortex.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --left -v 1'
     depends_on: Full mask cleanup pipeline (TCA + Dewisp + Scrubmask)
     timeout: 300
     validate:
@@ -726,9 +726,9 @@ tests:
   - name: QC multi-view visualization
     description: Generate QC images for all three views
     command: |
-      /opt/BrainSuite21a/bin/volslice -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/qc_axial.png -l ${output_dir}/pipeline/t1w.pvc.label.nii.gz --view 1 --labelalpha 100 -v 1 && \
+      bash -lc '/opt/BrainSuite21a/bin/volslice -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/qc_axial.png -l ${output_dir}/pipeline/t1w.pvc.label.nii.gz --view 1 --labelalpha 100 -v 1 && \
       /opt/BrainSuite21a/bin/volslice -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/qc_coronal.png -l ${output_dir}/pipeline/t1w.pvc.label.nii.gz --view 2 --labelalpha 100 -v 1 && \
-      /opt/BrainSuite21a/bin/volslice -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/qc_sagittal.png -l ${output_dir}/pipeline/t1w.pvc.label.nii.gz --view 3 --labelalpha 100 -v 1
+      /opt/BrainSuite21a/bin/volslice -i ${output_dir}/pipeline/t1w.bfc.nii.gz -o ${output_dir}/pipeline/qc_sagittal.png -l ${output_dir}/pipeline/t1w.pvc.label.nii.gz --view 3 --labelalpha 100 -v 1'
     depends_on: Full CSE pipeline (BSE + BFC + PVC)
     timeout: 180
     validate:
@@ -739,10 +739,10 @@ tests:
   - name: Surface QC multi-view
     description: Generate surface QC images from multiple viewpoints
     command: |
-      /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/qc_surface_left.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --left --bg 255 255 255 -v 1 && \
+      bash -lc '/opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/qc_surface_left.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --left --bg 255 255 255 -v 1 && \
       /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/qc_surface_right.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --right --bg 255 255 255 -v 1 && \
       /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/qc_surface_sup.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --sup --bg 255 255 255 -v 1 && \
-      /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/qc_surface_ant.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --ant --bg 255 255 255 -v 1
+      /opt/BrainSuite21a/bin/renderdfs -o ${output_dir}/pipeline/qc_surface_ant.png -s ${output_dir}/pipeline/t1w.inner.cortex.dfs --ant --bg 255 255 255 -v 1'
     depends_on: Surface generation pipeline
     timeout: 180
     validate:

--- a/recipes/bidsapphcppipelines/fulltest.yaml
+++ b/recipes/bidsapphcppipelines/fulltest.yaml
@@ -63,12 +63,12 @@ tests:
   # ==========================================================================
   - name: HCP Pipelines version file
     description: Check HCP Pipelines version
-    command: cat /opt/HCP-Pipelines/version.txt
+    command: "bash -lc 'cat /opt/HCP-Pipelines/version.txt'"
     expected_output_contains: "v4.3.0"
 
   - name: HCP Pipelines show_version script
     description: Run HCP show_version script
-    command: /opt/HCP-Pipelines/show_version
+    command: bash -lc '/opt/HCP-Pipelines/show_version'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -395,27 +395,27 @@ tests:
   # ==========================================================================
   - name: MNI152 1mm template exists
     description: Verify MNI152 1mm template
-    command: ls -la /opt/HCP-Pipelines/global/templates/MNI152_T1_1mm.nii.gz
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/templates/MNI152_T1_1mm.nii.gz'"
     expected_exit_code: 0
 
   - name: MNI152 2mm template exists
     description: Verify MNI152 2mm template
-    command: ls -la /opt/HCP-Pipelines/global/templates/MNI152_T1_2mm.nii.gz
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/templates/MNI152_T1_2mm.nii.gz'"
     expected_exit_code: 0
 
   - name: MNI152 T2 template exists
     description: Verify MNI152 T2 template
-    command: ls -la /opt/HCP-Pipelines/global/templates/MNI152_T2_1mm.nii.gz
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/templates/MNI152_T2_1mm.nii.gz'"
     expected_exit_code: 0
 
   - name: MNI152 brain mask exists
     description: Verify MNI brain mask template
-    command: ls -la /opt/HCP-Pipelines/global/templates/MNI152_T1_1mm_brain_mask.nii.gz
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/templates/MNI152_T1_1mm_brain_mask.nii.gz'"
     expected_exit_code: 0
 
   - name: Standard mesh atlases exist
     description: Verify standard mesh atlases directory
-    command: ls /opt/HCP-Pipelines/global/templates/standard_mesh_atlases/
+    command: "bash -lc 'ls /opt/HCP-Pipelines/global/templates/standard_mesh_atlases/'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -423,27 +423,27 @@ tests:
   # ==========================================================================
   - name: PreFreeSurfer pipeline exists
     description: Verify PreFreeSurfer pipeline script
-    command: ls -la /opt/HCP-Pipelines/PreFreeSurfer/PreFreeSurferPipeline.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/PreFreeSurfer/PreFreeSurferPipeline.sh'"
     expected_exit_code: 0
 
   - name: FreeSurfer pipeline exists
     description: Verify FreeSurfer pipeline script
-    command: ls -la /opt/HCP-Pipelines/FreeSurfer/FreeSurferPipeline.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/FreeSurfer/FreeSurferPipeline.sh'"
     expected_exit_code: 0
 
   - name: PostFreeSurfer pipeline exists
     description: Verify PostFreeSurfer pipeline script
-    command: ls -la /opt/HCP-Pipelines/PostFreeSurfer/PostFreeSurferPipeline.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/PostFreeSurfer/PostFreeSurferPipeline.sh'"
     expected_exit_code: 0
 
   - name: fMRIVolume pipeline exists
     description: Verify fMRIVolume pipeline script
-    command: ls -la /opt/HCP-Pipelines/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh'"
     expected_exit_code: 0
 
   - name: fMRISurface pipeline exists
     description: Verify fMRISurface pipeline script
-    command: ls -la /opt/HCP-Pipelines/fMRISurface/GenericfMRISurfaceProcessingPipeline.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/fMRISurface/GenericfMRISurfaceProcessingPipeline.sh'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -451,17 +451,17 @@ tests:
   # ==========================================================================
   - name: TopupPreprocessing script exists
     description: Verify Topup preprocessing script
-    command: ls -la /opt/HCP-Pipelines/global/scripts/TopupPreprocessingAll.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/scripts/TopupPreprocessingAll.sh'"
     expected_exit_code: 0
 
   - name: FieldMapPreprocessing script exists
     description: Verify FieldMap preprocessing script
-    command: ls -la /opt/HCP-Pipelines/global/scripts/FieldMapPreprocessingAll.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/scripts/FieldMapPreprocessingAll.sh'"
     expected_exit_code: 0
 
   - name: GradientDistortionUnwarp script exists
     description: Verify gradient distortion correction script
-    command: ls -la /opt/HCP-Pipelines/global/scripts/GradientDistortionUnwarp.sh
+    command: "bash -lc 'ls -la /opt/HCP-Pipelines/global/scripts/GradientDistortionUnwarp.sh'"
     expected_exit_code: 0
 
   # ==========================================================================

--- a/recipes/bidsapppymvpa/fulltest.yaml
+++ b/recipes/bidsapppymvpa/fulltest.yaml
@@ -50,17 +50,17 @@ tests:
   # ==========================================================================
   - name: Version check
     description: Verify PyMVPA BIDS-App version
-    command: /code/run.py -v 2>&1 | tail -1
+    command: bash -lc '/code/run.py -v 2>&1 | tail -1'
     expected_output_contains: "PyMVPA BIDS-App Version v4.0.3"
 
   - name: Help message
     description: Verify help documentation is accessible
-    command: /code/run.py --help 2>&1 | head -20
+    command: bash -lc '/code/run.py --help 2>&1 | head -20'
     expected_output_contains: "PyMVPA BIDS-App"
 
   - name: Argument parser verification
     description: Check that required arguments are documented
-    command: /code/run.py --help 2>&1
+    command: bash -lc '/code/run.py --help 2>&1'
     expected_output_contains: "bids_dir"
 
   # ==========================================================================
@@ -208,22 +208,22 @@ tests:
   # ==========================================================================
   - name: FSL directory check
     description: Verify FSL is installed
-    command: ls /opt/fsl-6.0.5.1/bin/ | head -5
+    command: "bash -lc 'ls /opt/fsl-6.0.5.1/bin/ | head -5'"
     expected_exit_code: 0
 
   - name: FSLDIR environment
     description: Verify FSLDIR environment can be set
-    command: export FSLDIR=/opt/fsl-6.0.5.1 && echo $FSLDIR
+    command: "bash -lc 'export FSLDIR=/opt/fsl-6.0.5.1 && echo $FSLDIR'"
     expected_output_contains: "/opt/fsl-6.0.5.1"
 
   - name: FSL flirt available
     description: Verify FLIRT registration tool is available
-    command: ls -la /opt/fsl-6.0.5.1/bin/flirt
+    command: "bash -lc 'ls -la /opt/fsl-6.0.5.1/bin/flirt'"
     expected_exit_code: 0
 
   - name: FSL bet available
     description: Verify BET brain extraction is available
-    command: ls -la /opt/fsl-6.0.5.1/bin/bet
+    command: "bash -lc 'ls -la /opt/fsl-6.0.5.1/bin/bet'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -236,7 +236,7 @@ tests:
 
   - name: Run script is executable
     description: Verify run.py has execute permissions
-    command: test -x /code/run.py && echo "executable"
+    command: bash -lc 'test -x /code/run.py && echo "executable"'
     expected_output_contains: "executable"
 
   - name: Version file exists
@@ -249,112 +249,112 @@ tests:
   # ==========================================================================
   - name: Analysis levels available
     description: Verify analysis levels are documented
-    command: /code/run.py --help 2>&1 | grep "participant_prep"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "participant_prep"'
     expected_output_contains: "participant_prep"
 
   - name: Participant ID argument
     description: Verify participant_id argument is documented
-    command: /code/run.py --help 2>&1 | grep "participant_id"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "participant_id"'
     expected_output_contains: "participant_id"
 
   - name: Session argument
     description: Verify session argument is available
-    command: /code/run.py --help 2>&1 | grep "session"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "session"'
     expected_output_contains: "session"
 
   - name: Task argument
     description: Verify task argument is documented
-    command: /code/run.py --help 2>&1 | grep "task"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "task"'
     expected_output_contains: "task"
 
   - name: Searchlight argument
     description: Verify searchlight argument is available
-    command: /code/run.py --help 2>&1 | grep "searchlight"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "searchlight"'
     expected_output_contains: "searchlight"
 
   - name: Conditions argument
     description: Verify conditions_to_classify argument is available
-    command: /code/run.py --help 2>&1 | grep "conditions_to_classify"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "conditions_to_classify"'
     expected_output_contains: "conditions"
 
   - name: RSA argument
     description: Verify RSA mode argument is available
-    command: /code/run.py --help 2>&1 | grep "\-\-rsa"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-rsa"'
     expected_output_contains: "rsa"
 
   - name: Surface mode argument
     description: Verify surface analysis argument is available
-    command: /code/run.py --help 2>&1 | grep "\-\-surf"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-surf"'
     expected_output_contains: "surf"
 
   - name: Mask argument
     description: Verify mask argument is available
-    command: /code/run.py --help 2>&1 | grep "\-\-mask"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-mask"'
     expected_output_contains: "mask"
 
   - name: Polynomial detrending argument
     description: Verify poly_detrend argument is available
-    command: /code/run.py --help 2>&1 | grep "poly_detrend"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "poly_detrend"'
     expected_output_contains: "poly_detrend"
 
   - name: Time-series zscore argument
     description: Verify tzscore argument is available
-    command: /code/run.py --help 2>&1 | grep "tzscore"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "tzscore"'
     expected_output_contains: "tzscore"
 
   - name: Beta zscore argument
     description: Verify bzscore argument is available
-    command: /code/run.py --help 2>&1 | grep "bzscore"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "bzscore"'
     expected_output_contains: "bzscore"
 
   - name: Feature selection argument
     description: Verify feature_select argument is available
-    command: /code/run.py --help 2>&1 | grep "feature_select"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "feature_select"'
     expected_output_contains: "feature_select"
 
   - name: Cross-validation type argument
     description: Verify cvtype argument is available
-    command: /code/run.py --help 2>&1 | grep "cvtype"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "cvtype"'
     expected_output_contains: "cvtype"
 
   - name: LSS argument
     description: Verify LSS (Least Squares Single) argument is available
-    command: /code/run.py --help 2>&1 | grep "\-\-lss"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-lss"'
     expected_output_contains: "lss"
 
   - name: Individual trials argument
     description: Verify indiv_trials argument is available
-    command: /code/run.py --help 2>&1 | grep "indiv_trials"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "indiv_trials"'
     expected_output_contains: "indiv_trials"
 
   - name: No info label argument
     description: Verify noinfolabel argument is available
-    command: /code/run.py --help 2>&1 | grep "noinfolabel"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "noinfolabel"'
     expected_output_contains: "noinfolabel"
 
   - name: Distance metric argument
     description: Verify distance metric argument is available
-    command: /code/run.py --help 2>&1 | grep "\-\-dist"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-dist"'
     expected_output_contains: "dist"
 
   - name: Number of processors argument
     description: Verify nproc argument is available
-    command: /code/run.py --help 2>&1 | grep "nproc"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "nproc"'
     expected_output_contains: "nproc"
 
   - name: Skip BIDS validator argument
     description: Verify skip_bids_validator argument is available
-    command: /code/run.py --help 2>&1 | grep "skip_bids_validator"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "skip_bids_validator"'
     expected_output_contains: "skip_bids_validator"
 
   - name: Space argument for surface
     description: Verify space argument for surface mode is available
-    command: /code/run.py --help 2>&1 | grep "\-\-space"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-space"'
     expected_output_contains: "fsnative"
 
   - name: Hemisphere argument
     description: Verify hemisphere argument is available
-    command: /code/run.py --help 2>&1 | grep "\-\-hemi"
+    command: bash -lc '/code/run.py --help 2>&1 | grep "\-\-hemi"'
     expected_output_contains: "hemi"
 
   # ==========================================================================
@@ -362,12 +362,12 @@ tests:
   # ==========================================================================
   - name: Missing required arguments error
     description: Verify error when required arguments are missing
-    command: /code/run.py 2>&1 | head -20
+    command: bash -lc '/code/run.py 2>&1 | head -20'
     expected_output_contains: "usage"
 
   - name: Invalid analysis level error
     description: Verify error for invalid analysis level
-    command: /code/run.py /tmp /tmp invalid_level 2>&1 | tail -5
+    command: bash -lc '/code/run.py /tmp /tmp invalid_level 2>&1 | tail -5'
     expected_output_contains: "invalid choice"
 
   # ==========================================================================

--- a/recipes/bidsappspm/fulltest.yaml
+++ b/recipes/bidsappspm/fulltest.yaml
@@ -48,42 +48,42 @@ tests:
   # ==========================================================================
   - name: Version check
     description: Verify SPM BIDS App reports version information
-    command: /opt/spm12/run.sh --version 2>&1
+    command: bash -lc '/opt/spm12/run.sh --version 2>&1'
     expected_output_contains: "SPM12"
 
   - name: Version check - MATLAB runtime
     description: Verify MATLAB runtime version is reported
-    command: /opt/spm12/run.sh --version 2>&1
+    command: bash -lc '/opt/spm12/run.sh --version 2>&1'
     expected_output_contains: "MATLAB"
 
   - name: Version check - SPM revision
     description: Verify SPM revision number
-    command: /opt/spm12/run.sh --version 2>&1
+    command: bash -lc '/opt/spm12/run.sh --version 2>&1'
     expected_output_contains: "7771"
 
   - name: Help output
     description: Verify help documentation is displayed
-    command: /opt/spm12/run.sh --help 2>&1
+    command: bash -lc '/opt/spm12/run.sh --help 2>&1'
     expected_output_contains: "Usage: bids/spm BIDS_DIR OUTPUT_DIR LEVEL"
 
   - name: Help shows participant option
     description: Verify participant_label option is documented
-    command: /opt/spm12/run.sh --help 2>&1
+    command: bash -lc '/opt/spm12/run.sh --help 2>&1'
     expected_output_contains: "--participant_label"
 
   - name: Help shows config option
     description: Verify config file option is documented
-    command: /opt/spm12/run.sh --help 2>&1
+    command: bash -lc '/opt/spm12/run.sh --help 2>&1'
     expected_output_contains: "--config"
 
   - name: Help shows skip-bids-validator option
     description: Verify skip-bids-validator option is documented
-    command: /opt/spm12/run.sh --help 2>&1
+    command: bash -lc '/opt/spm12/run.sh --help 2>&1'
     expected_output_contains: "--skip-bids-validator"
 
   - name: Help shows analysis levels
     description: Verify participant and group levels are documented
-    command: /opt/spm12/run.sh --help 2>&1
+    command: bash -lc '/opt/spm12/run.sh --help 2>&1'
     expected_output_contains: "{participant,group}"
 
   # ==========================================================================
@@ -91,22 +91,22 @@ tests:
   # ==========================================================================
   - name: SPM executable exists
     description: Verify SPM12 compiled executable is present
-    command: ls -la /opt/spm12/spm12
+    command: "bash -lc 'ls -la /opt/spm12/spm12'"
     expected_output_contains: "spm12"
 
   - name: SPM CTF archive exists
     description: Verify SPM12 component technology file archive is present
-    command: ls -la /opt/spm12/spm12.ctf
+    command: "bash -lc 'ls -la /opt/spm12/spm12.ctf'"
     expected_output_contains: "spm12.ctf"
 
   - name: Run script exists
     description: Verify main run.sh script is present and executable
-    command: ls -la /opt/spm12/run.sh
+    command: "bash -lc 'ls -la /opt/spm12/run.sh'"
     expected_output_contains: "rwx"
 
   - name: MCR directory exists
     description: Verify MATLAB Compiler Runtime is installed
-    command: ls -d /opt/mcr/v97
+    command: "bash -lc 'ls -d /opt/mcr/v97'"
     expected_output_contains: "/opt/mcr/v97"
 
   - name: SPM_DIR environment variable
@@ -134,17 +134,17 @@ tests:
   # ==========================================================================
   - name: Participant pipeline exists
     description: Verify default participant-level pipeline configuration
-    command: ls -la /opt/spm12/pipeline_participant.m
+    command: "bash -lc 'ls -la /opt/spm12/pipeline_participant.m'"
     expected_output_contains: "pipeline_participant.m"
 
   - name: Group pipeline exists
     description: Verify default group-level pipeline configuration
-    command: ls -la /opt/spm12/pipeline_group.m
+    command: "bash -lc 'ls -la /opt/spm12/pipeline_group.m'"
     expected_output_contains: "pipeline_group.m"
 
   - name: BIDS App main script exists
     description: Verify spm_BIDS_App.m is present
-    command: ls -la /opt/spm12/spm_BIDS_App.m
+    command: "bash -lc 'ls -la /opt/spm12/spm_BIDS_App.m'"
     expected_output_contains: "spm_BIDS_App.m"
 
   # ==========================================================================
@@ -152,22 +152,22 @@ tests:
   # ==========================================================================
   - name: Error on missing BIDS directory
     description: Verify error when BIDS directory does not exist
-    command: /opt/spm12/run.sh /nonexistent/path ${output_dir}/bidsappspm participant 2>&1 || true
+    command: bash -lc '/opt/spm12/run.sh /nonexistent/path ${output_dir}/bidsappspm participant 2>&1 || true'
     expected_output_contains: "does not exist"
 
   - name: Error on missing output directory for group level
     description: Verify error when output directory missing for group analysis
-    command: /opt/spm12/run.sh ${bids_dir} /nonexistent/output group 2>&1 || true
+    command: bash -lc '/opt/spm12/run.sh ${bids_dir} /nonexistent/output group 2>&1 || true'
     expected_output_contains: "does not exist"
 
   - name: Error on invalid analysis level
     description: Verify error on unknown analysis level
-    command: /opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm invalid_level 2>&1 || true
+    command: bash -lc '/opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm invalid_level 2>&1 || true'
     expected_output_contains: "Unknown analysis level"
 
   - name: Error on missing participant
     description: Verify error when specified participant does not exist
-    command: /opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm participant --participant_label 99 --skip-bids-validator 2>&1 || true
+    command: bash -lc '/opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm participant --participant_label 99 --skip-bids-validator 2>&1 || true'
     expected_output_contains: "does not exist"
 
   # ==========================================================================
@@ -203,12 +203,12 @@ tests:
   # ==========================================================================
   - name: SPM MCR toolbox directory
     description: Verify SPM toolbox directory structure
-    command: ls /opt/spm12/spm12_mcr/toolbox/
+    command: "bash -lc 'ls /opt/spm12/spm12_mcr/toolbox/'"
     expected_exit_code: 0
 
   - name: SPM MCR spm12 directory
     description: Verify SPM12 MCR subdirectory exists
-    command: ls /opt/spm12/spm12_mcr/spm12/
+    command: "bash -lc 'ls /opt/spm12/spm12_mcr/spm12/'"
     expected_output_contains: "spm12"
 
   # ==========================================================================
@@ -217,8 +217,8 @@ tests:
   - name: Participant level dry run syntax
     description: Verify participant level command parses correctly (check syntax only)
     command: |
-      # Just verify the command structure is valid by checking help
-      /opt/spm12/run.sh --help 2>&1 | grep -q "participant" && echo "Command syntax valid"
+      bash -lc '# Just verify the command structure is valid by checking help
+      /opt/spm12/run.sh --help 2>&1 | grep -q "participant" && echo "Command syntax valid"'
     expected_output_contains: "Command syntax valid"
 
   # ==========================================================================
@@ -229,9 +229,9 @@ tests:
   - name: Participant preprocessing - single subject
     description: Run full fMRI preprocessing pipeline for one subject
     command: |
-      /opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_participant participant \
+      bash -lc '/opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_participant participant \
         --participant_label 02 \
-        --skip-bids-validator 2>&1
+        --skip-bids-validator 2>&1'
     timeout: 1800
     validate:
       - output_exists: ${output_dir}/bidsappspm_participant/sub-02
@@ -314,8 +314,8 @@ tests:
     description: Run group-level analysis (mean T1w computation)
     depends_on: Participant preprocessing - single subject
     command: |
-      /opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_participant group \
-        --skip-bids-validator 2>&1
+      bash -lc '/opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_participant group \
+        --skip-bids-validator 2>&1'
     timeout: 600
     ignore_exit_code: true
     expected_output_contains: "SPM"
@@ -334,9 +334,9 @@ tests:
   - name: Multi-subject preprocessing
     description: Process multiple subjects in parallel
     command: |
-      /opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_multi participant \
+      bash -lc '/opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_multi participant \
         --participant_label 02 03 \
-        --skip-bids-validator 2>&1
+        --skip-bids-validator 2>&1'
     timeout: 3600
     validate:
       - output_exists: ${output_dir}/bidsappspm_multi/sub-02
@@ -349,9 +349,9 @@ tests:
   - name: Handle missing T1w gracefully
     description: Check error handling when T1w is missing (sub-01)
     command: |
-      /opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_error participant \
+      bash -lc '/opt/spm12/run.sh ${bids_dir} ${output_dir}/bidsappspm_error participant \
         --participant_label 01 \
-        --skip-bids-validator 2>&1 || true
+        --skip-bids-validator 2>&1 || true'
     expected_output_contains: "does not exist"
     tags: [error_handling]
 
@@ -367,12 +367,12 @@ tests:
   # ==========================================================================
   - name: MCR runtime libraries
     description: Verify MCR runtime libraries are accessible
-    command: ls /opt/mcr/v97/runtime/glnxa64/
+    command: "bash -lc 'ls /opt/mcr/v97/runtime/glnxa64/'"
     expected_output_contains: "."
 
   - name: MCR bin libraries
     description: Verify MCR bin libraries are accessible
-    command: ls /opt/mcr/v97/bin/glnxa64/
+    command: "bash -lc 'ls /opt/mcr/v97/bin/glnxa64/'"
     expected_output_contains: "."
 
   - name: LD_LIBRARY_PATH includes MCR
@@ -398,7 +398,7 @@ tests:
   # ==========================================================================
   - name: SPM GUI option exists
     description: Verify --gui option is available (cannot run in headless mode)
-    command: /opt/spm12/run.sh --help 2>&1 || true
+    command: bash -lc '/opt/spm12/run.sh --help 2>&1 || true'
     # Note: --gui option triggers SPM GUI which requires display
     # This test just verifies the container can parse GUI-related requests
     expected_output_contains: "Usage"
@@ -419,7 +419,7 @@ tests:
   # ==========================================================================
   - name: Container size check
     description: Report container size for resource planning
-    command: ls -lh /opt/spm12/spm12.ctf | awk '{print "CTF archive size:", $5}'
+    command: "bash -lc 'ls -lh /opt/spm12/spm12.ctf | awk '\"'\"'{print \"CTF archive size:\", $5}'\"'\"''"
     expected_output_contains: "CTF archive size"
 
 cleanup:

--- a/recipes/brainager/fulltest.yaml
+++ b/recipes/brainager/fulltest.yaml
@@ -68,53 +68,53 @@ tests:
   # ==========================================================================
   - name: Check SPM12 directory
     description: Verify SPM12 installation directory exists
-    command: ls -la /opt/spm12/ | head -5
+    command: "bash -lc 'ls -la /opt/spm12/ | head -5'"
     expected_output_contains: "spm12"
 
   - name: Check MATLAB MCR
     description: Verify MATLAB Compiler Runtime is installed
-    command: ls /opt/mcr/v93/
+    command: "bash -lc 'ls /opt/mcr/v93/'"
     expected_output_contains: "runtime"
 
   - name: Check brainageR directory
     description: Verify brainageR installation directory exists
-    command: ls /opt/brainageR/
+    command: "bash -lc 'ls /opt/brainageR/'"
     expected_output_contains: "brainager_segment.py"
 
   - name: Check GPR model file
     description: Verify GPR model file exists
-    command: ls -la /opt/brainageR/GPR_model_gm_wm_csf.RData
+    command: "bash -lc 'ls -la /opt/brainageR/GPR_model_gm_wm_csf.RData'"
     expected_output_contains: "GPR_model"
 
   - name: Check PCA files
     description: Verify PCA transformation files exist
-    command: ls /opt/brainageR/*.rds
+    command: bash -lc 'ls /opt/brainageR/*.rds'
     expected_output_contains: "pca_center.rds"
 
   - name: Check templates directory
     description: Verify DARTEL templates are available
-    command: ls /opt/brainageR/templates/
+    command: "bash -lc 'ls /opt/brainageR/templates/'"
     expected_output_contains: "Template_6.nii"
 
   - name: Check average tissue templates
     description: Verify average tissue probability maps exist
-    command: ls /opt/brainageR/templates/average_smwc*.nii
+    command: bash -lc 'ls /opt/brainageR/templates/average_smwc*.nii'
     expected_output_contains: "average_smwc1.nii"
 
   - name: Check SPM TPM
     description: Verify SPM tissue probability maps exist
-    command: ls /opt/spm12/spm12_mcr/spm/spm12/tpm/TPM.nii
+    command: "bash -lc 'ls /opt/spm12/spm12_mcr/spm/spm12/tpm/TPM.nii'"
     expected_output_contains: "TPM.nii"
     expected_exit_code: 0
 
   - name: Check R prediction script
     description: Verify R prediction script exists
-    command: ls /opt/brainageR/predict_new_data_gm_wm_csf.R
+    command: "bash -lc 'ls /opt/brainageR/predict_new_data_gm_wm_csf.R'"
     expected_output_contains: "predict_new_data"
 
   - name: Check batch template
     description: Verify SPM batch template exists
-    command: ls /opt/brainageR/brainager_batch.m
+    command: "bash -lc 'ls /opt/brainageR/brainager_batch.m'"
     expected_output_contains: "brainager_batch.m"
 
   # ==========================================================================
@@ -178,12 +178,12 @@ tests:
   # ==========================================================================
   - name: Check example T1 in container
     description: Verify example T1 image exists in container
-    command: ls -la /opt/brainageR/chris_t1.nii.gz
+    command: "bash -lc 'ls -la /opt/brainageR/chris_t1.nii.gz'"
     expected_output_contains: "chris_t1.nii.gz"
 
   - name: Copy example T1 to test directory
     description: Copy the bundled example T1 to test output directory
-    command: cp /opt/brainageR/chris_t1.nii.gz ${output_dir}/
+    command: "bash -lc 'cp /opt/brainageR/chris_t1.nii.gz ${output_dir}/'"
     validate:
       - output_exists: ${output_dir}/chris_t1.nii.gz
 
@@ -288,7 +288,7 @@ tests:
 
   - name: Check SPM environment variables
     description: Verify SPM-related environment variables are set
-    command: env | grep -E "SPM|MCR" | head -5
+    command: "bash -lc 'env | grep -E \"SPM|MCR\" | head -5'"
     expected_output_contains: "SPM"
 
   # ==========================================================================
@@ -296,12 +296,12 @@ tests:
   # ==========================================================================
   - name: Test NIfTI header reading
     description: Verify R can read NIfTI headers
-    command: Rscript -e "library(RNifti); img <- readNifti('/opt/brainageR/chris_t1.nii.gz'); cat('Dimensions:', dim(img), '\n')"
+    command: "bash -lc 'Rscript -e \"library(RNifti); img <- readNifti('\"'\"'/opt/brainageR/chris_t1.nii.gz'\"'\"'); cat('\"'\"'Dimensions:'\"'\"', dim(img), '\"'\"'\\n'\"'\"')\"'"
     expected_output_contains: "Dimensions:"
 
   - name: Test template dimensions
     description: Verify template image dimensions match expected MNI space
-    command: Rscript -e "library(RNifti); img <- readNifti('/opt/brainageR/templates/Template_6.nii'); cat('Template dims:', dim(img), '\n')"
+    command: "bash -lc 'Rscript -e \"library(RNifti); img <- readNifti('\"'\"'/opt/brainageR/templates/Template_6.nii'\"'\"'); cat('\"'\"'Template dims:'\"'\"', dim(img), '\"'\"'\\n'\"'\"')\"'"
     expected_output_contains: "Template dims:"
 
   # ==========================================================================
@@ -309,17 +309,17 @@ tests:
   # ==========================================================================
   - name: Model file checksum
     description: Verify GPR model file integrity
-    command: md5sum /opt/brainageR/GPR_model_gm_wm_csf.RData | cut -d' ' -f1
+    command: "bash -lc 'md5sum /opt/brainageR/GPR_model_gm_wm_csf.RData | cut -d'\"'\"' '\"'\"' -f1'"
     expected_exit_code: 0
 
   - name: PCA center checksum
     description: Verify PCA center file integrity
-    command: md5sum /opt/brainageR/pca_center.rds | cut -d' ' -f1
+    command: "bash -lc 'md5sum /opt/brainageR/pca_center.rds | cut -d'\"'\"' '\"'\"' -f1'"
     expected_exit_code: 0
 
   - name: Training labels check
     description: Verify training labels file exists and has content
-    command: wc -l /opt/brainageR/brains.train_labels.csv
+    command: "bash -lc 'wc -l /opt/brainageR/brains.train_labels.csv'"
     expected_output_contains: "brains.train_labels.csv"
 
   # ==========================================================================
@@ -327,12 +327,12 @@ tests:
   # ==========================================================================
   - name: Batch template check
     description: Verify batch processing template scripts exist
-    command: ls /opt/brainageR/*template*.sh 2>/dev/null | head -3
+    command: bash -lc 'ls /opt/brainageR/*template*.sh 2>/dev/null | head -3'
     expected_output_contains: "template"
 
   - name: Collate script check
     description: Verify result collation script exists
-    command: ls /opt/brainageR/collate_brain_ages.sh
+    command: "bash -lc 'ls /opt/brainageR/collate_brain_ages.sh'"
     expected_output_contains: "collate_brain_ages.sh"
 
 cleanup:

--- a/recipes/brainnetviewer/fulltest.yaml
+++ b/recipes/brainnetviewer/fulltest.yaml
@@ -58,12 +58,12 @@ tests:
   # ==========================================================================
   - name: BrainNet binary exists
     description: Verify BrainNet compiled binary is present at container root
-    command: test -f /BrainNet && echo "BrainNet binary found"
+    command: bash -lc 'test -f /BrainNet && echo "BrainNet binary found"'
     expected_output_contains: "BrainNet binary found"
 
   - name: BrainNet binary is executable
     description: Verify BrainNet binary has execute permissions
-    command: test -x /BrainNet && echo "BrainNet is executable"
+    command: bash -lc 'test -x /BrainNet && echo "BrainNet is executable"'
     expected_output_contains: "BrainNet is executable"
 
   - name: BrainNet binary is ELF executable
@@ -78,12 +78,12 @@ tests:
 
   - name: brainnetviewer wrapper script exists
     description: Verify brainnetviewer wrapper script is in /usr/bin
-    command: test -f /usr/bin/brainnetviewer && echo "Wrapper script found"
+    command: bash -lc 'test -f /usr/bin/brainnetviewer && echo "Wrapper script found"'
     expected_output_contains: "Wrapper script found"
 
   - name: brainnetviewer wrapper is executable
     description: Verify brainnetviewer wrapper has execute permissions
-    command: test -x /usr/bin/brainnetviewer && echo "Wrapper is executable"
+    command: bash -lc 'test -x /usr/bin/brainnetviewer && echo "Wrapper is executable"'
     expected_output_contains: "Wrapper is executable"
 
   - name: brainnetviewer wrapper content
@@ -98,12 +98,12 @@ tests:
 
   - name: Run script exists
     description: Verify run_BrainNet.sh wrapper script is present
-    command: test -f /run_BrainNet.sh && echo "Run script found"
+    command: bash -lc 'test -f /run_BrainNet.sh && echo "Run script found"'
     expected_output_contains: "Run script found"
 
   - name: Run script is executable
     description: Verify run_BrainNet.sh has execute permissions
-    command: test -x /run_BrainNet.sh && echo "Run script executable"
+    command: bash -lc 'test -x /run_BrainNet.sh && echo "Run script executable"'
     expected_output_contains: "Run script executable"
 
   # ==========================================================================
@@ -149,57 +149,57 @@ tests:
   # ==========================================================================
   - name: MCR directory exists
     description: Verify MATLAB Compiler Runtime is installed
-    command: test -d /opt/matlab/v94 && echo "MCR v94 directory found"
+    command: bash -lc 'test -d /opt/matlab/v94 && echo "MCR v94 directory found"'
     expected_output_contains: "MCR v94 directory found"
 
   - name: MCR version is R2018a
     description: Verify MCR version matches BrainNet requirements (R2018a)
-    command: cat /opt/matlab/v94/VersionInfo.xml
+    command: "bash -lc 'cat /opt/matlab/v94/VersionInfo.xml'"
     expected_output_contains: "R2018a"
 
   - name: MCR version number 9.4
     description: Verify MCR version 9.4 is installed
-    command: cat /opt/matlab/v94/VersionInfo.xml
+    command: "bash -lc 'cat /opt/matlab/v94/VersionInfo.xml'"
     expected_output_contains: "9.4"
 
   - name: MCR runtime libraries exist
     description: Verify MCR runtime library directory is present
-    command: test -d /opt/matlab/v94/runtime/glnxa64 && echo "MCR runtime found"
+    command: bash -lc 'test -d /opt/matlab/v94/runtime/glnxa64 && echo "MCR runtime found"'
     expected_output_contains: "MCR runtime found"
 
   - name: MCR bin libraries exist
     description: Verify MCR bin library directory is present
-    command: test -d /opt/matlab/v94/bin/glnxa64 && echo "MCR bin found"
+    command: bash -lc 'test -d /opt/matlab/v94/bin/glnxa64 && echo "MCR bin found"'
     expected_output_contains: "MCR bin found"
 
   - name: MCR system libraries exist
     description: Verify MCR system OS libraries are present
-    command: test -d /opt/matlab/v94/sys/os/glnxa64 && echo "MCR sys/os found"
+    command: bash -lc 'test -d /opt/matlab/v94/sys/os/glnxa64 && echo "MCR sys/os found"'
     expected_output_contains: "MCR sys/os found"
 
   - name: MCR OpenGL libraries exist
     description: Verify MCR OpenGL libraries directory is present
-    command: test -d /opt/matlab/v94/sys/opengl/lib/glnxa64 && echo "OpenGL libs found"
+    command: bash -lc 'test -d /opt/matlab/v94/sys/opengl/lib/glnxa64 && echo "OpenGL libs found"'
     expected_output_contains: "OpenGL libs found"
 
   - name: MCR toolbox directory exists
     description: Verify MCR toolbox directory is present
-    command: test -d /opt/matlab/v94/toolbox && echo "MCR toolbox found"
+    command: bash -lc 'test -d /opt/matlab/v94/toolbox && echo "MCR toolbox found"'
     expected_output_contains: "MCR toolbox found"
 
   - name: MCR Java runtime exists
     description: Verify MCR Java Runtime Environment is present
-    command: test -d /opt/matlab/v94/java && echo "MCR Java found"
+    command: bash -lc 'test -d /opt/matlab/v94/java && echo "MCR Java found"'
     expected_output_contains: "MCR Java found"
 
   - name: MCR resources directory exists
     description: Verify MCR resources directory is present
-    command: test -d /opt/matlab/v94/resources && echo "MCR resources found"
+    command: bash -lc 'test -d /opt/matlab/v94/resources && echo "MCR resources found"'
     expected_output_contains: "MCR resources found"
 
   - name: MCR extern directory exists
     description: Verify MCR extern directory is present
-    command: test -d /opt/matlab/v94/extern && echo "MCR extern found"
+    command: bash -lc 'test -d /opt/matlab/v94/extern && echo "MCR extern found"'
     expected_output_contains: "MCR extern found"
 
   # ==========================================================================
@@ -207,24 +207,22 @@ tests:
   # ==========================================================================
   - name: libmwmclmcrrt library exists
     description: Verify core MCR library is present
-    command: ls /opt/matlab/v94/runtime/glnxa64/libmwmclmcrrt.so* 2>/dev/null | head -1 && echo "libmwmclmcrrt found"
+    command: bash -lc 'ls /opt/matlab/v94/runtime/glnxa64/libmwmclmcrrt.so* 2>/dev/null | head -1 && echo "libmwmclmcrrt found"'
     expected_output_contains: "libmwmclmcrrt found"
 
   - name: MCR has runtime shared libraries
     description: Verify MCR runtime has shared libraries
-    command: ls /opt/matlab/v94/runtime/glnxa64/*.so* 2>/dev/null | wc -l
+    command: bash -lc 'ls /opt/matlab/v94/runtime/glnxa64/*.so* 2>/dev/null | wc -l'
     expected_exit_code: 0
 
   - name: MCR has bin shared libraries
     description: Verify MCR bin has shared libraries
-    command: ls /opt/matlab/v94/bin/glnxa64/*.so* 2>/dev/null | wc -l
+    command: bash -lc 'ls /opt/matlab/v94/bin/glnxa64/*.so* 2>/dev/null | wc -l'
     expected_exit_code: 0
 
   - name: MCR runtime library count
     description: Verify MCR has runtime libraries present
-    command: |
-      count=$(ls -1 /opt/matlab/v94/runtime/glnxa64/ 2>/dev/null | wc -l)
-      if [ "$count" -gt 2 ]; then echo "MCR runtime has $count files"; else echo "MCR incomplete"; fi
+    command: "bash -lc 'count=$(ls -1 /opt/matlab/v94/runtime/glnxa64/ 2>/dev/null | wc -l)\nif [ \"$count\" -gt 2 ]; then echo \"MCR runtime has $count files\"; else echo \"MCR incomplete\"; fi'"
     expected_output_contains: "MCR runtime has"
 
   # ==========================================================================
@@ -232,7 +230,7 @@ tests:
   # ==========================================================================
   - name: README exists in container root
     description: Verify README.md is present at container root
-    command: test -f /README.md && echo "README found"
+    command: bash -lc 'test -f /README.md && echo "README found"'
     expected_output_contains: "README found"
 
   - name: README contains BrainNet Viewer info
@@ -272,7 +270,7 @@ tests:
 
   - name: readme.txt exists
     description: Verify readme.txt is present at container root
-    command: test -f /readme.txt && echo "readme.txt found"
+    command: bash -lc 'test -f /readme.txt && echo "readme.txt found"'
     expected_output_contains: "readme.txt found"
 
   - name: readme.txt mentions MCR version
@@ -295,17 +293,17 @@ tests:
   # ==========================================================================
   - name: MCR license file exists
     description: Verify MCR license file is present
-    command: test -f /opt/matlab/v94/MCR_license.txt && echo "MCR license found"
+    command: bash -lc 'test -f /opt/matlab/v94/MCR_license.txt && echo "MCR license found"'
     expected_output_contains: "MCR license found"
 
   - name: MCR patents file exists
     description: Verify MCR patents file is present
-    command: test -f /opt/matlab/v94/patents.txt && echo "MCR patents found"
+    command: bash -lc 'test -f /opt/matlab/v94/patents.txt && echo "MCR patents found"'
     expected_output_contains: "MCR patents found"
 
   - name: MCR trademarks file exists
     description: Verify MCR trademarks file is present
-    command: test -f /opt/matlab/v94/trademarks.txt && echo "MCR trademarks found"
+    command: bash -lc 'test -f /opt/matlab/v94/trademarks.txt && echo "MCR trademarks found"'
     expected_output_contains: "MCR trademarks found"
 
   # ==========================================================================
@@ -377,27 +375,27 @@ tests:
   # ==========================================================================
   - name: Reproenv JSON exists
     description: Verify reproenv build metadata is present
-    command: test -f /.reproenv.json && echo "reproenv.json found"
+    command: bash -lc 'test -f /.reproenv.json && echo "reproenv.json found"'
     expected_output_contains: "reproenv.json found"
 
   - name: Singularity environment directory exists
     description: Verify Singularity metadata directory is present
-    command: test -d /.singularity.d && echo "Singularity metadata found"
+    command: bash -lc 'test -d /.singularity.d && echo "Singularity metadata found"'
     expected_output_contains: "Singularity metadata found"
 
   - name: Singularity runscript exists
     description: Verify Singularity runscript is present
-    command: test -f /.singularity.d/runscript && echo "Runscript found"
+    command: bash -lc 'test -f /.singularity.d/runscript && echo "Runscript found"'
     expected_output_contains: "Runscript found"
 
   - name: Environment scripts exist
     description: Verify environment setup scripts are present
-    command: test -d /.singularity.d/env && ls /.singularity.d/env/*.sh | wc -l
+    command: bash -lc 'test -d /.singularity.d/env && ls /.singularity.d/env/*.sh | wc -l'
     expected_exit_code: 0
 
   - name: Singularity labels present
     description: Verify Singularity labels file exists
-    command: test -f /.singularity.d/labels.json && echo "Labels file found"
+    command: bash -lc 'test -f /.singularity.d/labels.json && echo "Labels file found"'
     expected_output_contains: "Labels file found"
 
   # ==========================================================================
@@ -405,27 +403,27 @@ tests:
   # ==========================================================================
   - name: Standard mount points exist
     description: Verify standard mount point directories are present
-    command: test -d /data && echo "Data mount point found"
+    command: bash -lc 'test -d /data && echo "Data mount point found"'
     expected_output_contains: "Data mount point found"
 
   - name: Home directory accessible
     description: Verify home directory is accessible
-    command: test -d /home && echo "Home accessible"
+    command: bash -lc 'test -d /home && echo "Home accessible"'
     expected_output_contains: "Home accessible"
 
   - name: Tmp directory exists and writable
     description: Verify tmp directory exists and is writable
-    command: test -d /tmp && test -w /tmp && echo "Tmp writable"
+    command: bash -lc 'test -d /tmp && test -w /tmp && echo "Tmp writable"'
     expected_output_contains: "Tmp writable"
 
   - name: Proc filesystem mounted
     description: Verify proc filesystem is mounted
-    command: test -d /proc && echo "Proc mounted"
+    command: bash -lc 'test -d /proc && echo "Proc mounted"'
     expected_output_contains: "Proc mounted"
 
   - name: Neurodesktop storage directory exists
     description: Verify neurodesktop-storage mount point exists
-    command: test -d /neurodesktop-storage && echo "Neurodesktop storage found"
+    command: bash -lc 'test -d /neurodesktop-storage && echo "Neurodesktop storage found"'
     expected_output_contains: "Neurodesktop storage found"
 
   # ==========================================================================
@@ -450,7 +448,7 @@ tests:
   # ==========================================================================
   - name: System x86_64 libraries exist
     description: Verify system x86_64 library directory is present
-    command: test -d /usr/lib/x86_64-linux-gnu && echo "x86_64 libs found" || test -d /lib64 && echo "lib64 found"
+    command: bash -lc 'test -d /usr/lib/x86_64-linux-gnu && echo "x86_64 libs found" || test -d /lib64 && echo "lib64 found"'
     expected_exit_code: 0
 
   - name: Basic system utilities available
@@ -473,24 +471,22 @@ tests:
   # ==========================================================================
   - name: MCR MATLAB toolbox exists
     description: Verify core MATLAB toolbox is present
-    command: test -d /opt/matlab/v94/toolbox/matlab && echo "MATLAB toolbox found"
+    command: bash -lc 'test -d /opt/matlab/v94/toolbox/matlab && echo "MATLAB toolbox found"'
     expected_output_contains: "MATLAB toolbox found"
 
   - name: MCR shared toolbox exists
     description: Verify shared toolbox directory is present
-    command: test -d /opt/matlab/v94/toolbox/shared && echo "Shared toolbox found"
+    command: bash -lc 'test -d /opt/matlab/v94/toolbox/shared && echo "Shared toolbox found"'
     expected_output_contains: "Shared toolbox found"
 
   - name: MCR cefclient exists
     description: Verify CEF client directory is present (for web rendering)
-    command: test -d /opt/matlab/v94/cefclient && echo "CEF client found"
+    command: bash -lc 'test -d /opt/matlab/v94/cefclient && echo "CEF client found"'
     expected_output_contains: "CEF client found"
 
   - name: MCR resources count
     description: Verify MCR resources directory has content
-    command: |
-      count=$(ls -1 /opt/matlab/v94/resources/ 2>/dev/null | wc -l)
-      echo "MCR resources count: $count"
+    command: "bash -lc 'count=$(ls -1 /opt/matlab/v94/resources/ 2>/dev/null | wc -l)\necho \"MCR resources count: $count\"'"
     expected_exit_code: 0
 
   # ==========================================================================

--- a/recipes/brainstorm/fulltest.yaml
+++ b/recipes/brainstorm/fulltest.yaml
@@ -63,34 +63,32 @@ tests:
   # ==========================================================================
   - name: Brainstorm installation directory exists
     description: Verify main brainstorm directory exists
-    command: ls -la /opt/brainstorm-3.211130/
+    command: "bash -lc 'ls -la /opt/brainstorm-3.211130/'"
     expected_output_contains: "brainstorm3.command"
 
   - name: Brainstorm command script exists
     description: Verify brainstorm3.command script is present
-    command: test -f /opt/brainstorm-3.211130/brainstorm3.command && echo "Script exists"
+    command: bash -lc 'test -f /opt/brainstorm-3.211130/brainstorm3.command && echo "Script exists"'
     expected_output_contains: "Script exists"
 
   - name: Brainstorm command script executable
     description: Verify brainstorm3.command is executable
-    command: test -x /opt/brainstorm-3.211130/brainstorm3.command && echo "Executable"
+    command: bash -lc 'test -x /opt/brainstorm-3.211130/brainstorm3.command && echo "Executable"'
     expected_output_contains: "Executable"
 
   - name: Brainstorm JAR file exists
     description: Verify brainstorm3.jar compiled application exists
-    command: test -f /opt/brainstorm-3.211130/brainstorm3.jar && echo "JAR exists"
+    command: bash -lc 'test -f /opt/brainstorm-3.211130/brainstorm3.jar && echo "JAR exists"'
     expected_output_contains: "JAR exists"
 
   - name: Brainstorm JAR file size check
     description: Verify JAR file is complete (approximately 64MB)
-    command: |
-      size=$(stat -c%s /opt/brainstorm-3.211130/brainstorm3.jar 2>/dev/null || stat -f%z /opt/brainstorm-3.211130/brainstorm3.jar)
-      if [ "$size" -gt 60000000 ]; then echo "JAR size OK: $size bytes"; else echo "JAR too small: $size bytes"; fi
+    command: "bash -lc 'size=$(stat -c%s /opt/brainstorm-3.211130/brainstorm3.jar 2>/dev/null || stat -f%z /opt/brainstorm-3.211130/brainstorm3.jar)\nif [ \"$size\" -gt 60000000 ]; then echo \"JAR size OK: $size bytes\"; else echo \"JAR too small: $size bytes\"; fi'"
     expected_output_contains: "JAR size OK"
 
   - name: Brainstorm batch file exists
     description: Verify Windows batch file exists (for cross-platform support)
-    command: test -f /opt/brainstorm-3.211130/brainstorm3.bat && echo "Batch file exists"
+    command: bash -lc 'test -f /opt/brainstorm-3.211130/brainstorm3.bat && echo "Batch file exists"'
     expected_output_contains: "Batch file exists"
 
   # ==========================================================================
@@ -98,42 +96,42 @@ tests:
   # ==========================================================================
   - name: MCR installation directory exists
     description: Verify MCR v98 directory exists
-    command: ls -la /opt/MCR/v98/
+    command: "bash -lc 'ls -la /opt/MCR/v98/'"
     expected_output_contains: "runtime"
 
   - name: MCR version verification
     description: Verify MCR version is R2020a
-    command: cat /opt/MCR/v98/VersionInfo.xml
+    command: "bash -lc 'cat /opt/MCR/v98/VersionInfo.xml'"
     expected_output_contains: "R2020a"
 
   - name: MCR version number check
     description: Verify MCR version 9.8
-    command: cat /opt/MCR/v98/VersionInfo.xml
+    command: "bash -lc 'cat /opt/MCR/v98/VersionInfo.xml'"
     expected_output_contains: "9.8"
 
   - name: MCR runtime directory exists
     description: Verify MCR runtime libraries exist
-    command: test -d /opt/MCR/v98/runtime && echo "Runtime directory exists"
+    command: bash -lc 'test -d /opt/MCR/v98/runtime && echo "Runtime directory exists"'
     expected_output_contains: "Runtime directory exists"
 
   - name: MCR bin directory exists
     description: Verify MCR bin directory exists
-    command: test -d /opt/MCR/v98/bin && echo "Bin directory exists"
+    command: bash -lc 'test -d /opt/MCR/v98/bin && echo "Bin directory exists"'
     expected_output_contains: "Bin directory exists"
 
   - name: MCR toolbox directory exists
     description: Verify MCR toolbox directory exists
-    command: test -d /opt/MCR/v98/toolbox && echo "Toolbox directory exists"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox && echo "Toolbox directory exists"'
     expected_output_contains: "Toolbox directory exists"
 
   - name: MCR native library exists (Linux x64)
     description: Verify native dynamic loader library exists
-    command: test -f /opt/MCR/v98/bin/glnxa64/libnativedl.so && echo "Native library exists"
+    command: bash -lc 'test -f /opt/MCR/v98/bin/glnxa64/libnativedl.so && echo "Native library exists"'
     expected_output_contains: "Native library exists"
 
   - name: MCR license file exists
     description: Verify MCR license file is present
-    command: test -f /opt/MCR/v98/MCR_license.txt && echo "License exists"
+    command: bash -lc 'test -f /opt/MCR/v98/MCR_license.txt && echo "License exists"'
     expected_output_contains: "License exists"
 
   # ==========================================================================
@@ -141,22 +139,22 @@ tests:
   # ==========================================================================
   - name: Java installation exists
     description: Verify Java JRE is installed in MCR
-    command: test -d /opt/MCR/v98/sys/java/jre/glnxa64/jre && echo "Java JRE exists"
+    command: bash -lc 'test -d /opt/MCR/v98/sys/java/jre/glnxa64/jre && echo "Java JRE exists"'
     expected_output_contains: "Java JRE exists"
 
   - name: Java executable exists
     description: Verify Java executable exists
-    command: test -f /opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java && echo "Java executable exists"
+    command: bash -lc 'test -f /opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java && echo "Java executable exists"'
     expected_output_contains: "Java executable exists"
 
   - name: Java version check
     description: Verify Java version is 1.8
-    command: /opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java -version 2>&1
+    command: bash -lc '/opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java -version 2>&1'
     expected_output_contains: "1.8"
 
   - name: Java runtime environment check
     description: Verify Java runtime environment
-    command: /opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java -version 2>&1
+    command: bash -lc '/opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java -version 2>&1'
     expected_output_contains: "Java(TM) SE Runtime Environment"
 
   # ==========================================================================
@@ -164,42 +162,42 @@ tests:
   # ==========================================================================
   - name: Brainstorm help/usage display
     description: Verify brainstorm displays usage information
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "brainstorm start"
 
   - name: Brainstorm usage shows nogui mode
     description: Verify nogui mode is documented
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "nogui"
 
   - name: Brainstorm usage shows server mode
     description: Verify server mode is documented
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "server"
 
   - name: Brainstorm usage shows update command
     description: Verify update command is documented
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "update"
 
   - name: Brainstorm usage shows reset command
     description: Verify reset command is documented
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "reset"
 
   - name: Brainstorm usage shows tutorial command
     description: Verify tutorial command is documented
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "tutorial"
 
   - name: Brainstorm usage shows digitize command
     description: Verify digitize (Polhemus) command is documented
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "digitize"
 
   - name: Brainstorm returns without errors
     description: Verify compiled code returns without errors on help
-    command: /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true
+    command: bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 || true'
     expected_output_contains: "Compiled code returned without errors"
 
   # ==========================================================================
@@ -207,27 +205,27 @@ tests:
   # ==========================================================================
   - name: Brainstorm server mode startup
     description: Test server mode initialization (timeout after 30s)
-    command: timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true
+    command: "bash -lc 'timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true'"
     expected_output_contains: "Starting Brainstorm"
 
   - name: Brainstorm server mode version display
     description: Verify version is displayed during startup
-    command: timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true
+    command: "bash -lc 'timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true'"
     expected_output_contains: "Version"
 
   - name: Brainstorm server mode loads configuration
     description: Verify configuration is loaded
-    command: timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true
+    command: "bash -lc 'timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true'"
     expected_output_contains: "Loading configuration"
 
   - name: Brainstorm server mode loads montages
     description: Verify default montages are loaded
-    command: timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true
+    command: "bash -lc 'timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true'"
     expected_output_contains: "Loading default montages"
 
   - name: Brainstorm server mode reads processes
     description: Verify process folder is read
-    command: timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true
+    command: "bash -lc 'timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 || true'"
     expected_output_contains: "Reading process folder"
 
   # ==========================================================================
@@ -235,22 +233,22 @@ tests:
   # ==========================================================================
   - name: MCR signal processing toolbox
     description: Verify simbio toolbox exists (signal not bundled in this MCR)
-    command: test -d /opt/MCR/v98/toolbox/simbio && echo "Simbio toolbox exists"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/simbio && echo "Simbio toolbox exists"'
     expected_output_contains: "Simbio toolbox exists"
 
   - name: MCR parallel toolbox
     description: Verify parallel computing toolbox exists
-    command: test -d /opt/MCR/v98/toolbox/parallel && echo "Parallel toolbox exists"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/parallel && echo "Parallel toolbox exists"'
     expected_output_contains: "Parallel toolbox exists"
 
   - name: MCR images toolbox
     description: Verify image processing toolbox exists
-    command: test -d /opt/MCR/v98/toolbox/images && echo "Images toolbox exists"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/images && echo "Images toolbox exists"'
     expected_output_contains: "Images toolbox exists"
 
   - name: MCR shared toolbox
     description: Verify shared toolbox exists
-    command: test -d /opt/MCR/v98/toolbox/shared && echo "Shared toolbox exists"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/shared && echo "Shared toolbox exists"'
     expected_output_contains: "Shared toolbox exists"
 
   # ==========================================================================
@@ -258,12 +256,12 @@ tests:
   # ==========================================================================
   - name: MCR BLAS library exists
     description: Verify BLAS library is present
-    command: ls /opt/MCR/v98/bin/glnxa64/*blas* 2>/dev/null | head -1 && echo "BLAS found" || echo "BLAS not found"
+    command: bash -lc 'ls /opt/MCR/v98/bin/glnxa64/*blas* 2>/dev/null | head -1 && echo "BLAS found" || echo "BLAS not found"'
     expected_output_contains: "BLAS"
 
   - name: MCR LAPACK library exists
     description: Verify LAPACK library is present
-    command: ls /opt/MCR/v98/bin/glnxa64/*lapack* 2>/dev/null | head -1 && echo "LAPACK found" || echo "LAPACK not found"
+    command: bash -lc 'ls /opt/MCR/v98/bin/glnxa64/*lapack* 2>/dev/null | head -1 && echo "LAPACK found" || echo "LAPACK not found"'
     expected_output_contains: "LAPACK"
 
   # ==========================================================================
@@ -272,8 +270,8 @@ tests:
   - name: MATLABROOT configuration saved
     description: Verify MCR path is saved after first run
     command: |
-      /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 > /dev/null
-      test -f ~/.brainstorm/MATLABROOT98.txt && cat ~/.brainstorm/MATLABROOT98.txt
+      bash -lc '/opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 --help 2>&1 > /dev/null
+      test -f ~/.brainstorm/MATLABROOT98.txt && cat ~/.brainstorm/MATLABROOT98.txt'
     expected_output_contains: "/opt/MCR/v98"
 
   - name: Brainstorm defaults directory structure
@@ -296,7 +294,7 @@ tests:
 
   - name: GitHub repository label
     description: Verify container has GitHub repository label
-    command: cat /.singularity.d/labels.json 2>/dev/null || echo "No labels"
+    command: "bash -lc 'cat /.singularity.d/labels.json 2>/dev/null || echo \"No labels\"'"
     expected_output_contains: "NeuroDesk"
 
   # ==========================================================================
@@ -304,17 +302,17 @@ tests:
   # ==========================================================================
   - name: Standard mount point /data exists
     description: Verify /data mount point exists
-    command: test -d /data && echo "Data mount exists" || echo "No data mount"
+    command: bash -lc 'test -d /data && echo "Data mount exists" || echo "No data mount"'
     expected_exit_code: 0
 
   - name: Standard mount point /mnt exists
     description: Verify /mnt mount point exists
-    command: test -d /mnt && echo "Mnt mount exists"
+    command: bash -lc 'test -d /mnt && echo "Mnt mount exists"'
     expected_output_contains: "Mnt mount exists"
 
   - name: Home directory accessible
     description: Verify home directory is accessible
-    command: test -d /home && echo "Home accessible"
+    command: bash -lc 'test -d /home && echo "Home accessible"'
     expected_output_contains: "Home accessible"
 
   # ==========================================================================
@@ -323,17 +321,13 @@ tests:
   - name: Brainstorm script detects Linux system
     description: Verify script correctly identifies Linux
     command: |
-      source /opt/brainstorm-3.211130/brainstorm3.command 2>/dev/null <<< "" || true
-      if [ $(uname -s) == "Linux" ]; then echo "Linux detected"; fi
+      bash -lc 'source /opt/brainstorm-3.211130/brainstorm3.command 2>/dev/null <<< "" || true
+      if [ $(uname -s) == "Linux" ]; then echo "Linux detected"; fi'
     expected_output_contains: "Linux detected"
 
   - name: Brainstorm script finds JAR file
     description: Verify script logic can locate JAR file
-    command: |
-      SH_DIR="/opt/brainstorm-3.211130"
-      if [ -f "$SH_DIR/brainstorm3.jar" ]; then
-        echo "JAR found at: $SH_DIR/brainstorm3.jar"
-      fi
+    command: "bash -lc 'SH_DIR=\"/opt/brainstorm-3.211130\"\nif [ -f \"$SH_DIR/brainstorm3.jar\" ]; then\n  echo \"JAR found at: $SH_DIR/brainstorm3.jar\"\nfi'"
     expected_output_contains: "JAR found"
 
   # ==========================================================================
@@ -341,9 +335,7 @@ tests:
   # ==========================================================================
   - name: MCR cache creation
     description: Verify MCR creates cache on first run
-    command: |
-      timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 > /dev/null || true
-      test -d ~/.mcrCache9.8 && echo "MCR cache created" || echo "No MCR cache"
+    command: "bash -lc 'timeout 30 /opt/brainstorm-3.211130/brainstorm3.command /opt/MCR/v98 server 2>&1 > /dev/null || true\ntest -d ~/.mcrCache9.8 && echo \"MCR cache created\" || echo \"No MCR cache\"'"
     expected_output_contains: "MCR cache created"
 
 cleanup:

--- a/recipes/cat12/fulltest.yaml
+++ b/recipes/cat12/fulltest.yaml
@@ -46,22 +46,22 @@ tests:
   # ==========================================================================
   - name: SPM12 runner script exists
     description: Verify the main SPM12 runner script is present
-    command: test -f /opt/cat12/run_spm12.sh && echo "run_spm12.sh exists"
+    command: bash -lc 'test -f /opt/cat12/run_spm12.sh && echo "run_spm12.sh exists"'
     expected_output_contains: "run_spm12.sh exists"
 
   - name: MCR installation exists
     description: Verify MATLAB Compiler Runtime is installed
-    command: test -d /opt/mcr/v93 && echo "MCR v93 installed"
+    command: bash -lc 'test -d /opt/mcr/v93 && echo "MCR v93 installed"'
     expected_output_contains: "MCR v93 installed"
 
   - name: CAT12 standalone directory exists
     description: Verify CAT12 standalone batch files are present
-    command: ls /opt/cat12/standalone/*.m | wc -l
+    command: bash -lc 'ls /opt/cat12/standalone/*.m | wc -l'
     expected_output_contains: "13"
 
   - name: SPM12 binary exists
     description: Verify compiled SPM12 binary is present
-    command: test -x /opt/cat12/spm12 && echo "spm12 binary exists"
+    command: bash -lc 'test -x /opt/cat12/spm12 && echo "spm12 binary exists"'
     expected_output_contains: "spm12 binary exists"
 
   # ==========================================================================
@@ -69,72 +69,72 @@ tests:
   # ==========================================================================
   - name: Segmentation batch file exists
     description: Verify standard segmentation batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_segment.m && echo "segment batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_segment.m && echo "segment batch exists"'
     expected_output_contains: "segment batch exists"
 
   - name: Simple processing batch file exists
     description: Verify simple processing batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_simple.m && echo "simple batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_simple.m && echo "simple batch exists"'
     expected_output_contains: "simple batch exists"
 
   - name: Longitudinal segmentation batch exists
     description: Verify longitudinal processing batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_segment_long.m && echo "long batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_segment_long.m && echo "long batch exists"'
     expected_output_contains: "long batch exists"
 
   - name: ENIGMA segmentation batch exists
     description: Verify ENIGMA protocol batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_segment_enigma.m && echo "enigma batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_segment_enigma.m && echo "enigma batch exists"'
     expected_output_contains: "enigma batch exists"
 
   - name: Deface batch file exists
     description: Verify de-facing batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_deface.m && echo "deface batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_deface.m && echo "deface batch exists"'
     expected_output_contains: "deface batch exists"
 
   - name: Surface resample batch file exists
     description: Verify surface resampling batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_resample.m && echo "resample batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_resample.m && echo "resample batch exists"'
     expected_output_contains: "resample batch exists"
 
   - name: Smoothing batch file exists
     description: Verify smoothing batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_smooth.m && echo "smooth batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_smooth.m && echo "smooth batch exists"'
     expected_output_contains: "smooth batch exists"
 
   - name: TIV calculation batch file exists
     description: Verify total intracranial volume batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_get_TIV.m && echo "TIV batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_get_TIV.m && echo "TIV batch exists"'
     expected_output_contains: "TIV batch exists"
 
   - name: Quality measures batch file exists
     description: Verify quality measures batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_get_quality.m && echo "quality batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_get_quality.m && echo "quality batch exists"'
     expected_output_contains: "quality batch exists"
 
   - name: IQR batch file exists
     description: Verify image quality rating batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_get_IQR.m && echo "IQR batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_get_IQR.m && echo "IQR batch exists"'
     expected_output_contains: "IQR batch exists"
 
   - name: ROI values batch file exists
     description: Verify ROI extraction batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_get_ROI_values.m && echo "ROI batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_get_ROI_values.m && echo "ROI batch exists"'
     expected_output_contains: "ROI batch exists"
 
   - name: TFCE batch file exists
     description: Verify threshold-free cluster enhancement batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_tfce.m && echo "TFCE batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_tfce.m && echo "TFCE batch exists"'
     expected_output_contains: "TFCE batch exists"
 
   - name: DICOM import batch file exists
     description: Verify DICOM to NIfTI conversion batch file
-    command: test -f /opt/cat12/standalone/cat_standalone_dicom2nii.m && echo "dicom2nii batch exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_standalone_dicom2nii.m && echo "dicom2nii batch exists"'
     expected_output_contains: "dicom2nii batch exists"
 
   - name: Parallelization script exists
     description: Verify parallelization helper script
-    command: test -f /opt/cat12/standalone/cat_parallelize.sh && echo "parallelize script exists"
+    command: bash -lc 'test -f /opt/cat12/standalone/cat_parallelize.sh && echo "parallelize script exists"'
     expected_output_contains: "parallelize script exists"
 
   # ==========================================================================
@@ -142,12 +142,12 @@ tests:
   # ==========================================================================
   - name: CAT12 standalone help
     description: Test cat_standalone.sh help output
-    command: /opt/cat12/standalone/cat_standalone.sh --help 2>&1 | head -20
+    command: bash -lc '/opt/cat12/standalone/cat_standalone.sh --help 2>&1 | head -20'
     expected_output_contains: "USAGE"
 
   - name: CAT12 standalone version info
     description: Verify cat_standalone.sh contains version information
-    command: /opt/cat12/standalone/cat_standalone.sh -V 2>&1 | head -5
+    command: bash -lc '/opt/cat12/standalone/cat_standalone.sh -V 2>&1 | head -5'
     expected_output_contains: "cat_standalone.sh"
 
   # ==========================================================================
@@ -155,12 +155,12 @@ tests:
   # ==========================================================================
   - name: TPM templates directory exists
     description: Verify tissue probability map templates are present
-    command: ls /opt/cat12/spm12_mcr/spm12/spm12/toolbox/cat12/templates_MNI152NLin2009cAsym/ 2>/dev/null | head -5 || ls /opt/cat12/spm12_mcr/home/gaser/spm/spm12/toolbox/cat12/templates_MNI152NLin2009cAsym/ 2>/dev/null | head -5 || echo "templates found"
+    command: "bash -lc 'ls /opt/cat12/spm12_mcr/spm12/spm12/toolbox/cat12/templates_MNI152NLin2009cAsym/ 2>/dev/null | head -5 || ls /opt/cat12/spm12_mcr/home/gaser/spm/spm12/toolbox/cat12/templates_MNI152NLin2009cAsym/ 2>/dev/null | head -5 || echo \"templates found\"'"
     expected_exit_code: 0
 
   - name: CAT12 atlas files present
     description: Verify CAT12 atlas files are available
-    command: find /opt/cat12 -name "*atlas*" -type f 2>/dev/null | head -3 || echo "atlas search complete"
+    command: "bash -lc 'find /opt/cat12 -name \"*atlas*\" -type f 2>/dev/null | head -3 || echo \"atlas search complete\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -168,9 +168,7 @@ tests:
   # ==========================================================================
   - name: SPM12 MCR initialization
     description: Test SPM12 can initialize with MCR (basic startup test)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ quit 2>&1 | tail -20 || echo "SPM12 init test complete"
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ quit 2>&1 | tail -20 || echo \"SPM12 init test complete\"'"
     expected_exit_code: 0
     timeout: 180
 
@@ -194,11 +192,7 @@ tests:
 
   - name: CAT12 segmentation dry run
     description: Verify segmentation batch file can be parsed (no actual processing)
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_segment.m ${output_dir}/cat12_work/test_segment.m && \
-      NIIFILE="${output_dir}/sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|'${NIIFILE}'|g" ${output_dir}/cat12_work/test_segment.m && \
-      head -30 ${output_dir}/cat12_work/test_segment.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_segment.m ${output_dir}/cat12_work/test_segment.m && \\\nNIIFILE=\"${output_dir}/sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|'\"'\"'${NIIFILE}'\"'\"'|g\" ${output_dir}/cat12_work/test_segment.m && \\\nhead -30 ${output_dir}/cat12_work/test_segment.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "matlabbatch"
 
@@ -207,11 +201,7 @@ tests:
   # ==========================================================================
   - name: CAT12 simple batch preparation
     description: Prepare simple processing batch for testing
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_simple.m ${output_dir}/cat12_work/test_simple.m && \
-      NIIFILE="${output_dir}/sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|'${NIIFILE}'|g" ${output_dir}/cat12_work/test_simple.m && \
-      grep -c "matlabbatch" ${output_dir}/cat12_work/test_simple.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_simple.m ${output_dir}/cat12_work/test_simple.m && \\\nNIIFILE=\"${output_dir}/sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|'\"'\"'${NIIFILE}'\"'\"'|g\" ${output_dir}/cat12_work/test_simple.m && \\\ngrep -c \"matlabbatch\" ${output_dir}/cat12_work/test_simple.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_exit_code: 0
 
@@ -220,22 +210,13 @@ tests:
   # ==========================================================================
   - name: Prepare smoothing batch
     description: Prepare volume smoothing batch file
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_smooth.m ${output_dir}/cat12_work/test_smooth.m && \
-      # Add FWHM setting
-      echo "matlabbatch{1}.spm.spatial.smooth.fwhm = [6 6 6];" >> ${output_dir}/cat12_work/test_smooth.m && \
-      echo "matlabbatch{1}.spm.spatial.smooth.prefix = 's6';" >> ${output_dir}/cat12_work/test_smooth.m && \
-      NIIFILE="${output_dir}/sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|{'${NIIFILE}'}|g" ${output_dir}/cat12_work/test_smooth.m && \
-      cat ${output_dir}/cat12_work/test_smooth.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_smooth.m ${output_dir}/cat12_work/test_smooth.m && \\\n# Add FWHM setting\necho \"matlabbatch{1}.spm.spatial.smooth.fwhm = [6 6 6];\" >> ${output_dir}/cat12_work/test_smooth.m && \\\necho \"matlabbatch{1}.spm.spatial.smooth.prefix = '\"'\"'s6'\"'\"';\" >> ${output_dir}/cat12_work/test_smooth.m && \\\nNIIFILE=\"${output_dir}/sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${NIIFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_smooth.m && \\\ncat ${output_dir}/cat12_work/test_smooth.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "matlabbatch"
 
   - name: Run SPM12 smoothing
     description: Test SPM12 smoothing via CAT12 container (quick operation)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 300 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_smooth.m 2>&1 | tail -30
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 300 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_smooth.m 2>&1 | tail -30'"
     depends_on: Prepare smoothing batch
     timeout: 360
     validate:
@@ -246,19 +227,13 @@ tests:
   # ==========================================================================
   - name: Prepare deface batch
     description: Prepare de-facing batch file
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_deface.m ${output_dir}/cat12_work/test_deface.m && \
-      NIIFILE="${output_dir}/sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|{'${NIIFILE}'}|g" ${output_dir}/cat12_work/test_deface.m && \
-      cat ${output_dir}/cat12_work/test_deface.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_deface.m ${output_dir}/cat12_work/test_deface.m && \\\nNIIFILE=\"${output_dir}/sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${NIIFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_deface.m && \\\ncat ${output_dir}/cat12_work/test_deface.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "matlabbatch"
 
   - name: Run SPM12 deface
     description: Test SPM12 de-facing operation
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 300 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_deface.m 2>&1 | tail -30
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 300 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_deface.m 2>&1 | tail -30'"
     depends_on: Prepare deface batch
     timeout: 360
     validate:
@@ -270,11 +245,11 @@ tests:
   - name: CAT standalone segment help
     description: Test cat_standalone.sh with segment batch help
     command: |
-      /opt/cat12/standalone/cat_standalone.sh \
+      bash -lc '/opt/cat12/standalone/cat_standalone.sh \
         -s /opt/cat12 \
         -m /opt/mcr/v93 \
         -b /opt/cat12/standalone/cat_standalone_segment.m \
-        --help 2>&1 | head -30 || echo "Help displayed"
+        --help 2>&1 | head -30 || echo "Help displayed"'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -282,23 +257,13 @@ tests:
   # ==========================================================================
   - name: Prepare no-surface segmentation batch
     description: Create segmentation batch without surface processing (faster)
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_segment.m ${output_dir}/cat12_work/test_segment_nosurf.m && \
-      # Disable surface processing for faster test
-      sed -i "s/output.surface = 1/output.surface = 0/g" ${output_dir}/cat12_work/test_segment_nosurf.m && \
-      # Disable verbose printing
-      sed -i "s/admin.print = 2/admin.print = 0/g" ${output_dir}/cat12_work/test_segment_nosurf.m && \
-      NIIFILE="${output_dir}/sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|{'${NIIFILE}'}|g" ${output_dir}/cat12_work/test_segment_nosurf.m && \
-      grep "output.surface" ${output_dir}/cat12_work/test_segment_nosurf.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_segment.m ${output_dir}/cat12_work/test_segment_nosurf.m && \\\n# Disable surface processing for faster test\nsed -i \"s/output.surface = 1/output.surface = 0/g\" ${output_dir}/cat12_work/test_segment_nosurf.m && \\\n# Disable verbose printing\nsed -i \"s/admin.print = 2/admin.print = 0/g\" ${output_dir}/cat12_work/test_segment_nosurf.m && \\\nNIIFILE=\"${output_dir}/sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${NIIFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_segment_nosurf.m && \\\ngrep \"output.surface\" ${output_dir}/cat12_work/test_segment_nosurf.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "surface = 0"
 
   - name: Run CAT12 segmentation (no surface)
     description: Run CAT12 segmentation - known container bug (MEX files need GLIBC_2.29 but container has older glibc)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_segment_nosurf.m 2>&1
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_segment_nosurf.m 2>&1'"
     depends_on: Prepare no-surface segmentation batch
     timeout: 180
     expected_output_contains: "CAT Preprocessing error"
@@ -329,23 +294,20 @@ tests:
 
   - name: Verify MEX file glibc requirement
     description: Confirm container bug - CAT12 MEX files require GLIBC_2.29 not available in container
-    command: |
-      ldd /opt/cat12/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_sanlm.mexa64 2>&1
+    command: "bash -lc 'ldd /opt/cat12/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/cat_sanlm.mexa64 2>&1'"
     expected_output_contains: "GLIBC_2.29"
 
   - name: Verify all CAT12 MEX files present
     description: Check that MEX files exist (they are present but incompatible with container glibc)
     command: |
-      count=$(ls /opt/cat12/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/*.mexa64 2>/dev/null | wc -l)
+      bash -lc 'count=$(ls /opt/cat12/spm12_mcr/home/gaser/gaser/spm/spm12/toolbox/cat12/*.mexa64 2>/dev/null | wc -l)
       echo "Found $count MEX files"
-      [ "$count" -gt 10 ] && echo "MEX files present" || echo "MEX files missing"
+      [ "$count" -gt 10 ] && echo "MEX files present" || echo "MEX files missing"'
     expected_output_contains: "MEX files present"
 
   - name: Verify CAT12 batch error handling
     description: Check that ignoreErrors=1 in batch allows SPM12 to continue after MEX failure
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_segment_nosurf.m 2>&1 | tail -5
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_segment_nosurf.m 2>&1 | tail -5'"
     depends_on: Prepare no-surface segmentation batch
     timeout: 180
     expected_output_contains: "Bye for now"
@@ -355,21 +317,13 @@ tests:
   # ==========================================================================
   - name: Prepare TIV extraction batch
     description: Prepare total intracranial volume extraction batch file
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_get_TIV.m ${output_dir}/cat12_work/test_tiv.m && \
-      XMLFILE="${output_dir}/report/cat_sub-01_T1w.xml" && \
-      sed -i "s|'<UNDEFINED>'|{'${XMLFILE}'}|g" ${output_dir}/cat12_work/test_tiv.m && \
-      echo "matlabbatch{1}.spm.tools.cat.tools.calcvol.calcvol_TIV = 0;" >> ${output_dir}/cat12_work/test_tiv.m && \
-      echo "matlabbatch{1}.spm.tools.cat.tools.calcvol.calcvol_name = 'TIV_output.txt';" >> ${output_dir}/cat12_work/test_tiv.m && \
-      cat ${output_dir}/cat12_work/test_tiv.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_get_TIV.m ${output_dir}/cat12_work/test_tiv.m && \\\nXMLFILE=\"${output_dir}/report/cat_sub-01_T1w.xml\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${XMLFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_tiv.m && \\\necho \"matlabbatch{1}.spm.tools.cat.tools.calcvol.calcvol_TIV = 0;\" >> ${output_dir}/cat12_work/test_tiv.m && \\\necho \"matlabbatch{1}.spm.tools.cat.tools.calcvol.calcvol_name = '\"'\"'TIV_output.txt'\"'\"';\" >> ${output_dir}/cat12_work/test_tiv.m && \\\ncat ${output_dir}/cat12_work/test_tiv.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "calcvol"
 
   - name: Run TIV extraction
     description: Run TIV extraction - fails on MEX error (known container bug, same GLIBC_2.29 issue)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_tiv.m 2>&1
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_tiv.m 2>&1'"
     depends_on: Prepare TIV extraction batch
     timeout: 180
     expected_output_contains: "Bye for now"
@@ -379,21 +333,13 @@ tests:
   # ==========================================================================
   - name: Prepare quality measures batch
     description: Prepare sample homogeneity/quality check batch file
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_get_quality.m ${output_dir}/cat12_work/test_quality.m && \
-      NIIFILE="${output_dir}/mri/mwp1sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|{'${NIIFILE}'}|g" ${output_dir}/cat12_work/test_quality.m && \
-      echo "matlabbatch{1}.spm.tools.cat.tools.quality_measures.csv_name = 'quality_output.csv';" >> ${output_dir}/cat12_work/test_quality.m && \
-      echo "matlabbatch{1}.spm.tools.cat.tools.quality_measures.globals = 1;" >> ${output_dir}/cat12_work/test_quality.m && \
-      cat ${output_dir}/cat12_work/test_quality.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_get_quality.m ${output_dir}/cat12_work/test_quality.m && \\\nNIIFILE=\"${output_dir}/mri/mwp1sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${NIIFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_quality.m && \\\necho \"matlabbatch{1}.spm.tools.cat.tools.quality_measures.csv_name = '\"'\"'quality_output.csv'\"'\"';\" >> ${output_dir}/cat12_work/test_quality.m && \\\necho \"matlabbatch{1}.spm.tools.cat.tools.quality_measures.globals = 1;\" >> ${output_dir}/cat12_work/test_quality.m && \\\ncat ${output_dir}/cat12_work/test_quality.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "quality_measures"
 
   - name: Run quality measures
     description: Run quality measures - input missing (segmentation failed due to GLIBC_2.29 MEX bug)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_quality.m 2>&1
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_quality.m 2>&1'"
     depends_on: Prepare quality measures batch
     timeout: 180
     ignore_exit_code: true
@@ -404,20 +350,13 @@ tests:
   # ==========================================================================
   - name: Prepare IQR extraction batch
     description: Prepare image quality rating extraction batch file
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_get_IQR.m ${output_dir}/cat12_work/test_iqr.m && \
-      XMLFILE="${output_dir}/report/cat_sub-01_T1w.xml" && \
-      sed -i "s|'<UNDEFINED>'|{'${XMLFILE}'}|g" ${output_dir}/cat12_work/test_iqr.m && \
-      echo "matlabbatch{1}.spm.tools.cat.tools.iqr.iqr_name = 'IQR_output.txt';" >> ${output_dir}/cat12_work/test_iqr.m && \
-      cat ${output_dir}/cat12_work/test_iqr.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_get_IQR.m ${output_dir}/cat12_work/test_iqr.m && \\\nXMLFILE=\"${output_dir}/report/cat_sub-01_T1w.xml\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${XMLFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_iqr.m && \\\necho \"matlabbatch{1}.spm.tools.cat.tools.iqr.iqr_name = '\"'\"'IQR_output.txt'\"'\"';\" >> ${output_dir}/cat12_work/test_iqr.m && \\\ncat ${output_dir}/cat12_work/test_iqr.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "iqr"
 
   - name: Run IQR extraction
     description: Run IQR extraction - input missing (segmentation failed due to GLIBC_2.29 MEX bug)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_iqr.m 2>&1
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_iqr.m 2>&1'"
     depends_on: Prepare IQR extraction batch
     timeout: 180
     expected_output_contains: "Bye for now"
@@ -427,21 +366,13 @@ tests:
   # ==========================================================================
   - name: Prepare GM smoothing batch
     description: Prepare smoothing batch for modulated GM (input would come from segmentation)
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_smooth.m ${output_dir}/cat12_work/test_smooth_gm.m && \
-      echo "matlabbatch{1}.spm.spatial.smooth.fwhm = [8 8 8];" >> ${output_dir}/cat12_work/test_smooth_gm.m && \
-      echo "matlabbatch{1}.spm.spatial.smooth.prefix = 's8';" >> ${output_dir}/cat12_work/test_smooth_gm.m && \
-      NIIFILE="${output_dir}/mri/mwp1sub-01_T1w.nii" && \
-      sed -i "s|'<UNDEFINED>'|{'${NIIFILE}'}|g" ${output_dir}/cat12_work/test_smooth_gm.m && \
-      cat ${output_dir}/cat12_work/test_smooth_gm.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_smooth.m ${output_dir}/cat12_work/test_smooth_gm.m && \\\necho \"matlabbatch{1}.spm.spatial.smooth.fwhm = [8 8 8];\" >> ${output_dir}/cat12_work/test_smooth_gm.m && \\\necho \"matlabbatch{1}.spm.spatial.smooth.prefix = '\"'\"'s8'\"'\"';\" >> ${output_dir}/cat12_work/test_smooth_gm.m && \\\nNIIFILE=\"${output_dir}/mri/mwp1sub-01_T1w.nii\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${NIIFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_smooth_gm.m && \\\ncat ${output_dir}/cat12_work/test_smooth_gm.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "smooth"
 
   - name: Run GM smoothing
     description: Run GM smoothing - input missing (segmentation failed due to GLIBC_2.29 MEX bug)
-    command: |
-      cd ${output_dir}/cat12_work && \
-      timeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_smooth_gm.m 2>&1
+    command: "bash -lc 'cd ${output_dir}/cat12_work && \\\ntimeout 120 /opt/cat12/run_spm12.sh /opt/mcr/v93/ batch test_smooth_gm.m 2>&1'"
     depends_on: Prepare GM smoothing batch
     timeout: 180
     ignore_exit_code: true
@@ -452,12 +383,7 @@ tests:
   # ==========================================================================
   - name: Prepare ROI extraction batch
     description: Prepare ROI-based volume extraction batch file
-    command: |
-      cp /opt/cat12/standalone/cat_standalone_get_ROI_values.m ${output_dir}/cat12_work/test_roi.m && \
-      XMLFILE="${output_dir}/label/catROI_sub-01_T1w.xml" && \
-      sed -i "s|'<UNDEFINED>'|{'${XMLFILE}'}|g" ${output_dir}/cat12_work/test_roi.m && \
-      echo "matlabbatch{1}.spm.tools.cat.tools.calcroi.calcroi_name = 'ROI_values';" >> ${output_dir}/cat12_work/test_roi.m && \
-      grep "calcroi" ${output_dir}/cat12_work/test_roi.m
+    command: "bash -lc 'cp /opt/cat12/standalone/cat_standalone_get_ROI_values.m ${output_dir}/cat12_work/test_roi.m && \\\nXMLFILE=\"${output_dir}/label/catROI_sub-01_T1w.xml\" && \\\nsed -i \"s|'\"'\"'<UNDEFINED>'\"'\"'|{'\"'\"'${XMLFILE}'\"'\"'}|g\" ${output_dir}/cat12_work/test_roi.m && \\\necho \"matlabbatch{1}.spm.tools.cat.tools.calcroi.calcroi_name = '\"'\"'ROI_values'\"'\"';\" >> ${output_dir}/cat12_work/test_roi.m && \\\ngrep \"calcroi\" ${output_dir}/cat12_work/test_roi.m'"
     depends_on: Prepare uncompressed T1w for CAT12
     expected_output_contains: "calcroi"
 

--- a/recipes/code/fulltest.yaml
+++ b/recipes/code/fulltest.yaml
@@ -39,32 +39,32 @@ tests:
   # ==========================================================================
   - name: VSCode version check
     description: Verify VSCode binary runs and reports version
-    command: /usr/bin/code --version 2>&1 | head -1
+    command: bash -lc '/usr/bin/code --version 2>&1 | head -1'
     expected_output_contains: "1.76.1"
 
   - name: VSCode help
     description: Verify VSCode help command works
-    command: /usr/bin/code --help 2>&1 | head -5
+    command: bash -lc '/usr/bin/code --help 2>&1 | head -5'
     expected_output_contains: "Visual Studio Code"
 
   - name: VSCode list extensions
     description: List installed VSCode extensions
-    command: /usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1
+    command: bash -lc '/usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1'
     expected_output_contains: "ms-python.python"
 
   - name: VSCode Python extension
     description: Verify Python extension is installed
-    command: /usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1
+    command: bash -lc '/usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1'
     expected_output_contains: "ms-python.vscode-pylance"
 
   - name: VSCode Julia extension
     description: Verify Julia extension is installed
-    command: /usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1
+    command: bash -lc '/usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1'
     expected_output_contains: "julialang.language-julia"
 
   - name: VSCode Jupyter extension
     description: Verify Jupyter extension is installed
-    command: /usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1
+    command: bash -lc '/usr/bin/code --list-extensions --extensions-dir=/opt/vscode-extensions 2>&1'
     expected_output_contains: "ms-toolsai.jupyter"
 
   # ==========================================================================
@@ -416,39 +416,39 @@ tests:
   # ==========================================================================
   - name: Julia version
     description: Verify Julia version
-    command: /opt/julia-1.6.3/bin/julia --version 2>&1
+    command: bash -lc '/opt/julia-1.6.3/bin/julia --version 2>&1'
     expected_output_contains: "julia version 1.6.3"
 
   - name: Julia help
     description: Verify Julia help works
-    command: /opt/julia-1.6.3/bin/julia --help 2>&1 | head -5
+    command: bash -lc '/opt/julia-1.6.3/bin/julia --help 2>&1 | head -5'
     expected_output_contains: "julia"
 
   - name: Julia basic execution
     description: Test basic Julia execution
-    command: /opt/julia-1.6.3/bin/julia -e 'println(2 + 2)'
+    command: bash -lc '/opt/julia-1.6.3/bin/julia -e '\''println(2 + 2)'\'''
     expected_output_contains: "4"
 
   - name: Julia array operations
     description: Test Julia array creation and sum
-    command: "/opt/julia-1.6.3/bin/julia -e 'a = [1, 2, 3, 4, 5]; println(\"Sum: \", sum(a))'"
+    command: "bash -lc '/opt/julia-1.6.3/bin/julia -e '\"'\"'a = [1, 2, 3, 4, 5]; println(\"Sum: \", sum(a))'\"'\"''"
     expected_output_contains: "Sum: 15"
 
   - name: Julia matrix operations
     description: Test Julia matrix multiplication
-    command: "/opt/julia-1.6.3/bin/julia -e 'using LinearAlgebra; A = [1 2; 3 4]; println(\"Det: \", det(A))'"
+    command: "bash -lc '/opt/julia-1.6.3/bin/julia -e '\"'\"'using LinearAlgebra; A = [1 2; 3 4]; println(\"Det: \", det(A))'\"'\"''"
     expected_output_contains: "Det: -2.0"
 
   - name: Julia file I/O
     description: Test Julia can write and read files
     command: |
-      /opt/julia-1.6.3/bin/julia -e '
+      bash -lc '/opt/julia-1.6.3/bin/julia -e '\''
       open("${output_dir}/julia_test.txt", "w") do f
           write(f, "Hello from Julia!")
       end
       content = read("${output_dir}/julia_test.txt", String)
       println(content)
-      '
+      '\'''
     expected_output_contains: "Hello from Julia"
     validate:
       - output_exists: ${output_dir}/julia_test.txt

--- a/recipes/conn/fulltest.yaml
+++ b/recipes/conn/fulltest.yaml
@@ -53,27 +53,27 @@ tests:
   # ==========================================================================
   - name: CONN version check
     description: Verify CONN returns version string
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn('ver'))\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn('\''ver'\''))\""'
     expected_output_contains: "22.a"
 
   - name: SPM version check
     description: Verify SPM12 is available in CONN
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(spm('ver'))\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(spm('\''ver'\''))\""'
     expected_output_contains: "SPM12"
 
   - name: MATLAB platform check
     description: Verify MATLAB runtime platform
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(computer)\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(computer)\""'
     expected_output_contains: "GLNXA64"
 
   - name: CONN cache initialization
     description: Initialize CONN cache directory
-    command: /opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 cache
+    command: bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 cache'
     expected_output_contains: "cache"
 
   - name: Display test message
     description: Verify basic disp functionality
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 disp \"'CONN test suite initialized'\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 disp \"'\''CONN test suite initialized'\''\""'
     expected_output_contains: "CONN test suite"
 
   # ==========================================================================
@@ -81,17 +81,17 @@ tests:
   # ==========================================================================
   - name: Batch command recognition
     description: Test conn_batch function exists
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_batch\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_batch\""'
     expected_output_contains: "conn_batch"
 
   - name: Run MATLAB command pwd
     description: Test run command with pwd
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"pwd\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"pwd\""'
     expected_output_contains: "ans"
 
   - name: Run MATLAB date command
     description: Test run command with date
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(date)\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(date)\""'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -99,27 +99,27 @@ tests:
   # ==========================================================================
   - name: SPM vol read header
     description: Read NIfTI header using spm_vol
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');disp(V.dim)\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');disp(V.dim)\"'"
     expected_output_contains: "128"
 
   - name: SPM vol dimensions
     description: Verify T2 image dimensions
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');disp(['Dims ' num2str(V.dim)])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');disp(['\"'\"'Dims '\"'\"' num2str(V.dim)])\"'"
     expected_output_contains: "128"
 
   - name: SPM vol datatype
     description: Check image datatype via spm_vol
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');disp(V.dt)\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');disp(V.dt)\"'"
     expected_exit_code: 0
 
   - name: SPM read voxels
     description: Read voxel data using spm_read_vols
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');Y=spm_read_vols(V);disp(['Size ' num2str(size(Y))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');Y=spm_read_vols(V);disp(['\"'\"'Size '\"'\"' num2str(size(Y))])\"'"
     expected_output_contains: "128"
 
   - name: SPM vol voxel size
     description: Get voxel dimensions from header
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');vox=sqrt(sum(V.mat(1:3,1:3).^2));disp(['Voxel size ' num2str(vox)])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');vox=sqrt(sum(V.mat(1:3,1:3).^2));disp(['\"'\"'Voxel size '\"'\"' num2str(vox)])\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -127,27 +127,27 @@ tests:
   # ==========================================================================
   - name: CONN existfile function
     description: Test conn_existfile with existing file
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_existfile('test_output/sub-01_inplaneT2.nii'))\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_existfile('\''test_output/sub-01_inplaneT2.nii'\''))\""'
     expected_output_contains: "1"
 
   - name: CONN existfile nonexistent
     description: Test conn_existfile with nonexistent file
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_existfile('nonexistent_file.nii'))\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_existfile('\''nonexistent_file.nii'\''))\""'
     expected_output_contains: "0"
 
   - name: CONN fullfile function
     description: Test conn_fullfile path construction
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_fullfile('/path','to','file.nii'))\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_fullfile('\''/path'\'','\''to'\'','\''file.nii'\''))\""'
     expected_output_contains: "file.nii"
 
   - name: CONN dir function
     description: Test conn_dir directory listing
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"files=conn_dir('test_output/*.nii');disp(length(files))\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"files=conn_dir('\"'\"'test_output/*.nii'\"'\"');disp(length(files))\"'"
     expected_exit_code: 0
 
   - name: CONN prepend function
     description: Test conn_prepend filename prepending
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_prepend('r','test_output/sub-01_inplaneT2.nii'))\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"disp(conn_prepend('\''r'\'','\''test_output/sub-01_inplaneT2.nii'\''))\""'
     expected_output_contains: "rsub-01"
 
   # ==========================================================================
@@ -155,17 +155,17 @@ tests:
   # ==========================================================================
   - name: CONN vol_read function exists
     description: Verify conn_vol_read is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_vol_read\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_vol_read\""'
     expected_output_contains: "conn_vol_read"
 
   - name: CONN vol_write function exists
     description: Verify conn_vol_write is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_vol_write\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_vol_write\""'
     expected_output_contains: "conn_vol_write"
 
   - name: CONN file function exists
     description: Verify conn_file is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_file\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_file\""'
     expected_output_contains: "conn_file"
 
   # ==========================================================================
@@ -173,27 +173,27 @@ tests:
   # ==========================================================================
   - name: SPM smooth function available
     description: Verify spm_smooth is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_smooth\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_smooth\""'
     expected_output_contains: "spm_smooth"
 
   - name: SPM realign function available
     description: Verify spm_realign is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_realign\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_realign\""'
     expected_output_contains: "spm_realign"
 
   - name: SPM coregister function available
     description: Verify spm_coreg is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_coreg\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_coreg\""'
     expected_output_contains: "spm_coreg"
 
   - name: SPM reslice function available
     description: Verify spm_reslice is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_reslice\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_reslice\""'
     expected_output_contains: "spm_reslice"
 
   - name: SPM preproc8 (segmentation) available
     description: Verify spm_preproc8 is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_preproc8\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_preproc8\""'
     expected_output_contains: "spm_preproc8"
 
   # ==========================================================================
@@ -201,27 +201,27 @@ tests:
   # ==========================================================================
   - name: CONN GLM function available
     description: Verify conn_glm is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_glm\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_glm\""'
     expected_output_contains: "conn_glm"
 
   - name: CONN FDR correction available
     description: Verify conn_fdr is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_fdr\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_fdr\""'
     expected_output_contains: "conn_fdr"
 
   - name: CONN FDR calculation
     description: Test FDR correction on p-values
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"p=[0.001 0.01 0.05 0.1];q=conn_fdr(p);disp(q)\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"p=[0.001 0.01 0.05 0.1];q=conn_fdr(p);disp(q)\"'"
     expected_exit_code: 0
 
   - name: CONN TFCE available
     description: Verify conn_tfce is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_tfce\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_tfce\""'
     expected_output_contains: "conn_tfce"
 
   - name: CONN clusters available
     description: Verify conn_clusters is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_clusters\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_clusters\""'
     expected_output_contains: "conn_clusters"
 
   # ==========================================================================
@@ -229,27 +229,27 @@ tests:
   # ==========================================================================
   - name: CONN filter function available
     description: Verify conn_filter is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_filter\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_filter\""'
     expected_output_contains: "conn_filter"
 
   - name: CONN bandpass filter test
     description: Test bandpass filtering on simulated data
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"x=randn(100,1);y=conn_filter(2,[0.01 0.1],x);disp(['Filtered size ' num2str(length(y))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"x=randn(100,1);y=conn_filter(2,[0.01 0.1],x);disp(['\"'\"'Filtered size '\"'\"' num2str(length(y))])\"'"
     expected_output_contains: "100"
 
   - name: CONN despike function available
     description: Verify conn_despike is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_despike\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_despike\""'
     expected_output_contains: "conn_despike"
 
   - name: CONN detrend function (wdemean)
     description: Verify conn_wdemean is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_wdemean\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_wdemean\""'
     expected_output_contains: "conn_wdemean"
 
   - name: CONN derivative function
     description: Verify conn_deriv is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_deriv\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_deriv\""'
     expected_output_contains: "conn_deriv"
 
   # ==========================================================================
@@ -257,32 +257,32 @@ tests:
   # ==========================================================================
   - name: CONN surf_read function available
     description: Verify conn_surf_read is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_read\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_read\""'
     expected_output_contains: "conn_surf_read"
 
   - name: CONN surf_write function available
     description: Verify conn_surf_write is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_write\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_write\""'
     expected_output_contains: "conn_surf_write"
 
   - name: CONN surf_vol2surf available
     description: Verify conn_surf_vol2surf is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_vol2surf\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_vol2surf\""'
     expected_output_contains: "conn_surf_vol2surf"
 
   - name: CONN surf_surf2vol available
     description: Verify conn_surf_surf2vol is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_surf2vol\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_surf2vol\""'
     expected_output_contains: "conn_surf_surf2vol"
 
   - name: CONN surf_smooth available
     description: Verify conn_surf_smooth is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_smooth\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_smooth\""'
     expected_output_contains: "conn_surf_smooth"
 
   - name: CONN surf_resample available
     description: Verify conn_surf_resample is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_resample\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_surf_resample\""'
     expected_output_contains: "conn_surf_resample"
 
   # ==========================================================================
@@ -290,27 +290,27 @@ tests:
   # ==========================================================================
   - name: CONN network_measures available
     description: Verify conn_network_measures is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_network_measures\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_network_measures\""'
     expected_output_contains: "conn_network_measures"
 
   - name: CONN randomise available
     description: Verify conn_randomise is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_randomise\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_randomise\""'
     expected_output_contains: "conn_randomise"
 
   - name: CONN statscluster available
     description: Verify conn_statscluster is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_statscluster\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_statscluster\""'
     expected_output_contains: "conn_statscluster"
 
   - name: CONN statslinkage available
     description: Verify conn_statslinkage is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_statslinkage\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_statslinkage\""'
     expected_output_contains: "conn_statslinkage"
 
   - name: CONN statsdendrogram available
     description: Verify conn_statsdendrogram is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_statsdendrogram\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_statsdendrogram\""'
     expected_output_contains: "conn_statsdendrogram"
 
   # ==========================================================================
@@ -318,27 +318,27 @@ tests:
   # ==========================================================================
   - name: CONN rex function available
     description: Verify conn_rex is available (ROI extraction)
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_rex\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_rex\""'
     expected_output_contains: "conn_rex"
 
   - name: CONN roicenters available
     description: Verify conn_roicenters is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roicenters\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roicenters\""'
     expected_output_contains: "conn_roicenters"
 
   - name: CONN roilabels available
     description: Verify conn_roilabels is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roilabels\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roilabels\""'
     expected_output_contains: "conn_roilabels"
 
   - name: CONN createmniroi available
     description: Verify conn_createmniroi is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_createmniroi\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_createmniroi\""'
     expected_output_contains: "conn_createmniroi"
 
   - name: CONN createvoxelroi available
     description: Verify conn_createvoxelroi is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_createvoxelroi\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_createvoxelroi\""'
     expected_output_contains: "conn_createvoxelroi"
 
   # ==========================================================================
@@ -346,22 +346,22 @@ tests:
   # ==========================================================================
   - name: CONN slice_display available
     description: Verify conn_slice_display is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_slice_display\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_slice_display\""'
     expected_output_contains: "conn_slice_display"
 
   - name: CONN displayroi available
     description: Verify conn_displayroi is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_displayroi\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_displayroi\""'
     expected_output_contains: "conn_displayroi"
 
   - name: CONN displaynetwork available
     description: Verify conn_displaynetwork is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_displaynetwork\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_displaynetwork\""'
     expected_output_contains: "conn_displaynetwork"
 
   - name: CONN disp function available
     description: Verify conn_disp is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_disp\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_disp\""'
     expected_output_contains: "conn_disp"
 
   # ==========================================================================
@@ -369,17 +369,17 @@ tests:
   # ==========================================================================
   - name: CONN dcm2nii available
     description: Verify conn_dcm2nii is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_dcm2nii\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_dcm2nii\""'
     expected_output_contains: "conn_dcm2nii"
 
   - name: CONN annot2nii available
     description: Verify conn_annot2nii is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_annot2nii\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_annot2nii\""'
     expected_output_contains: "conn_annot2nii"
 
   - name: CONN cat2mgh available
     description: Verify conn_cat2mgh is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_cat2mgh\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_cat2mgh\""'
     expected_output_contains: "conn_cat2mgh"
 
   # ==========================================================================
@@ -387,22 +387,22 @@ tests:
   # ==========================================================================
   - name: CONN FreeSurfer read_surf available
     description: Verify conn_freesurfer_read_surf is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_read_surf\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_read_surf\""'
     expected_output_contains: "conn_freesurfer_read_surf"
 
   - name: CONN FreeSurfer write_surf available
     description: Verify conn_freesurfer_write_surf is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_write_surf\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_write_surf\""'
     expected_output_contains: "conn_freesurfer_write_surf"
 
   - name: CONN FreeSurfer read_annotation available
     description: Verify conn_freesurfer_read_annotation is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_read_annotation\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_read_annotation\""'
     expected_output_contains: "conn_freesurfer_read_annotation"
 
   - name: CONN FreeSurfer load_mgh available
     description: Verify conn_freesurfer_load_mgh is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_load_mgh\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_freesurfer_load_mgh\""'
     expected_output_contains: "conn_freesurfer_load_mgh"
 
   # ==========================================================================
@@ -410,12 +410,12 @@ tests:
   # ==========================================================================
   - name: ART function available
     description: Verify art function is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which art\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which art\""'
     expected_output_contains: "art"
 
   - name: CONN art wrapper available
     description: Verify conn_art is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_art\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_art\""'
     expected_output_contains: "conn_art"
 
   # ==========================================================================
@@ -423,17 +423,17 @@ tests:
   # ==========================================================================
   - name: CONN designmatrix available
     description: Verify conn_designmatrix is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_designmatrix\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_designmatrix\""'
     expected_output_contains: "conn_designmatrix"
 
   - name: CONN conditionnames available
     description: Verify conn_conditionnames is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_conditionnames\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_conditionnames\""'
     expected_output_contains: "conn_conditionnames"
 
   - name: CONN convertcondition2covariate available
     description: Verify conn_convertcondition2covariate is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_convertcondition2covariate\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_convertcondition2covariate\""'
     expected_output_contains: "conn_convertcondition2covariate"
 
   # ==========================================================================
@@ -441,17 +441,17 @@ tests:
   # ==========================================================================
   - name: CONN convolution available
     description: Verify conn_conv is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_conv\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_conv\""'
     expected_output_contains: "conn_conv"
 
   - name: SPM HRF function available
     description: Verify spm_hrf is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_hrf\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which spm_hrf\""'
     expected_output_contains: "spm_hrf"
 
   - name: Create canonical HRF
     description: Generate canonical HRF with SPM
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"h=spm_hrf(2);disp(['HRF length ' num2str(length(h))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"h=spm_hrf(2);disp(['\"'\"'HRF length '\"'\"' num2str(length(h))])\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -459,23 +459,23 @@ tests:
   # ==========================================================================
   - name: CONN bsxfun available
     description: Verify conn_bsxfun is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_bsxfun\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_bsxfun\""'
     expected_output_contains: "conn_bsxfun"
 
   - name: Matrix operations test
     description: Test basic matrix operations
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"A=randn(10,10);B=A*A';disp(['Size ' num2str(size(B))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"A=randn(10,10);B=A*A'\"'\"';disp(['\"'\"'Size '\"'\"' num2str(size(B))])\"'"
     expected_output_contains: "10"
     expected_exit_code: 0
 
   - name: Correlation computation
     description: Test correlation matrix computation
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"X=randn(100,5);C=corrcoef(X);disp(['Corr size ' num2str(size(C))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"X=randn(100,5);C=corrcoef(X);disp(['\"'\"'Corr size '\"'\"' num2str(size(C))])\"'"
     expected_output_contains: "5"
 
   - name: Fisher z-transform
     description: Test Fisher z-transformation
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"r=0.5;z=atanh(r);disp(['Z = ' num2str(z)])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"r=0.5;z=atanh(r);disp(['\"'\"'Z = '\"'\"' num2str(z)])\"'"
     expected_output_contains: "0.5"
 
   # ==========================================================================
@@ -483,12 +483,12 @@ tests:
   # ==========================================================================
   - name: CONN watershed available
     description: Verify conn_watershed is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_watershed\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_watershed\""'
     expected_output_contains: "conn_watershed"
 
   - name: CONN est_smoothness available
     description: Verify conn_est_smoothness is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_est_smoothness\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_est_smoothness\""'
     expected_output_contains: "conn_est_smoothness"
 
   # ==========================================================================
@@ -496,17 +496,17 @@ tests:
   # ==========================================================================
   - name: CONN setup_preproc available
     description: Verify conn_setup_preproc is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_setup_preproc\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_setup_preproc\""'
     expected_output_contains: "conn_setup_preproc"
 
   - name: CONN process available
     description: Verify conn_process is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_process\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_process\""'
     expected_output_contains: "conn_process"
 
   - name: CONN module available
     description: Verify conn_module is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_module\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_module\""'
     expected_output_contains: "conn_module"
 
   # ==========================================================================
@@ -514,12 +514,12 @@ tests:
   # ==========================================================================
   - name: CONN qaplots available
     description: Verify conn_qaplots is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_qaplots\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_qaplots\""'
     expected_output_contains: "conn_qaplots"
 
   - name: CONN qaplotsexplore available
     description: Verify conn_qaplotsexplore is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_qaplotsexplore\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_qaplotsexplore\""'
     expected_output_contains: "conn_qaplotsexplore"
 
   # ==========================================================================
@@ -527,17 +527,17 @@ tests:
   # ==========================================================================
   - name: CONN importbids available
     description: Verify conn_importbids is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_importbids\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_importbids\""'
     expected_output_contains: "conn_importbids"
 
   - name: CONN importspm available
     description: Verify conn_importspm is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_importspm\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_importspm\""'
     expected_output_contains: "conn_importspm"
 
   - name: CONN bidsdir available
     description: Verify conn_bidsdir is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_bidsdir\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_bidsdir\""'
     expected_output_contains: "conn_bidsdir"
 
   # ==========================================================================
@@ -545,17 +545,17 @@ tests:
   # ==========================================================================
   - name: CONN coords2labels available
     description: Verify conn_coords2labels is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_coords2labels\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_coords2labels\""'
     expected_output_contains: "conn_coords2labels"
 
   - name: CONN convertcoordinates available
     description: Verify conn_convertcoordinates is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_convertcoordinates\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_convertcoordinates\""'
     expected_output_contains: "conn_convertcoordinates"
 
   - name: CONN definelabels available
     description: Verify conn_definelabels is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_definelabels\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_definelabels\""'
     expected_output_contains: "conn_definelabels"
 
   # ==========================================================================
@@ -563,17 +563,17 @@ tests:
   # ==========================================================================
   - name: CONN checksliceorder available
     description: Verify conn_checksliceorder is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_checksliceorder\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_checksliceorder\""'
     expected_output_contains: "conn_checksliceorder"
 
   - name: CONN computeMaskMovement available
     description: Verify conn_computeMaskMovement is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_computeMaskMovement\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_computeMaskMovement\""'
     expected_output_contains: "conn_computeMaskMovement"
 
   - name: CONN sliceintensitycorrection available
     description: Verify conn_sliceintensitycorrection is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_sliceintensitycorrection\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_sliceintensitycorrection\""'
     expected_output_contains: "conn_sliceintensitycorrection"
 
   # ==========================================================================
@@ -581,12 +581,12 @@ tests:
   # ==========================================================================
   - name: SPM tcdf function available
     description: Verify spm t-distribution CDF is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_tcdf\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_tcdf\""'
     expected_output_contains: "conn_tcdf"
 
   - name: Calculate t-statistic CDF
     description: Test t-distribution CDF calculation
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"p=conn_tcdf(2,100);disp(['P = ' num2str(p)])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"p=conn_tcdf(2,100);disp(['\"'\"'P = '\"'\"' num2str(p)])\"'"
     expected_output_contains: "0.9"
 
   # ==========================================================================
@@ -594,27 +594,27 @@ tests:
   # ==========================================================================
   - name: Read 3D image and compute mean
     description: Load T2 image and compute mean intensity
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');Y=spm_read_vols(V);disp(['Mean ' num2str(mean(Y(:)))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');Y=spm_read_vols(V);disp(['\"'\"'Mean '\"'\"' num2str(mean(Y(:)))])\"'"
     expected_exit_code: 0
 
   - name: Read 3D image and compute std
     description: Load T2 image and compute standard deviation
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');Y=spm_read_vols(V);disp(['Std ' num2str(std(Y(:)))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');Y=spm_read_vols(V);disp(['\"'\"'Std '\"'\"' num2str(std(Y(:)))])\"'"
     expected_exit_code: 0
 
   - name: Read 3D image and compute max
     description: Load T2 image and compute maximum intensity
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');Y=spm_read_vols(V);disp(['Max ' num2str(max(Y(:)))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');Y=spm_read_vols(V);disp(['\"'\"'Max '\"'\"' num2str(max(Y(:)))])\"'"
     expected_exit_code: 0
 
   - name: Read 3D image and compute min
     description: Load T2 image and compute minimum intensity
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');Y=spm_read_vols(V);disp(['Min ' num2str(min(Y(:)))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');Y=spm_read_vols(V);disp(['\"'\"'Min '\"'\"' num2str(min(Y(:)))])\"'"
     expected_exit_code: 0
 
   - name: Count nonzero voxels
     description: Count number of nonzero voxels in T2 image
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('test_output/sub-01_inplaneT2.nii');Y=spm_read_vols(V);disp(['Nonzero ' num2str(nnz(Y))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"V=spm_vol('\"'\"'test_output/sub-01_inplaneT2.nii'\"'\"');Y=spm_read_vols(V);disp(['\"'\"'Nonzero '\"'\"' num2str(nnz(Y))])\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -622,12 +622,12 @@ tests:
   # ==========================================================================
   - name: Create random connectivity matrix
     description: Generate and threshold random connectivity matrix
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"C=randn(10,10);C=(C+C')/2;C=C.*(abs(C)>1);disp(['Nonzero ' num2str(nnz(C))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"C=randn(10,10);C=(C+C'\"'\"')/2;C=C.*(abs(C)>1);disp(['\"'\"'Nonzero '\"'\"' num2str(nnz(C))])\"'"
     expected_exit_code: 0
 
   - name: Fisher z-transform matrix
     description: Apply Fisher z-transform to correlation matrix
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"C=rand(5,5)*0.8;C=(C+C')/2;Z=atanh(C);disp(['Z range ' num2str(min(Z(:))) ' to ' num2str(max(Z(:)))])\""
+    command: "bash -lc '/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"C=rand(5,5)*0.8;C=(C+C'\"'\"')/2;Z=atanh(C);disp(['\"'\"'Z range '\"'\"' num2str(min(Z(:))) '\"'\"' to '\"'\"' num2str(max(Z(:)))])\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -635,12 +635,12 @@ tests:
   # ==========================================================================
   - name: CONN sortfilenames available
     description: Verify conn_sortfilenames is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_sortfilenames\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_sortfilenames\""'
     expected_output_contains: "conn_sortfilenames"
 
   - name: CONN rulebasedfilename available
     description: Verify conn_rulebasedfilename is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_rulebasedfilename\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_rulebasedfilename\""'
     expected_output_contains: "conn_rulebasedfilename"
 
   # ==========================================================================
@@ -648,17 +648,17 @@ tests:
   # ==========================================================================
   - name: CONN tcpip available
     description: Verify conn_tcpip is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_tcpip\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_tcpip\""'
     expected_output_contains: "conn_tcpip"
 
   - name: CONN server available
     description: Verify conn_server is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_server\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_server\""'
     expected_output_contains: "conn_server"
 
   - name: CONN server_ssh available
     description: Verify conn_server_ssh is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_server_ssh\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_server_ssh\""'
     expected_output_contains: "conn_server_ssh"
 
   # ==========================================================================
@@ -666,12 +666,12 @@ tests:
   # ==========================================================================
   - name: CONN update available
     description: Verify conn_update is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_update\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_update\""'
     expected_output_contains: "conn_update"
 
   - name: CONN updatefilepaths available
     description: Verify conn_updatefilepaths is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_updatefilepaths\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_updatefilepaths\""'
     expected_output_contains: "conn_updatefilepaths"
 
   # ==========================================================================
@@ -679,17 +679,17 @@ tests:
   # ==========================================================================
   - name: CONN export2cov available
     description: Verify conn_export2cov is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_export2cov\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_export2cov\""'
     expected_output_contains: "conn_export2cov"
 
   - name: CONN exportlist available
     description: Verify conn_exportlist is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_exportlist\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_exportlist\""'
     expected_output_contains: "conn_exportlist"
 
   - name: CONN exporttable available
     description: Verify conn_exporttable is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_exporttable\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_exporttable\""'
     expected_output_contains: "conn_exporttable"
 
   # ==========================================================================
@@ -697,17 +697,17 @@ tests:
   # ==========================================================================
   - name: CONN withinbetweenROItest available
     description: Verify conn_withinbetweenROItest is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_withinbetweenROItest\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_withinbetweenROItest\""'
     expected_output_contains: "conn_withinbetweenROItest"
 
   - name: CONN roioverlaps available
     description: Verify conn_roioverlaps is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roioverlaps\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roioverlaps\""'
     expected_output_contains: "conn_roioverlaps"
 
   - name: CONN roiclusters available
     description: Verify conn_roiclusters is available
-    command: "/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roiclusters\""
+    command: bash -lc '"/opt/conn-22a/run_conn.sh /opt/MCR-2022a/v912 run \"which conn_roiclusters\""'
     expected_output_contains: "conn_roiclusters"
 
 cleanup:

--- a/recipes/dcm2bids/fulltest.yaml
+++ b/recipes/dcm2bids/fulltest.yaml
@@ -516,17 +516,17 @@ tests:
   # ==========================================================================
   - name: Access container example config
     description: Verify access to bundled example config
-    command: cat /dcm2bids/example/config.json 2>&1 | head -20
+    command: "bash -lc 'cat /dcm2bids/example/config.json 2>&1 | head -20'"
     expected_output_contains: "descriptions"
 
   - name: Access container test configs
     description: Verify access to bundled test configurations
-    command: ls /dcm2bids/tests/data/*.json 2>&1 | head -10
+    command: bash -lc 'ls /dcm2bids/tests/data/*.json 2>&1 | head -10'
     expected_output_contains: "config_test.json"
 
   - name: Access container test sidecars
     description: Verify access to bundled test sidecar files
-    command: ls /dcm2bids/tests/data/sidecars/*.json 2>&1 | head -5
+    command: bash -lc 'ls /dcm2bids/tests/data/sidecars/*.json 2>&1 | head -5'
     expected_output_contains: ".json"
 
   # ==========================================================================
@@ -686,7 +686,6 @@ tests:
     command: |
       echo "=== Test output summary ===" && \
       du -sh ${output_dir}/*/ 2>/dev/null | head -20 || echo "Listing outputs"
-
 cleanup:
   script: |
     #!/usr/bin/env bash

--- a/recipes/deepretinotopy/fulltest.yaml
+++ b/recipes/deepretinotopy/fulltest.yaml
@@ -105,27 +105,27 @@ tests:
   # ===========================================================================
   - name: Polar angle models exist
     description: Verify polar angle prediction models are installed
-    command: ls -la /opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_polarAngle_*.pt
+    command: bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_polarAngle_*.pt'
     expected_output_contains: "deepRetinotopy_polarAngle_LH_model.pt"
 
   - name: Eccentricity models exist
     description: Verify eccentricity prediction models are installed
-    command: ls -la /opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_eccentricity_*.pt
+    command: bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_eccentricity_*.pt'
     expected_output_contains: "deepRetinotopy_eccentricity_LH_model.pt"
 
   - name: pRF size models exist
     description: Verify pRF size prediction models are installed
-    command: ls -la /opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_pRFsize_*.pt
+    command: bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_pRFsize_*.pt'
     expected_output_contains: "deepRetinotopy_pRFsize_LH_model.pt"
 
   - name: Model file count
     description: Verify all 6 model files are present (LH/RH for 3 maps)
-    command: ls /opt/deepRetinotopy_TheToolbox/models/*.pt | wc -l
+    command: bash -lc 'ls /opt/deepRetinotopy_TheToolbox/models/*.pt | wc -l'
     expected_output_contains: "6"
 
   - name: Load PyTorch model
     description: Test loading a deepRetinotopy model file
-    command: python -c "import torch; m=torch.load('/opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_polarAngle_LH_model.pt', map_location='cpu', weights_only=False); print('Model loaded successfully')"
+    command: "bash -lc 'python -c \"import torch; m=torch.load('\"'\"'/opt/deepRetinotopy_TheToolbox/models/deepRetinotopy_polarAngle_LH_model.pt'\"'\"', map_location='\"'\"'cpu'\"'\"', weights_only=False); print('\"'\"'Model loaded successfully'\"'\"')\"'"
     expected_output_contains: "Model loaded successfully"
 
   # ===========================================================================
@@ -133,22 +133,22 @@ tests:
   # ===========================================================================
   - name: Inference script exists
     description: Verify main inference script is present
-    command: ls -la /opt/deepRetinotopy_TheToolbox/main/2_inference.py
+    command: "bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/main/2_inference.py'"
     expected_output_contains: "2_inference.py"
 
   - name: Native to fsaverage script exists
     description: Verify surface transformation script is present
-    command: ls -la /opt/deepRetinotopy_TheToolbox/main/1_native2fsaverage.sh
+    command: "bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/main/1_native2fsaverage.sh'"
     expected_output_contains: "1_native2fsaverage.sh"
 
   - name: fsaverage to native script exists
     description: Verify reverse transformation script is present
-    command: ls -la /opt/deepRetinotopy_TheToolbox/main/3_fsaverage2native.sh
+    command: "bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/main/3_fsaverage2native.sh'"
     expected_output_contains: "3_fsaverage2native.sh"
 
   - name: Sign maps script exists
     description: Verify visual field sign calculation script is present
-    command: ls -la /opt/deepRetinotopy_TheToolbox/main/4_signmaps.py
+    command: "bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/main/4_signmaps.py'"
     expected_output_contains: "4_signmaps.py"
 
   # ===========================================================================
@@ -301,7 +301,7 @@ tests:
 
   - name: FreeSurfer SUBJECTS_DIR
     description: Verify SUBJECTS_DIR environment is accessible
-    command: echo $FREESURFER_HOME || ls /opt/freesurfer-7.3.2
+    command: "bash -lc 'echo $FREESURFER_HOME || ls /opt/freesurfer-7.3.2'"
     expected_exit_code: 0
 
   # ===========================================================================
@@ -624,48 +624,48 @@ tests:
   - name: Import deepRetinotopy dataset module
     description: Test importing dataset utilities
     command: |
-      cd /opt/deepRetinotopy_TheToolbox && python -c "
+      bash -lc 'cd /opt/deepRetinotopy_TheToolbox && python -c "
       from utils.dataset import SurfaceDataset
-      print('SurfaceDataset class imported successfully')
-      " 2>&1 | tail -2
+      print('\''SurfaceDataset class imported successfully'\'')
+      " 2>&1 | tail -2'
     expected_output_contains: "SurfaceDataset"
 
   - name: Import deepRetinotopy read_data module
     description: Test importing data reading utilities
     command: |
-      cd /opt/deepRetinotopy_TheToolbox && python -c "
+      bash -lc 'cd /opt/deepRetinotopy_TheToolbox && python -c "
       from utils.read_data import read_gifti
-      print('read_gifti function imported successfully')
-      " 2>&1 | tail -2
+      print('\''read_gifti function imported successfully'\'')
+      " 2>&1 | tail -2'
     expected_output_contains: "read_gifti"
 
   - name: Import deepRetinotopy labels module
     description: Test importing label utilities
     command: |
-      cd /opt/deepRetinotopy_TheToolbox && python -c "
+      bash -lc 'cd /opt/deepRetinotopy_TheToolbox && python -c "
       from utils.labels import ROI_WangParcelsPlusFovea
-      print('ROI labels imported successfully')
-      " 2>&1 | tail -2
+      print('\''ROI labels imported successfully'\'')
+      " 2>&1 | tail -2'
     expected_output_contains: "ROI labels"
 
   - name: Import deepRetinotopy fieldSign module
     description: Test importing field sign calculation
     command: |
-      cd /opt/deepRetinotopy_TheToolbox && python -c "
+      bash -lc 'cd /opt/deepRetinotopy_TheToolbox && python -c "
       from utils.fieldSign import FieldSign
-      print('FieldSign class imported successfully')
-      " 2>&1 | tail -2
+      print('\''FieldSign class imported successfully'\'')
+      " 2>&1 | tail -2'
     expected_output_contains: "FieldSign"
 
   - name: Check model architecture
     description: Verify model architecture is loadable
     command: |
-      cd /opt/deepRetinotopy_TheToolbox && python -c "
+      bash -lc 'cd /opt/deepRetinotopy_TheToolbox && python -c "
       import torch
       from utils.model import Model
       # Just verify the Model class exists and has expected methods
-      print('Model class has forward method:', hasattr(Model, 'forward') or hasattr(Model, '__call__'))
-      " 2>&1 | tail -2
+      print('\''Model class has forward method:'\'', hasattr(Model, '\''forward'\'') or hasattr(Model, '\''__call__'\''))
+      " 2>&1 | tail -2'
     expected_exit_code: 0
 
   # ===========================================================================
@@ -868,12 +868,12 @@ tests:
   # ===========================================================================
   - name: Labels directory exists
     description: Verify retinotopy labels are available
-    command: ls -la /opt/deepRetinotopy_TheToolbox/labels/
+    command: "bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/labels/'"
     expected_output_contains: "total"
 
   - name: Utils templates exist
     description: Verify template utilities are available
-    command: ls -la /opt/deepRetinotopy_TheToolbox/utils/templates/
+    command: "bash -lc 'ls -la /opt/deepRetinotopy_TheToolbox/utils/templates/'"
     expected_exit_code: 0
 
   # ===========================================================================

--- a/recipes/dicompare/fulltest.yaml
+++ b/recipes/dicompare/fulltest.yaml
@@ -116,27 +116,27 @@ tests:
   # ==========================================================================
   - name: webapp directory exists
     description: Verify /opt/dicompare directory exists
-    command: ls -d /opt/dicompare
+    command: "bash -lc 'ls -d /opt/dicompare'"
     expected_output_contains: "/opt/dicompare"
 
   - name: dist directory exists
     description: Verify built webapp exists
-    command: ls -d /opt/dicompare/dist
+    command: "bash -lc 'ls -d /opt/dicompare/dist'"
     expected_output_contains: "/opt/dicompare/dist"
 
   - name: start.sh exists
     description: Verify startup script exists
-    command: ls /opt/dicompare/start.sh
+    command: "bash -lc 'ls /opt/dicompare/start.sh'"
     expected_output_contains: "start.sh"
 
   - name: start.sh is executable
     description: Verify startup script has execute permissions
-    command: test -x /opt/dicompare/start.sh && echo "executable"
+    command: bash -lc 'test -x /opt/dicompare/start.sh && echo "executable"'
     expected_output_contains: "executable"
 
   - name: start.sh contains serve command
     description: Verify startup script runs serve
-    command: cat /opt/dicompare/start.sh
+    command: "bash -lc 'cat /opt/dicompare/start.sh'"
     expected_output_contains: "serve -s dist -l 3001"
 
   # ==========================================================================
@@ -144,22 +144,22 @@ tests:
   # ==========================================================================
   - name: index.html exists
     description: Verify main HTML file exists
-    command: ls /opt/dicompare/dist/index.html
+    command: "bash -lc 'ls /opt/dicompare/dist/index.html'"
     expected_output_contains: "index.html"
 
   - name: index.html has content
     description: Verify index.html is not empty
-    command: test -s /opt/dicompare/dist/index.html && echo "has content"
+    command: bash -lc 'test -s /opt/dicompare/dist/index.html && echo "has content"'
     expected_output_contains: "has content"
 
   - name: index.html is valid HTML
     description: Check for basic HTML structure
-    command: cat /opt/dicompare/dist/index.html | head -20
+    command: "bash -lc 'cat /opt/dicompare/dist/index.html | head -20'"
     expected_output_contains: "<!DOCTYPE html>"
 
   - name: index.html includes app root
     description: Verify React mount point exists
-    command: cat /opt/dicompare/dist/index.html
+    command: "bash -lc 'cat /opt/dicompare/dist/index.html'"
     expected_output_contains: "<div id=\"root\""
 
   # ==========================================================================
@@ -167,47 +167,47 @@ tests:
   # ==========================================================================
   - name: assets directory exists
     description: Verify assets directory is present
-    command: ls -d /opt/dicompare/dist/assets
+    command: "bash -lc 'ls -d /opt/dicompare/dist/assets'"
     expected_output_contains: "/opt/dicompare/dist/assets"
 
   - name: JavaScript bundle exists
     description: Verify main JS bundle is present
-    command: ls /opt/dicompare/dist/assets/*.js | head -1
+    command: bash -lc 'ls /opt/dicompare/dist/assets/*.js | head -1'
     expected_exit_code: 0
 
   - name: CSS bundle exists
     description: Verify main CSS bundle is present
-    command: ls /opt/dicompare/dist/assets/*.css | head -1
+    command: bash -lc 'ls /opt/dicompare/dist/assets/*.css | head -1'
     expected_exit_code: 0
 
   - name: favicon exists
     description: Verify favicon is present
-    command: ls /opt/dicompare/dist/favicon.ico
+    command: "bash -lc 'ls /opt/dicompare/dist/favicon.ico'"
     expected_output_contains: "favicon.ico"
 
   - name: manifest.json exists
     description: Verify PWA manifest is present
-    command: ls /opt/dicompare/dist/manifest.json
+    command: "bash -lc 'ls /opt/dicompare/dist/manifest.json'"
     expected_output_contains: "manifest.json"
 
   - name: manifest.json is valid JSON
     description: Verify manifest.json can be parsed
-    command: cat /opt/dicompare/dist/manifest.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/manifest.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: robots.txt exists
     description: Verify robots.txt is present
-    command: ls /opt/dicompare/dist/robots.txt
+    command: "bash -lc 'ls /opt/dicompare/dist/robots.txt'"
     expected_output_contains: "robots.txt"
 
   - name: logo images exist
     description: Verify logo images are present
-    command: ls /opt/dicompare/dist/logo*.png | wc -l
+    command: bash -lc 'ls /opt/dicompare/dist/logo*.png | wc -l'
     expected_output_contains: "2"
 
   - name: hero images exist
     description: Verify hero images are present
-    command: ls /opt/dicompare/dist/hero*.png | wc -l
+    command: bash -lc 'ls /opt/dicompare/dist/hero*.png | wc -l'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -215,13 +215,13 @@ tests:
   # ==========================================================================
   - name: Pyodide worker exists
     description: Verify Pyodide web worker is bundled
-    command: ls /opt/dicompare/dist/assets/pyodide.worker*.js | head -1
+    command: bash -lc 'ls /opt/dicompare/dist/assets/pyodide.worker*.js | head -1'
     expected_exit_code: 0
 
   - name: Pyodide worker has content
     description: Verify Pyodide worker is not empty
     command: |
-      ls -s /opt/dicompare/dist/assets/pyodide.worker*.js | awk '{print ($1 > 0 ? "has content" : "empty")}'
+      bash -lc 'ls -s /opt/dicompare/dist/assets/pyodide.worker*.js | awk '\''{print ($1 > 0 ? "has content" : "empty")}'\'''
     expected_output_contains: "has content"
 
   # ==========================================================================
@@ -229,97 +229,97 @@ tests:
   # ==========================================================================
   - name: schemas directory exists
     description: Verify schemas directory is present
-    command: ls -d /opt/dicompare/dist/schemas
+    command: "bash -lc 'ls -d /opt/dicompare/dist/schemas'"
     expected_output_contains: "/opt/dicompare/dist/schemas"
 
   - name: schemas index.json exists
     description: Verify schema index file is present
-    command: ls /opt/dicompare/dist/schemas/index.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/index.json'"
     expected_output_contains: "index.json"
 
   - name: schemas index.json is valid JSON
     description: Verify schema index can be parsed
-    command: cat /opt/dicompare/dist/schemas/index.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/index.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: MS CMSC Guidelines schema exists
     description: Verify MS CMSC Guidelines schema is present
-    command: ls /opt/dicompare/dist/schemas/MS_CMSC_Guidelines_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/MS_CMSC_Guidelines_v1.0.json'"
     expected_output_contains: "MS_CMSC_Guidelines"
 
   - name: MS CMSC Guidelines schema is valid JSON
     description: Verify MS CMSC Guidelines schema can be parsed
-    command: cat /opt/dicompare/dist/schemas/MS_CMSC_Guidelines_v1.0.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/MS_CMSC_Guidelines_v1.0.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: ASL Clinical Guidelines schema exists
     description: Verify ASL Clinical Guidelines schema is present
-    command: ls /opt/dicompare/dist/schemas/ASL_Clinical_Guidelines_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/ASL_Clinical_Guidelines_v1.0.json'"
     expected_output_contains: "ASL_Clinical_Guidelines"
 
   - name: ASL Clinical Guidelines schema is valid JSON
     description: Verify ASL Clinical Guidelines schema can be parsed
-    command: cat /opt/dicompare/dist/schemas/ASL_Clinical_Guidelines_v1.0.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/ASL_Clinical_Guidelines_v1.0.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: QSM Consensus Guidelines schema exists
     description: Verify QSM Consensus Guidelines schema is present
-    command: ls /opt/dicompare/dist/schemas/QSM_Consensus_Guidelines_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/QSM_Consensus_Guidelines_v1.0.json'"
     expected_output_contains: "QSM_Consensus_Guidelines"
 
   - name: QSM Consensus Guidelines schema is valid JSON
     description: Verify QSM Consensus Guidelines schema can be parsed
-    command: cat /opt/dicompare/dist/schemas/QSM_Consensus_Guidelines_v1.0.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/QSM_Consensus_Guidelines_v1.0.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: MY-RADS Myeloma schema exists
     description: Verify MY-RADS Myeloma schema is present
-    command: ls /opt/dicompare/dist/schemas/MY-RADS_Myeloma_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/MY-RADS_Myeloma_v1.0.json'"
     expected_output_contains: "MY-RADS_Myeloma"
 
   - name: UK Biobank schema exists
     description: Verify UK Biobank schema is present
-    command: ls /opt/dicompare/dist/schemas/UK_Biobank_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/UK_Biobank_v1.0.json'"
     expected_output_contains: "UK_Biobank"
 
   - name: UK Biobank schema is valid JSON
     description: Verify UK Biobank schema can be parsed
-    command: cat /opt/dicompare/dist/schemas/UK_Biobank_v1.0.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/UK_Biobank_v1.0.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: UMMS Ping schema exists
     description: Verify UMMS Ping schema is present
-    command: ls /opt/dicompare/dist/schemas/UMMS_Ping_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/UMMS_Ping_v1.0.json'"
     expected_output_contains: "UMMS_Ping"
 
   - name: Generic Spine schema exists
     description: Verify Generic Spine schema is present
-    command: ls /opt/dicompare/dist/schemas/Generic_Spine_v1.0.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/Generic_Spine_v1.0.json'"
     expected_output_contains: "Generic_Spine"
 
   - name: HCP schema exists
     description: Verify HCP schema is present
-    command: ls /opt/dicompare/dist/schemas/hcp_schema.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/hcp_schema.json'"
     expected_output_contains: "hcp_schema"
 
   - name: HCP schema is valid JSON
     description: Verify HCP schema can be parsed
-    command: cat /opt/dicompare/dist/schemas/hcp_schema.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/hcp_schema.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: ABCD schema exists
     description: Verify ABCD schema is present
-    command: ls /opt/dicompare/dist/schemas/abcd_schema_cleaned.json
+    command: "bash -lc 'ls /opt/dicompare/dist/schemas/abcd_schema_cleaned.json'"
     expected_output_contains: "abcd_schema"
 
   - name: ABCD schema is valid JSON
     description: Verify ABCD schema can be parsed
-    command: cat /opt/dicompare/dist/schemas/abcd_schema_cleaned.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/abcd_schema_cleaned.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: All schemas count
     description: Verify expected number of schema files
-    command: ls /opt/dicompare/dist/schemas/*.json | wc -l
+    command: bash -lc 'ls /opt/dicompare/dist/schemas/*.json | wc -l'
     expected_output_contains: "10"
 
   # ==========================================================================
@@ -327,112 +327,112 @@ tests:
   # ==========================================================================
   - name: validation-functions directory exists
     description: Verify validation-functions directory is present
-    command: ls -d /opt/dicompare/dist/validation-functions
+    command: "bash -lc 'ls -d /opt/dicompare/dist/validation-functions'"
     expected_output_contains: "/opt/dicompare/dist/validation-functions"
 
   - name: validate_bvalue_shells function exists
     description: Verify b-value shells validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_bvalue_shells.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_bvalue_shells.json'"
     expected_output_contains: "validate_bvalue_shells"
 
   - name: validate_bvalue_shells is valid JSON
     description: Verify b-value shells validation function can be parsed
-    command: cat /opt/dicompare/dist/validation-functions/validate_bvalue_shells.json | python3 -c "import sys,json; json.load(sys.stdin); print('valid')"
+    command: "bash -lc 'cat /opt/dicompare/dist/validation-functions/validate_bvalue_shells.json | python3 -c \"import sys,json; json.load(sys.stdin); print('\"'\"'valid'\"'\"')\"'"
     expected_output_contains: "valid"
 
   - name: validate_diffusion_directions function exists
     description: Verify diffusion directions validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_diffusion_directions.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_diffusion_directions.json'"
     expected_output_contains: "validate_diffusion_directions"
 
   - name: validate_echo_count function exists
     description: Verify echo count validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_echo_count.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_echo_count.json'"
     expected_output_contains: "validate_echo_count"
 
   - name: validate_echo_times function exists
     description: Verify echo times validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_echo_times.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_echo_times.json'"
     expected_output_contains: "validate_echo_times"
 
   - name: validate_exact_echo_count function exists
     description: Verify exact echo count validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_exact_echo_count.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_exact_echo_count.json'"
     expected_output_contains: "validate_exact_echo_count"
 
   - name: validate_first_echo function exists
     description: Verify first echo validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_first_echo.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_first_echo.json'"
     expected_output_contains: "validate_first_echo"
 
   - name: validate_flip_angle function exists
     description: Verify flip angle validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_flip_angle.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_flip_angle.json'"
     expected_output_contains: "validate_flip_angle"
 
   - name: validate_image_slices function exists
     description: Verify image slices validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_image_slices.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_image_slices.json'"
     expected_output_contains: "validate_image_slices"
 
   - name: validate_image_type function exists
     description: Verify image type validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_image_type.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_image_type.json'"
     expected_output_contains: "validate_image_type"
 
   - name: validate_magnitude_phase_pairs function exists
     description: Verify magnitude phase pairs validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_magnitude_phase_pairs.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_magnitude_phase_pairs.json'"
     expected_output_contains: "validate_magnitude_phase_pairs"
 
   - name: validate_mra_type function exists
     description: Verify MRA type validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_mra_type.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_mra_type.json'"
     expected_output_contains: "validate_mra_type"
 
   - name: validate_phase_encoding_polarity function exists
     description: Verify phase encoding polarity validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_phase_encoding_polarity.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_phase_encoding_polarity.json'"
     expected_output_contains: "validate_phase_encoding_polarity"
 
   - name: validate_pixel_bandwidth function exists
     description: Verify pixel bandwidth validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_pixel_bandwidth.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_pixel_bandwidth.json'"
     expected_output_contains: "validate_pixel_bandwidth"
 
   - name: validate_pixel_spacing function exists
     description: Verify pixel spacing validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_pixel_spacing.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_pixel_spacing.json'"
     expected_output_contains: "validate_pixel_spacing"
 
   - name: validate_repetition_time function exists
     description: Verify repetition time validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_repetition_time.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_repetition_time.json'"
     expected_output_contains: "validate_repetition_time"
 
   - name: validate_slice_count function exists
     description: Verify slice count validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_slice_count.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_slice_count.json'"
     expected_output_contains: "validate_slice_count"
 
   - name: validate_temporal_positions function exists
     description: Verify temporal positions validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_temporal_positions.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_temporal_positions.json'"
     expected_output_contains: "validate_temporal_positions"
 
   - name: validate_voxel_shape function exists
     description: Verify voxel shape validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/validate_voxel_shape.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/validate_voxel_shape.json'"
     expected_output_contains: "validate_voxel_shape"
 
   - name: uniform_echo_spacing function exists
     description: Verify uniform echo spacing validation function is present
-    command: ls /opt/dicompare/dist/validation-functions/uniform_echo_spacing.json
+    command: "bash -lc 'ls /opt/dicompare/dist/validation-functions/uniform_echo_spacing.json'"
     expected_output_contains: "uniform_echo_spacing"
 
   - name: All validation functions count
     description: Verify expected number of validation function files
-    command: ls /opt/dicompare/dist/validation-functions/*.json | wc -l
+    command: bash -lc 'ls /opt/dicompare/dist/validation-functions/*.json | wc -l'
     expected_output_contains: "19"
 
   # ==========================================================================
@@ -483,71 +483,43 @@ tests:
   # ==========================================================================
   - name: Web server can start
     description: Test that serve can start serving files
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3002 &
-      sleep 2
-      curl -s -o /dev/null -w "%{http_code}" http://localhost:3002/ || echo "failed"
-      pkill -f "serve.*3002" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3002 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3002/ || echo \"failed\"\npkill -f \"serve.*3002\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server serves index.html
     description: Test that serve returns HTML content
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3003 &
-      sleep 2
-      curl -s http://localhost:3003/ | head -1 || echo "failed"
-      pkill -f "serve.*3003" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3003 &\nsleep 2\ncurl -s http://localhost:3003/ | head -1 || echo \"failed\"\npkill -f \"serve.*3003\" 2>/dev/null || true'"
     expected_output_contains: "<!DOCTYPE html>"
     timeout: 10
 
   - name: Web server serves favicon
     description: Test that serve returns favicon
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3004 &
-      sleep 2
-      curl -s -o /dev/null -w "%{http_code}" http://localhost:3004/favicon.ico || echo "failed"
-      pkill -f "serve.*3004" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3004 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3004/favicon.ico || echo \"failed\"\npkill -f \"serve.*3004\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server serves manifest.json
     description: Test that serve returns manifest.json
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3005 &
-      sleep 2
-      curl -s -o /dev/null -w "%{http_code}" http://localhost:3005/manifest.json || echo "failed"
-      pkill -f "serve.*3005" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3005 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3005/manifest.json || echo \"failed\"\npkill -f \"serve.*3005\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server serves schema files
     description: Test that serve returns schema index
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3006 &
-      sleep 2
-      curl -s http://localhost:3006/schemas/index.json | head -1 || echo "failed"
-      pkill -f "serve.*3006" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3006 &\nsleep 2\ncurl -s http://localhost:3006/schemas/index.json | head -1 || echo \"failed\"\npkill -f \"serve.*3006\" 2>/dev/null || true'"
     expected_output_contains: "["
     timeout: 10
 
   - name: Web server serves validation functions
     description: Test that serve returns validation function
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3007 &
-      sleep 2
-      curl -s -o /dev/null -w "%{http_code}" http://localhost:3007/validation-functions/validate_echo_count.json || echo "failed"
-      pkill -f "serve.*3007" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3007 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3007/validation-functions/validate_echo_count.json || echo \"failed\"\npkill -f \"serve.*3007\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server single page mode works
     description: Test that SPA routing redirects to index.html
-    command: |
-      timeout 5s serve -s /opt/dicompare/dist -l 3008 &
-      sleep 2
-      curl -s -o /dev/null -w "%{http_code}" http://localhost:3008/nonexistent/path || echo "failed"
-      pkill -f "serve.*3008" 2>/dev/null || true
+    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3008 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3008/nonexistent/path || echo \"failed\"\npkill -f \"serve.*3008\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
@@ -556,22 +528,22 @@ tests:
   # ==========================================================================
   - name: HCP schema has series definitions
     description: Verify HCP schema contains acquisitions definitions
-    command: cat /opt/dicompare/dist/schemas/hcp_schema.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('acquisitions' if 'acquisitions' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/hcp_schema.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'acquisitions'\"'\"' if '\"'\"'acquisitions'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "acquisitions"
 
   - name: ABCD schema has series definitions
     description: Verify ABCD schema contains acquisitions definitions
-    command: cat /opt/dicompare/dist/schemas/abcd_schema_cleaned.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('acquisitions' if 'acquisitions' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/abcd_schema_cleaned.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'acquisitions'\"'\"' if '\"'\"'acquisitions'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "acquisitions"
 
   - name: MS CMSC schema has series definitions
     description: Verify MS CMSC schema contains acquisitions definitions
-    command: cat /opt/dicompare/dist/schemas/MS_CMSC_Guidelines_v1.0.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('acquisitions' if 'acquisitions' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/MS_CMSC_Guidelines_v1.0.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'acquisitions'\"'\"' if '\"'\"'acquisitions'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "acquisitions"
 
   - name: UK Biobank schema has series definitions
     description: Verify UK Biobank schema contains acquisitions definitions
-    command: cat /opt/dicompare/dist/schemas/UK_Biobank_v1.0.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('acquisitions' if 'acquisitions' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/schemas/UK_Biobank_v1.0.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'acquisitions'\"'\"' if '\"'\"'acquisitions'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "acquisitions"
 
   # ==========================================================================
@@ -579,17 +551,17 @@ tests:
   # ==========================================================================
   - name: validate_echo_count has Python code
     description: Verify validation function contains implementation
-    command: cat /opt/dicompare/dist/validation-functions/validate_echo_count.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('implementation' if 'implementation' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/validation-functions/validate_echo_count.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'implementation'\"'\"' if '\"'\"'implementation'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "implementation"
 
   - name: validate_flip_angle has Python code
     description: Verify validation function contains implementation
-    command: cat /opt/dicompare/dist/validation-functions/validate_flip_angle.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('implementation' if 'implementation' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/validation-functions/validate_flip_angle.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'implementation'\"'\"' if '\"'\"'implementation'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "implementation"
 
   - name: validate_repetition_time has Python code
     description: Verify validation function contains implementation
-    command: cat /opt/dicompare/dist/validation-functions/validate_repetition_time.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('implementation' if 'implementation' in d else 'missing')"
+    command: "bash -lc 'cat /opt/dicompare/dist/validation-functions/validate_repetition_time.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print('\"'\"'implementation'\"'\"' if '\"'\"'implementation'\"'\"' in d else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "implementation"
 
   # ==========================================================================
@@ -597,12 +569,12 @@ tests:
   # ==========================================================================
   - name: JavaScript bundle has substantial size
     description: Verify main JS bundle is properly built
-    command: ls -l /opt/dicompare/dist/assets/index*.js | awk '{if($5 > 100000) print "large enough"; else print "too small"}'
+    command: bash -lc 'ls -l /opt/dicompare/dist/assets/index*.js | awk '\''{if($5 > 100000) print "large enough"; else print "too small"}'\'''
     expected_output_contains: "large enough"
 
   - name: CSS bundle has substantial size
     description: Verify main CSS bundle is properly built
-    command: ls -l /opt/dicompare/dist/assets/index*.css | awk '{if($5 > 10000) print "large enough"; else print "too small"}'
+    command: bash -lc 'ls -l /opt/dicompare/dist/assets/index*.css | awk '\''{if($5 > 10000) print "large enough"; else print "too small"}'\'''
     expected_output_contains: "large enough"
 
   # ==========================================================================
@@ -656,13 +628,13 @@ tests:
   # ==========================================================================
   - name: Export schema to test_output
     description: Copy a schema file to test output directory
-    command: cp /opt/dicompare/dist/schemas/hcp_schema.json test_output/
+    command: "bash -lc 'cp /opt/dicompare/dist/schemas/hcp_schema.json test_output/'"
     validate:
       - output_exists: ${output_dir}/hcp_schema.json
 
   - name: Export validation function to test_output
     description: Copy a validation function file to test output directory
-    command: cp /opt/dicompare/dist/validation-functions/validate_echo_count.json test_output/
+    command: "bash -lc 'cp /opt/dicompare/dist/validation-functions/validate_echo_count.json test_output/'"
     validate:
       - output_exists: ${output_dir}/validate_echo_count.json
 

--- a/recipes/diffusiontoolkit/fulltest.yaml
+++ b/recipes/diffusiontoolkit/fulltest.yaml
@@ -683,42 +683,42 @@ tests:
   # ==========================================================================
   - name: DSI matrix 515x181 exists
     description: Verify DSI reconstruction matrix 515x181 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_matrix_515x181.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_matrix_515x181.dat'"
     expected_exit_code: 0
 
   - name: DSI matrix 258x181 exists
     description: Verify DSI reconstruction matrix 258x181 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_matrix_258x181.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_matrix_258x181.dat'"
     expected_exit_code: 0
 
   - name: DSI matrix 125x181 exists
     description: Verify DSI reconstruction matrix 125x181 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_matrix_125x181.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_matrix_125x181.dat'"
     expected_exit_code: 0
 
   - name: DSI mesh 181 exists
     description: Verify DSI mesh file 181 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_mesh_181.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_mesh_181.dat'"
     expected_exit_code: 0
 
   - name: DSI vectors 181 exists
     description: Verify DSI vectors file 181 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_vectors_181.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_vectors_181.dat'"
     expected_exit_code: 0
 
   - name: DSI neighbors 181 exists
     description: Verify DSI neighbors file 181 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_neighbors_181.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_neighbors_181.dat'"
     expected_exit_code: 0
 
   - name: DSI sharpness 515 exists
     description: Verify DSI sharpness file 515 is available
-    command: ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_sharpness_515.dat
+    command: "bash -lc 'ls -la /opt/diffusiontoolkit-0.6.4.1/matrices/DSI_sharpness_515.dat'"
     expected_exit_code: 0
 
   - name: Matrix directory listing
     description: List all available matrix files
-    command: ls /opt/diffusiontoolkit-0.6.4.1/matrices/
+    command: "bash -lc 'ls /opt/diffusiontoolkit-0.6.4.1/matrices/'"
     expected_output_contains: "DSI_matrix"
 
   # ==========================================================================
@@ -784,12 +784,12 @@ tests:
 
   - name: Installation directory exists
     description: Verify installation directory structure
-    command: ls /opt/diffusiontoolkit-0.6.4.1/
+    command: "bash -lc 'ls /opt/diffusiontoolkit-0.6.4.1/'"
     expected_output_contains: "dti_recon"
 
   - name: README exists
     description: Verify README file is present
-    command: ls /opt/diffusiontoolkit-0.6.4.1/README.txt
+    command: "bash -lc 'ls /opt/diffusiontoolkit-0.6.4.1/README.txt'"
     expected_exit_code: 0
 
   # ==========================================================================

--- a/recipes/dsistudio/fulltest.yaml
+++ b/recipes/dsistudio/fulltest.yaml
@@ -58,22 +58,22 @@ tests:
   # ==========================================================================
   - name: DSI Studio binary exists
     description: Verify dsi_studio binary is in PATH
-    command: which dsi_studio
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen which dsi_studio'"
     expected_output_contains: "dsi_studio"
 
   - name: DSI Studio version check
     description: Check DSI Studio version output
-    command: dsi_studio --version 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --version 2>&1 || true'"
     expected_output_contains: "DSI Studio"
 
   - name: DSI Studio atlas directory exists
     description: Verify atlas directory is present
-    command: ls -la /opt/dsi-studio/atlas/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls -la /opt/dsi-studio/atlas/'\"'\"''"
     expected_output_contains: "ICBM152_adult"
 
   - name: DSI Studio ICBM152 template files exist
     description: Verify ICBM152 adult template files are present
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/*.fz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/*.fz'\"'\"''"
     expected_output_contains: "ICBM152_adult.fz"
 
   # ==========================================================================
@@ -81,7 +81,7 @@ tests:
   # ==========================================================================
   - name: src action help check
     description: Verify src action is recognized (generates SRC from NIFTI/DICOM)
-    command: timeout 10 dsi_studio --action=src --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=src --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=src"
 
   # ==========================================================================
@@ -90,7 +90,7 @@ tests:
   # ==========================================================================
   - name: rec action help check
     description: Verify rec action help shows reconstruction parameters
-    command: timeout 10 dsi_studio --action=rec --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=rec --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=rec"
 
   # ==========================================================================
@@ -99,7 +99,7 @@ tests:
   # ==========================================================================
   - name: trk action help check
     description: Verify trk action for fiber tracking is available
-    command: timeout 10 dsi_studio --action=trk --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=trk --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=trk"
 
   # ==========================================================================
@@ -107,7 +107,7 @@ tests:
   # ==========================================================================
   - name: ana action help check
     description: Verify ana action for tract/region analysis is available
-    command: timeout 10 dsi_studio --action=ana --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=ana --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=ana"
 
   # ==========================================================================
@@ -115,7 +115,7 @@ tests:
   # ==========================================================================
   - name: atk action help check
     description: Verify atk action for automatic bundle tracking is available
-    command: timeout 10 dsi_studio --action=atk --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=atk --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=atk"
 
   # ==========================================================================
@@ -123,7 +123,7 @@ tests:
   # ==========================================================================
   - name: exp action help check
     description: Verify exp action for exporting data is available
-    command: timeout 10 dsi_studio --action=exp --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=exp --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=exp"
 
   # ==========================================================================
@@ -132,53 +132,32 @@ tests:
   # ==========================================================================
   - name: reg action help check
     description: Verify reg action for image registration is available
-    command: timeout 10 dsi_studio --action=reg --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=reg"
 
   - name: reg action - linear registration T1w to template
     description: Register subject T1w to ICBM152 template (linear only, timeout before completion - CUDA prevents saving output)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --reg_type=0 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --reg_type=0 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "linear registration"
 
   - name: reg action - apply mapping parameter check
     description: Verify reg action accepts --apply_warp parameter for transforming images
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --apply_warp=${t2} 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --apply_warp=${t2} 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "from="
 
   - name: reg action - nonlinear registration T1w to template
     description: Register subject T1w to ICBM152 template with nonlinear warping (timeout - CUDA prevents saving output)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --reg_type=1 \
-        --resolution=4 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --reg_type=1 \\\n  --resolution=4 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "reg_type=1"
 
   - name: reg action - subject to template transformation
     description: Verify reg action accepts --from and --to with s2t parameter (timeout - CUDA prevents saving)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --s2t=${t2} 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --s2t=${t2} 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "from dim"
 
   - name: reg action - multi-modality registration
     description: Verify reg action accepts comma-separated multi-modality input (comma format not supported with --from, checks parameter received)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w},${t2} \
-        --to=${template_t1w},${template_t1w} \
-        --reg_type=0 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w},${t2} \\\n  --to=${template_t1w},${template_t1w} \\\n  --reg_type=0 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "from="
 
   # ==========================================================================
@@ -187,26 +166,17 @@ tests:
   # ==========================================================================
   - name: exp action - export QA from template FIB
     description: Export QA metric from ICBM152 template FIB file (writes inside container)
-    command: |
-      dsi_studio --action=exp \
-        --source=${template_fib} \
-        --export=qa 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=exp \\\n  --source=${template_fib} \\\n  --export=qa 2>&1 || true'"
     expected_output_contains: "saving"
 
   - name: exp action - export ISO from template FIB
     description: Export ISO metric from ICBM152 template FIB file
-    command: |
-      dsi_studio --action=exp \
-        --source=${template_fib} \
-        --export=iso 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=exp \\\n  --source=${template_fib} \\\n  --export=iso 2>&1 || true'"
     expected_exit_code: 0
 
   - name: exp action - export multiple metrics
     description: Export multiple diffusion metrics from template FIB
-    command: |
-      dsi_studio --action=exp \
-        --source=${template_fib} \
-        --export=qa,iso,rd,ad 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=exp \\\n  --source=${template_fib} \\\n  --export=qa,iso,rd,ad 2>&1 || true'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -215,48 +185,25 @@ tests:
   # ==========================================================================
   - name: trk action - whole brain tracking (limited)
     description: Run limited whole-brain tracking on ICBM152 template
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --output=test_output/template_wb_tracks.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --output=test_output/template_wb_tracks.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_wb_tracks.tt.gz
 
   - name: trk action - tracking with parameters
     description: Test fiber tracking with custom parameters
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --fa_threshold=0.1 \
-        --turning_angle=60 \
-        --step_size=1.0 \
-        --min_length=20 \
-        --max_length=200 \
-        --output=test_output/template_tracks_params.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --fa_threshold=0.1 \\\n  --turning_angle=60 \\\n  --step_size=1.0 \\\n  --min_length=20 \\\n  --max_length=200 \\\n  --output=test_output/template_tracks_params.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_params.tt.gz
 
   - name: trk action - tracking with ROI
     description: Test fiber tracking with region of interest
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --roi=HCP-MMP:L_V1 \
-        --output=test_output/template_tracks_roi.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --roi=HCP-MMP:L_V1 \\\n  --output=test_output/template_tracks_roi.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_roi.tt.gz
 
   - name: trk action - tracking with connectome
     description: Test fiber tracking with connectivity matrix output
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --connectivity=Brodmann \
-        --output=test_output/template_tracks_conn.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --connectivity=Brodmann \\\n  --output=test_output/template_tracks_conn.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_conn.tt.gz
 
@@ -265,40 +212,23 @@ tests:
   # ==========================================================================
   - name: atk action - track arcuate fasciculus
     description: Automatic tracking of arcuate fasciculus bundle
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Arcuate \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Arcuate \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   - name: atk action - track corticospinal tract
     description: Automatic tracking of corticospinal tract
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Corticos \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Corticos \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   - name: atk action - track multiple bundles
     description: Automatic tracking of multiple bundles
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Arcuate,Cingulum,Fornix \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Arcuate,Cingulum,Fornix \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
     timeout: 300
 
   - name: atk action - with custom tolerance
     description: Automatic tracking with adjusted tolerance
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Uncinate \
-        --tolerance=22,26,30 \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Uncinate \\\n  --tolerance=22,26,30 \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -306,50 +236,30 @@ tests:
   # ==========================================================================
   - name: ana action - tract statistics
     description: Generate tract statistics from tracked fibers
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --tract=test_output/template_wb_tracks.tt.gz \
-        --export=stat 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --tract=test_output/template_wb_tracks.tt.gz \\\n  --export=stat 2>&1 || true'"
     depends_on: trk action - whole brain tracking (limited)
     expected_exit_code: 0
 
   - name: ana action - tract density image
     description: Generate tract density image from tracked fibers
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --tract=test_output/template_wb_tracks.tt.gz \
-        --export=tdi 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --tract=test_output/template_wb_tracks.tt.gz \\\n  --export=tdi 2>&1 || true'"
     depends_on: trk action - whole brain tracking (limited)
     expected_exit_code: 0
 
   - name: ana action - tract to region connectivity
     description: Calculate tract-to-region connectivity matrix
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --tract=test_output/template_wb_tracks.tt.gz \
-        --connectivity=Brodmann 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --tract=test_output/template_wb_tracks.tt.gz \\\n  --connectivity=Brodmann 2>&1 || true'"
     depends_on: trk action - whole brain tracking (limited)
     expected_exit_code: 0
 
   - name: ana action - region statistics with atlas
     description: Get region statistics using HCP-MMP atlas
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --region=HCP-MMP:L_V1 \
-        --export=stat 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --region=HCP-MMP:L_V1 \\\n  --export=stat 2>&1 || true'"
     expected_exit_code: 0
 
   - name: ana action - export tract endpoints
     description: Export tract endpoint coordinates
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --tract=test_output/template_wb_tracks.tt.gz \
-        --export=end_point 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --tract=test_output/template_wb_tracks.tt.gz \\\n  --export=end_point 2>&1 || true'"
     depends_on: trk action - whole brain tracking (limited)
     expected_exit_code: 0
 
@@ -358,7 +268,7 @@ tests:
   # ==========================================================================
   - name: cnt action help check
     description: Verify cnt action for correlational tractography is available
-    command: timeout 10 dsi_studio --action=cnt --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=cnt --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=cnt"
 
   # ==========================================================================
@@ -366,7 +276,7 @@ tests:
   # ==========================================================================
   - name: ren action help check
     description: Verify ren action for file renaming/conversion is available
-    command: timeout 10 dsi_studio --action=ren --source=nonexistent 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=ren --source=nonexistent 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "action=ren"
 
   # ==========================================================================
@@ -374,42 +284,42 @@ tests:
   # ==========================================================================
   - name: Atlas Brodmann exists
     description: Verify Brodmann atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/Brodmann.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/Brodmann.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Atlas HCP-MMP exists
     description: Verify HCP-MMP atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/HCP-MMP.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/HCP-MMP.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Atlas FreeSurferDKT exists
     description: Verify FreeSurfer DKT atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/FreeSurferDKT_Cortical.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/FreeSurferDKT_Cortical.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Atlas Brainnectome exists
     description: Verify Brainnectome atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/Brainnectome.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/Brainnectome.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Atlas CerebrA exists
     description: Verify CerebrA atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/CerebrA.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/CerebrA.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Atlas HCPex exists
     description: Verify HCPex atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/HCPex.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/HCPex.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Atlas JulichBrain exists
     description: Verify JulichBrain atlas is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/JulichBrain.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/JulichBrain.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: HCP842 tractography template exists
     description: Verify HCP842 tractography template is available
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/HCP842_tractography.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/HCP842_tractography.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -417,27 +327,27 @@ tests:
   # ==========================================================================
   - name: Mouse atlas exists
     description: Verify C57BL6 mouse atlas is available
-    command: ls /opt/dsi-studio/atlas/C57BL6_mouse/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/C57BL6_mouse/'\"'\"''"
     expected_exit_code: 0
 
   - name: Rat atlas exists
     description: Verify WHS SD rat atlas is available
-    command: ls /opt/dsi-studio/atlas/WHS_SD_rat/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/WHS_SD_rat/'\"'\"''"
     expected_exit_code: 0
 
   - name: Marmoset atlas exists
     description: Verify Pitt marmoset atlas is available
-    command: ls /opt/dsi-studio/atlas/Pitt_marmoset/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/Pitt_marmoset/'\"'\"''"
     expected_exit_code: 0
 
   - name: Rhesus atlas exists
     description: Verify INDI rhesus atlas is available
-    command: ls /opt/dsi-studio/atlas/INDI_rhesus/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/INDI_rhesus/'\"'\"''"
     expected_exit_code: 0
 
   - name: Neonate atlas exists
     description: Verify dHCP neonate atlas is available
-    command: ls /opt/dsi-studio/atlas/dHCP_neonate/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/dHCP_neonate/'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -445,12 +355,12 @@ tests:
   # ==========================================================================
   - name: Network files exist
     description: Verify network definition files are available
-    command: ls /opt/dsi-studio/network/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/network/'\"'\"''"
     expected_exit_code: 0
 
   - name: Color map files exist
     description: Verify color map files are available
-    command: ls /opt/dsi-studio/color_map/
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/color_map/'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -458,42 +368,24 @@ tests:
   # ==========================================================================
   - name: trk action - differential tracking help
     description: Test differential tracking parameters are recognized
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --dt_threshold=0.1 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --dt_threshold=0.1 2>&1 || true'"
     expected_exit_code: 0
 
   - name: trk action - tracking with smoothing
     description: Test fiber tracking with smoothing parameter
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --smoothing=0.5 \
-        --output=test_output/template_tracks_smooth.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --smoothing=0.5 \\\n  --output=test_output/template_tracks_smooth.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_smooth.tt.gz
 
   - name: trk action - delete repeat streamlines
     description: Test fiber tracking with duplicate removal
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --delete_repeat=1 \
-        --output=test_output/template_tracks_unique.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --delete_repeat=1 \\\n  --output=test_output/template_tracks_unique.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_unique.tt.gz
 
   - name: trk action - output tract statistics
     description: Test fiber tracking with inline statistics export
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --export=stat \
-        --output=test_output/template_tracks_stat.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --export=stat \\\n  --output=test_output/template_tracks_stat.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_stat.tt.gz
 
@@ -502,36 +394,19 @@ tests:
   # ==========================================================================
   - name: trk action - HCP-MMP connectivity
     description: Generate connectivity matrix using HCP-MMP parcellation
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=200 \
-        --connectivity=HCP-MMP \
-        --connectivity_type=pass \
-        --output=test_output/template_conn_hcpmmp.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=200 \\\n  --connectivity=HCP-MMP \\\n  --connectivity_type=pass \\\n  --output=test_output/template_conn_hcpmmp.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_conn_hcpmmp.tt.gz
 
   - name: trk action - multiple atlas connectivity
     description: Generate connectivity matrices for multiple atlases
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --connectivity=Brodmann,FreeSurferDKT_Cortical \
-        --output=test_output/template_conn_multi.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --connectivity=Brodmann,FreeSurferDKT_Cortical \\\n  --output=test_output/template_conn_multi.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_conn_multi.tt.gz
 
   - name: trk action - endpoint connectivity
     description: Generate endpoint-based connectivity matrix
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --connectivity=Brodmann \
-        --connectivity_type=end \
-        --output=test_output/template_conn_end.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --connectivity=Brodmann \\\n  --connectivity_type=end \\\n  --output=test_output/template_conn_end.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_conn_end.tt.gz
 
@@ -540,32 +415,17 @@ tests:
   # ==========================================================================
   - name: reg action - cost function mutual information
     description: Test registration accepts mutual information cost function parameter (timeout - CUDA prevents saving)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --cost_function=mi \
-        --reg_type=0 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --cost_function=mi \\\n  --reg_type=0 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "cost_function=mi"
 
   - name: reg action - high resolution registration
     description: Test registration accepts resolution parameter (timeout - CUDA prevents saving)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --resolution=2 \
-        --reg_type=0 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --resolution=2 \\\n  --reg_type=0 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "linear registration"
 
   - name: reg action - smoothed registration
     description: Test registration accepts smoothing parameter (timeout - CUDA prevents saving)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --smoothing=0.5 \
-        --reg_type=0 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --smoothing=0.5 \\\n  --reg_type=0 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true'"
     expected_output_contains: "linear registration"
 
   # ==========================================================================
@@ -573,47 +433,27 @@ tests:
   # ==========================================================================
   - name: atk action - inferior longitudinal fasciculus
     description: Track inferior longitudinal fasciculus
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=InferiorLongitudinal \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=InferiorLongitudinal \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   - name: atk action - superior longitudinal fasciculus
     description: Track superior longitudinal fasciculus
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=SuperiorLongitudinal \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=SuperiorLongitudinal \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   - name: atk action - optic radiation
     description: Track optic radiation
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Optic \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Optic \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   - name: atk action - corpus callosum
     description: Track corpus callosum
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Corpus \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Corpus \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   - name: atk action - thalamic radiation
     description: Track thalamic radiation
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=ThalamicR \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=ThalamicR \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -621,17 +461,17 @@ tests:
   # ==========================================================================
   - name: Device configuration exists
     description: Verify device configuration file is present
-    command: ls /opt/dsi-studio/device.txt
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/device.txt'\"'\"''"
     expected_exit_code: 0
 
   - name: TOPUP parameter file exists
     description: Verify TOPUP parameter file is present
-    command: ls /opt/dsi-studio/topup_param.txt
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/topup_param.txt'\"'\"''"
     expected_exit_code: 0
 
   - name: License file exists
     description: Verify license file is present
-    command: ls /opt/dsi-studio/LICENSE
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/LICENSE'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -639,30 +479,27 @@ tests:
   # ==========================================================================
   - name: Template FIB file valid
     description: Verify template FIB file can be queried
-    command: |
-      dsi_studio --action=exp \
-        --source=${template_fib} \
-        --export=fa 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=exp \\\n  --source=${template_fib} \\\n  --export=fa 2>&1 || true'"
     expected_exit_code: 0
 
   - name: Template tract file exists
     description: Verify template tractography file exists
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.tt.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.tt.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Template mask file exists
     description: Verify template mask file exists
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.mask.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.mask.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Template white matter file exists
     description: Verify template white matter file exists
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.WM.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.WM.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   - name: Template ROI file exists
     description: Verify template ROI file exists
-    command: ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.roi.nii.gz
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/dsi-studio/atlas/ICBM152_adult/ICBM152_adult.roi.nii.gz'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -670,29 +507,17 @@ tests:
   # ==========================================================================
   - name: ana action - Brodmann region analysis
     description: Analyze specific Brodmann area
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --region=Brodmann:17 \
-        --export=stat 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --region=Brodmann:17 \\\n  --export=stat 2>&1 || true'"
     expected_exit_code: 0
 
   - name: ana action - FreeSurfer region analysis
     description: Analyze FreeSurfer DKT region
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --region=FreeSurferDKT_Cortical:L_precentral \
-        --export=stat 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --region=FreeSurferDKT_Cortical:L_precentral \\\n  --export=stat 2>&1 || true'"
     expected_exit_code: 0
 
   - name: ana action - cerebellum region analysis
     description: Analyze cerebellum region using SUIT atlas
-    command: |
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --region=Cerebellum-SUIT:Left_I_IV \
-        --export=stat 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --region=Cerebellum-SUIT:Left_I_IV \\\n  --export=stat 2>&1 || true'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -700,11 +525,7 @@ tests:
   # ==========================================================================
   - name: trk action - output as TRK format
     description: Test fiber tracking with TRK output format
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --output=test_output/template_tracks.trk.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --output=test_output/template_tracks.trk.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks.trk.gz
 
@@ -713,12 +534,12 @@ tests:
   # ==========================================================================
   - name: Missing source file error
     description: Verify proper error handling for missing source file
-    command: timeout 10 dsi_studio --action=rec --source=nonexistent_file.src.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=rec --source=nonexistent_file.src.gz 2>&1 || true'"
     expected_output_contains: "does not exist"
 
   - name: Invalid action error
     description: Verify proper error handling for invalid action
-    command: timeout 10 dsi_studio --action=invalid_action --source=nonexistent 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=invalid_action --source=nonexistent 2>&1 || true'"
     expected_output_contains: "unknown action"
 
   # ==========================================================================
@@ -726,23 +547,13 @@ tests:
   # ==========================================================================
   - name: trk action - single threaded
     description: Test fiber tracking with single thread
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --thread_count=1 \
-        --output=test_output/template_tracks_1thread.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --thread_count=1 \\\n  --output=test_output/template_tracks_1thread.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_1thread.tt.gz
 
   - name: trk action - multi threaded
     description: Test fiber tracking with multiple threads
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --thread_count=4 \
-        --output=test_output/template_tracks_4thread.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --thread_count=4 \\\n  --output=test_output/template_tracks_4thread.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/template_tracks_4thread.tt.gz
 
@@ -751,40 +562,19 @@ tests:
   # ==========================================================================
   - name: Pipeline - register and track
     description: Verify reg action starts then run tracking on template (reg can't save output without CUDA)
-    command: |
-      timeout 10 dsi_studio --action=reg \
-        --from=${t1w} \
-        --to=${template_t1w} \
-        --reg_type=0 2>&1 | sed 's/\x1b\[[0-9;]*m//g' || true
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=50 \
-        --output=test_output/pipeline_tracks.tt.gz 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen timeout 10 dsi_studio --action=reg \\\n  --from=${t1w} \\\n  --to=${template_t1w} \\\n  --reg_type=0 2>&1 | sed '\"'\"'s/\\x1b\\[[0-9;]*m//g'\"'\"' || true\ndsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=50 \\\n  --output=test_output/pipeline_tracks.tt.gz 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/pipeline_tracks.tt.gz
 
   - name: Pipeline - track and analyze
     description: Run tracking and then analyze the resulting tracts
-    command: |
-      dsi_studio --action=trk \
-        --source=${template_fib} \
-        --seed_count=100 \
-        --output=test_output/pipeline_ana_tracks.tt.gz 2>&1 && \
-      dsi_studio --action=ana \
-        --source=${template_fib} \
-        --tract=test_output/pipeline_ana_tracks.tt.gz \
-        --connectivity=Brodmann 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=trk \\\n  --source=${template_fib} \\\n  --seed_count=100 \\\n  --output=test_output/pipeline_ana_tracks.tt.gz 2>&1 && \\\ndsi_studio --action=ana \\\n  --source=${template_fib} \\\n  --tract=test_output/pipeline_ana_tracks.tt.gz \\\n  --connectivity=Brodmann 2>&1 || true'"
     validate:
       - output_exists: ${output_dir}/pipeline_ana_tracks.tt.gz
 
   - name: Pipeline - autotrack multiple bundles with export
     description: Automatically track bundles and export statistics
-    command: |
-      dsi_studio --action=atk \
-        --source=${template_fib} \
-        --track_id=Arcuate,Uncinate \
-        --export=stat \
-        --output=test_output/ 2>&1 || true
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen dsi_studio --action=atk \\\n  --source=${template_fib} \\\n  --track_id=Arcuate,Uncinate \\\n  --export=stat \\\n  --output=test_output/ 2>&1 || true'"
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/eeglab/fulltest.yaml
+++ b/recipes/eeglab/fulltest.yaml
@@ -49,12 +49,12 @@ tests:
   # ==========================================================================
   - name: EEGLAB binary exists
     description: Verify EEGLAB binary is present in expected location
-    command: test -f /opt/eeglab-2020.0/EEGLAB && echo "EEGLAB binary found"
+    command: bash -lc 'test -f /opt/eeglab-2020.0/EEGLAB && echo "EEGLAB binary found"'
     expected_output_contains: "EEGLAB binary found"
 
   - name: EEGLAB binary is executable
     description: Verify EEGLAB binary has execute permissions
-    command: test -x /opt/eeglab-2020.0/EEGLAB && echo "EEGLAB is executable"
+    command: bash -lc 'test -x /opt/eeglab-2020.0/EEGLAB && echo "EEGLAB is executable"'
     expected_output_contains: "EEGLAB is executable"
 
   - name: EEGLAB in PATH
@@ -64,17 +64,17 @@ tests:
 
   - name: EEGLAB binary is ELF executable
     description: Verify EEGLAB binary is a valid Linux ELF executable
-    command: od -c -N 4 /opt/eeglab-2020.0/EEGLAB | head -1
+    command: "bash -lc 'od -c -N 4 /opt/eeglab-2020.0/EEGLAB | head -1'"
     expected_output_contains: "E   L   F"
 
   - name: EEGLAB run script exists
     description: Verify run_EEGLAB.sh wrapper script is present
-    command: test -f /opt/eeglab-2020.0/run_EEGLAB.sh && echo "Run script found"
+    command: bash -lc 'test -f /opt/eeglab-2020.0/run_EEGLAB.sh && echo "Run script found"'
     expected_output_contains: "Run script found"
 
   - name: EEGLAB run script is executable
     description: Verify run_EEGLAB.sh has execute permissions
-    command: test -x /opt/eeglab-2020.0/run_EEGLAB.sh && echo "Run script executable"
+    command: bash -lc 'test -x /opt/eeglab-2020.0/run_EEGLAB.sh && echo "Run script executable"'
     expected_output_contains: "Run script executable"
 
   # ==========================================================================
@@ -82,52 +82,52 @@ tests:
   # ==========================================================================
   - name: MCR directory exists
     description: Verify MATLAB Compiler Runtime is installed
-    command: test -d /opt/MCR/v98 && echo "MCR v98 directory found"
+    command: bash -lc 'test -d /opt/MCR/v98 && echo "MCR v98 directory found"'
     expected_output_contains: "MCR v98 directory found"
 
   - name: MCR version is R2020a
     description: Verify MCR version matches EEGLAB requirements (R2020a)
-    command: cat /opt/MCR/v98/VersionInfo.xml
+    command: "bash -lc 'cat /opt/MCR/v98/VersionInfo.xml'"
     expected_output_contains: "R2020a"
 
   - name: MCR version number
     description: Verify MCR version 9.8 is installed
-    command: cat /opt/MCR/v98/VersionInfo.xml
+    command: "bash -lc 'cat /opt/MCR/v98/VersionInfo.xml'"
     expected_output_contains: "9.8"
 
   - name: MCR runtime libraries exist
     description: Verify MCR runtime library directory is present
-    command: test -d /opt/MCR/v98/runtime/glnxa64 && echo "MCR runtime found"
+    command: bash -lc 'test -d /opt/MCR/v98/runtime/glnxa64 && echo "MCR runtime found"'
     expected_output_contains: "MCR runtime found"
 
   - name: MCR bin libraries exist
     description: Verify MCR bin library directory is present
-    command: test -d /opt/MCR/v98/bin/glnxa64 && echo "MCR bin found"
+    command: bash -lc 'test -d /opt/MCR/v98/bin/glnxa64 && echo "MCR bin found"'
     expected_output_contains: "MCR bin found"
 
   - name: MCR system libraries exist
     description: Verify MCR system OS libraries are present
-    command: test -d /opt/MCR/v98/sys/os/glnxa64 && echo "MCR sys/os found"
+    command: bash -lc 'test -d /opt/MCR/v98/sys/os/glnxa64 && echo "MCR sys/os found"'
     expected_output_contains: "MCR sys/os found"
 
   - name: MCR Java runtime exists
     description: Verify MCR Java Runtime Environment is present
-    command: test -d /opt/MCR/v98/sys/java/jre/glnxa64/jre && echo "MCR JRE found"
+    command: bash -lc 'test -d /opt/MCR/v98/sys/java/jre/glnxa64/jre && echo "MCR JRE found"'
     expected_output_contains: "MCR JRE found"
 
   - name: MCR toolbox directory exists
     description: Verify MCR toolbox directory is present
-    command: test -d /opt/MCR/v98/toolbox && echo "MCR toolbox found"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox && echo "MCR toolbox found"'
     expected_output_contains: "MCR toolbox found"
 
   - name: MCR MATLAB core toolbox exists
     description: Verify core MATLAB toolbox is installed
-    command: test -d /opt/MCR/v98/toolbox/matlab && echo "MATLAB toolbox found"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/matlab && echo "MATLAB toolbox found"'
     expected_output_contains: "MATLAB toolbox found"
 
   - name: MCR signal processing toolbox
     description: Check if signal processing toolbox components are present
-    command: ls -d /opt/MCR/v98/toolbox/shared/signal* 2>/dev/null && echo "Signal processing found" || echo "Signal processing not separate"
+    command: bash -lc 'ls -d /opt/MCR/v98/toolbox/shared/signal* 2>/dev/null && echo "Signal processing found" || echo "Signal processing not separate"'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -168,7 +168,7 @@ tests:
   # ==========================================================================
   - name: README exists in container root
     description: Verify README.md is present at container root
-    command: test -f /README.md && echo "README found"
+    command: bash -lc 'test -f /README.md && echo "README found"'
     expected_output_contains: "README found"
 
   - name: README contains EEGLAB info
@@ -193,37 +193,37 @@ tests:
 
   - name: EEGLAB license file exists
     description: Verify EEGLAB license file is present
-    command: test -f /opt/eeglab-2020.0/eeglablicense.txt && echo "License found"
+    command: bash -lc 'test -f /opt/eeglab-2020.0/eeglablicense.txt && echo "License found"'
     expected_output_contains: "License found"
 
   - name: EEGLAB license is BSD
     description: Verify EEGLAB is released under BSD license
-    command: cat /opt/eeglab-2020.0/eeglablicense.txt
+    command: "bash -lc 'cat /opt/eeglab-2020.0/eeglablicense.txt'"
     expected_output_contains: "Redistribution"
 
   - name: EEGLAB readme file exists
     description: Verify EEGLAB readme.txt is present
-    command: test -f /opt/eeglab-2020.0/readme.txt && echo "EEGLAB readme found"
+    command: bash -lc 'test -f /opt/eeglab-2020.0/readme.txt && echo "EEGLAB readme found"'
     expected_output_contains: "EEGLAB readme found"
 
   - name: EEGLAB readme mentions MCR requirements
     description: Verify readme mentions MATLAB Runtime requirements
-    command: cat /opt/eeglab-2020.0/readme.txt
+    command: "bash -lc 'cat /opt/eeglab-2020.0/readme.txt'"
     expected_output_contains: "MATLAB Runtime"
 
   - name: EEGLAB readme mentions version 9.8
     description: Verify readme specifies MCR version 9.8 (R2020a)
-    command: cat /opt/eeglab-2020.0/readme.txt
+    command: "bash -lc 'cat /opt/eeglab-2020.0/readme.txt'"
     expected_output_contains: "9.8"
 
   - name: MCR license file exists
     description: Verify MCR license file is present
-    command: test -f /opt/MCR/v98/MCR_license.txt && echo "MCR license found"
+    command: bash -lc 'test -f /opt/MCR/v98/MCR_license.txt && echo "MCR license found"'
     expected_output_contains: "MCR license found"
 
   - name: MCR patents file exists
     description: Verify MCR patents file is present
-    command: test -f /opt/MCR/v98/patents.txt && echo "MCR patents found"
+    command: bash -lc 'test -f /opt/MCR/v98/patents.txt && echo "MCR patents found"'
     expected_output_contains: "MCR patents found"
 
   # ==========================================================================
@@ -231,12 +231,12 @@ tests:
   # ==========================================================================
   - name: EEGLAB splash image exists
     description: Verify EEGLAB splash screen image is present
-    command: test -f /opt/eeglab-2020.0/splash.png && echo "Splash image found"
+    command: bash -lc 'test -f /opt/eeglab-2020.0/splash.png && echo "Splash image found"'
     expected_output_contains: "Splash image found"
 
   - name: Splash image is valid image
     description: Verify splash.png exists and has valid image header (actually JPEG)
-    command: test -f /opt/eeglab-2020.0/splash.png && echo "Splash image file exists"
+    command: bash -lc 'test -f /opt/eeglab-2020.0/splash.png && echo "Splash image file exists"'
     expected_output_contains: "Splash image file exists"
 
   # ==========================================================================
@@ -244,17 +244,17 @@ tests:
   # ==========================================================================
   - name: libmwmclmcrrt library exists
     description: Verify core MCR library is present
-    command: ls /opt/MCR/v98/runtime/glnxa64/libmwmclmcrrt.so* 2>/dev/null | head -1 | xargs test -f && echo "libmwmclmcrrt found"
+    command: bash -lc 'ls /opt/MCR/v98/runtime/glnxa64/libmwmclmcrrt.so* 2>/dev/null | head -1 | xargs test -f && echo "libmwmclmcrrt found"'
     expected_output_contains: "libmwmclmcrrt found"
 
   - name: MCR libmwcpp_shared exists
     description: Verify MCR C++ shared library is present
-    command: ls /opt/MCR/v98/bin/glnxa64/libmwcpp_shared.so* 2>/dev/null | head -1 | xargs test -f && echo "libmwcpp_shared found"
+    command: bash -lc 'ls /opt/MCR/v98/bin/glnxa64/libmwcpp_shared.so* 2>/dev/null | head -1 | xargs test -f && echo "libmwcpp_shared found"'
     expected_output_contains: "libmwcpp_shared found"
 
   - name: MCR OpenGL libraries exist
     description: Verify MCR OpenGL libraries directory is present
-    command: test -d /opt/MCR/v98/sys/opengl/lib/glnxa64 && echo "OpenGL libs found"
+    command: bash -lc 'test -d /opt/MCR/v98/sys/opengl/lib/glnxa64 && echo "OpenGL libs found"'
     expected_output_contains: "OpenGL libs found"
 
   # ==========================================================================
@@ -290,7 +290,7 @@ tests:
   # ==========================================================================
   - name: Reproenv JSON exists
     description: Verify reproenv build metadata is present
-    command: test -f /.reproenv.json && echo "reproenv.json found"
+    command: bash -lc 'test -f /.reproenv.json && echo "reproenv.json found"'
     expected_output_contains: "reproenv.json found"
 
   - name: Container based on Ubuntu
@@ -300,17 +300,17 @@ tests:
 
   - name: Singularity environment directory exists
     description: Verify Singularity metadata directory is present
-    command: test -d /.singularity.d && echo "Singularity metadata found"
+    command: bash -lc 'test -d /.singularity.d && echo "Singularity metadata found"'
     expected_output_contains: "Singularity metadata found"
 
   - name: Singularity runscript exists
     description: Verify Singularity runscript is present
-    command: test -f /.singularity.d/runscript && echo "Runscript found"
+    command: bash -lc 'test -f /.singularity.d/runscript && echo "Runscript found"'
     expected_output_contains: "Runscript found"
 
   - name: Environment scripts exist
     description: Verify environment setup scripts are present
-    command: test -d /.singularity.d/env && ls /.singularity.d/env/*.sh | wc -l
+    command: bash -lc 'test -d /.singularity.d/env && ls /.singularity.d/env/*.sh | wc -l'
     expected_output_contains: "6"
 
   # ==========================================================================
@@ -318,12 +318,12 @@ tests:
   # ==========================================================================
   - name: System x86_64 libraries exist
     description: Verify system x86_64 library directory is present
-    command: test -d /usr/lib/x86_64-linux-gnu && echo "x86_64 libs found"
+    command: bash -lc 'test -d /usr/lib/x86_64-linux-gnu && echo "x86_64 libs found"'
     expected_output_contains: "x86_64 libs found"
 
   - name: System lib64 directory exists
     description: Verify lib64 directory is present
-    command: test -d /lib64 && echo "lib64 found"
+    command: bash -lc 'test -d /lib64 && echo "lib64 found"'
     expected_output_contains: "lib64 found"
 
   - name: Basic system utilities available
@@ -341,27 +341,27 @@ tests:
   # ==========================================================================
   - name: MCR compiler toolbox exists
     description: Verify MATLAB compiler toolbox is present
-    command: test -d /opt/MCR/v98/toolbox/compiler && echo "Compiler toolbox found"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/compiler && echo "Compiler toolbox found"'
     expected_output_contains: "Compiler toolbox found"
 
   - name: MCR images toolbox exists
     description: Verify image processing toolbox components are present
-    command: test -d /opt/MCR/v98/toolbox/images && echo "Images toolbox found"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/images && echo "Images toolbox found"'
     expected_output_contains: "Images toolbox found"
 
   - name: MCR shared toolbox exists
     description: Verify shared toolbox directory is present
-    command: test -d /opt/MCR/v98/toolbox/shared && echo "Shared toolbox found"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/shared && echo "Shared toolbox found"'
     expected_output_contains: "Shared toolbox found"
 
   - name: MCR parallel toolbox exists
     description: Verify parallel computing toolbox components are present
-    command: test -d /opt/MCR/v98/toolbox/parallel && echo "Parallel toolbox found"
+    command: bash -lc 'test -d /opt/MCR/v98/toolbox/parallel && echo "Parallel toolbox found"'
     expected_output_contains: "Parallel toolbox found"
 
   - name: MCR statistics functions available
     description: Check for statistics-related toolbox components
-    command: ls -d /opt/MCR/v98/toolbox/shared/statslib* 2>/dev/null && echo "Stats lib found" || ls /opt/MCR/v98/toolbox/shared/ | grep -i stat || echo "Stats in shared"
+    command: bash -lc 'ls -d /opt/MCR/v98/toolbox/shared/statslib* 2>/dev/null && echo "Stats lib found" || ls /opt/MCR/v98/toolbox/shared/ | grep -i stat || echo "Stats in shared"'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -369,27 +369,27 @@ tests:
   # ==========================================================================
   - name: Run script sets MCRROOT
     description: Verify run_EEGLAB.sh configures MCRROOT
-    command: cat /opt/eeglab-2020.0/run_EEGLAB.sh
+    command: "bash -lc 'cat /opt/eeglab-2020.0/run_EEGLAB.sh'"
     expected_output_contains: "MCRROOT"
 
   - name: Run script sets LD_LIBRARY_PATH
     description: Verify run_EEGLAB.sh configures LD_LIBRARY_PATH
-    command: cat /opt/eeglab-2020.0/run_EEGLAB.sh
+    command: "bash -lc 'cat /opt/eeglab-2020.0/run_EEGLAB.sh'"
     expected_output_contains: "LD_LIBRARY_PATH"
 
   - name: Run script includes runtime path
     description: Verify run_EEGLAB.sh includes runtime/glnxa64 path
-    command: cat /opt/eeglab-2020.0/run_EEGLAB.sh
+    command: "bash -lc 'cat /opt/eeglab-2020.0/run_EEGLAB.sh'"
     expected_output_contains: "runtime/glnxa64"
 
   - name: Run script includes bin path
     description: Verify run_EEGLAB.sh includes bin/glnxa64 path
-    command: cat /opt/eeglab-2020.0/run_EEGLAB.sh
+    command: "bash -lc 'cat /opt/eeglab-2020.0/run_EEGLAB.sh'"
     expected_output_contains: "bin/glnxa64"
 
   - name: Run script includes OpenGL path
     description: Verify run_EEGLAB.sh includes OpenGL library path
-    command: cat /opt/eeglab-2020.0/run_EEGLAB.sh
+    command: "bash -lc 'cat /opt/eeglab-2020.0/run_EEGLAB.sh'"
     expected_output_contains: "opengl"
 
   # ==========================================================================
@@ -397,22 +397,22 @@ tests:
   # ==========================================================================
   - name: Standard mount points exist
     description: Verify standard mount point directories are present
-    command: test -d /data && test -d /scratch && echo "Mount points found"
+    command: bash -lc 'test -d /data && test -d /scratch && echo "Mount points found"'
     expected_output_contains: "Mount points found"
 
   - name: Home directory accessible
     description: Verify home directory is accessible
-    command: test -d /home && echo "Home accessible"
+    command: bash -lc 'test -d /home && echo "Home accessible"'
     expected_output_contains: "Home accessible"
 
   - name: Tmp directory exists and writable
     description: Verify tmp directory exists and is writable
-    command: test -d /tmp && test -w /tmp && echo "Tmp writable"
+    command: bash -lc 'test -d /tmp && test -w /tmp && echo "Tmp writable"'
     expected_output_contains: "Tmp writable"
 
   - name: Proc filesystem mounted
     description: Verify proc filesystem is mounted
-    command: test -d /proc && echo "Proc mounted"
+    command: bash -lc 'test -d /proc && echo "Proc mounted"'
     expected_output_contains: "Proc mounted"
 
   # ==========================================================================
@@ -420,16 +420,14 @@ tests:
   # ==========================================================================
   - name: EEGLAB binary has reasonable size
     description: Verify EEGLAB binary size is greater than 100MB (compiled application)
-    command: |
-      size=$(stat -c%s /opt/eeglab-2020.0/EEGLAB 2>/dev/null || stat -f%z /opt/eeglab-2020.0/EEGLAB 2>/dev/null)
-      if [ "$size" -gt 100000000 ]; then echo "Binary size OK: $size bytes"; else echo "Binary too small"; fi
+    command: "bash -lc 'size=$(stat -c%s /opt/eeglab-2020.0/EEGLAB 2>/dev/null || stat -f%z /opt/eeglab-2020.0/EEGLAB 2>/dev/null)\nif [ \"$size\" -gt 100000000 ]; then echo \"Binary size OK: $size bytes\"; else echo \"Binary too small\"; fi'"
     expected_output_contains: "Binary size OK"
 
   - name: MCR installation has significant size
     description: Verify MCR installation is substantial (multiple GB expected)
     command: |
-      count=$(find /opt/MCR/v98/ -name '*.so*' 2>/dev/null | wc -l)
-      if [ "$count" -gt 50 ]; then echo "MCR runtime has $count libraries"; else echo "MCR incomplete: $count"; fi
+      bash -lc 'count=$(find /opt/MCR/v98/ -name '\''*.so*'\'' 2>/dev/null | wc -l)
+      if [ "$count" -gt 50 ]; then echo "MCR runtime has $count libraries"; else echo "MCR incomplete: $count"; fi'
     expected_output_contains: "MCR runtime has"
 
   # ==========================================================================
@@ -437,12 +435,12 @@ tests:
   # ==========================================================================
   - name: Java binary exists in MCR
     description: Verify Java binary is present in MCR
-    command: test -f /opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java && echo "Java binary found"
+    command: bash -lc 'test -f /opt/MCR/v98/sys/java/jre/glnxa64/jre/bin/java && echo "Java binary found"'
     expected_output_contains: "Java binary found"
 
   - name: Java libraries exist
     description: Verify Java library directory exists
-    command: test -d /opt/MCR/v98/sys/java/jre/glnxa64/jre/lib && echo "Java libs found"
+    command: bash -lc 'test -d /opt/MCR/v98/sys/java/jre/glnxa64/jre/lib && echo "Java libs found"'
     expected_output_contains: "Java libs found"
 
   # ==========================================================================

--- a/recipes/ezbids/fulltest.yaml
+++ b/recipes/ezbids/fulltest.yaml
@@ -250,7 +250,7 @@ tests:
 
   - name: flirt to MNI template
     description: Register T1w to MNI152 template
-    command: flirt -in ${t1w} -ref /usr/local/fsl/data/standard/MNI152_T1_2mm_brain.nii.gz -out test_output/t1w_mni.nii.gz -omat test_output/t1w_to_mni.mat -dof 12
+    command: "bash -lc 'flirt -in ${t1w} -ref /usr/local/fsl/data/standard/MNI152_T1_2mm_brain.nii.gz -out test_output/t1w_mni.nii.gz -omat test_output/t1w_to_mni.mat -dof 12'"
     validate:
       - output_exists: ${output_dir}/t1w_mni.nii.gz
       - output_exists: ${output_dir}/t1w_to_mni.mat
@@ -266,14 +266,14 @@ tests:
   # ==========================================================================
   - name: ROBEX brain extraction
     description: Extract brain from T1w using ROBEX
-    command: /ROBEX/runROBEX.sh ${t1w} test_output/t1w_brain_robex.nii.gz test_output/t1w_brain_mask_robex.nii.gz
+    command: bash -lc '/ROBEX/runROBEX.sh ${t1w} test_output/t1w_brain_robex.nii.gz test_output/t1w_brain_mask_robex.nii.gz'
     validate:
       - output_exists: ${output_dir}/t1w_brain_robex.nii.gz
       - output_exists: ${output_dir}/t1w_brain_mask_robex.nii.gz
 
   - name: ROBEX brain only
     description: Extract brain without saving mask
-    command: /ROBEX/runROBEX.sh ${t1w} test_output/t1w_brain_only.nii.gz
+    command: bash -lc '/ROBEX/runROBEX.sh ${t1w} test_output/t1w_brain_only.nii.gz'
     validate:
       - output_exists: ${output_dir}/t1w_brain_only.nii.gz
 
@@ -592,10 +592,10 @@ tests:
   - name: Complete T1w processing pipeline
     description: Full pipeline - reorient (nibabel), brain extract, register to MNI
     command: |
-      python3 -c "import nibabel as nib; img = nib.load('${t1w}'); nib.save(nib.as_closest_canonical(img), 'test_output/pipeline_reoriented.nii.gz')" && \
+      bash -lc 'python3 -c "import nibabel as nib; img = nib.load('\''${t1w}'\''); nib.save(nib.as_closest_canonical(img), '\''test_output/pipeline_reoriented.nii.gz'\'')" && \
       /ROBEX/runROBEX.sh test_output/pipeline_reoriented.nii.gz test_output/pipeline_brain.nii.gz test_output/pipeline_mask.nii.gz && \
       flirt -in test_output/pipeline_brain.nii.gz -ref /usr/local/fsl/data/standard/MNI152_T1_2mm_brain.nii.gz -out test_output/pipeline_mni.nii.gz -dof 12 && \
-      echo "Pipeline complete"
+      echo "Pipeline complete"'
     validate:
       - output_exists: ${output_dir}/pipeline_reoriented.nii.gz
       - output_exists: ${output_dir}/pipeline_brain.nii.gz
@@ -605,9 +605,9 @@ tests:
   - name: Brain extraction and defacing pipeline
     description: Extract brain, then deface original using mask
     command: |
-      /ROBEX/runROBEX.sh ${t1w} test_output/pipeline2_brain.nii.gz test_output/pipeline2_mask.nii.gz && \
+      bash -lc '/ROBEX/runROBEX.sh ${t1w} test_output/pipeline2_brain.nii.gz test_output/pipeline2_mask.nii.gz && \
       quickshear ${t1w} test_output/pipeline2_mask.nii.gz test_output/pipeline2_defaced.nii.gz && \
-      echo "Defacing pipeline complete"
+      echo "Defacing pipeline complete"'
     validate:
       - output_exists: ${output_dir}/pipeline2_brain.nii.gz
       - output_exists: ${output_dir}/pipeline2_mask.nii.gz
@@ -703,7 +703,7 @@ tests:
 
   - name: MNI template exists
     description: Verify MNI152 template is available
-    command: ls -la /usr/local/fsl/data/standard/MNI152_T1_2mm_brain.nii.gz
+    command: "bash -lc 'ls -la /usr/local/fsl/data/standard/MNI152_T1_2mm_brain.nii.gz'"
     expected_output_contains: "MNI152"
 
 cleanup:

--- a/recipes/fastcsr/fulltest.yaml
+++ b/recipes/fastcsr/fulltest.yaml
@@ -43,22 +43,22 @@ tests:
   # ==========================================================================
   - name: FastCSR pipeline help
     description: Verify FastCSR pipeline.py displays help information
-    command: python3 /opt/FastCSR/pipeline.py --help 2>&1
+    command: "bash -lc 'python3 /opt/FastCSR/pipeline.py --help 2>&1'"
     expected_output_contains: "--sid"
 
   - name: FastCSR model inference help
     description: Verify fastcsr_model_infer.py displays help
-    command: python3 /opt/FastCSR/fastcsr_model_infer.py --help 2>&1
+    command: "bash -lc 'python3 /opt/FastCSR/fastcsr_model_infer.py --help 2>&1'"
     expected_output_contains: "--hemi"
 
   - name: FastCSR brain finalsurfs model help
     description: Verify brain_finalsurfs_model_infer.py displays help
-    command: python3 /opt/FastCSR/brain_finalsurfs_model_infer.py --help 2>&1
+    command: "bash -lc 'python3 /opt/FastCSR/brain_finalsurfs_model_infer.py --help 2>&1'"
     expected_output_contains: "--subj"
 
   - name: FastCSR levelset2surf help
     description: Verify levelset2surf.py displays help
-    command: python3 /opt/FastCSR/levelset2surf.py --help 2>&1
+    command: "bash -lc 'python3 /opt/FastCSR/levelset2surf.py --help 2>&1'"
     expected_output_contains: "--suffix"
 
   # ==========================================================================
@@ -66,15 +66,12 @@ tests:
   # ==========================================================================
   - name: FreeSurfer environment setup
     description: Verify FreeSurfer home directory exists
-    command: ls /opt/freesurfer-6.0.0/SetUpFreeSurfer.sh
+    command: "bash -lc 'ls /opt/freesurfer-6.0.0/SetUpFreeSurfer.sh'"
     expected_exit_code: 0
 
   - name: FreeSurfer version check
     description: Verify FreeSurfer installation version
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      cat $FREESURFER_HOME/build-stamp.txt 2>/dev/null || echo "freesurfer-6.0"
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\ncat $FREESURFER_HOME/build-stamp.txt 2>/dev/null || echo \"freesurfer-6.0\"'"
     expected_output_contains: "freesurfer"
 
   # ==========================================================================
@@ -82,55 +79,37 @@ tests:
   # ==========================================================================
   - name: mri_convert help
     description: Verify mri_convert displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert --help 2>&1 | head -20'"
     expected_output_contains: "mri_convert"
 
   - name: Convert NIfTI to MGZ
     description: Convert T1w NIfTI to FreeSurfer MGZ format
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert ${t1w} test_output/t1w_orig.mgz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert ${t1w} test_output/t1w_orig.mgz'"
     validate:
       - output_exists: ${output_dir}/t1w_orig.mgz
 
   - name: Convert MGZ back to NIfTI
     description: Convert MGZ back to NIfTI format
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert test_output/t1w_orig.mgz test_output/t1w_reconvert.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert test_output/t1w_orig.mgz test_output/t1w_reconvert.nii.gz'"
     depends_on: Convert NIfTI to MGZ
     validate:
       - output_exists: ${output_dir}/t1w_reconvert.nii.gz
 
   - name: Conform volume to 256x256x256
     description: Conform T1w to standard FreeSurfer dimensions
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert ${t1w} --conform test_output/t1w_conformed.mgz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert ${t1w} --conform test_output/t1w_conformed.mgz'"
     validate:
       - output_exists: ${output_dir}/t1w_conformed.mgz
 
   - name: Convert with resampling
     description: Resample T1w to 1mm isotropic voxels
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert ${t1w} -vs 1 1 1 test_output/t1w_1mm.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert ${t1w} -vs 1 1 1 test_output/t1w_1mm.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_1mm.nii.gz
 
   - name: Convert with output type specification
     description: Convert with explicit output data type
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert ${t1w} --out_type nii test_output/t1w_nii.nii
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert ${t1w} --out_type nii test_output/t1w_nii.nii'"
     validate:
       - output_exists: ${output_dir}/t1w_nii.nii
 
@@ -139,50 +118,32 @@ tests:
   # ==========================================================================
   - name: mri_info basic
     description: Display basic volume information
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info ${t1w} 2>&1
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info ${t1w} 2>&1'"
     expected_output_contains: "dimensions"
 
   - name: mri_info dimensions
     description: Get volume dimensions
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info --dim ${t1w}
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info --dim ${t1w}'"
     expected_exit_code: 0
 
   - name: mri_info resolution
     description: Get volume resolution
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info --res ${t1w}
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info --res ${t1w}'"
     expected_exit_code: 0
 
   - name: mri_info voxel volume
     description: Get voxel volume
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info --voxvol ${t1w}
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info --voxvol ${t1w}'"
     expected_exit_code: 0
 
   - name: mri_info orientation
     description: Get volume orientation
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info --orientation ${t1w}
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info --orientation ${t1w}'"
     expected_exit_code: 0
 
   - name: mri_info vox2ras matrix
     description: Get voxel to RAS transformation matrix
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info --vox2ras ${t1w}
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info --vox2ras ${t1w}'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -190,27 +151,18 @@ tests:
   # ==========================================================================
   - name: mri_normalize help
     description: Verify mri_normalize displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_normalize --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_normalize --help 2>&1 | head -20'"
     expected_output_contains: "mri_normalize"
 
   - name: Normalize T1w intensity
     description: Normalize white matter intensity to ~110
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_normalize ${t1w} test_output/t1w_norm.mgz 2>&1
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_normalize ${t1w} test_output/t1w_norm.mgz 2>&1'"
     validate:
       - output_exists: ${output_dir}/t1w_norm.mgz
 
   - name: Normalize with gentle mode
     description: Perform gentle normalization
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_normalize -gentle ${t1w} test_output/t1w_norm_gentle.mgz 2>&1
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_normalize -gentle ${t1w} test_output/t1w_norm_gentle.mgz 2>&1'"
     validate:
       - output_exists: ${output_dir}/t1w_norm_gentle.mgz
 
@@ -219,18 +171,12 @@ tests:
   # ==========================================================================
   - name: mri_watershed help
     description: Verify mri_watershed displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_watershed --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_watershed --help 2>&1 | head -20'"
     expected_output_contains: "watershed"
 
   - name: Skull strip T1w
     description: Remove skull using watershed algorithm
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_watershed ${t1w} test_output/t1w_brain.mgz 2>&1
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_watershed ${t1w} test_output/t1w_brain.mgz 2>&1'"
     validate:
       - output_exists: ${output_dir}/t1w_brain.mgz
 
@@ -239,63 +185,42 @@ tests:
   # ==========================================================================
   - name: mri_binarize help
     description: Verify mri_binarize displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --help 2>&1 | head -20'"
     expected_output_contains: "mri_binarize"
 
   - name: Binarize with minimum threshold
     description: Create binary mask with minimum threshold
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --i ${t1w} --min 50 --o test_output/t1w_bin_min50.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --i ${t1w} --min 50 --o test_output/t1w_bin_min50.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_bin_min50.nii.gz
 
   - name: Binarize with max threshold
     description: Create binary mask with max threshold
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --i ${t1w} --max 200 --o test_output/t1w_bin_max200.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --i ${t1w} --max 200 --o test_output/t1w_bin_max200.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_bin_max200.nii.gz
 
   - name: Binarize with range
     description: Create binary mask with min and max thresholds
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --i ${t1w} --min 50 --max 200 --o test_output/t1w_bin_range.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --i ${t1w} --min 50 --max 200 --o test_output/t1w_bin_range.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_bin_range.nii.gz
 
   - name: Binarize and dilate
     description: Create binary mask and dilate
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --i ${t1w} --min 50 --dilate 2 --o test_output/t1w_bin_dilate.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --i ${t1w} --min 50 --dilate 2 --o test_output/t1w_bin_dilate.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_bin_dilate.nii.gz
 
   - name: Binarize and erode
     description: Create binary mask and erode
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --i ${t1w} --min 50 --erode 2 --o test_output/t1w_bin_erode.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --i ${t1w} --min 50 --erode 2 --o test_output/t1w_bin_erode.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_bin_erode.nii.gz
 
   - name: Binarize invert
     description: Create inverted binary mask
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_binarize --i ${t1w} --min 50 --inv --o test_output/t1w_bin_inv.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_binarize --i ${t1w} --min 50 --inv --o test_output/t1w_bin_inv.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_bin_inv.nii.gz
 
@@ -304,18 +229,12 @@ tests:
   # ==========================================================================
   - name: mri_mask help
     description: Verify mri_mask displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_mask --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_mask --help 2>&1 | head -20'"
     expected_output_contains: "mri_mask"
 
   - name: Apply mask to volume
     description: Apply binary mask to T1w volume
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_mask ${t1w} test_output/t1w_bin_min50.nii.gz test_output/t1w_masked.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_mask ${t1w} test_output/t1w_bin_min50.nii.gz test_output/t1w_masked.nii.gz'"
     depends_on: Binarize with minimum threshold
     validate:
       - output_exists: ${output_dir}/t1w_masked.nii.gz
@@ -325,36 +244,24 @@ tests:
   # ==========================================================================
   - name: mri_vol2vol help
     description: Verify mri_vol2vol displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_vol2vol --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_vol2vol --help 2>&1 | head -20'"
     expected_output_contains: "mri_vol2vol"
 
   - name: Resample volume with identity transform
     description: Resample volume using identity registration
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_vol2vol --mov ${t1w} --targ ${t1w} --regheader --o test_output/t1w_resampled.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_vol2vol --mov ${t1w} --targ ${t1w} --regheader --o test_output/t1w_resampled.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_resampled.nii.gz
 
   - name: Resample with nearest neighbor
     description: Resample volume using nearest neighbor interpolation
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_vol2vol --mov ${t1w} --targ ${t1w} --regheader --nearest --o test_output/t1w_nn.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_vol2vol --mov ${t1w} --targ ${t1w} --regheader --nearest --o test_output/t1w_nn.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_nn.nii.gz
 
   - name: Resample with cubic interpolation
     description: Resample volume using cubic B-spline interpolation
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_vol2vol --mov ${t1w} --targ ${t1w} --regheader --cubic --o test_output/t1w_cubic.nii.gz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_vol2vol --mov ${t1w} --targ ${t1w} --regheader --cubic --o test_output/t1w_cubic.nii.gz'"
     validate:
       - output_exists: ${output_dir}/t1w_cubic.nii.gz
 
@@ -363,10 +270,7 @@ tests:
   # ==========================================================================
   - name: mri_segment help
     description: Verify mri_segment displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_segment --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_segment --help 2>&1 | head -20'"
     expected_output_contains: "mri_segment"
 
   # ==========================================================================
@@ -374,10 +278,7 @@ tests:
   # ==========================================================================
   - name: mri_tessellate help
     description: Verify mri_tessellate displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_tessellate --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_tessellate --help 2>&1 | head -20'"
     expected_output_contains: "mri_tessellate"
 
   # ==========================================================================
@@ -385,10 +286,7 @@ tests:
   # ==========================================================================
   - name: mri_fill help
     description: Verify mri_fill displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_fill --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_fill --help 2>&1 | head -20'"
     expected_output_contains: "mri_fill"
 
   # ==========================================================================
@@ -396,10 +294,7 @@ tests:
   # ==========================================================================
   - name: mris_convert help
     description: Verify mris_convert displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_convert --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_convert --help 2>&1 | head -20'"
     expected_output_contains: "mris_convert"
 
   # ==========================================================================
@@ -407,10 +302,7 @@ tests:
   # ==========================================================================
   - name: mris_info help
     description: Verify mris_info displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_info --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_info --help 2>&1 | head -20'"
     expected_output_contains: "mris_info"
 
   # ==========================================================================
@@ -418,10 +310,7 @@ tests:
   # ==========================================================================
   - name: mris_smooth help
     description: Verify mris_smooth displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_smooth --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_smooth --help 2>&1 | head -20'"
     expected_output_contains: "mris_smooth"
 
   # ==========================================================================
@@ -429,10 +318,7 @@ tests:
   # ==========================================================================
   - name: mris_inflate help
     description: Verify mris_inflate displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_inflate --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_inflate --help 2>&1 | head -20'"
     expected_output_contains: "mris_inflate"
 
   # ==========================================================================
@@ -440,10 +326,7 @@ tests:
   # ==========================================================================
   - name: mris_curvature help
     description: Verify mris_curvature displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_curvature --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_curvature --help 2>&1 | head -20'"
     expected_output_contains: "mris_curvature"
 
   # ==========================================================================
@@ -451,10 +334,7 @@ tests:
   # ==========================================================================
   - name: mris_sphere help
     description: Verify mris_sphere displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_sphere --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_sphere --help 2>&1 | head -20'"
     expected_output_contains: "mris_sphere"
 
   # ==========================================================================
@@ -462,10 +342,7 @@ tests:
   # ==========================================================================
   - name: mris_register help
     description: Verify mris_register displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_register --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_register --help 2>&1 | head -20'"
     expected_output_contains: "mris_register"
 
   # ==========================================================================
@@ -473,10 +350,7 @@ tests:
   # ==========================================================================
   - name: mris_fix_topology help
     description: Verify mris_fix_topology displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_fix_topology --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_fix_topology --help 2>&1 | head -20'"
     expected_output_contains: "mris_fix_topology"
 
   # ==========================================================================
@@ -484,10 +358,7 @@ tests:
   # ==========================================================================
   - name: mris_anatomical_stats help
     description: Verify mris_anatomical_stats displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_anatomical_stats --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_anatomical_stats --help 2>&1 | head -20'"
     expected_output_contains: "mris_anatomical_stats"
 
   # ==========================================================================
@@ -495,18 +366,12 @@ tests:
   # ==========================================================================
   - name: recon-all help
     description: Verify recon-all displays help
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      recon-all --help 2>&1 | head -30
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nrecon-all --help 2>&1 | head -30'"
     expected_output_contains: "recon-all"
 
   - name: recon-all version
     description: Check recon-all version
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      recon-all --version 2>&1
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nrecon-all --version 2>&1'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -552,27 +417,27 @@ tests:
   # ==========================================================================
   - name: FastCSR model directory exists
     description: Verify FastCSR model directory exists
-    command: ls -la /opt/FastCSR/model/
+    command: "bash -lc 'ls -la /opt/FastCSR/model/'"
     expected_exit_code: 0
 
   - name: FastCSR left hemisphere model exists
     description: Verify left hemisphere model file exists
-    command: ls /opt/FastCSR/model/lh_model.pth
+    command: "bash -lc 'ls /opt/FastCSR/model/lh_model.pth'"
     expected_exit_code: 0
 
   - name: FastCSR right hemisphere model exists
     description: Verify right hemisphere model file exists
-    command: ls /opt/FastCSR/model/rh_model.pth
+    command: "bash -lc 'ls /opt/FastCSR/model/rh_model.pth'"
     expected_exit_code: 0
 
   - name: FastCSR brain finalsurfs model exists
     description: Verify brain finalsurfs model file exists
-    command: ls /opt/FastCSR/model/brain_finalsurfs_model.pth
+    command: "bash -lc 'ls /opt/FastCSR/model/brain_finalsurfs_model.pth'"
     expected_exit_code: 0
 
   - name: nnUNet trained models exist
     description: Verify nnUNet trained models directory exists
-    command: ls -la /opt/FastCSR/model/nnUNet_trained_models/nnUNet/3d_fullres/
+    command: "bash -lc 'ls -la /opt/FastCSR/model/nnUNet_trained_models/nnUNet/3d_fullres/'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -580,74 +445,47 @@ tests:
   # ==========================================================================
   - name: mri_concat help
     description: Verify mri_concat for concatenating volumes
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_concat --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_concat --help 2>&1 | head -10'"
     expected_output_contains: "mri_concat"
 
   - name: mri_diff help
     description: Verify mri_diff for comparing volumes
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_diff --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_diff --help 2>&1 | head -10'"
     expected_output_contains: "mri_diff"
 
   - name: mri_robust_register help
     description: Verify mri_robust_register for robust registration
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_robust_register --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_robust_register --help 2>&1 | head -10'"
     expected_output_contains: "mri_robust_register"
 
   - name: mri_label2vol help
     description: Verify mri_label2vol for label to volume conversion
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_label2vol --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_label2vol --help 2>&1 | head -10'"
     expected_output_contains: "mri_label2vol"
 
   - name: mri_extract_label help
     description: Verify mri_extract_label for extracting ROIs
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_extract_label --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_extract_label --help 2>&1 | head -10'"
     expected_exit_code: 0
 
   - name: mri_aparc2aseg help
     description: Verify mri_aparc2aseg for parcellation mapping
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_aparc2aseg --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_aparc2aseg --help 2>&1 | head -10'"
     expected_output_contains: "mri_aparc2aseg"
 
   - name: mri_fwhm help
     description: Verify mri_fwhm for smoothness estimation
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_fwhm --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_fwhm --help 2>&1 | head -10'"
     expected_output_contains: "mri_fwhm"
 
   - name: mri_surf2vol help
     description: Verify mri_surf2vol for surface to volume mapping
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_surf2vol --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_surf2vol --help 2>&1 | head -10'"
     expected_output_contains: "mri_surf2vol"
 
   - name: mri_vol2surf help
     description: Verify mri_vol2surf for volume to surface mapping
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_vol2surf --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_vol2surf --help 2>&1 | head -10'"
     expected_output_contains: "mri_vol2surf"
 
   # ==========================================================================
@@ -655,42 +493,27 @@ tests:
   # ==========================================================================
   - name: mris_calc help
     description: Verify mris_calc for surface calculations
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_calc --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_calc --help 2>&1 | head -10'"
     expected_output_contains: "mris_calc"
 
   - name: mris_thickness help
     description: Verify mris_thickness for cortical thickness
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_thickness --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_thickness --help 2>&1 | head -10'"
     expected_exit_code: 0
 
   - name: mris_sample_parc help
     description: Verify mris_sample_parc for parcellation sampling
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_sample_parc --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_sample_parc --help 2>&1 | head -10'"
     expected_exit_code: 0
 
   - name: mris_decimate help
     description: Verify mris_decimate for surface decimation
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_decimate --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_decimate --help 2>&1 | head -10'"
     expected_exit_code: 0
 
   - name: mris_extract_main_component help
     description: Verify mris_extract_main_component for surface cleanup
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mris_extract_main_component --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmris_extract_main_component --help 2>&1 | head -10'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -698,10 +521,7 @@ tests:
   # ==========================================================================
   - name: bbregister help
     description: Verify bbregister for registration
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      bbregister --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nbbregister --help 2>&1 | head -20'"
     expected_output_contains: "bbregister"
 
   # ==========================================================================
@@ -709,10 +529,7 @@ tests:
   # ==========================================================================
   - name: talairach_avi help
     description: Verify talairach_avi for Talairach registration
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      talairach_avi 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\ntalairach_avi 2>&1 | head -10'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -720,28 +537,17 @@ tests:
   # ==========================================================================
   - name: mri_segstats help
     description: Verify mri_segstats for segmentation statistics
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_segstats --help 2>&1 | head -20
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_segstats --help 2>&1 | head -20'"
     expected_output_contains: "mri_segstats"
 
   - name: asegstats2table help
     description: Verify asegstats2table for stats table generation (needs python→python3 symlink)
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      ln -sf /usr/bin/python3 /tmp/python && export PATH=/tmp:$PATH
-      asegstats2table --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nln -sf /usr/bin/python3 /tmp/python && export PATH=/tmp:$PATH\nasegstats2table --help 2>&1 | head -10'"
     expected_output_contains: "asegstats2table"
 
   - name: aparcstats2table help
     description: Verify aparcstats2table for parcellation stats (needs python→python3 symlink)
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      ln -sf /usr/bin/python3 /tmp/python && export PATH=/tmp:$PATH
-      aparcstats2table --help 2>&1 | head -10
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nln -sf /usr/bin/python3 /tmp/python && export PATH=/tmp:$PATH\naparcstats2table --help 2>&1 | head -10'"
     expected_output_contains: "aparcstats2table"
 
   # ==========================================================================
@@ -759,29 +565,20 @@ tests:
 
   - name: Create orig.mgz for FastCSR
     description: Convert T1w to orig.mgz required by FastCSR
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_convert ${t1w} test_output/subjects/test_sub/mri/orig.mgz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_convert ${t1w} test_output/subjects/test_sub/mri/orig.mgz'"
     depends_on: Prepare subject directory structure
     validate:
       - output_exists: ${output_dir}/subjects/test_sub/mri/orig.mgz
 
   - name: Verify orig.mgz dimensions
     description: Check that orig.mgz has correct dimensions
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_info --dim test_output/subjects/test_sub/mri/orig.mgz
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_info --dim test_output/subjects/test_sub/mri/orig.mgz'"
     depends_on: Create orig.mgz for FastCSR
     expected_exit_code: 0
 
   - name: Compare two identical volumes
     description: Use mri_diff to compare identical volumes
-    command: |
-      export FREESURFER_HOME=/opt/freesurfer-6.0.0
-      source $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null
-      mri_diff ${t1w} ${t1w} 2>&1
+    command: "bash -lc 'export FREESURFER_HOME=/opt/freesurfer-6.0.0\nsource $FREESURFER_HOME/SetUpFreeSurfer.sh 2>/dev/null\nmri_diff ${t1w} ${t1w} 2>&1'"
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -130,7 +130,7 @@ tests:
   # ==========================================================================
   - name: FreeSurfer license file exists
     description: Verify FreeSurfer license is present at expected location
-    command: test -f /opt/license.txt && echo "License exists"
+    command: bash -lc 'test -f /opt/license.txt && echo "License exists"'
     expected_output_contains: "License exists"
 
   - name: FS_LICENSE environment variable
@@ -194,12 +194,12 @@ tests:
   # ==========================================================================
   - name: Checkpoints directory exists
     description: Verify deep learning model checkpoints are present
-    command: ls /fastsurfer/checkpoints/ 2>&1 | head -5
+    command: "bash -lc 'ls /fastsurfer/checkpoints/ 2>&1 | head -5'"
     expected_output_contains: ""
 
   - name: FastSurferVINN checkpoints
     description: Verify FastSurferVINN model checkpoints exist
-    command: ls /fastsurfer/checkpoints/ | grep -i "vinn" || ls /fastsurfer/checkpoints/
+    command: "bash -lc 'ls /fastsurfer/checkpoints/ | grep -i \"vinn\" || ls /fastsurfer/checkpoints/'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -263,22 +263,22 @@ tests:
   # ==========================================================================
   - name: recon-surf.sh availability
     description: Verify recon-surf.sh surface reconstruction script exists
-    command: test -f /fastsurfer/recon_surf/recon-surf.sh && echo "recon-surf.sh exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/recon-surf.sh && echo "recon-surf.sh exists"'
     expected_output_contains: "recon-surf.sh exists"
 
   - name: recon-surfreg.sh availability
     description: Verify recon-surfreg.sh registration script exists
-    command: test -f /fastsurfer/recon_surf/recon-surfreg.sh && echo "recon-surfreg.sh exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/recon-surfreg.sh && echo "recon-surfreg.sh exists"'
     expected_output_contains: "recon-surfreg.sh exists"
 
   - name: talairach-reg.sh availability
     description: Verify talairach registration script exists
-    command: test -f /fastsurfer/recon_surf/talairach-reg.sh && echo "talairach-reg.sh exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/talairach-reg.sh && echo "talairach-reg.sh exists"'
     expected_output_contains: "talairach-reg.sh exists"
 
   - name: long_prepare_template.sh availability
     description: Verify longitudinal template preparation script exists
-    command: test -f /fastsurfer/recon_surf/long_prepare_template.sh && echo "long_prepare_template.sh exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/long_prepare_template.sh && echo "long_prepare_template.sh exists"'
     expected_output_contains: "long_prepare_template.sh exists"
 
   # ==========================================================================
@@ -286,17 +286,17 @@ tests:
   # ==========================================================================
   - name: DKT atlas lookup table
     description: Verify DKT atlas lookup table exists
-    command: test -f /fastsurfer/recon_surf/DKTatlaslookup.txt && echo "DKT LUT exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/DKTatlaslookup.txt && echo "DKT LUT exists"'
     expected_output_contains: "DKT LUT exists"
 
   - name: Left hemisphere DKT lookup
     description: Verify left hemisphere DKT lookup exists
-    command: test -f /fastsurfer/recon_surf/lh.DKTatlaslookup.txt && echo "lh DKT LUT exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/lh.DKTatlaslookup.txt && echo "lh DKT LUT exists"'
     expected_output_contains: "lh DKT LUT exists"
 
   - name: Right hemisphere DKT lookup
     description: Verify right hemisphere DKT lookup exists
-    command: test -f /fastsurfer/recon_surf/rh.DKTatlaslookup.txt && echo "rh DKT LUT exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/rh.DKTatlaslookup.txt && echo "rh DKT LUT exists"'
     expected_output_contains: "rh DKT LUT exists"
 
   # ==========================================================================
@@ -324,17 +324,17 @@ tests:
   # ==========================================================================
   - name: FastSurferCNN config directory
     description: Verify FastSurferCNN config directory exists
-    command: ls /fastsurfer/FastSurferCNN/config/ 2>&1 | head -5
+    command: "bash -lc 'ls /fastsurfer/FastSurferCNN/config/ 2>&1 | head -5'"
     expected_exit_code: 0
 
   - name: CerebNet config directory
     description: Verify CerebNet config directory exists
-    command: ls /fastsurfer/CerebNet/config/ 2>&1 | head -5
+    command: "bash -lc 'ls /fastsurfer/CerebNet/config/ 2>&1 | head -5'"
     expected_exit_code: 0
 
   - name: HypVINN config directory
     description: Verify HypVINN config directory exists
-    command: ls /fastsurfer/HypVINN/config/ 2>&1 | head -5
+    command: "bash -lc 'ls /fastsurfer/HypVINN/config/ 2>&1 | head -5'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -408,7 +408,7 @@ tests:
 
   - name: FASTSURFER_HOME set
     description: Verify FASTSURFER_HOME environment variable is set
-    command: test -n "$FASTSURFER_HOME" && echo "FASTSURFER_HOME is set" || echo "Default is /fastsurfer"
+    command: "bash -lc 'test -n \"$FASTSURFER_HOME\" && echo \"FASTSURFER_HOME is set\" || echo \"Default is /fastsurfer\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -416,12 +416,12 @@ tests:
   # ==========================================================================
   - name: BUILD.info exists
     description: Verify BUILD.info file exists in container
-    command: test -f /fastsurfer/BUILD.info && echo "BUILD.info exists"
+    command: bash -lc 'test -f /fastsurfer/BUILD.info && echo "BUILD.info exists"'
     expected_output_contains: "BUILD.info exists"
 
   - name: Read BUILD.info
     description: Display build information
-    command: cat /fastsurfer/BUILD.info 2>&1 | head -20
+    command: "bash -lc 'cat /fastsurfer/BUILD.info 2>&1 | head -20'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -451,12 +451,12 @@ tests:
   # ==========================================================================
   - name: make_upright utility
     description: Verify make_upright utility exists
-    command: test -f /fastsurfer/recon_surf/make_upright && echo "make_upright exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/make_upright && echo "make_upright exists"'
     expected_output_contains: "make_upright exists"
 
   - name: fs_time utility
     description: Verify fs_time utility exists
-    command: test -f /fastsurfer/recon_surf/fs_time && echo "fs_time exists"
+    command: bash -lc 'test -f /fastsurfer/recon_surf/fs_time && echo "fs_time exists"'
     expected_output_contains: "fs_time exists"
 
   # ==========================================================================
@@ -464,12 +464,12 @@ tests:
   # ==========================================================================
   - name: brun_fastsurfer.sh availability
     description: Verify batch processing script exists
-    command: test -f /fastsurfer/brun_fastsurfer.sh && echo "brun_fastsurfer.sh exists"
+    command: bash -lc 'test -f /fastsurfer/brun_fastsurfer.sh && echo "brun_fastsurfer.sh exists"'
     expected_output_contains: "brun_fastsurfer.sh exists"
 
   - name: stools.sh availability
     description: Verify supplementary tools script exists
-    command: test -f /fastsurfer/stools.sh && echo "stools.sh exists"
+    command: bash -lc 'test -f /fastsurfer/stools.sh && echo "stools.sh exists"'
     expected_output_contains: "stools.sh exists"
 
   # ==========================================================================
@@ -477,7 +477,7 @@ tests:
   # ==========================================================================
   - name: Docker directory exists
     description: Verify Docker configuration directory exists
-    command: test -d /fastsurfer/Docker && echo "Docker dir exists"
+    command: bash -lc 'test -d /fastsurfer/Docker && echo "Docker dir exists"'
     expected_output_contains: "Docker dir exists"
 
   # ==========================================================================
@@ -485,7 +485,7 @@ tests:
   # ==========================================================================
   - name: Test directory exists
     description: Verify test directory exists in container
-    command: test -d /fastsurfer/test && echo "test dir exists"
+    command: bash -lc 'test -d /fastsurfer/test && echo "test dir exists"'
     expected_output_contains: "test dir exists"
 
 cleanup:

--- a/recipes/fatsegnet/fulltest.yaml
+++ b/recipes/fatsegnet/fulltest.yaml
@@ -63,12 +63,12 @@ tests:
 
   - name: Verify container labels
     description: Check Singularity/Apptainer labels exist
-    command: cat /.singularity.d/labels.json
+    command: "bash -lc 'cat /.singularity.d/labels.json'"
     expected_output_contains: "GITHUB"
 
   - name: Verify CUDA version in labels
     description: Check CUDA version information
-    command: cat /.singularity.d/labels.json
+    command: "bash -lc 'cat /.singularity.d/labels.json'"
     expected_output_contains: "cuda"
 
   # ==========================================================================
@@ -94,7 +94,7 @@ tests:
   # ==========================================================================
   - name: FatSegNet directory exists
     description: Verify FatSegNet is installed in /opt
-    command: ls -la /opt/FatSegNet/
+    command: "bash -lc 'ls -la /opt/FatSegNet/'"
     expected_output_contains: "README.md"
 
   - name: FatSegNet tool directory exists
@@ -157,27 +157,27 @@ tests:
   # ==========================================================================
   - name: Example data folder exists
     description: Verify example data directory
-    command: ls -la /opt/FatSegNet/example_data_folder/
+    command: "bash -lc 'ls -la /opt/FatSegNet/example_data_folder/'"
     expected_output_contains: "participants.csv"
 
   - name: Example participants file exists
     description: Verify sample participants CSV
-    command: cat /opt/FatSegNet/example_data_folder/participants.csv
+    command: "bash -lc 'cat /opt/FatSegNet/example_data_folder/participants.csv'"
     expected_output_contains: "subject_1"
 
   - name: Example subject directories exist
     description: Verify subject folder structure
-    command: ls /opt/FatSegNet/example_data_folder/
+    command: "bash -lc 'ls /opt/FatSegNet/example_data_folder/'"
     expected_output_contains: "subject_1"
 
   - name: Example fat image exists
     description: Verify example fat image file
-    command: ls /opt/FatSegNet/example_data_folder/subject_1/
+    command: "bash -lc 'ls /opt/FatSegNet/example_data_folder/subject_1/'"
     expected_output_contains: "FatImaging_F.nii.gz"
 
   - name: Example water image exists
     description: Verify example water image file
-    command: ls /opt/FatSegNet/example_data_folder/subject_1/
+    command: "bash -lc 'ls /opt/FatSegNet/example_data_folder/subject_1/'"
     expected_output_contains: "FatImaging_W.nii.gz"
 
   # ==========================================================================
@@ -564,32 +564,32 @@ tests:
   # ==========================================================================
   - name: FatSegNet README has usage instructions
     description: Verify detailed documentation exists
-    command: grep -c "Usage" /opt/FatSegNet/README.md
+    command: "bash -lc 'grep -c \"Usage\" /opt/FatSegNet/README.md'"
     expected_exit_code: 0
 
   - name: FatSegNet README has input format description
     description: Verify input data format is documented
-    command: grep "Input Data format" /opt/FatSegNet/README.md
+    command: "bash -lc 'grep \"Input Data format\" /opt/FatSegNet/README.md'"
     expected_output_contains: "Input"
 
   - name: FatSegNet README has output format description
     description: Verify output data format is documented
-    command: grep "Output Data format" /opt/FatSegNet/README.md
+    command: "bash -lc 'grep \"Output Data format\" /opt/FatSegNet/README.md'"
     expected_output_contains: "Output"
 
   - name: FatSegNet README documents arguments
     description: Verify command arguments are documented
-    command: grep "Arguments" /opt/FatSegNet/README.md
+    command: "bash -lc 'grep \"Arguments\" /opt/FatSegNet/README.md'"
     expected_output_contains: "Arguments"
 
   - name: FatSegNet README has citation
     description: Verify citation is provided
-    command: grep "cite" /opt/FatSegNet/README.md
+    command: "bash -lc 'grep \"cite\" /opt/FatSegNet/README.md'"
     expected_output_contains: "cite"
 
   - name: FatSegNet variables PDF exists
     description: Verify variables documentation PDF
-    command: ls -la /opt/FatSegNet/FatSegNet_Variables.pdf
+    command: "bash -lc 'ls -la /opt/FatSegNet/FatSegNet_Variables.pdf'"
     expected_output_contains: "FatSegNet_Variables.pdf"
 
   # ==========================================================================

--- a/recipes/fieldtrip/fulltest.yaml
+++ b/recipes/fieldtrip/fulltest.yaml
@@ -41,7 +41,7 @@ tests:
   # ==========================================================================
   - name: FieldTrip help message
     description: Verify FieldTrip binary runs and shows usage information
-    command: /opt/fieldtrip-20220617/run_fieldtrip.sh /opt/MCR/v99 2>&1 | head -5
+    command: bash -lc '/opt/fieldtrip-20220617/run_fieldtrip.sh /opt/MCR/v99 2>&1 | head -5'
     expected_output_contains: "You should start the compiled FieldTrip application"
 
   - name: FieldTrip ft_defaults initialization

--- a/recipes/gingerale/fulltest.yaml
+++ b/recipes/gingerale/fulltest.yaml
@@ -224,22 +224,22 @@ tests:
   # ==========================================================================
   - name: getALE2 usage/help
     description: Display getALE2 command usage and options
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1'"
     expected_output_contains: "getALE2 usage"
 
   - name: getALE2 required parameters
     description: Verify required parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1'"
     expected_output_contains: "Foci_Text"
 
   - name: getALE2 mask options
     description: Verify mask parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1'"
     expected_output_contains: "-mask="
 
   - name: getALE2 threshold options
     description: Verify thresholding method options
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1'"
     expected_output_contains: "Thresholding Method"
 
   # ==========================================================================
@@ -247,12 +247,7 @@ tests:
   # ==========================================================================
   - name: Basic ALE analysis (Talairach)
     description: Run basic ALE meta-analysis on Talairach coordinates
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_tal_ALE \
-        -pval=test_output/gingerale/ale_results/motor_tal_P \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_tal_ALE \\\n  -pval=test_output/gingerale/ale_results/motor_tal_P \\\n  2>&1'"
     expected_output_contains: "Foci"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_tal_ALE.nii
@@ -260,25 +255,14 @@ tests:
 
   - name: Basic ALE analysis (MNI)
     description: Run basic ALE meta-analysis on MNI coordinates
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_mni.txt \
-        -mask=MNI_wb.nii \
-        -ale=test_output/gingerale/ale_results/motor_mni_ALE \
-        -pval=test_output/gingerale/ale_results/motor_mni_P \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_mni.txt \\\n  -mask=MNI_wb.nii \\\n  -ale=test_output/gingerale/ale_results/motor_mni_ALE \\\n  -pval=test_output/gingerale/ale_results/motor_mni_P \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_mni_ALE.nii
       - output_exists: ${output_dir}/gingerale/ale_results/motor_mni_P.nii
 
   - name: ALE with minimal foci
     description: Run ALE on minimal dataset for quick test
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -ale=test_output/gingerale/ale_results/minimal_ALE \
-        -pval=test_output/gingerale/ale_results/minimal_P \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_ALE \\\n  -pval=test_output/gingerale/ale_results/minimal_P \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/minimal_ALE.nii
 
@@ -287,45 +271,25 @@ tests:
   # ==========================================================================
   - name: ALE with Talairach conservative mask
     description: Use more conservative Talairach whole brain mask
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -mask=Tal_wb.nii \
-        -ale=test_output/gingerale/ale_results/tal_conservative_ALE \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -mask=Tal_wb.nii \\\n  -ale=test_output/gingerale/ale_results/tal_conservative_ALE \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/tal_conservative_ALE.nii
 
   - name: ALE with Talairach dilated mask
     description: Use less conservative (dilated) Talairach mask
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -mask=Tal_wb_dil.nii \
-        -ale=test_output/gingerale/ale_results/tal_dilated_ALE \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -mask=Tal_wb_dil.nii \\\n  -ale=test_output/gingerale/ale_results/tal_dilated_ALE \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/tal_dilated_ALE.nii
 
   - name: ALE with MNI conservative mask
     description: Use more conservative MNI whole brain mask
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_mni.txt \
-        -mask=MNI_wb.nii \
-        -ale=test_output/gingerale/ale_results/mni_conservative_ALE \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_mni.txt \\\n  -mask=MNI_wb.nii \\\n  -ale=test_output/gingerale/ale_results/mni_conservative_ALE \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/mni_conservative_ALE.nii
 
   - name: ALE with MNI dilated mask
     description: Use less conservative (dilated) MNI mask
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_mni.txt \
-        -mask=MNI_wb_dil.nii \
-        -ale=test_output/gingerale/ale_results/mni_dilated_ALE \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_mni.txt \\\n  -mask=MNI_wb_dil.nii \\\n  -ale=test_output/gingerale/ale_results/mni_dilated_ALE \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/mni_dilated_ALE.nii
 
@@ -334,40 +298,20 @@ tests:
   # ==========================================================================
   - name: ALE with uncorrected p-value threshold (p=0.05)
     description: Apply uncorrected p-value threshold at 0.05
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_p05_ALE \
-        -pval=test_output/gingerale/ale_results/motor_p05_P \
-        -thresh=test_output/gingerale/ale_results/motor_p05_thresh \
-        -p=0.05 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_p05_ALE \\\n  -pval=test_output/gingerale/ale_results/motor_p05_P \\\n  -thresh=test_output/gingerale/ale_results/motor_p05_thresh \\\n  -p=0.05 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p05_ALE.nii
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p05_thresh.nii
 
   - name: ALE with uncorrected p-value threshold (p=0.01)
     description: Apply stricter uncorrected p-value threshold at 0.01
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_p01_ALE \
-        -pval=test_output/gingerale/ale_results/motor_p01_P \
-        -thresh=test_output/gingerale/ale_results/motor_p01_thresh \
-        -p=0.01 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_p01_ALE \\\n  -pval=test_output/gingerale/ale_results/motor_p01_P \\\n  -thresh=test_output/gingerale/ale_results/motor_p01_thresh \\\n  -p=0.01 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_thresh.nii
 
   - name: ALE with uncorrected p-value threshold (p=0.001)
     description: Apply very strict uncorrected p-value threshold at 0.001
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_p001_ALE \
-        -thresh=test_output/gingerale/ale_results/motor_p001_thresh \
-        -p=0.001 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_p001_ALE \\\n  -thresh=test_output/gingerale/ale_results/motor_p001_thresh \\\n  -p=0.001 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p001_thresh.nii
 
@@ -376,25 +320,13 @@ tests:
   # ==========================================================================
   - name: ALE with FDR pN correction (q=0.05)
     description: Apply FDR pN threshold at q=0.05
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_fdrN_ALE \
-        -thresh=test_output/gingerale/ale_results/motor_fdrN_thresh \
-        -pN=0.05 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_fdrN_ALE \\\n  -thresh=test_output/gingerale/ale_results/motor_fdrN_thresh \\\n  -pN=0.05 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_fdrN_thresh.nii
 
   - name: ALE with FDR pID correction (q=0.05)
     description: Apply FDR pID threshold at q=0.05
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_fdrID_ALE \
-        -thresh=test_output/gingerale/ale_results/motor_fdrID_thresh \
-        -pID=0.05 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_fdrID_ALE \\\n  -thresh=test_output/gingerale/ale_results/motor_fdrID_thresh \\\n  -pID=0.05 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_fdrID_thresh.nii
 
@@ -403,28 +335,14 @@ tests:
   # ==========================================================================
   - name: ALE with FWE correction (100 perms)
     description: Apply family-wise error correction with 100 permutations
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -ale=test_output/gingerale/ale_results/minimal_fwe_ALE \
-        -thresh=test_output/gingerale/ale_results/minimal_fwe_thresh \
-        -perm=100 \
-        -fwe=0.05 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_fwe_ALE \\\n  -thresh=test_output/gingerale/ale_results/minimal_fwe_thresh \\\n  -perm=100 \\\n  -fwe=0.05 \\\n  2>&1'"
     expected_output_contains: "Perm"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/minimal_fwe_ALE.nii
 
   - name: ALE with FWE correction (500 perms)
     description: Apply FWE correction with more permutations for accuracy
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -ale=test_output/gingerale/ale_results/minimal_fwe500_ALE \
-        -thresh=test_output/gingerale/ale_results/minimal_fwe500_thresh \
-        -perm=500 \
-        -fwe=0.05 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_fwe500_ALE \\\n  -thresh=test_output/gingerale/ale_results/minimal_fwe500_thresh \\\n  -perm=500 \\\n  -fwe=0.05 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/minimal_fwe500_ALE.nii
 
@@ -433,15 +351,7 @@ tests:
   # ==========================================================================
   - name: ALE with cluster-level inference
     description: Apply cluster-level FWE correction with forming threshold
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -ale=test_output/gingerale/ale_results/minimal_clust_ALE \
-        -thresh=test_output/gingerale/ale_results/minimal_clust_thresh \
-        -perm=100 \
-        -p=0.001 \
-        -clust=0.05 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_clust_ALE \\\n  -thresh=test_output/gingerale/ale_results/minimal_clust_thresh \\\n  -perm=100 \\\n  -p=0.001 \\\n  -clust=0.05 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/minimal_clust_ALE.nii
 
@@ -450,14 +360,7 @@ tests:
   # ==========================================================================
   - name: ALE with minimum cluster volume
     description: Apply minimum cluster size threshold
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_minvol_ALE \
-        -thresh=test_output/gingerale/ale_results/motor_minvol_thresh \
-        -p=0.01 \
-        -minVol=200 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_minvol_ALE \\\n  -thresh=test_output/gingerale/ale_results/motor_minvol_thresh \\\n  -p=0.01 \\\n  -minVol=200 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_minvol_thresh.nii
 
@@ -466,24 +369,13 @@ tests:
   # ==========================================================================
   - name: ALE with non-additive method
     description: Use Turkeltaub non-additive ALE method (HBM 2012)
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/ale_results/motor_nonadd_ALE \
-        -pval=test_output/gingerale/ale_results/motor_nonadd_P \
-        -nonadd \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/ale_results/motor_nonadd_ALE \\\n  -pval=test_output/gingerale/ale_results/motor_nonadd_P \\\n  -nonadd \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_nonadd_ALE.nii
 
   - name: ALE only (no P-value image)
     description: Generate only ALE image without P-value computation
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/minimal_tal.txt \
-        -ale=test_output/gingerale/ale_results/minimal_aleonly \
-        -noPVal \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_aleonly \\\n  -noPVal \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/minimal_aleonly.nii
 
@@ -492,46 +384,32 @@ tests:
   # ==========================================================================
   - name: getClustersOnly usage/help
     description: Display getClustersOnly command usage and options
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly 2>&1'"
     expected_output_contains: "required arguments"
 
   - name: getClustersOnly optional parameters
     description: Verify optional parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly 2>&1'"
     expected_output_contains: "-min="
 
   - name: Basic cluster detection
     description: Detect clusters from thresholded ALE image
     depends_on: ALE with uncorrected p-value threshold (p=0.01)
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly \
-        test_output/gingerale/ale_results/motor_p01_thresh.nii \
-        -out=test_output/gingerale/ale_results/motor_p01_clust \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly \\\n  test_output/gingerale/ale_results/motor_p01_thresh.nii \\\n  -out=test_output/gingerale/ale_results/motor_p01_clust \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_clust.nii
 
   - name: Cluster detection with minimum volume
     description: Detect clusters with minimum volume threshold
     depends_on: ALE with uncorrected p-value threshold (p=0.01)
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly \
-        test_output/gingerale/ale_results/motor_p01_thresh.nii \
-        -min=100 \
-        -out=test_output/gingerale/ale_results/motor_p01_clust_min100 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly \\\n  test_output/gingerale/ale_results/motor_p01_thresh.nii \\\n  -min=100 \\\n  -out=test_output/gingerale/ale_results/motor_p01_clust_min100 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_clust_min100.nii
 
   - name: Cluster detection with large minimum volume
     description: Detect only large clusters (min 500 mm3)
     depends_on: ALE with uncorrected p-value threshold (p=0.01)
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly \
-        test_output/gingerale/ale_results/motor_p01_thresh.nii \
-        -min=500 \
-        -out=test_output/gingerale/ale_results/motor_p01_clust_min500 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly \\\n  test_output/gingerale/ale_results/motor_p01_thresh.nii \\\n  -min=500 \\\n  -out=test_output/gingerale/ale_results/motor_p01_clust_min500 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_clust_min500.nii
 
@@ -540,71 +418,44 @@ tests:
   # ==========================================================================
   - name: getClustersStats usage/help
     description: Display getClustersStats command usage and options
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats 2>&1'"
     expected_output_contains: "getClustersStats usage"
 
   - name: getClustersStats required parameters
     description: Verify required parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats 2>&1'"
     expected_output_contains: "Foci_Text.txt"
 
   - name: getClustersStats optional parameters
     description: Verify optional parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats 2>&1'"
     expected_output_contains: "-mni"
 
   - name: Basic cluster statistics
     description: Generate cluster statistics with Talairach labels
     depends_on: Basic cluster detection
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        test_output/gingerale/ale_results/motor_p01_ALE.nii \
-        test_output/gingerale/ale_results/motor_p01_clust.nii \
-        -out=test_output/gingerale/ale_results/motor_p01_stats \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  test_output/gingerale/ale_results/motor_p01_ALE.nii \\\n  test_output/gingerale/ale_results/motor_p01_clust.nii \\\n  -out=test_output/gingerale/ale_results/motor_p01_stats \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_stats.txt
 
   - name: Cluster statistics with P values
     description: Include P values in cluster statistics
     depends_on: Basic cluster detection
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        test_output/gingerale/ale_results/motor_p01_ALE.nii \
-        test_output/gingerale/ale_results/motor_p01_clust.nii \
-        -p=test_output/gingerale/ale_results/motor_p01_P.nii \
-        -out=test_output/gingerale/ale_results/motor_p01_stats_pval \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  test_output/gingerale/ale_results/motor_p01_ALE.nii \\\n  test_output/gingerale/ale_results/motor_p01_clust.nii \\\n  -p=test_output/gingerale/ale_results/motor_p01_P.nii \\\n  -out=test_output/gingerale/ale_results/motor_p01_stats_pval \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_stats_pval.txt
 
   - name: Cluster statistics including all labels
     description: Include non-gray matter labels in statistics
     depends_on: Basic cluster detection
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        test_output/gingerale/ale_results/motor_p01_ALE.nii \
-        test_output/gingerale/ale_results/motor_p01_clust.nii \
-        -noGrayOnly \
-        -out=test_output/gingerale/ale_results/motor_p01_stats_alllab \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  test_output/gingerale/ale_results/motor_p01_ALE.nii \\\n  test_output/gingerale/ale_results/motor_p01_clust.nii \\\n  -noGrayOnly \\\n  -out=test_output/gingerale/ale_results/motor_p01_stats_alllab \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_stats_alllab.txt
 
   - name: Cluster statistics with foci listing
     description: List contributing foci for each cluster
     depends_on: Basic cluster detection
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        test_output/gingerale/ale_results/motor_p01_ALE.nii \
-        test_output/gingerale/ale_results/motor_p01_clust.nii \
-        -printFoci \
-        -out=test_output/gingerale/ale_results/motor_p01_stats_foci \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersStats \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  test_output/gingerale/ale_results/motor_p01_ALE.nii \\\n  test_output/gingerale/ale_results/motor_p01_clust.nii \\\n  -printFoci \\\n  -out=test_output/gingerale/ale_results/motor_p01_stats_foci \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_p01_stats_foci.txt
 
@@ -613,114 +464,56 @@ tests:
   # ==========================================================================
   - name: getALE2Contrast usage/help
     description: Display getALE2Contrast command usage and options
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast 2>&1'"
     expected_output_contains: "getALE2Contrast usage"
 
   - name: getALE2Contrast required parameters
     description: Verify required parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast 2>&1'"
     expected_output_contains: "ALE_1"
 
   - name: getALE2Contrast optional parameters
     description: Verify optional parameter documentation
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast 2>&1'"
     expected_output_contains: "-perm="
 
   # Create ALE images for contrast analysis
   - name: ALE for contrast dataset 1 (motor)
     description: Generate ALE image for motor task dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/motor_task_tal.txt \
-        -ale=test_output/gingerale/contrast/motor_ALE \
-        -thresh=test_output/gingerale/contrast/motor_thresh \
-        -p=0.01 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/motor_task_tal.txt \\\n  -ale=test_output/gingerale/contrast/motor_ALE \\\n  -thresh=test_output/gingerale/contrast/motor_thresh \\\n  -p=0.01 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/contrast/motor_thresh.nii
 
   - name: ALE for contrast dataset 2 (cognitive)
     description: Generate ALE image for cognitive task dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/cognitive_task_tal.txt \
-        -ale=test_output/gingerale/contrast/cognitive_ALE \
-        -thresh=test_output/gingerale/contrast/cognitive_thresh \
-        -p=0.01 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/cognitive_task_tal.txt \\\n  -ale=test_output/gingerale/contrast/cognitive_ALE \\\n  -thresh=test_output/gingerale/contrast/cognitive_thresh \\\n  -p=0.01 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/contrast/cognitive_thresh.nii
 
   - name: ALE for pooled dataset
     description: Generate ALE image for pooled (combined) dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \
-        test_output/gingerale/foci/pooled_foci_tal.txt \
-        -ale=test_output/gingerale/contrast/pooled_ALE \
-        -thresh=test_output/gingerale/contrast/pooled_thresh \
-        -p=0.01 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/pooled_foci_tal.txt \\\n  -ale=test_output/gingerale/contrast/pooled_ALE \\\n  -thresh=test_output/gingerale/contrast/pooled_thresh \\\n  -p=0.01 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/contrast/pooled_thresh.nii
 
   - name: Basic contrast analysis
     description: Run contrast analysis between motor and cognitive datasets
     depends_on: ALE for pooled dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \
-        test_output/gingerale/contrast/motor_thresh.nii \
-        test_output/gingerale/contrast/cognitive_thresh.nii \
-        test_output/gingerale/contrast/pooled_thresh.nii \
-        -out1=Motor \
-        -out2=Cognitive \
-        -perm=100 \
-        2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \\\n  test_output/gingerale/contrast/motor_thresh.nii \\\n  test_output/gingerale/contrast/cognitive_thresh.nii \\\n  test_output/gingerale/contrast/pooled_thresh.nii \\\n  -out1=Motor \\\n  -out2=Cognitive \\\n  -perm=100 \\\n  2>&1'"
     expected_output_contains: "Contrast"
 
   - name: Contrast with uncorrected threshold
     description: Contrast analysis with uncorrected p-value threshold
     depends_on: ALE for pooled dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \
-        test_output/gingerale/contrast/motor_thresh.nii \
-        test_output/gingerale/contrast/cognitive_thresh.nii \
-        test_output/gingerale/contrast/pooled_thresh.nii \
-        -out1=Motor \
-        -out2=Cognitive \
-        -perm=100 \
-        -p=0.05 \
-        2>&1
-
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \\\n  test_output/gingerale/contrast/motor_thresh.nii \\\n  test_output/gingerale/contrast/cognitive_thresh.nii \\\n  test_output/gingerale/contrast/pooled_thresh.nii \\\n  -out1=Motor \\\n  -out2=Cognitive \\\n  -perm=100 \\\n  -p=0.05 \\\n  2>&1'"
   - name: Contrast with foci files
     description: Contrast analysis specifying original foci files
     depends_on: ALE for pooled dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \
-        test_output/gingerale/contrast/motor_thresh.nii \
-        test_output/gingerale/contrast/cognitive_thresh.nii \
-        test_output/gingerale/contrast/pooled_thresh.nii \
-        -foci1=test_output/gingerale/foci/motor_task_tal.txt \
-        -foci2=test_output/gingerale/foci/cognitive_task_tal.txt \
-        -foci3=test_output/gingerale/foci/pooled_foci_tal.txt \
-        -out1=Motor \
-        -out2=Cognitive \
-        -perm=100 \
-        2>&1
-
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \\\n  test_output/gingerale/contrast/motor_thresh.nii \\\n  test_output/gingerale/contrast/cognitive_thresh.nii \\\n  test_output/gingerale/contrast/pooled_thresh.nii \\\n  -foci1=test_output/gingerale/foci/motor_task_tal.txt \\\n  -foci2=test_output/gingerale/foci/cognitive_task_tal.txt \\\n  -foci3=test_output/gingerale/foci/pooled_foci_tal.txt \\\n  -out1=Motor \\\n  -out2=Cognitive \\\n  -perm=100 \\\n  2>&1'"
   - name: Contrast with non-additive method
     description: Contrast analysis using Turkeltaub non-additive method
     depends_on: ALE for pooled dataset
-    command: |
-      java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \
-        test_output/gingerale/contrast/motor_thresh.nii \
-        test_output/gingerale/contrast/cognitive_thresh.nii \
-        test_output/gingerale/contrast/pooled_thresh.nii \
-        -out1=Motor \
-        -out2=Cognitive \
-        -perm=100 \
-        -nonadd \
-        2>&1
-
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2Contrast \\\n  test_output/gingerale/contrast/motor_thresh.nii \\\n  test_output/gingerale/contrast/cognitive_thresh.nii \\\n  test_output/gingerale/contrast/pooled_thresh.nii \\\n  -out1=Motor \\\n  -out2=Cognitive \\\n  -perm=100 \\\n  -nonadd \\\n  2>&1'"
   # ==========================================================================
   # JAVA VERSION AND RUNTIME
   # ==========================================================================
@@ -731,7 +524,7 @@ tests:
 
   - name: Java heap size test
     description: Verify Java can run with adequate heap
-    command: java -Xmx1g -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1
+    command: "bash -lc 'java -Xmx1g -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 2>&1'"
     expected_output_contains: "getALE2 usage"
 
   # ==========================================================================
@@ -739,12 +532,12 @@ tests:
   # ==========================================================================
   - name: Error on missing foci file
     description: Verify graceful error when foci file is missing
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 nonexistent_file.txt 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 nonexistent_file.txt 2>&1'"
     expected_exit_code: 0
 
   - name: Error on missing ALE image for clustering
     description: Verify error when ALE image for clustering is missing
-    command: java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly nonexistent_ale.nii 2>&1
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getClustersOnly nonexistent_ale.nii 2>&1'"
     expected_exit_code: 0
 
   # ==========================================================================

--- a/recipes/glmsingle/fulltest.yaml
+++ b/recipes/glmsingle/fulltest.yaml
@@ -58,7 +58,7 @@ tests:
 
   - name: Container labels check
     description: Verify container metadata labels exist
-    command: cat /.singularity.d/labels.json
+    command: "bash -lc 'cat /.singularity.d/labels.json'"
     expected_output_contains: "NeuroDesk"
 
   # ==========================================================================

--- a/recipes/globus/fulltest.yaml
+++ b/recipes/globus/fulltest.yaml
@@ -146,62 +146,62 @@ tests:
   # ==========================================================================
   - name: GridFTP server help
     description: Verify globus-gridftp-server displays help
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1 | head -10
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1 | head -10'
     expected_output_contains: "Informational Options"
 
   - name: GridFTP server version
     description: Verify globus-gridftp-server displays version
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -version 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -version 2>&1'
     expected_output_contains: "globus_connect_gridftp_server"
 
   - name: GridFTP server library versions
     description: Verify globus-gridftp-server shows all library versions
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_gridftp_server"
 
   - name: GridFTP server longhelp
     description: Verify globus-gridftp-server long help display
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1 | head -20
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1 | head -20'
     expected_output_contains: "Informational Options"
 
   - name: GridFTP help shows daemon mode
     description: Verify help includes daemon mode
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1'
     expected_output_contains: "-daemon"
 
   - name: GridFTP help shows inetd mode
     description: Verify help includes inetd mode
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1'
     expected_output_contains: "-inetd"
 
   - name: GridFTP help shows SSH mode
     description: Verify help includes SSH mode
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1'
     expected_output_contains: "-ssh"
 
   - name: GridFTP help shows detach option
     description: Verify help includes detach option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1'
     expected_output_contains: "-detach"
 
   - name: GridFTP help shows threading option
     description: Verify help includes threads option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-threads"
 
   - name: GridFTP help shows fork option
     description: Verify help includes fork option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1'
     expected_output_contains: "-fork"
 
   - name: GridFTP help shows single connection option
     description: Verify help includes single connection option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -help 2>&1'
     expected_output_contains: "-single"
 
   - name: GridFTP help shows chroot option
     description: Verify help includes chroot-path option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-chroot-path"
 
   # ==========================================================================
@@ -209,42 +209,42 @@ tests:
   # ==========================================================================
   - name: GridFTP help shows auth-level option
     description: Verify help includes auth-level option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-auth-level"
 
   - name: GridFTP help shows process-user option
     description: Verify help includes process-user option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-process-user"
 
   - name: GridFTP help shows allow-from option
     description: Verify help includes allow-from option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-allow-from"
 
   - name: GridFTP help shows deny-from option
     description: Verify help includes deny-from option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-deny-from"
 
   - name: GridFTP help shows encrypt-data option
     description: Verify help includes encrypt-data option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-encrypt-data"
 
   - name: GridFTP help shows anonymous access option
     description: Verify help includes allow-anonymous option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-allow-anonymous"
 
   - name: GridFTP help shows sharing-dn option
     description: Verify help includes sharing-dn option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-sharing-dn"
 
   - name: GridFTP help shows sharing-control option
     description: Verify help includes sharing-control option
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -longhelp 2>&1'
     expected_output_contains: "-sharing-control"
 
   # ==========================================================================
@@ -252,17 +252,17 @@ tests:
   # ==========================================================================
   - name: Version file exists
     description: Verify VERSION file exists and contains version
-    command: cat /opt/globusconnectpersonal-3.2.2/VERSION 2>&1
+    command: "bash -lc 'cat /opt/globusconnectpersonal-3.2.2/VERSION 2>&1'"
     expected_output_contains: "3.2.2"
 
   - name: README file exists
     description: Verify README file exists
-    command: cat /opt/globusconnectpersonal-3.2.2/README 2>&1
+    command: "bash -lc 'cat /opt/globusconnectpersonal-3.2.2/README 2>&1'"
     expected_output_contains: "Globus Connect Personal"
 
   - name: LICENSE file exists
     description: Verify LICENSE file exists
-    command: cat /opt/globusconnectpersonal-3.2.2/LICENSE 2>&1 | head -5
+    command: "bash -lc 'cat /opt/globusconnectpersonal-3.2.2/LICENSE 2>&1 | head -5'"
     expected_output_contains: "License"
 
   - name: Container README exists
@@ -298,32 +298,32 @@ tests:
   # ==========================================================================
   - name: Globus XIO library present
     description: Verify globus_xio library is loaded
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_xio:"
 
   - name: Globus GSI library present
     description: Verify globus_gsi_gssapi library is loaded
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_gsi_gssapi:"
 
   - name: Globus credential library present
     description: Verify globus_credential library is loaded
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_credential:"
 
   - name: Globus FTP control library present
     description: Verify globus_ftp_control library is loaded
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_ftp_control:"
 
   - name: Globus common library present
     description: Verify globus_common library is loaded
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_common:"
 
   - name: Globus IO library present
     description: Verify globus_io library is loaded
-    command: /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1
+    command: bash -lc '/opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server -versions 2>&1'
     expected_output_contains: "globus_io:"
 
   # ==========================================================================
@@ -331,32 +331,32 @@ tests:
   # ==========================================================================
   - name: Main executable exists
     description: Verify globusconnectpersonal executable exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/globusconnectpersonal 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/globusconnectpersonal 2>&1'"
     expected_output_contains: "globusconnectpersonal"
 
   - name: Globus connect symlink exists
     description: Verify globusconnect symlink exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/globusconnect 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/globusconnect 2>&1'"
     expected_output_contains: "globusconnect -> globusconnectpersonal"
 
   - name: GridFTP server binary exists
     description: Verify globus-gridftp-server binary exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/gt_amd64/sbin/globus-gridftp-server 2>&1'"
     expected_output_contains: "globus-gridftp-server"
 
   - name: SSH binary exists
     description: Verify bundled ssh binary exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/gt_amd64/bin/ssh 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/gt_amd64/bin/ssh 2>&1'"
     expected_output_contains: "ssh"
 
   - name: Register binary exists
     description: Verify register binary exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/gt_amd64/bin/register 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/gt_amd64/bin/register 2>&1'"
     expected_output_contains: "register"
 
   - name: Tclkit interpreter exists
     description: Verify tclkit interpreter exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/tclkit 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/tclkit 2>&1'"
     expected_output_contains: "tclkit"
 
   # ==========================================================================
@@ -364,27 +364,27 @@ tests:
   # ==========================================================================
   - name: TCL GUI script exists
     description: Verify globusconnect.tcl GUI script exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/globusconnect.tcl 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/globusconnect.tcl 2>&1'"
     expected_output_contains: "globusconnect.tcl"
 
   - name: Access paths TCL exists
     description: Verify accessPaths.tcl script exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/accessPaths.tcl 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/accessPaths.tcl 2>&1'"
     expected_output_contains: "accessPaths.tcl"
 
   - name: Python control script exists
     description: Verify gc-ctrl.py script exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/gc-ctrl.py 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/gc-ctrl.py 2>&1'"
     expected_output_contains: "gc-ctrl.py"
 
   - name: Main Python script exists
     description: Verify gc.py script exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/gc.py 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/gc.py 2>&1'"
     expected_output_contains: "gc.py"
 
   - name: Uninstall utility exists
     description: Verify remove_globusconnect utility exists
-    command: ls -la /opt/globusconnectpersonal-3.2.2/util/remove_globusconnect 2>&1
+    command: "bash -lc 'ls -la /opt/globusconnectpersonal-3.2.2/util/remove_globusconnect 2>&1'"
     expected_output_contains: "remove_globusconnect"
 
   # ==========================================================================

--- a/recipes/halfpipe/fulltest.yaml
+++ b/recipes/halfpipe/fulltest.yaml
@@ -389,7 +389,7 @@ tests:
 
   - name: FreeSurfer environment check
     description: Check FreeSurfer environment variables
-    command: echo "FREESURFER_HOME=${FREESURFER_HOME:-/opt/freesurfer}"
+    command: "bash -lc 'echo \"FREESURFER_HOME=${FREESURFER_HOME:-/opt/freesurfer}\"'"
     expected_output_contains: "FREESURFER_HOME"
 
   # ==========================================================================
@@ -397,12 +397,12 @@ tests:
   # ==========================================================================
   - name: ICA-AROMA files check
     description: Verify ICA-AROMA files are present
-    command: ls -la /opt/ICA-AROMA/
+    command: "bash -lc 'ls -la /opt/ICA-AROMA/'"
     expected_output_contains: "ICA_AROMA.py"
 
   - name: ICA-AROMA help
     description: Check ICA-AROMA help (requires specific environment)
-    command: python3 /opt/ICA-AROMA/ICA_AROMA.py --help 2>&1 | head -20 || echo "ICA-AROMA available"
+    command: "bash -lc 'python3 /opt/ICA-AROMA/ICA_AROMA.py --help 2>&1 | head -20 || echo \"ICA-AROMA available\"'"
     expected_exit_code: 0
 
   # ==========================================================================

--- a/recipes/hmri/fulltest.yaml
+++ b/recipes/hmri/fulltest.yaml
@@ -53,27 +53,27 @@ tests:
   # ==========================================================================
   - name: SPM12 help display
     description: Verify SPM12 standalone runs and displays help
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --help
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --help'
     expected_output_contains: "SPM12 - Statistical Parametric Mapping"
 
   - name: SPM12 version information
     description: Check SPM12 version and MATLAB runtime version
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --version
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --version'
     expected_output_contains: "SPM12, version 7771"
 
   - name: MATLAB runtime version
     description: Verify MATLAB Runtime R2023a is installed
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --version
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --version'
     expected_output_contains: "MATLAB, version 9.14"
 
   - name: SPM directory location
     description: Check SPM installation directory
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('dir'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''dir'\''))"'
     expected_output_contains: "SPM12"
 
   - name: SPM version string
     description: Get SPM version string via function call
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('ver'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''ver'\''))"'
     expected_output_contains: "SPM12"
 
   # ==========================================================================
@@ -81,27 +81,27 @@ tests:
   # ==========================================================================
   - name: hMRI toolbox version
     description: Check hMRI toolbox version
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "v=hmri_get_version;disp(v{1})"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "v=hmri_get_version;disp(v{1})"'
     expected_output_contains: "hMRI v0.6.1"
 
   - name: hMRI defaults availability
     description: Verify hmri_defaults function is accessible
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(which('hmri_defaults'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_defaults'\''))"'
     expected_output_contains: "hmri_defaults"
 
   - name: hMRI get_defaults function
     description: Test hmri_get_defaults returns configuration structure
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
     expected_output_contains: "centre"
 
   - name: hMRI B1 defaults availability
     description: Check B1 mapping defaults are accessible
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(which('hmri_b1_standard_defaults'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
     expected_output_contains: "hmri_b1_standard_defaults"
 
   - name: hMRI toolbox directory
     description: Verify hMRI toolbox installation path
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/'"
     expected_output_contains: "hmri_get_version.m"
 
   # ==========================================================================
@@ -109,42 +109,42 @@ tests:
   # ==========================================================================
   - name: hmri_calc_R1 function exists
     description: Check R1 calculation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_calc_R1'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R1'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_R2s function exists
     description: Check R2* calculation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_calc_R2s'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R2s'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_A function exists
     description: Check A (PD-related) calculation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_calc_A'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_A'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_MTProt function exists
     description: Check MT protocol creation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_create_MTProt'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_MTProt'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_b1map function exists
     description: Check B1 map creation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_create_b1map'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_b1map'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_unicort function exists
     description: Check UNICORT RF correction function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_create_unicort'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_unicort'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_coreg function exists
     description: Check coregistration function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_coreg'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_autoreorient function exists
     description: Check autoreorient function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_autoreorient'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_autoreorient'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -152,27 +152,27 @@ tests:
   # ==========================================================================
   - name: hmri_proc_MPMsmooth function exists
     description: Check MPM smoothing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_proc_MPMsmooth'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_US function exists
     description: Check unified segmentation processing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_run_proc_US'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_US'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_dartel_norm function exists
     description: Check DARTEL normalization function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_run_proc_dartel_norm'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_build function exists
     description: Check QUIQI (quality assurance) build function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_quiqi_build'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_build'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_check function exists
     description: Check QUIQI check function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_quiqi_check'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_check'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -180,22 +180,22 @@ tests:
   # ==========================================================================
   - name: hmri_read_vols function exists
     description: Check volume reading function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_read_vols'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_nifti function exists
     description: Check NIfTI creation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_create_nifti'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_nifti'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_log function exists
     description: Check logging function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_log'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_log'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quality_display function exists
     description: Check quality display function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_quality_display'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quality_display'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -203,17 +203,17 @@ tests:
   # ==========================================================================
   - name: tbx_cfg_hmri function exists
     description: Check hMRI batch configuration function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('tbx_cfg_hmri'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_cfg_hmri'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_create function exists
     description: Check hMRI map creation batch config is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('tbx_scfg_hmri_create'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_B1_create function exists
     description: Check B1 map creation batch config is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('tbx_scfg_hmri_B1_create'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -221,52 +221,52 @@ tests:
   # ==========================================================================
   - name: spm_vol function exists
     description: Check SPM volume reading function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_vol'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_read_vols function exists
     description: Check SPM volume data reading function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_read_vols'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: spm_write_vol function exists
     description: Check SPM volume writing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_write_vol'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_write_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_smooth function exists
     description: Check SPM smoothing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_smooth'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_smooth'\''))"'
     expected_output_contains: "2"
 
   - name: spm_realign function exists
     description: Check SPM realignment function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_realign'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_realign'\''))"'
     expected_output_contains: "2"
 
   - name: spm_coreg function exists
     description: Check SPM coregistration function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_coreg'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: spm_preproc function exists
     description: Check SPM preprocessing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_preproc'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc'\''))"'
     expected_output_contains: "2"
 
   - name: spm_normalise function exists
     description: Check SPM normalisation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_normalise'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_normalise'\''))"'
     expected_output_contains: "2"
 
   - name: spm_segment function exists
     description: Check SPM new segment function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_preproc_run'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc_run'\''))"'
     expected_output_contains: "2"
 
   - name: spm_slice_timing function exists
     description: Check SPM slice timing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_slice_timing'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_slice_timing'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -274,12 +274,12 @@ tests:
   # ==========================================================================
   - name: spm_dicom_headers function exists
     description: Check DICOM header reading function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_dicom_headers'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_headers'\''))"'
     expected_output_contains: "2"
 
   - name: spm_dicom_convert function exists
     description: Check DICOM conversion function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_dicom_convert'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_convert'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -287,22 +287,22 @@ tests:
   # ==========================================================================
   - name: DARTEL toolbox available
     description: Check DARTEL toolbox is installed
-    command: ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/DARTEL/
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/DARTEL/'"
     expected_output_contains: "spm_dartel"
 
   - name: FieldMap toolbox available
     description: Check FieldMap toolbox is installed
-    command: ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/FieldMap/
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/FieldMap/'"
     expected_output_contains: "FieldMap.m"
 
   - name: Longitudinal toolbox available
     description: Check Longitudinal toolbox is installed
-    command: ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/Longitudinal/
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/Longitudinal/'"
     expected_output_contains: "spm_pairwise"
 
   - name: Shoot toolbox available
     description: Check Shoot (geodesic shooting) toolbox is installed
-    command: ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/Shoot/
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/Shoot/'"
     expected_output_contains: "spm_shoot"
 
   # ==========================================================================
@@ -310,32 +310,32 @@ tests:
   # ==========================================================================
   - name: TPM file exists
     description: Check tissue probability map is available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/TPM.nii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/TPM.nii'"
     expected_output_contains: "TPM.nii"
 
   - name: ICV mask exists
     description: Check intracranial volume mask is available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/mask_ICV.nii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/mask_ICV.nii'"
     expected_output_contains: "mask_ICV.nii"
 
   - name: Neuromorphometrics labels exist
     description: Check Neuromorphometrics labels are available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/labels_Neuromorphometrics.nii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/labels_Neuromorphometrics.nii'"
     expected_output_contains: "labels_Neuromorphometrics.nii"
 
   - name: Canonical T1 template exists
     description: Check T1 template is available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/avg152T1.nii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/avg152T1.nii'"
     expected_output_contains: "avg152T1.nii"
 
   - name: Canonical T2 template exists
     description: Check T2 template is available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/avg152T2.nii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/avg152T2.nii'"
     expected_output_contains: "avg152T2.nii"
 
   - name: Single subject T1 template exists
     description: Check single subject T1 template is available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/single_subj_T1.nii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/single_subj_T1.nii'"
     expected_output_contains: "single_subj_T1.nii"
 
   # ==========================================================================
@@ -343,27 +343,27 @@ tests:
   # ==========================================================================
   - name: hMRI defaults - centre
     description: Get default hMRI centre setting
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.centre)"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.centre)"'
     expected_output_contains: "centre"
 
   - name: hMRI defaults - cleanup setting
     description: Get default cleanup setting
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.cleanup)"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - JSON setting
     description: Get default JSON output setting
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.json)"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.json)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - interpolation
     description: Get default interpolation setting
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.interp)"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.interp)"'
     expected_exit_code: 0
 
   - name: hMRI B1 defaults structure
     description: Get B1 mapping defaults
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
     expected_output_contains: "i3D_AFI"
 
   # ==========================================================================
@@ -371,12 +371,12 @@ tests:
   # ==========================================================================
   - name: EPG_GRE function exists
     description: Check EPG gradient echo function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('EPG_GRE'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''EPG_GRE'\''))"'
     expected_output_contains: "2"
 
   - name: EPG directory exists
     description: Check EPG toolbox directory
-    command: ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/EPG_for_hmri_tbx/
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/EPG_for_hmri_tbx/'"
     expected_output_contains: "EPG-src"
 
   # ==========================================================================
@@ -384,22 +384,22 @@ tests:
   # ==========================================================================
   - name: get_metadata function exists
     description: Check metadata retrieval function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('get_metadata'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata'\''))"'
     expected_output_contains: "2"
 
   - name: get_metadata_val function exists
     description: Check metadata value retrieval function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('get_metadata_val'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata_val'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonread function exists
     description: Check JSON reading function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_jsonread'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonread'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonwrite function exists
     description: Check JSON writing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_jsonwrite'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonwrite'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -407,12 +407,12 @@ tests:
   # ==========================================================================
   - name: hmri_corr_imperf_spoil function exists
     description: Check imperfect spoiling correction function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('hmri_corr_imperf_spoil'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   - name: Imperfect spoiling config exists
     description: Check imperfect spoiling batch config is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('tbx_scfg_hmri_imperf_spoil'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -420,17 +420,17 @@ tests:
   # ==========================================================================
   - name: MATLAB basic arithmetic
     description: Test basic MATLAB arithmetic via eval
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(2+2)"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(2+2)"'
     expected_output_contains: "4"
 
   - name: MATLAB matrix creation
     description: Test MATLAB matrix creation via eval
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "A=eye(3);disp(size(A))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "A=eye(3);disp(size(A))"'
     expected_output_contains: "3     3"
 
   - name: MATLAB path check
     description: Verify MATLAB path includes SPM
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "p=path;disp(contains(p,'spm12'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "p=path;disp(contains(p,'\''spm12'\''))"'
     expected_output_contains: "1"
 
   # ==========================================================================
@@ -438,12 +438,12 @@ tests:
   # ==========================================================================
   - name: spm_jobman function exists
     description: Check batch job manager function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_jobman'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jobman'\''))"'
     expected_output_contains: "2"
 
   - name: cfg_util function exists
     description: Check batch utility function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('cfg_util'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''cfg_util'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -451,12 +451,12 @@ tests:
   # ==========================================================================
   - name: nifti class exists
     description: Check NIfTI class is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('nifti'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''nifti'\''))"'
     expected_output_contains: "2"
 
   - name: file_array class exists
     description: Check file_array class is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('file_array'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''file_array'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -464,12 +464,12 @@ tests:
   # ==========================================================================
   - name: gifti class exists
     description: Check GIfTI class is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('gifti'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''gifti'\''))"'
     expected_output_contains: "2"
 
   - name: Cortex surface file exists
     description: Check cortex surface template is available
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/cortex_20484.surf.gii
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/cortex_20484.surf.gii'"
     expected_output_contains: "cortex_20484.surf.gii"
 
   # ==========================================================================
@@ -477,12 +477,12 @@ tests:
   # ==========================================================================
   - name: spm_global function exists
     description: Check global intensity calculation function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_global'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_global'\''))"'
     expected_output_contains: "2"
 
   - name: spm_max function exists
     description: Check maximum finding function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_max'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_max'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -490,17 +490,17 @@ tests:
   # ==========================================================================
   - name: spm_imatrix function exists
     description: Check affine matrix decomposition function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_imatrix'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_imatrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_matrix function exists
     description: Check affine matrix construction function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_matrix'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_matrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_get_space function exists
     description: Check space getting function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_get_space'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_get_space'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -508,12 +508,12 @@ tests:
   # ==========================================================================
   - name: spm_reslice function exists
     description: Check image reslicing function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_reslice'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_reslice'\''))"'
     expected_output_contains: "2"
 
   - name: spm_bsplinc function exists
     description: Check B-spline coefficient function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_bsplinc'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_bsplinc'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -521,12 +521,12 @@ tests:
   # ==========================================================================
   - name: spm_spm function exists
     description: Check SPM statistics function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_spm'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_spm'\''))"'
     expected_output_contains: "2"
 
   - name: spm_contrasts function exists
     description: Check contrast definition function is available
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('spm_contrasts'))"
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_contrasts'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -534,12 +534,12 @@ tests:
   # ==========================================================================
   - name: MCR directory structure
     description: Check MATLAB Compiler Runtime directory exists
-    command: ls -la /opt/mcr/R2023a/
+    command: "bash -lc 'ls -la /opt/mcr/R2023a/'"
     expected_output_contains: "runtime"
 
   - name: hMRI README exists
     description: Check hMRI README is present
-    command: ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/README.md
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/README.md'"
     expected_output_contains: "README.md"
 
   - name: Container README
@@ -552,7 +552,7 @@ tests:
   # ==========================================================================
   - name: hMRI etpm directory exists
     description: Check enhanced TPM directory
-    command: ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/etpm/
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/etpm/'"
     expected_output_contains: "eTPM.nii"
 
   # ==========================================================================
@@ -560,7 +560,7 @@ tests:
   # ==========================================================================
   - name: Script mode basic test
     description: Test script execution mode
-    command: echo "disp('script test passed')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a script /tmp/test_script.m 2>&1 | tail -10
+    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a script /tmp/test_script.m 2>&1 | tail -10'
     expected_output_contains: "script test passed"
 
   # ==========================================================================
@@ -568,7 +568,7 @@ tests:
   # ==========================================================================
   - name: Invalid function error handling
     description: Test error handling for non-existent function
-    command: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "nonexistent_function_xyz" 2>&1 || true
+    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "nonexistent_function_xyz" 2>&1 || true'
     expected_output_contains: "Error"
 
 cleanup:

--- a/recipes/ilastik/fulltest.yaml
+++ b/recipes/ilastik/fulltest.yaml
@@ -118,12 +118,12 @@ tests:
 
   - name: Python environment check
     description: Verify ilastik Python environment is configured
-    command: ls /opt/ilastik-1.4.0-Linux/bin/python 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/bin/python 2>&1'"
     expected_output_contains: "python"
 
   - name: Ilastik binary exists
     description: Verify ilastik entry point script exists
-    command: ls /opt/ilastik-1.4.0-Linux/bin/ilastik 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/bin/ilastik 2>&1'"
     expected_output_contains: "ilastik"
 
   # ==========================================================================
@@ -150,47 +150,47 @@ tests:
   # ==========================================================================
   - name: Pixel Classification workflow available
     description: Verify Pixel Classification workflow module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/pixelClassification/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/pixelClassification/ 2>&1'"
     expected_output_contains: "pixelClassificationWorkflow.py"
 
   - name: Object Classification workflow available
     description: Verify Object Classification workflow module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/objectClassification/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/objectClassification/ 2>&1'"
     expected_output_contains: "objectClassificationWorkflow.py"
 
   - name: Autocontext workflow available
     description: Verify Autocontext workflow module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/newAutocontext/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/newAutocontext/ 2>&1'"
     expected_output_contains: "newAutocontextWorkflow.py"
 
   - name: Counting workflow available
     description: Verify Counting workflow module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/counting/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/counting/ 2>&1'"
     expected_output_contains: "countingWorkflow.py"
 
   - name: Carving workflow available
     description: Verify Carving workflow module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/carving/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/carving/ 2>&1'"
     expected_output_contains: "carvingWorkflow.py"
 
   - name: Tracking workflow available
     description: Verify Tracking workflow modules exist
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/ 2>&1'"
     expected_output_contains: "manual"
 
   - name: Multicut workflow available
     description: Verify Edge Training with Multicut workflow exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/edgeTrainingWithMulticut/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/edgeTrainingWithMulticut/ 2>&1'"
     expected_output_contains: "edgeTrainingWithMulticutWorkflow.py"
 
   - name: Neural Network workflow available
     description: Verify Neural Network workflow modules exist
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/neuralNetwork/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/neuralNetwork/ 2>&1'"
     expected_output_contains: "_nnWorkflowBase.py"
 
   - name: Data Conversion workflow available
     description: Verify Data Conversion workflow exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/examples/dataConversion/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/examples/dataConversion/ 2>&1'"
     expected_output_contains: "dataConversionWorkflow.py"
 
   # ==========================================================================
@@ -198,77 +198,77 @@ tests:
   # ==========================================================================
   - name: Data Selection applet available
     description: Verify Data Selection applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataSelection/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataSelection/ 2>&1'"
     expected_output_contains: "dataSelectionApplet.py"
 
   - name: Feature Selection applet available
     description: Verify Feature Selection applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/featureSelection/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/featureSelection/ 2>&1'"
     expected_output_contains: "featureSelectionApplet.py"
 
   - name: Pixel Classification applet available
     description: Verify Pixel Classification applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/pixelClassification/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/pixelClassification/ 2>&1'"
     expected_output_contains: "pixelClassificationApplet.py"
 
   - name: Object Classification applet available
     description: Verify Object Classification applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/objectClassification/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/objectClassification/ 2>&1'"
     expected_output_contains: "objectClassificationApplet.py"
 
   - name: Object Extraction applet available
     description: Verify Object Extraction applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/objectExtraction/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/objectExtraction/ 2>&1'"
     expected_output_contains: "objectExtractionApplet.py"
 
   - name: Data Export applet available
     description: Verify Data Export applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataExport/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataExport/ 2>&1'"
     expected_output_contains: "dataExportApplet.py"
 
   - name: Batch Processing applet available
     description: Verify Batch Processing applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/batchProcessing/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/batchProcessing/ 2>&1'"
     expected_output_contains: "batchProcessingApplet.py"
 
   - name: Labeling applet available
     description: Verify Labeling applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/labeling/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/labeling/ 2>&1'"
     expected_output_contains: "labelingApplet.py"
 
   - name: Threshold applet available
     description: Verify Threshold Two Levels applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/thresholdTwoLevels/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/thresholdTwoLevels/ 2>&1'"
     expected_output_contains: "thresholdTwoLevelsApplet.py"
 
   - name: Counting applet available
     description: Verify Counting applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/counting/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/counting/ 2>&1'"
     expected_output_contains: "countingApplet.py"
 
   - name: Neural Network applet available
     description: Verify Neural Network applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/neuralNetwork/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/neuralNetwork/ 2>&1'"
     expected_output_contains: "nnClassApplet"
 
   - name: Tracking applet available
     description: Verify Tracking feature extraction applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/trackingFeatureExtraction/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/trackingFeatureExtraction/ 2>&1'"
     expected_output_contains: ""
 
   - name: Multicut applet available
     description: Verify Multicut applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/multicut/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/multicut/ 2>&1'"
     expected_output_contains: "multicutApplet.py"
 
   - name: Edge Training applet available
     description: Verify Edge Training applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/edgeTraining/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/edgeTraining/ 2>&1'"
     expected_output_contains: "edgeTrainingApplet.py"
 
   - name: WSDT applet available
     description: Verify Watershed applet exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/wsdt/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/wsdt/ 2>&1'"
     expected_output_contains: "wsdtApplet.py"
 
   # ==========================================================================
@@ -276,47 +276,47 @@ tests:
   # ==========================================================================
   - name: Vigra library available
     description: Verify vigra image processing library is available
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/vigra/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/vigra/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Lazyflow library available
     description: Verify lazyflow framework is available
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: NumPy available
     description: Verify NumPy is available
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/numpy/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/numpy/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: H5py available
     description: Verify HDF5 Python library is available
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/h5py/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/h5py/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Scikit-learn available
     description: Verify scikit-learn is available
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/sklearn/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/sklearn/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Z5py available for N5 support
     description: Verify z5py library for N5 format support
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/z5py/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/z5py/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Tifffile available
     description: Verify tifffile library for TIFF support
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/tifffile/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/tifffile/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: BioImageIO available
     description: Verify BioImage.IO model spec support via Python import
-    command: /opt/ilastik-1.4.0-Linux/bin/python -c "import bioimageio; print('bioimageio available')" 2>&1
+    command: bash -lc '/opt/ilastik-1.4.0-Linux/bin/python -c "import bioimageio; print('\''bioimageio available'\'')" 2>&1'
     expected_output_contains: "bioimageio available"
 
   - name: ONNX runtime check
     description: Check if ONNX support is available (not installed in this build)
-    command: /opt/ilastik-1.4.0-Linux/bin/python -c "import onnxruntime; print('onnx available')" 2>&1 || echo "ONNX not installed in this build"
+    command: bash -lc '/opt/ilastik-1.4.0-Linux/bin/python -c "import onnxruntime; print('\''onnx available'\'')" 2>&1 || echo "ONNX not installed in this build"'
     expected_output_contains: "ONNX not installed"
 
   # ==========================================================================
@@ -324,27 +324,27 @@ tests:
   # ==========================================================================
   - name: HDF5 format export support
     description: Verify HDF5 export is supported
-    command: grep -r "hdf5" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1
+    command: "bash -lc 'grep -r \"hdf5\" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1'"
     expected_output_contains: "hdf5"
 
   - name: N5 format export support
     description: Verify N5 export is supported
-    command: grep -r '"n5"' /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1
+    command: "bash -lc 'grep -r '\"'\"'\"n5\"'\"'\"' /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1'"
     expected_output_contains: "n5"
 
   - name: TIFF format export support
     description: Verify TIFF export is supported
-    command: grep -r "tiff" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1
+    command: "bash -lc 'grep -r \"tiff\" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1'"
     expected_output_contains: "tiff"
 
   - name: NumPy format export support
     description: Verify NumPy export is supported
-    command: grep -r '"numpy"' /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1
+    command: "bash -lc 'grep -r '\"'\"'\"numpy\"'\"'\"' /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/opExportSlot.py 2>&1 | head -1'"
     expected_output_contains: "numpy"
 
   - name: PNG format support via vigra
     description: Verify PNG is in supported extensions
-    command: ls /opt/ilastik-1.4.0-Linux/lib/libpng*.so* 2>&1 | head -1
+    command: bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/libpng*.so* 2>&1 | head -1'
     expected_output_contains: "libpng"
 
   # ==========================================================================
@@ -352,12 +352,12 @@ tests:
   # ==========================================================================
   - name: Plugin manager available
     description: Verify ilastik plugin system is importable
-    command: /opt/ilastik-1.4.0-Linux/bin/python -c "import ilastik.plugins; print('plugins module available')" 2>&1
+    command: bash -lc '/opt/ilastik-1.4.0-Linux/bin/python -c "import ilastik.plugins; print('\''plugins module available'\'')" 2>&1'
     expected_output_contains: "plugins module available"
 
   - name: Feature plugin base available
     description: Verify ilastik applets can be imported
-    command: /opt/ilastik-1.4.0-Linux/bin/python -c "import ilastik.applets; print('applets module available')" 2>&1
+    command: bash -lc '/opt/ilastik-1.4.0-Linux/bin/python -c "import ilastik.applets; print('\''applets module available'\'')" 2>&1'
     expected_output_contains: "applets module available"
 
   # ==========================================================================
@@ -365,12 +365,12 @@ tests:
   # ==========================================================================
   - name: Config module available
     description: Verify ilastik config module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/config.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/config.py 2>&1'"
     expected_output_contains: "config.py"
 
   - name: Shell module available
     description: Verify ilastik shell module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/shell/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/shell/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   # ==========================================================================
@@ -378,22 +378,22 @@ tests:
   # ==========================================================================
   - name: Ilastik tools module available
     description: Verify ilastiktools package exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastiktools/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastiktools/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Ilastik RAG module available
     description: Verify ilastikrag (region adjacency graph) package exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastikrag/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastikrag/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Ilastik feature selection module available
     description: Verify ilastik feature selection package exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik_feature_selection/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik_feature_selection/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: ELF ilastik integration available
     description: Verify ELF (EMBL Segmentation Library) ilastik integration
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/elf/ilastik/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/elf/ilastik/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   # ==========================================================================
@@ -406,7 +406,7 @@ tests:
 
   - name: License file available
     description: Verify license file exists
-    command: ls /opt/ilastik-1.4.0-Linux/LICENSE.txt 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/LICENSE.txt 2>&1'"
     expected_output_contains: "LICENSE.txt"
 
   # ==========================================================================
@@ -437,12 +437,12 @@ tests:
   # ==========================================================================
   - name: Feature Selection operator available
     description: Verify feature selection operator exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/featureSelection/opFeatureSelection.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/featureSelection/opFeatureSelection.py 2>&1'"
     expected_output_contains: "opFeatureSelection.py"
 
   - name: Gaussian smoothing features available
     description: Verify Gaussian smoothing feature computation
-    command: grep -l "GaussianSmoothing" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/featureSelection/*.py 2>&1 | head -1
+    command: bash -lc 'grep -l "GaussianSmoothing" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/featureSelection/*.py 2>&1 | head -1'
     expected_output_contains: ".py"
 
   # ==========================================================================
@@ -450,7 +450,7 @@ tests:
   # ==========================================================================
   - name: Random Forest classifier available
     description: Verify Vigra Random Forest is available
-    command: grep -l "RandomForest" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/pixelClassification/*.py 2>&1 | head -1
+    command: bash -lc 'grep -l "RandomForest" /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/pixelClassification/*.py 2>&1 | head -1'
     expected_output_contains: ".py"
 
   # ==========================================================================
@@ -458,17 +458,17 @@ tests:
   # ==========================================================================
   - name: Lazyflow operators available
     description: Verify lazyflow operator infrastructure
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: IO operators available
     description: Verify I/O operators for file handling
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/ioOperators/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   - name: Generic operators available
     description: Verify generic operators
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/generic.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/lazyflow/operators/generic.py 2>&1'"
     expected_output_contains: "generic.py"
 
   # ==========================================================================
@@ -476,12 +476,12 @@ tests:
   # ==========================================================================
   - name: Project serializer available
     description: Verify project serialization module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataSelection/dataSelectionSerializer.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataSelection/dataSelectionSerializer.py 2>&1'"
     expected_output_contains: "dataSelectionSerializer.py"
 
   - name: Data export serializer available
     description: Verify data export serialization
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataExport/dataExportSerializer.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/applets/dataExport/dataExportSerializer.py 2>&1'"
     expected_output_contains: "dataExportSerializer.py"
 
   # ==========================================================================
@@ -489,22 +489,22 @@ tests:
   # ==========================================================================
   - name: Conservation tracking available
     description: Verify conservation tracking workflow exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/conservation/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/conservation/ 2>&1'"
     expected_output_contains: "conservationTrackingWorkflow.py"
 
   - name: Animal tracking available
     description: Verify animal conservation tracking workflow exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/conservation/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/conservation/ 2>&1'"
     expected_output_contains: "animalConservationTrackingWorkflow.py"
 
   - name: Manual tracking available
     description: Verify manual tracking workflow exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/manual/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/manual/ 2>&1'"
     expected_output_contains: "manualTrackingWorkflow.py"
 
   - name: Structured tracking available
     description: Verify structured tracking workflow exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/structured/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/workflows/tracking/structured/ 2>&1'"
     expected_output_contains: "structuredTrackingWorkflow.py"
 
   # ==========================================================================
@@ -512,12 +512,12 @@ tests:
   # ==========================================================================
   - name: Qt libraries available
     description: Verify Qt libraries are available
-    command: ls /opt/ilastik-1.4.0-Linux/plugins/platforms/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/plugins/platforms/ 2>&1'"
     expected_output_contains: ""
 
   - name: GUI shell available
     description: Verify ilastik GUI shell module exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/shell/gui/ 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/shell/gui/ 2>&1'"
     expected_output_contains: "__init__.py"
 
   # ==========================================================================
@@ -525,12 +525,12 @@ tests:
   # ==========================================================================
   - name: Command line processing utilities available
     description: Verify CLI processing utilities exist
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/utility/commandLineProcessing.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/utility/commandLineProcessing.py 2>&1'"
     expected_output_contains: "commandLineProcessing.py"
 
   - name: OpMultiLaneWrapper available
     description: Verify multi-lane operator wrapper exists
-    command: ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/utility/opMultiLaneWrapper.py 2>&1
+    command: "bash -lc 'ls /opt/ilastik-1.4.0-Linux/lib/python3.7/site-packages/ilastik/utility/opMultiLaneWrapper.py 2>&1'"
     expected_output_contains: "opMultiLaneWrapper.py"
 
 cleanup:

--- a/recipes/lashis/fulltest.yaml
+++ b/recipes/lashis/fulltest.yaml
@@ -36,53 +36,53 @@ tests:
   # ==========================================================================
   - name: LASHiS help
     description: Verify LASHiS main script displays help information
-    command: /LASHiS/LASHiS.sh -h 2>&1 | head -50
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1 | head -50'
     expected_output_contains: "LASHiS.sh performs a longitudinal estimation"
 
   - name: LASHiS script exists
     description: Verify LASHiS main script is executable
-    command: test -x /LASHiS/LASHiS.sh && echo "LASHiS script is executable"
+    command: bash -lc 'test -x /LASHiS/LASHiS.sh && echo "LASHiS script is executable"'
     expected_output_contains: "executable"
 
   - name: LASHiS usage information
     description: Check LASHiS displays required arguments
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Required arguments"
 
   - name: LASHiS optional arguments
     description: Check LASHiS displays optional arguments
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Optional arguments"
 
   - name: LASHiS atlas option
     description: Verify atlas selection option is documented
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "-a: Atlas selection"
 
   - name: LASHiS output prefix option
     description: Verify output prefix option is documented
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "-o:  Output prefix"
 
   - name: LASHiS parallel computation option
     description: Verify parallel computation control option
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "control type"
 
   - name: LASHiS N4 bias correction option
     description: Verify N4 bias correction option exists
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "N4 Bias Correction"
 
   - name: LASHiS denoising option
     description: Verify denoising option exists
-    command: /LASHiS/LASHiS.sh -h 2>&1
+    command: bash -lc '/LASHiS/LASHiS.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "denoise"
 
@@ -114,47 +114,47 @@ tests:
   # ==========================================================================
   - name: ASHS main script help
     description: Verify ASHS main script displays help
-    command: /opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1 | head -30
+    command: bash -lc '/opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1 | head -30'
     expected_output_contains: "ashs_main: automatic segmentation of hippocampal subfields"
 
   - name: ASHS required options
     description: Verify ASHS documents required options
-    command: /opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1
+    command: bash -lc '/opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1'
     expected_output_contains: "required options"
 
   - name: ASHS atlas option
     description: Verify ASHS atlas directory option
-    command: /opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1
+    command: bash -lc '/opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1'
     expected_output_contains: "-a dir"
 
   - name: ASHS T1w input option
     description: Verify ASHS gradient echo (T1w) option
-    command: /opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1
+    command: bash -lc '/opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1'
     expected_output_contains: "-g image"
 
   - name: ASHS T2w input option
     description: Verify ASHS fast spin echo (T2w) option
-    command: /opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1
+    command: bash -lc '/opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1'
     expected_output_contains: "-f image"
 
   - name: ASHS working directory option
     description: Verify ASHS working directory option
-    command: /opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1
+    command: bash -lc '/opt/ashs-2.0.0/bin/ashs_main.sh -h 2>&1'
     expected_output_contains: "-w path"
 
   - name: ASHS config file exists
     description: Verify ASHS config file exists
-    command: test -f /opt/ashs-2.0.0/bin/ashs_config.sh && echo "config exists"
+    command: bash -lc 'test -f /opt/ashs-2.0.0/bin/ashs_config.sh && echo "config exists"'
     expected_output_contains: "config exists"
 
   - name: ASHS library file exists
     description: Verify ASHS library file exists
-    command: test -f /opt/ashs-2.0.0/bin/ashs_lib.sh && echo "library exists"
+    command: bash -lc 'test -f /opt/ashs-2.0.0/bin/ashs_lib.sh && echo "library exists"'
     expected_output_contains: "library exists"
 
   - name: ASHS train script exists
     description: Verify ASHS training script exists
-    command: test -x /opt/ashs-2.0.0/bin/ashs_train.sh && echo "train script exists"
+    command: bash -lc 'test -x /opt/ashs-2.0.0/bin/ashs_train.sh && echo "train script exists"'
     expected_output_contains: "train script exists"
 
   # ==========================================================================
@@ -162,27 +162,27 @@ tests:
   # ==========================================================================
   - name: Magdeburg 7T atlas exists
     description: Verify Magdeburg 7T atlas directory exists
-    command: test -d /ashs_atlas_magdeburg_7t_20180416 && echo "atlas exists"
+    command: bash -lc 'test -d /ashs_atlas_magdeburg_7t_20180416 && echo "atlas exists"'
     expected_output_contains: "atlas exists"
 
   - name: Atlas variables file
     description: Verify atlas variables file exists
-    command: test -f /ashs_atlas_magdeburg_7t_20180416/ashs_atlas_vars.sh && echo "vars exists"
+    command: bash -lc 'test -f /ashs_atlas_magdeburg_7t_20180416/ashs_atlas_vars.sh && echo "vars exists"'
     expected_output_contains: "vars exists"
 
   - name: Atlas template directory
     description: Verify atlas template directory exists
-    command: test -d /ashs_atlas_magdeburg_7t_20180416/template && echo "template exists"
+    command: bash -lc 'test -d /ashs_atlas_magdeburg_7t_20180416/template && echo "template exists"'
     expected_output_contains: "template exists"
 
   - name: Atlas training directory
     description: Verify atlas training directory exists
-    command: test -d /ashs_atlas_magdeburg_7t_20180416/train && echo "train exists"
+    command: bash -lc 'test -d /ashs_atlas_magdeburg_7t_20180416/train && echo "train exists"'
     expected_output_contains: "train exists"
 
   - name: Atlas snap directory
     description: Verify atlas snap labels directory exists
-    command: test -d /ashs_atlas_magdeburg_7t_20180416/snap && echo "snap exists"
+    command: bash -lc 'test -d /ashs_atlas_magdeburg_7t_20180416/snap && echo "snap exists"'
     expected_output_contains: "snap exists"
 
   # ==========================================================================
@@ -190,42 +190,42 @@ tests:
   # ==========================================================================
   - name: antsRegistration help
     description: Verify antsRegistration displays help
-    command: /opt/ants-2.3.0/antsRegistration --help 2>&1 | head -10
+    command: bash -lc '/opt/ants-2.3.0/antsRegistration --help 2>&1 | head -10'
     expected_output_contains: "antsRegistration"
 
   - name: antsRegistration dimensionality option
     description: Verify antsRegistration dimensionality option
-    command: /opt/ants-2.3.0/antsRegistration --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsRegistration --help 2>&1'
     expected_output_contains: "--dimensionality"
 
   - name: antsRegistration output option
     description: Verify antsRegistration output option
-    command: /opt/ants-2.3.0/antsRegistration --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsRegistration --help 2>&1'
     expected_output_contains: "--output"
 
   - name: antsRegistrationSyN.sh help
     description: Verify SyN registration script help
-    command: /opt/ants-2.3.0/antsRegistrationSyN.sh -h 2>&1 | head -20
+    command: bash -lc '/opt/ants-2.3.0/antsRegistrationSyN.sh -h 2>&1 | head -20'
     expected_output_contains: "antsRegistrationSyN.sh"
 
   - name: antsRegistrationSyNQuick.sh help
     description: Verify quick SyN registration script help
-    command: /opt/ants-2.3.0/antsRegistrationSyNQuick.sh -h 2>&1 | head -20
+    command: bash -lc '/opt/ants-2.3.0/antsRegistrationSyNQuick.sh -h 2>&1 | head -20'
     expected_output_contains: "antsRegistrationSyN"
 
   - name: antsApplyTransforms help
     description: Verify antsApplyTransforms displays help
-    command: /opt/ants-2.3.0/antsApplyTransforms --help 2>&1 | head -10
+    command: bash -lc '/opt/ants-2.3.0/antsApplyTransforms --help 2>&1 | head -10'
     expected_output_contains: "antsApplyTransforms"
 
   - name: antsApplyTransforms input option
     description: Verify antsApplyTransforms input option
-    command: /opt/ants-2.3.0/antsApplyTransforms --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsApplyTransforms --help 2>&1'
     expected_output_contains: "--input"
 
   - name: antsApplyTransforms reference option
     description: Verify antsApplyTransforms reference option
-    command: /opt/ants-2.3.0/antsApplyTransforms --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsApplyTransforms --help 2>&1'
     expected_output_contains: "--reference-image"
 
   # ==========================================================================
@@ -233,18 +233,18 @@ tests:
   # ==========================================================================
   - name: antsMultivariateTemplateConstruction2.sh help
     description: Verify template construction script help
-    command: /opt/ants-2.3.0/antsMultivariateTemplateConstruction2.sh -h 2>&1 | head -20
+    command: bash -lc '/opt/ants-2.3.0/antsMultivariateTemplateConstruction2.sh -h 2>&1 | head -20'
     expected_output_contains: "antsMultivariateTemplateConstruction2"
 
   - name: Template construction dimensionality option
     description: Verify template construction dimensionality option
-    command: /opt/ants-2.3.0/antsMultivariateTemplateConstruction2.sh -h 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsMultivariateTemplateConstruction2.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "ImageDimension"
 
   - name: Template construction parallel option
     description: Verify template construction parallel option
-    command: /opt/ants-2.3.0/antsMultivariateTemplateConstruction2.sh -h 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsMultivariateTemplateConstruction2.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "parallel"
 
@@ -253,22 +253,22 @@ tests:
   # ==========================================================================
   - name: N4BiasFieldCorrection help
     description: Verify N4BiasFieldCorrection displays help
-    command: /opt/ants-2.3.0/N4BiasFieldCorrection --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/N4BiasFieldCorrection --help 2>&1 | head -15'
     expected_output_contains: "N4BiasFieldCorrection"
 
   - name: N4BiasFieldCorrection input option
     description: Verify N4BiasFieldCorrection input option
-    command: /opt/ants-2.3.0/N4BiasFieldCorrection --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/N4BiasFieldCorrection --help 2>&1'
     expected_output_contains: "--input-image"
 
   - name: N4BiasFieldCorrection mask option
     description: Verify N4BiasFieldCorrection mask option
-    command: /opt/ants-2.3.0/N4BiasFieldCorrection --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/N4BiasFieldCorrection --help 2>&1'
     expected_output_contains: "--mask-image"
 
   - name: N4BiasFieldCorrection on test data
     description: Run N4BiasFieldCorrection on test T1w image
-    command: /opt/ants-2.3.0/N4BiasFieldCorrection -d 3 -i ${t1w} -o test_output/t1w_n4.nii.gz -s 4 -c [50x50x50,0.0] 2>&1
+    command: bash -lc '/opt/ants-2.3.0/N4BiasFieldCorrection -d 3 -i ${t1w} -o test_output/t1w_n4.nii.gz -s 4 -c [50x50x50,0.0] 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_n4.nii.gz
 
@@ -277,17 +277,17 @@ tests:
   # ==========================================================================
   - name: DenoiseImage help
     description: Verify DenoiseImage displays help
-    command: /opt/ants-2.3.0/DenoiseImage --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/DenoiseImage --help 2>&1 | head -15'
     expected_output_contains: "DenoiseImage"
 
   - name: DenoiseImage noise model option
     description: Verify DenoiseImage noise model option
-    command: /opt/ants-2.3.0/DenoiseImage --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/DenoiseImage --help 2>&1'
     expected_output_contains: "--noise-model"
 
   - name: DenoiseImage on test data
     description: Run DenoiseImage on test T1w image
-    command: /opt/ants-2.3.0/DenoiseImage -d 3 -i ${t1w} -o test_output/t1w_denoised.nii.gz -s 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/DenoiseImage -d 3 -i ${t1w} -o test_output/t1w_denoised.nii.gz -s 2 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_denoised.nii.gz
 
@@ -296,22 +296,22 @@ tests:
   # ==========================================================================
   - name: Atropos help
     description: Verify Atropos displays help
-    command: /opt/ants-2.3.0/Atropos --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/Atropos --help 2>&1 | head -15'
     expected_output_contains: "Atropos"
 
   - name: Atropos segmentation description
     description: Verify Atropos describes FMM segmentation
-    command: /opt/ants-2.3.0/Atropos --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/Atropos --help 2>&1'
     expected_output_contains: "finite mixture modeling"
 
   - name: Atropos intensity image option
     description: Verify Atropos intensity image option
-    command: /opt/ants-2.3.0/Atropos --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/Atropos --help 2>&1'
     expected_output_contains: "--intensity-image"
 
   - name: antsAtroposN4.sh help
     description: Verify combined Atropos/N4 script help
-    command: /opt/ants-2.3.0/antsAtroposN4.sh -h 2>&1 | head -20
+    command: bash -lc '/opt/ants-2.3.0/antsAtroposN4.sh -h 2>&1 | head -20'
     expected_output_contains: "antsAtroposN4"
 
   # ==========================================================================
@@ -319,18 +319,18 @@ tests:
   # ==========================================================================
   - name: antsBrainExtraction.sh help
     description: Verify brain extraction script help
-    command: /opt/ants-2.3.0/antsBrainExtraction.sh -h 2>&1 | head -20
+    command: bash -lc '/opt/ants-2.3.0/antsBrainExtraction.sh -h 2>&1 | head -20'
     expected_output_contains: "antsBrainExtraction.sh performs template-based brain extraction"
 
   - name: Brain extraction anatomical image option
     description: Verify brain extraction anatomical image option
-    command: /opt/ants-2.3.0/antsBrainExtraction.sh -h 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsBrainExtraction.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "-a:  Anatomical image"
 
   - name: Brain extraction template option
     description: Verify brain extraction template option
-    command: /opt/ants-2.3.0/antsBrainExtraction.sh -h 2>&1
+    command: bash -lc '/opt/ants-2.3.0/antsBrainExtraction.sh -h 2>&1'
     ignore_exit_code: true
     expected_output_contains: "-e:  Brain extraction template"
 
@@ -339,12 +339,12 @@ tests:
   # ==========================================================================
   - name: antsCorticalThickness.sh exists
     description: Verify cortical thickness script exists
-    command: test -x /opt/ants-2.3.0/antsCorticalThickness.sh && echo "script exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/antsCorticalThickness.sh && echo "script exists"'
     expected_output_contains: "script exists"
 
   - name: antsLongitudinalCorticalThickness.sh exists
     description: Verify longitudinal cortical thickness script exists
-    command: test -x /opt/ants-2.3.0/antsLongitudinalCorticalThickness.sh && echo "script exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/antsLongitudinalCorticalThickness.sh && echo "script exists"'
     expected_output_contains: "script exists"
 
   # ==========================================================================
@@ -352,17 +352,17 @@ tests:
   # ==========================================================================
   - name: antsJointFusion help
     description: Verify antsJointFusion binary displays help
-    command: /opt/ants-2.3.0/antsJointFusion --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/antsJointFusion --help 2>&1 | head -15'
     expected_output_contains: "antsJointFusion"
 
   - name: antsJointLabelFusion.sh exists
     description: Verify joint label fusion script exists
-    command: test -f /opt/ants-2.3.0/antsJointLabelFusion.sh && echo "script exists"
+    command: bash -lc 'test -f /opt/ants-2.3.0/antsJointLabelFusion.sh && echo "script exists"'
     expected_output_contains: "script exists"
 
   - name: antsLongitudinalJointLabelFusion.sh exists
     description: Verify longitudinal joint label fusion script exists
-    command: test -f /opt/ants-2.3.0/antsLongitudinalJointLabelFusion.sh && echo "script exists"
+    command: bash -lc 'test -f /opt/ants-2.3.0/antsLongitudinalJointLabelFusion.sh && echo "script exists"'
     expected_output_contains: "script exists"
 
   # ==========================================================================
@@ -370,57 +370,57 @@ tests:
   # ==========================================================================
   - name: ImageMath usage
     description: Verify ImageMath displays usage
-    command: /opt/ants-2.3.0/ImageMath 3 2>&1 | head -10
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 2>&1 | head -10'
     expected_output_contains: "ImageMath"
 
   - name: ImageMath mathematical operations
     description: Verify ImageMath documents math operations
-    command: /opt/ants-2.3.0/ImageMath 3 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Mathematical Operations"
 
   - name: ImageMath spatial filtering
     description: Verify ImageMath documents spatial filtering
-    command: /opt/ants-2.3.0/ImageMath 3 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Spatial Filtering"
 
   - name: ImageMath multiply operation
     description: Test ImageMath multiply operation
-    command: /opt/ants-2.3.0/ImageMath 3 test_output/t1w_doubled.nii.gz m ${t1w} 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 test_output/t1w_doubled.nii.gz m ${t1w} 2 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_doubled.nii.gz
 
   - name: ImageMath Gaussian smoothing
     description: Test ImageMath Gaussian smoothing
-    command: /opt/ants-2.3.0/ImageMath 3 test_output/t1w_smooth.nii.gz G ${t1w} 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 test_output/t1w_smooth.nii.gz G ${t1w} 2 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_smooth.nii.gz
 
   - name: PrintHeader usage
     description: Verify PrintHeader displays usage
-    command: /opt/ants-2.3.0/PrintHeader 2>&1
+    command: bash -lc '/opt/ants-2.3.0/PrintHeader 2>&1'
     ignore_exit_code: true
     expected_output_contains: "PrintHeader"
 
   - name: PrintHeader origin
     description: Test PrintHeader origin output
-    command: /opt/ants-2.3.0/PrintHeader ${t1w} 0 2>&1
+    command: bash -lc '/opt/ants-2.3.0/PrintHeader ${t1w} 0 2>&1'
     expected_exit_code: 0
 
   - name: PrintHeader spacing
     description: Test PrintHeader spacing output
-    command: /opt/ants-2.3.0/PrintHeader ${t1w} 1 2>&1
+    command: bash -lc '/opt/ants-2.3.0/PrintHeader ${t1w} 1 2>&1'
     expected_exit_code: 0
 
   - name: PrintHeader size
     description: Test PrintHeader size output
-    command: /opt/ants-2.3.0/PrintHeader ${t1w} 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/PrintHeader ${t1w} 2 2>&1'
     expected_exit_code: 0
 
   - name: PrintHeader direction
     description: Test PrintHeader direction output
-    command: /opt/ants-2.3.0/PrintHeader ${t1w} 4 2>&1
+    command: bash -lc '/opt/ants-2.3.0/PrintHeader ${t1w} 4 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -428,25 +428,25 @@ tests:
   # ==========================================================================
   - name: ThresholdImage usage
     description: Verify ThresholdImage displays usage
-    command: /opt/ants-2.3.0/ThresholdImage 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ThresholdImage 2>&1'
     ignore_exit_code: true
     expected_output_contains: "ThresholdImage"
 
   - name: ThresholdImage Otsu option
     description: Verify ThresholdImage Otsu option
-    command: /opt/ants-2.3.0/ThresholdImage 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ThresholdImage 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Otsu"
 
   - name: ThresholdImage basic threshold
     description: Test basic threshold operation
-    command: /opt/ants-2.3.0/ThresholdImage 3 ${t1w} test_output/t1w_thresh.nii.gz 100 10000 1 0 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ThresholdImage 3 ${t1w} test_output/t1w_thresh.nii.gz 100 10000 1 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_thresh.nii.gz
 
   - name: ThresholdImage Otsu thresholding
     description: Test Otsu automatic thresholding
-    command: /opt/ants-2.3.0/ThresholdImage 3 ${t1w} test_output/t1w_otsu.nii.gz Otsu 3 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ThresholdImage 3 ${t1w} test_output/t1w_otsu.nii.gz Otsu 3 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_otsu.nii.gz
 
@@ -455,19 +455,19 @@ tests:
   # ==========================================================================
   - name: ConvertImagePixelType usage
     description: Verify ConvertImagePixelType displays usage
-    command: /opt/ants-2.3.0/ConvertImagePixelType 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ConvertImagePixelType 2>&1'
     ignore_exit_code: true
     expected_output_contains: "ConvertImagePixelType"
 
   - name: ConvertImagePixelType types
     description: Verify pixel type options are documented
-    command: /opt/ants-2.3.0/ConvertImagePixelType 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ConvertImagePixelType 2>&1'
     ignore_exit_code: true
     expected_output_contains: "unsigned char"
 
   - name: ConvertImage exists
     description: Verify ConvertImage binary exists
-    command: test -x /opt/ants-2.3.0/ConvertImage && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ConvertImage && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -475,17 +475,17 @@ tests:
   # ==========================================================================
   - name: ResampleImage usage
     description: Verify ResampleImage displays usage
-    command: /opt/ants-2.3.0/ResampleImage 2>&1 | head -20
+    command: bash -lc '/opt/ants-2.3.0/ResampleImage 2>&1 | head -20'
     expected_output_contains: "ResampleImage"
 
   - name: ResampleImageBySpacing usage
     description: Verify ResampleImageBySpacing displays usage
-    command: /opt/ants-2.3.0/ResampleImageBySpacing 2>&1 | head -10
+    command: bash -lc '/opt/ants-2.3.0/ResampleImageBySpacing 2>&1 | head -10'
     expected_output_contains: "ResampleImageBySpacing"
 
   - name: ResampleImageBySpacing test
     description: Test resampling to 2mm isotropic
-    command: /opt/ants-2.3.0/ResampleImageBySpacing 3 ${t1w} test_output/t1w_2mm.nii.gz 2 2 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ResampleImageBySpacing 3 ${t1w} test_output/t1w_2mm.nii.gz 2 2 2 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_2mm.nii.gz
 
@@ -494,13 +494,13 @@ tests:
   # ==========================================================================
   - name: AverageImages usage
     description: Verify AverageImages displays usage
-    command: /opt/ants-2.3.0/AverageImages 2>&1
+    command: bash -lc '/opt/ants-2.3.0/AverageImages 2>&1'
     ignore_exit_code: true
     expected_output_contains: "AverageImages"
 
   - name: AverageImages normalize option
     description: Verify AverageImages normalize option
-    command: /opt/ants-2.3.0/AverageImages 2>&1
+    command: bash -lc '/opt/ants-2.3.0/AverageImages 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Normalize"
 
@@ -509,13 +509,13 @@ tests:
   # ==========================================================================
   - name: LabelGeometryMeasures usage
     description: Verify LabelGeometryMeasures displays usage
-    command: /opt/ants-2.3.0/LabelGeometryMeasures 2>&1
+    command: bash -lc '/opt/ants-2.3.0/LabelGeometryMeasures 2>&1'
     ignore_exit_code: true
     expected_output_contains: "LabelGeometryMeasures"
 
   - name: LabelGeometryMeasures test
     description: Test label geometry measurement on Otsu segmentation
-    command: /opt/ants-2.3.0/LabelGeometryMeasures 3 test_output/t1w_otsu.nii.gz 2>&1
+    command: bash -lc '/opt/ants-2.3.0/LabelGeometryMeasures 3 test_output/t1w_otsu.nii.gz 2>&1'
     depends_on: ThresholdImage Otsu thresholding
     expected_exit_code: 0
 
@@ -524,12 +524,12 @@ tests:
   # ==========================================================================
   - name: MeasureImageSimilarity help
     description: Verify MeasureImageSimilarity displays help
-    command: /opt/ants-2.3.0/MeasureImageSimilarity --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/MeasureImageSimilarity --help 2>&1 | head -15'
     expected_output_contains: "MeasureImageSimilarity"
 
   - name: MeasureImageSimilarity metrics
     description: Verify similarity metrics are documented
-    command: /opt/ants-2.3.0/MeasureImageSimilarity --help 2>&1
+    command: bash -lc '/opt/ants-2.3.0/MeasureImageSimilarity --help 2>&1'
     expected_output_contains: "CC"
 
   # ==========================================================================
@@ -537,17 +537,17 @@ tests:
   # ==========================================================================
   - name: ComposeMultiTransform usage
     description: Verify ComposeMultiTransform displays usage
-    command: /opt/ants-2.3.0/ComposeMultiTransform 2>&1 | head -10
+    command: bash -lc '/opt/ants-2.3.0/ComposeMultiTransform 2>&1 | head -10'
     expected_output_contains: "ComposeMultiTransform"
 
   - name: antsTransformInfo exists
     description: Verify antsTransformInfo binary exists
-    command: test -x /opt/ants-2.3.0/antsTransformInfo && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/antsTransformInfo && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: CreateJacobianDeterminantImage exists
     description: Verify CreateJacobianDeterminantImage exists
-    command: test -x /opt/ants-2.3.0/CreateJacobianDeterminantImage && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/CreateJacobianDeterminantImage && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -555,12 +555,12 @@ tests:
   # ==========================================================================
   - name: antsMotionCorr help
     description: Verify antsMotionCorr displays help
-    command: /opt/ants-2.3.0/antsMotionCorr --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/antsMotionCorr --help 2>&1 | head -15'
     expected_output_contains: "antsMotionCorr"
 
   - name: antsMotionCorrStats exists
     description: Verify antsMotionCorrStats binary exists
-    command: test -x /opt/ants-2.3.0/antsMotionCorrStats && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/antsMotionCorrStats && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -568,28 +568,28 @@ tests:
   # ==========================================================================
   - name: CreateImage usage
     description: Verify CreateImage displays usage
-    command: /opt/ants-2.3.0/CreateImage 2>&1
+    command: bash -lc '/opt/ants-2.3.0/CreateImage 2>&1'
     ignore_exit_code: true
     expected_output_contains: "CreateImage"
 
   - name: CopyImageHeaderInformation exists
     description: Verify CopyImageHeaderInformation exists
-    command: test -x /opt/ants-2.3.0/CopyImageHeaderInformation && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/CopyImageHeaderInformation && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: SetOrigin exists
     description: Verify SetOrigin binary exists
-    command: test -x /opt/ants-2.3.0/SetOrigin && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/SetOrigin && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: SetSpacing exists
     description: Verify SetSpacing binary exists
-    command: test -x /opt/ants-2.3.0/SetSpacing && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/SetSpacing && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: ResetDirection exists
     description: Verify ResetDirection binary exists
-    command: test -x /opt/ants-2.3.0/ResetDirection && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ResetDirection && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -597,28 +597,28 @@ tests:
   # ==========================================================================
   - name: ImageMath morphological dilation
     description: Test morphological dilation
-    command: /opt/ants-2.3.0/ImageMath 3 test_output/t1w_dilated.nii.gz MD test_output/t1w_otsu.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 test_output/t1w_dilated.nii.gz MD test_output/t1w_otsu.nii.gz 2 2>&1'
     depends_on: ThresholdImage Otsu thresholding
     validate:
       - output_exists: ${output_dir}/t1w_dilated.nii.gz
 
   - name: ImageMath morphological erosion
     description: Test morphological erosion
-    command: /opt/ants-2.3.0/ImageMath 3 test_output/t1w_eroded.nii.gz ME test_output/t1w_otsu.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 test_output/t1w_eroded.nii.gz ME test_output/t1w_otsu.nii.gz 2 2>&1'
     depends_on: ThresholdImage Otsu thresholding
     validate:
       - output_exists: ${output_dir}/t1w_eroded.nii.gz
 
   - name: ImageMath morphological opening
     description: Test morphological opening
-    command: /opt/ants-2.3.0/ImageMath 3 test_output/t1w_opened.nii.gz MO test_output/t1w_otsu.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 test_output/t1w_opened.nii.gz MO test_output/t1w_otsu.nii.gz 2 2>&1'
     depends_on: ThresholdImage Otsu thresholding
     validate:
       - output_exists: ${output_dir}/t1w_opened.nii.gz
 
   - name: ImageMath morphological closing
     description: Test morphological closing
-    command: /opt/ants-2.3.0/ImageMath 3 test_output/t1w_closed.nii.gz MC test_output/t1w_otsu.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants-2.3.0/ImageMath 3 test_output/t1w_closed.nii.gz MC test_output/t1w_otsu.nii.gz 2 2>&1'
     depends_on: ThresholdImage Otsu thresholding
     validate:
       - output_exists: ${output_dir}/t1w_closed.nii.gz
@@ -628,12 +628,12 @@ tests:
   # ==========================================================================
   - name: SmoothImage usage
     description: Verify SmoothImage displays usage
-    command: /opt/ants-2.3.0/SmoothImage 2>&1 | head -10
+    command: bash -lc '/opt/ants-2.3.0/SmoothImage 2>&1 | head -10'
     expected_output_contains: "SmoothImage"
 
   - name: SmoothImage test
     description: Test image smoothing
-    command: /opt/ants-2.3.0/SmoothImage 3 ${t1w} 2 test_output/t1w_smoothed.nii.gz 2>&1
+    command: bash -lc '/opt/ants-2.3.0/SmoothImage 3 ${t1w} 2 test_output/t1w_smoothed.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_smoothed.nii.gz
 
@@ -642,17 +642,17 @@ tests:
   # ==========================================================================
   - name: ExtractRegionFromImage exists
     description: Verify ExtractRegionFromImage exists
-    command: test -x /opt/ants-2.3.0/ExtractRegionFromImage && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ExtractRegionFromImage && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: ExtractSliceFromImage exists
     description: Verify ExtractSliceFromImage exists
-    command: test -x /opt/ants-2.3.0/ExtractSliceFromImage && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ExtractSliceFromImage && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: ExtractRegionFromImageByMask exists
     description: Verify ExtractRegionFromImageByMask exists
-    command: test -x /opt/ants-2.3.0/ExtractRegionFromImageByMask && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ExtractRegionFromImageByMask && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -660,17 +660,17 @@ tests:
   # ==========================================================================
   - name: TileImages exists
     description: Verify TileImages binary exists
-    command: test -x /opt/ants-2.3.0/TileImages && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/TileImages && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: CreateTiledMosaic exists
     description: Verify CreateTiledMosaic exists
-    command: test -x /opt/ants-2.3.0/CreateTiledMosaic && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/CreateTiledMosaic && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: StackSlices exists
     description: Verify StackSlices binary exists
-    command: test -x /opt/ants-2.3.0/StackSlices && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/StackSlices && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -678,17 +678,17 @@ tests:
   # ==========================================================================
   - name: antsAffineInitializer help
     description: Verify antsAffineInitializer displays help
-    command: /opt/ants-2.3.0/antsAffineInitializer --help 2>&1 | head -15
+    command: bash -lc '/opt/ants-2.3.0/antsAffineInitializer --help 2>&1 | head -15'
     expected_output_contains: "antsAffineInitializer"
 
   - name: AverageAffineTransform exists
     description: Verify AverageAffineTransform exists
-    command: test -x /opt/ants-2.3.0/AverageAffineTransform && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/AverageAffineTransform && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: AverageAffineTransformNoRigid exists
     description: Verify AverageAffineTransformNoRigid exists
-    command: test -x /opt/ants-2.3.0/AverageAffineTransformNoRigid && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/AverageAffineTransformNoRigid && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -696,12 +696,12 @@ tests:
   # ==========================================================================
   - name: antsLandmarkBasedTransformInitializer exists
     description: Verify antsLandmarkBasedTransformInitializer exists
-    command: test -x /opt/ants-2.3.0/antsLandmarkBasedTransformInitializer && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/antsLandmarkBasedTransformInitializer && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: ANTSUseLandmarkImagesToGetAffineTransform exists
     description: Verify landmark affine tool exists
-    command: test -x /opt/ants-2.3.0/ANTSUseLandmarkImagesToGetAffineTransform && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ANTSUseLandmarkImagesToGetAffineTransform && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -709,12 +709,12 @@ tests:
   # ==========================================================================
   - name: SuperResolution exists
     description: Verify SuperResolution binary exists
-    command: test -x /opt/ants-2.3.0/SuperResolution && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/SuperResolution && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: NonLocalSuperResolution exists
     description: Verify NonLocalSuperResolution exists
-    command: test -x /opt/ants-2.3.0/NonLocalSuperResolution && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/NonLocalSuperResolution && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -722,12 +722,12 @@ tests:
   # ==========================================================================
   - name: TextureCooccurrenceFeatures exists
     description: Verify TextureCooccurrenceFeatures exists
-    command: test -x /opt/ants-2.3.0/TextureCooccurrenceFeatures && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/TextureCooccurrenceFeatures && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: TextureRunLengthFeatures exists
     description: Verify TextureRunLengthFeatures exists
-    command: test -x /opt/ants-2.3.0/TextureRunLengthFeatures && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/TextureRunLengthFeatures && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -735,12 +735,12 @@ tests:
   # ==========================================================================
   - name: SurfaceBasedSmoothing exists
     description: Verify SurfaceBasedSmoothing exists
-    command: test -x /opt/ants-2.3.0/SurfaceBasedSmoothing && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/SurfaceBasedSmoothing && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: SurfaceCurvature exists
     description: Verify SurfaceCurvature exists
-    command: test -x /opt/ants-2.3.0/SurfaceCurvature && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/SurfaceCurvature && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -748,12 +748,12 @@ tests:
   # ==========================================================================
   - name: ANTSJacobian exists
     description: Verify ANTSJacobian binary exists
-    command: test -x /opt/ants-2.3.0/ANTSJacobian && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/ANTSJacobian && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: CreateJacobianDeterminantImage help
     description: Verify CreateJacobianDeterminantImage displays help
-    command: /opt/ants-2.3.0/CreateJacobianDeterminantImage 2>&1 | head -5
+    command: bash -lc '/opt/ants-2.3.0/CreateJacobianDeterminantImage 2>&1 | head -5'
     expected_output_contains: "CreateJacobianDeterminantImage"
 
   # ==========================================================================
@@ -761,22 +761,22 @@ tests:
   # ==========================================================================
   - name: WarpImageMultiTransform exists
     description: Verify WarpImageMultiTransform exists
-    command: test -x /opt/ants-2.3.0/WarpImageMultiTransform && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/WarpImageMultiTransform && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: WarpTimeSeriesImageMultiTransform exists
     description: Verify WarpTimeSeriesImageMultiTransform exists
-    command: test -x /opt/ants-2.3.0/WarpTimeSeriesImageMultiTransform && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/WarpTimeSeriesImageMultiTransform && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: CreateWarpedGridImage exists
     description: Verify CreateWarpedGridImage exists
-    command: test -x /opt/ants-2.3.0/CreateWarpedGridImage && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/CreateWarpedGridImage && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   - name: CreateDisplacementField exists
     description: Verify CreateDisplacementField exists
-    command: test -x /opt/ants-2.3.0/CreateDisplacementField && echo "binary exists"
+    command: bash -lc 'test -x /opt/ants-2.3.0/CreateDisplacementField && echo "binary exists"'
     expected_output_contains: "binary exists"
 
   # ==========================================================================
@@ -784,7 +784,7 @@ tests:
   # ==========================================================================
   - name: Container README exists
     description: Verify container README file exists
-    command: test -f /README.md && echo "README exists"
+    command: bash -lc 'test -f /README.md && echo "README exists"'
     expected_output_contains: "README exists"
 
   - name: Container LASHiS directory structure
@@ -794,7 +794,7 @@ tests:
 
   - name: Container experiment files
     description: Verify experiment files directory exists
-    command: test -d /LASHiS/Experiment_files_for_LASHiS && echo "experiment files exist"
+    command: bash -lc 'test -d /LASHiS/Experiment_files_for_LASHiS && echo "experiment files exist"'
     expected_output_contains: "experiment files exist"
 
 cleanup:

--- a/recipes/laynii/fulltest.yaml
+++ b/recipes/laynii/fulltest.yaml
@@ -266,33 +266,7 @@ tests:
   # ==========================================================================
   - name: Copy container test data
     description: Copy LayNii test data from container for subsequent tests
-    command: |
-      cp /opt/laynii-2.2.1/test_data/sc_rim.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_layers.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_midGM.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_VASO_act.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_BOLD_act.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_UNI.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_INV1.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_INV2.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_columns_3dcolumns.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_layers_3dcolumns.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_landmarks.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_landmarks_3dcolumns.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_BOLD_intemp.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_Nulled_intemp.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_BOLD_act.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_VASO_act.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_gradT1.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_layers.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_columns.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_ALF.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_rim_LL.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_sc_layers.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/lo_T1EPI.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_distlay_1000.nii.gz test_output/
-      cp /opt/laynii-2.2.1/test_data/sc_leakylay_1000.nii.gz test_output/
-      echo "Test data copied successfully"
+    command: "bash -lc 'cp /opt/laynii-2.2.1/test_data/sc_rim.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_layers.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_midGM.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_VASO_act.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_BOLD_act.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_UNI.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_INV1.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_INV2.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_columns_3dcolumns.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_layers_3dcolumns.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_landmarks.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_landmarks_3dcolumns.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_BOLD_intemp.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_Nulled_intemp.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_BOLD_act.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_VASO_act.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_gradT1.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_layers.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_columns.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_ALF.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_rim_LL.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_sc_layers.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/lo_T1EPI.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_distlay_1000.nii.gz test_output/\ncp /opt/laynii-2.2.1/test_data/sc_leakylay_1000.nii.gz test_output/\necho \"Test data copied successfully\"'"
     expected_output_contains: "Test data copied successfully"
 
   # ==========================================================================

--- a/recipes/lcmodel/fulltest.yaml
+++ b/recipes/lcmodel/fulltest.yaml
@@ -40,7 +40,7 @@ tests:
   # ==========================================================================
   - name: LCModel binary exists
     description: Verify main lcmodel binary is present and executable
-    command: test -x /opt/lcmodel-6.3/.lcmodel/bin/lcmodel && echo "lcmodel executable found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/bin/lcmodel && echo "lcmodel executable found"'
     expected_output_contains: "lcmodel executable found"
 
   - name: LCModel responds to input
@@ -50,7 +50,7 @@ tests:
 
   - name: Makebasis binary exists
     description: Verify makebasis binary is present and executable
-    command: test -x /opt/lcmodel-6.3/.lcmodel/bin/makebasis && echo "makebasis executable found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/bin/makebasis && echo "makebasis executable found"'
     expected_output_contains: "makebasis executable found"
 
   - name: Makebasis responds to input
@@ -60,7 +60,7 @@ tests:
 
   - name: Plotraw binary exists
     description: Verify plotraw binary is present and executable
-    command: test -x /opt/lcmodel-6.3/.lcmodel/bin/plotraw && echo "plotraw executable found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/bin/plotraw && echo "plotraw executable found"'
     expected_output_contains: "plotraw executable found"
 
   - name: Plotraw responds to input
@@ -70,7 +70,7 @@ tests:
 
   - name: KECC binary exists
     description: Verify kecc (eddy current correction) binary is present
-    command: test -x /opt/lcmodel-6.3/.lcmodel/bin/kecc && echo "kecc executable found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/bin/kecc && echo "kecc executable found"'
     expected_output_contains: "kecc executable found"
 
   - name: KECC responds to input
@@ -80,7 +80,7 @@ tests:
 
   - name: LCMgui binary exists
     description: Verify lcmgui (GUI) binary is present
-    command: test -x /opt/lcmodel-6.3/.lcmodel/lcmgui && echo "lcmgui executable found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/lcmgui && echo "lcmgui executable found"'
     expected_output_contains: "lcmgui executable found"
 
   # ==========================================================================
@@ -88,27 +88,27 @@ tests:
   # ==========================================================================
   - name: Setup script exists
     description: Verify setup_lcmodel.sh is present
-    command: test -f /opt/lcmodel-6.3/.lcmodel/bin/setup_lcmodel.sh && echo "setup script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/bin/setup_lcmodel.sh && echo "setup script found"'
     expected_output_contains: "setup script found"
 
   - name: Testrun script exists
     description: Verify testrun script for running test analysis
-    command: test -f /opt/lcmodel-6.3/.lcmodel/bin/testrun && echo "testrun script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/bin/testrun && echo "testrun script found"'
     expected_output_contains: "testrun script found"
 
   - name: Run-batch script exists
     description: Verify run-batch script for batch processing
-    command: test -f /opt/lcmodel-6.3/.lcmodel/bin/run-batch && echo "run-batch script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/bin/run-batch && echo "run-batch script found"'
     expected_output_contains: "run-batch script found"
 
   - name: Cat-paged-ps script exists
     description: Verify PostScript output utility
-    command: test -f /opt/lcmodel-6.3/.lcmodel/bin/cat-paged-ps && echo "cat-paged-ps found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/bin/cat-paged-ps && echo "cat-paged-ps found"'
     expected_output_contains: "cat-paged-ps found"
 
   - name: Time-testrun script exists
     description: Verify timing script for test runs
-    command: test -f /opt/lcmodel-6.3/.lcmodel/bin/time-testrun && echo "time-testrun found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/bin/time-testrun && echo "time-testrun found"'
     expected_output_contains: "time-testrun found"
 
   # ==========================================================================
@@ -116,22 +116,22 @@ tests:
   # ==========================================================================
   - name: Standard execution script exists
     description: Verify standard execution script for LCMgui
-    command: test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/standard && echo "standard script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/standard && echo "standard script found"'
     expected_output_contains: "standard script found"
 
   - name: Nice execution script exists
     description: Verify nice execution script
-    command: test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/nice && echo "nice script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/nice && echo "nice script found"'
     expected_output_contains: "nice script found"
 
   - name: ECC execution script exists
     description: Verify eddy current correction execution script
-    command: test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/ecc && echo "ecc script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/ecc && echo "ecc script found"'
     expected_output_contains: "ecc script found"
 
   - name: Make-batch execution script exists
     description: Verify make-batch script for batch processing
-    command: test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/make-batch && echo "make-batch script found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/execution-scripts/make-batch && echo "make-batch script found"'
     expected_output_contains: "make-batch script found"
 
   # ==========================================================================
@@ -139,27 +139,27 @@ tests:
   # ==========================================================================
   - name: Test RAW data file exists
     description: Verify test spectroscopy data is present
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/test.RAW && echo "test.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/test.RAW && echo "test.RAW found"'
     expected_output_contains: "test.RAW found"
 
   - name: Test control file exists
     description: Verify test control parameter file is present
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/control/test.control && echo "test.control found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/control/test.control && echo "test.control found"'
     expected_output_contains: "test.control found"
 
   - name: Makebasis input file exists
     description: Verify makebasis test input file is present
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in && echo "makebasis.in found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in && echo "makebasis.in found"'
     expected_output_contains: "makebasis.in found"
 
   - name: Plotraw input file exists
     description: Verify plotraw test input file is present
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/control/plotraw.in && echo "plotraw.in found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/control/plotraw.in && echo "plotraw.in found"'
     expected_output_contains: "plotraw.in found"
 
   - name: Test output directory exists
     description: Verify test output directory structure
-    command: test -d /opt/lcmodel-6.3/.lcmodel/test/output && echo "output directory found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/test/output && echo "output directory found"'
     expected_output_contains: "output directory found"
 
   # ==========================================================================
@@ -167,42 +167,42 @@ tests:
   # ==========================================================================
   - name: NAA test RAW file exists
     description: Verify N-acetylaspartate test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/NAA_3.RAW && echo "NAA_3.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/NAA_3.RAW && echo "NAA_3.RAW found"'
     expected_output_contains: "NAA_3.RAW found"
 
   - name: Creatine test RAW file exists
     description: Verify Creatine test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Cr_3.RAW && echo "Cr_3.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Cr_3.RAW && echo "Cr_3.RAW found"'
     expected_output_contains: "Cr_3.RAW found"
 
   - name: Choline test RAW file exists
     description: Verify Choline test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Cho_bruker_1.RAW && echo "Cho_bruker_1.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Cho_bruker_1.RAW && echo "Cho_bruker_1.RAW found"'
     expected_output_contains: "Cho_bruker_1.RAW found"
 
   - name: Glutamate test RAW file exists
     description: Verify Glutamate test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Glu_3.RAW && echo "Glu_3.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Glu_3.RAW && echo "Glu_3.RAW found"'
     expected_output_contains: "Glu_3.RAW found"
 
   - name: GABA test RAW file exists
     description: Verify GABA test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/GABA_3.RAW && echo "GABA_3.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/GABA_3.RAW && echo "GABA_3.RAW found"'
     expected_output_contains: "GABA_3.RAW found"
 
   - name: Lactate test RAW file exists
     description: Verify Lactate test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Lac_3.RAW && echo "Lac_3.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Lac_3.RAW && echo "Lac_3.RAW found"'
     expected_output_contains: "Lac_3.RAW found"
 
   - name: Myo-inositol test RAW file exists
     description: Verify Myo-inositol test spectrum
-    command: test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Ins_3.RAW && echo "Ins_3.RAW found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/test/raw/Ins_3.RAW && echo "Ins_3.RAW found"'
     expected_output_contains: "Ins_3.RAW found"
 
   - name: Count test RAW files
     description: Verify all expected test RAW files are present
-    command: ls -1 /opt/lcmodel-6.3/.lcmodel/test/raw/*.RAW 2>/dev/null | wc -l
+    command: bash -lc 'ls -1 /opt/lcmodel-6.3/.lcmodel/test/raw/*.RAW 2>/dev/null | wc -l'
     expected_output_contains: "19"
 
   # ==========================================================================
@@ -210,32 +210,32 @@ tests:
   # ==========================================================================
   - name: 1.5T basis sets directory exists
     description: Verify 1.5T basis sets are available
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t && echo "1.5t basis sets found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t && echo "1.5t basis sets found"'
     expected_output_contains: "1.5t basis sets found"
 
   - name: 1.5T PRESS TE30 basis set exists
     description: Verify PRESS TE30 basis set at 1.5T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/press_te30_1.5t_v3.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/press_te30_1.5t_v3.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 1.5T PRESS TE35 basis set exists
     description: Verify PRESS TE35 basis set at 1.5T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/press_te35_1.5t_v3.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/press_te35_1.5t_v3.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 1.5T STEAM TE20 basis set exists
     description: Verify STEAM TE20 basis set at 1.5T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/steam_te20_1.5t_99c.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/steam_te20_1.5t_99c.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 1.5T gamma PRESS TE20 basis set exists
     description: Verify gamma-simulated PRESS TE20 at 1.5T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/gamma_press_te20_1.5t_v1.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/gamma_press_te20_1.5t_v1.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 1.5T README exists
     description: Verify 1.5T basis set documentation
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/README-1.5t.txt && echo "README found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/1.5t/README-1.5t.txt && echo "README found"'
     expected_output_contains: "README found"
 
   # ==========================================================================
@@ -243,47 +243,47 @@ tests:
   # ==========================================================================
   - name: 3T basis sets directory exists
     description: Verify 3T basis sets are available
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/3t && echo "3t basis sets found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/3t && echo "3t basis sets found"'
     expected_output_contains: "3t basis sets found"
 
   - name: 3T PRESS TE30 basis set exists
     description: Verify PRESS TE30 basis set at 3T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te30_3t_v3.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te30_3t_v3.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 3T PRESS TE25 basis set exists
     description: Verify PRESS TE25 basis set at 3T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te25_3t_v3.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te25_3t_v3.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 3T PRESS TE135 basis set exists
     description: Verify PRESS TE135 (long TE) basis set at 3T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te135_3t_v3.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te135_3t_v3.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 3T STEAM TE20 basis set exists
     description: Verify STEAM TE20 basis set at 3T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/steam_te20_3t_01a.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/steam_te20_3t_01a.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 3T gamma PRESS TE20 basis set exists
     description: Verify gamma-simulated PRESS TE20 at 3T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/gamma_press_te20_3t_v1.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/gamma_press_te20_3t_v1.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 3T gamma TE0 basis set exists
     description: Verify gamma-simulated TE0 (ideal) at 3T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/gamma_te0_3t_v1.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/gamma_te0_3t_v1.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 3T all metabolites basis set directory exists
     description: Verify extended basis sets with all metabolites at 3T
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/all && echo "all directory found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/all && echo "all directory found"'
     expected_output_contains: "all directory found"
 
   - name: 3T README exists
     description: Verify 3T basis set documentation
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/README-3t.txt && echo "README found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/README-3t.txt && echo "README found"'
     expected_output_contains: "README found"
 
   # ==========================================================================
@@ -291,22 +291,22 @@ tests:
   # ==========================================================================
   - name: 7T basis sets directory exists
     description: Verify 7T (ultra-high field) basis sets are available
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/7t && echo "7t basis sets found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/7t && echo "7t basis sets found"'
     expected_output_contains: "7t basis sets found"
 
   - name: 7T gamma PRESS TE20 basis set exists
     description: Verify gamma-simulated PRESS TE20 at 7T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/7t/gamma_press_te20_7t_v1.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/7t/gamma_press_te20_7t_v1.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 7T gamma PRESS TE10 basis set exists
     description: Verify gamma-simulated PRESS TE10 (short TE) at 7T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/7t/gamma_press_te10_7t_v1.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/7t/gamma_press_te10_7t_v1.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 7T README exists
     description: Verify 7T basis set documentation
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/7t/README-7t.txt && echo "README found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/7t/README-7t.txt && echo "README found"'
     expected_output_contains: "README found"
 
   # ==========================================================================
@@ -314,17 +314,17 @@ tests:
   # ==========================================================================
   - name: 9.4T basis sets directory exists
     description: Verify 9.4T (ultra-high field) basis sets are available
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/9.4t && echo "9.4t basis sets found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/9.4t && echo "9.4t basis sets found"'
     expected_output_contains: "9.4t basis sets found"
 
   - name: 9.4T gamma PRESS TE20 basis set exists
     description: Verify gamma-simulated PRESS TE20 at 9.4T
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/9.4t/gamma_press_te20_9.4t_v1.basis && echo "basis found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/9.4t/gamma_press_te20_9.4t_v1.basis && echo "basis found"'
     expected_output_contains: "basis found"
 
   - name: 9.4T README exists
     description: Verify 9.4T basis set documentation
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/9.4t/README-9.4t.txt && echo "README found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/9.4t/README-9.4t.txt && echo "README found"'
     expected_output_contains: "README found"
 
   # ==========================================================================
@@ -332,22 +332,22 @@ tests:
   # ==========================================================================
   - name: sLASER basis set directory exists
     description: Verify sLASER Siemens TE20 BW2500 raw basis files
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024 && echo "sLASER basis found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024 && echo "sLASER basis found"'
     expected_output_contains: "sLASER basis found"
 
   - name: sLASER NAA raw file exists
     description: Verify NAA raw spectrum for sLASER
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024/NAA.raw && echo "NAA.raw found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024/NAA.raw && echo "NAA.raw found"'
     expected_output_contains: "NAA.raw found"
 
   - name: sLASER GABA raw file exists
     description: Verify GABA raw spectrum for sLASER
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024/GABA.raw && echo "GABA.raw found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024/GABA.raw && echo "GABA.raw found"'
     expected_output_contains: "GABA.raw found"
 
   - name: sLASER metabolite count
     description: Verify number of metabolite raw files in sLASER basis
-    command: ls -1 /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024/*.raw 2>/dev/null | wc -l
+    command: bash -lc 'ls -1 /opt/lcmodel-6.3/.lcmodel/basis-sets/RawBasis_for_sLASERSiemens_TE_20_BW_2500_NPts_1024/*.raw 2>/dev/null | wc -l'
     expected_output_contains: "34"
 
   # ==========================================================================
@@ -355,12 +355,12 @@ tests:
   # ==========================================================================
   - name: Generic LCModel basis set directory exists
     description: Verify basisset_LCModel directory with example files
-    command: test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/basisset_LCModel && echo "basisset_LCModel found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/basis-sets/basisset_LCModel && echo "basisset_LCModel found"'
     expected_output_contains: "basisset_LCModel found"
 
   - name: Generic PRESS 3T 30ms basis file exists
     description: Verify compiled PRESS 3T TE30 basis file
-    command: test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/basisset_LCModel/press3T_30ms.BASIS && echo "press3T_30ms.BASIS found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/basis-sets/basisset_LCModel/press3T_30ms.BASIS && echo "press3T_30ms.BASIS found"'
     expected_output_contains: "press3T_30ms.BASIS found"
 
   # ==========================================================================
@@ -368,7 +368,7 @@ tests:
   # ==========================================================================
   - name: Siemens bin2raw converter exists
     description: Verify Siemens raw data converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/siemens/bin2raw && echo "siemens bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/siemens/bin2raw && echo "siemens bin2raw found"'
     expected_output_contains: "siemens bin2raw found"
 
   # ==========================================================================
@@ -376,17 +376,17 @@ tests:
   # ==========================================================================
   - name: Philips bin2raw converter exists
     description: Verify Philips raw data converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/philips/bin2raw && echo "philips bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/philips/bin2raw && echo "philips bin2raw found"'
     expected_output_contains: "philips bin2raw found"
 
   - name: Philips bin2asc converter exists
     description: Verify Philips binary to ASCII converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/philips/bin2asc && echo "philips bin2asc found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/philips/bin2asc && echo "philips bin2asc found"'
     expected_output_contains: "philips bin2asc found"
 
   - name: Philips DICOM converter exists
     description: Verify Philips DICOM to raw converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/philips/bin2raw-dicom && echo "philips bin2raw-dicom found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/philips/bin2raw-dicom && echo "philips bin2raw-dicom found"'
     expected_output_contains: "philips bin2raw-dicom found"
 
   # ==========================================================================
@@ -394,17 +394,17 @@ tests:
   # ==========================================================================
   - name: Bruker bin2raw converter exists
     description: Verify Bruker raw data converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/bruker/bin2raw && echo "bruker bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/bruker/bin2raw && echo "bruker bin2raw found"'
     expected_output_contains: "bruker bin2raw found"
 
   - name: Bruker bin2asc converter exists
     description: Verify Bruker binary to ASCII converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/bruker/bin2asc && echo "bruker bin2asc found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/bruker/bin2asc && echo "bruker bin2asc found"'
     expected_output_contains: "bruker bin2asc found"
 
   - name: Bruker truncate preprocessor exists
     description: Verify Bruker truncate preprocessor script
-    command: test -f /opt/lcmodel-6.3/.lcmodel/bruker/preprocessors/truncate && echo "bruker truncate found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/bruker/preprocessors/truncate && echo "bruker truncate found"'
     expected_output_contains: "bruker truncate found"
 
   # ==========================================================================
@@ -412,22 +412,22 @@ tests:
   # ==========================================================================
   - name: GE5 bin2raw converter exists
     description: Verify GE5 (older) P-file converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/ge5/bin2raw && echo "ge5 bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/ge5/bin2raw && echo "ge5 bin2raw found"'
     expected_output_contains: "ge5 bin2raw found"
 
   - name: GE LX bin2raw converter exists
     description: Verify GE LX (newer) P-file converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/gelx/bin2raw && echo "gelx bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/gelx/bin2raw && echo "gelx bin2raw found"'
     expected_output_contains: "gelx bin2raw found"
 
   - name: GE LX select-frames preprocessor exists
     description: Verify GE LX frame selection preprocessor
-    command: test -f /opt/lcmodel-6.3/.lcmodel/gelx/preprocessors/select-frames && echo "select-frames found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/gelx/preprocessors/select-frames && echo "select-frames found"'
     expected_output_contains: "select-frames found"
 
   - name: GE use-unsuppressed preprocessor exists
     description: Verify GE unsuppressed water reference preprocessor
-    command: test -f /opt/lcmodel-6.3/.lcmodel/gelx/preprocessors/use-unsuppressed && echo "use-unsuppressed found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/gelx/preprocessors/use-unsuppressed && echo "use-unsuppressed found"'
     expected_output_contains: "use-unsuppressed found"
 
   # ==========================================================================
@@ -435,12 +435,12 @@ tests:
   # ==========================================================================
   - name: Varian bin2raw converter exists
     description: Verify Varian raw data converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/varian/bin2raw && echo "varian bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/varian/bin2raw && echo "varian bin2raw found"'
     expected_output_contains: "varian bin2raw found"
 
   - name: Varian bin2asc converter exists
     description: Verify Varian binary to ASCII converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/varian/bin2asc && echo "varian bin2asc found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/varian/bin2asc && echo "varian bin2asc found"'
     expected_output_contains: "varian bin2asc found"
 
   # ==========================================================================
@@ -448,12 +448,12 @@ tests:
   # ==========================================================================
   - name: Marconi bin2raw converter exists
     description: Verify Marconi raw data converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/marconi/bin2raw && echo "marconi bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/marconi/bin2raw && echo "marconi bin2raw found"'
     expected_output_contains: "marconi bin2raw found"
 
   - name: Marconi bin2asc converter exists
     description: Verify Marconi binary to ASCII converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/marconi/bin2asc && echo "marconi bin2asc found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/marconi/bin2asc && echo "marconi bin2asc found"'
     expected_output_contains: "marconi bin2asc found"
 
   # ==========================================================================
@@ -461,7 +461,7 @@ tests:
   # ==========================================================================
   - name: Toshiba bin2raw converter exists
     description: Verify Toshiba raw data converter
-    command: test -x /opt/lcmodel-6.3/.lcmodel/toshiba/bin2raw && echo "toshiba bin2raw found"
+    command: bash -lc 'test -x /opt/lcmodel-6.3/.lcmodel/toshiba/bin2raw && echo "toshiba bin2raw found"'
     expected_output_contains: "toshiba bin2raw found"
 
   # ==========================================================================
@@ -469,7 +469,7 @@ tests:
   # ==========================================================================
   - name: Other/generic bin2raw converter exists
     description: Verify generic bin2raw converter
-    command: test -f /opt/lcmodel-6.3/.lcmodel/other/bin2raw && echo "other bin2raw found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/other/bin2raw && echo "other bin2raw found"'
     expected_output_contains: "other bin2raw found"
 
   # ==========================================================================
@@ -477,22 +477,22 @@ tests:
   # ==========================================================================
   - name: LCModel manual PDF exists
     description: Verify LCModel manual is present
-    command: test -f /opt/lcmodel-6.3/.lcmodel/doc/manual.pdf && echo "manual.pdf found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/doc/manual.pdf && echo "manual.pdf found"'
     expected_output_contains: "manual.pdf found"
 
   - name: LCModel figures PDF exists
     description: Verify LCModel figures documentation
-    command: test -f /opt/lcmodel-6.3/.lcmodel/doc/figures.pdf && echo "figures.pdf found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/doc/figures.pdf && echo "figures.pdf found"'
     expected_output_contains: "figures.pdf found"
 
   - name: Root manual PDF exists
     description: Verify manual at root installation level
-    command: test -f /opt/lcmodel-6.3/manual.pdf && echo "root manual.pdf found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/manual.pdf && echo "root manual.pdf found"'
     expected_output_contains: "root manual.pdf found"
 
   - name: Doc preprocessors README exists
     description: Verify preprocessors documentation
-    command: test -f /opt/lcmodel-6.3/.lcmodel/doc/preprocessors/README.txt && echo "preprocessors README found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/doc/preprocessors/README.txt && echo "preprocessors README found"'
     expected_output_contains: "preprocessors README found"
 
   # ==========================================================================
@@ -500,17 +500,17 @@ tests:
   # ==========================================================================
   - name: Profiles directory exists
     description: Verify profiles directory for user configurations
-    command: test -d /opt/lcmodel-6.3/.lcmodel/profiles && echo "profiles directory found"
+    command: bash -lc 'test -d /opt/lcmodel-6.3/.lcmodel/profiles && echo "profiles directory found"'
     expected_output_contains: "profiles directory found"
 
   - name: License file location exists
     description: Verify license file placeholder exists
-    command: test -f /opt/lcmodel-6.3/.lcmodel/license && echo "license file found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/license && echo "license file found"'
     expected_output_contains: "license file found"
 
   - name: Queries file exists
     description: Verify queries configuration file
-    command: test -f /opt/lcmodel-6.3/.lcmodel/.queries && echo ".queries file found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.lcmodel/.queries && echo ".queries file found"'
     expected_output_contains: ".queries file found"
 
   # ==========================================================================
@@ -518,27 +518,27 @@ tests:
   # ==========================================================================
   - name: Test control file has LCMODL section
     description: Verify test control file format
-    command: grep -c "LCMODL" /opt/lcmodel-6.3/.lcmodel/test/control/test.control
+    command: "bash -lc 'grep -c \"LCMODL\" /opt/lcmodel-6.3/.lcmodel/test/control/test.control'"
     expected_output_contains: "1"
 
   - name: Test control file has FILRAW parameter
     description: Verify input file specification in control
-    command: grep -c "FILRAW" /opt/lcmodel-6.3/.lcmodel/test/control/test.control
+    command: "bash -lc 'grep -c \"FILRAW\" /opt/lcmodel-6.3/.lcmodel/test/control/test.control'"
     expected_output_contains: "1"
 
   - name: Test control file has FILBAS parameter
     description: Verify basis file specification in control
-    command: grep -c "FILBAS" /opt/lcmodel-6.3/.lcmodel/test/control/test.control
+    command: "bash -lc 'grep -c \"FILBAS\" /opt/lcmodel-6.3/.lcmodel/test/control/test.control'"
     expected_output_contains: "1"
 
   - name: Test control file has NUNFIL parameter
     description: Verify number of points parameter
-    command: grep -c "NUNFIL" /opt/lcmodel-6.3/.lcmodel/test/control/test.control
+    command: "bash -lc 'grep -c \"NUNFIL\" /opt/lcmodel-6.3/.lcmodel/test/control/test.control'"
     expected_output_contains: "1"
 
   - name: Test control file has HZPPPM parameter
     description: Verify Hz per ppm (field strength) parameter
-    command: grep -c "HZPPPM" /opt/lcmodel-6.3/.lcmodel/test/control/test.control
+    command: "bash -lc 'grep -c \"HZPPPM\" /opt/lcmodel-6.3/.lcmodel/test/control/test.control'"
     expected_output_contains: "1"
 
   # ==========================================================================
@@ -546,17 +546,17 @@ tests:
   # ==========================================================================
   - name: Makebasis input has seqpar section
     description: Verify sequence parameters in makebasis input
-    command: grep -c "seqpar" /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in
+    command: "bash -lc 'grep -c \"seqpar\" /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in'"
     expected_output_contains: "1"
 
   - name: Makebasis input has nmall section
     description: Verify nmall parameters in makebasis input
-    command: grep -c "nmall" /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in
+    command: "bash -lc 'grep -c \"nmall\" /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in'"
     expected_output_contains: "1"
 
   - name: Makebasis input has nmeach sections
     description: Verify individual metabolite sections exist
-    command: grep -c "nmeach" /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in
+    command: "bash -lc 'grep -c \"nmeach\" /opt/lcmodel-6.3/.lcmodel/test/control/makebasis.in'"
     expected_output_contains: "15"
 
   # ==========================================================================
@@ -564,12 +564,12 @@ tests:
   # ==========================================================================
   - name: Install script exists
     description: Verify LCModel installation script
-    command: test -f /opt/lcmodel-6.3/install-lcmodel && echo "install-lcmodel found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/install-lcmodel && echo "install-lcmodel found"'
     expected_output_contains: "install-lcmodel found"
 
   - name: Uninstall script exists
     description: Verify LCModel uninstall script
-    command: test -f /opt/lcmodel-6.3/.uninstall-lcmodel && echo ".uninstall-lcmodel found"
+    command: bash -lc 'test -f /opt/lcmodel-6.3/.uninstall-lcmodel && echo ".uninstall-lcmodel found"'
     expected_output_contains: ".uninstall-lcmodel found"
 
   # ==========================================================================
@@ -577,27 +577,27 @@ tests:
   # ==========================================================================
   - name: LCModel binary size check
     description: Verify lcmodel binary has expected size (>100MB)
-    command: test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/bin/lcmodel) -gt 100000000 && echo "lcmodel size OK"
+    command: bash -lc 'test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/bin/lcmodel) -gt 100000000 && echo "lcmodel size OK"'
     expected_output_contains: "lcmodel size OK"
 
   - name: Makebasis binary size check
     description: Verify makebasis binary has expected size (>1MB)
-    command: test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/bin/makebasis) -gt 1000000 && echo "makebasis size OK"
+    command: bash -lc 'test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/bin/makebasis) -gt 1000000 && echo "makebasis size OK"'
     expected_output_contains: "makebasis size OK"
 
   - name: LCMgui binary size check
     description: Verify lcmgui binary has expected size (>3MB)
-    command: test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/lcmgui) -gt 3000000 && echo "lcmgui size OK"
+    command: bash -lc 'test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/lcmgui) -gt 3000000 && echo "lcmgui size OK"'
     expected_output_contains: "lcmgui size OK"
 
   - name: Test RAW file size check
     description: Verify test.RAW has expected size (>50KB)
-    command: test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/test/raw/test.RAW) -gt 50000 && echo "test.RAW size OK"
+    command: bash -lc 'test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/test/raw/test.RAW) -gt 50000 && echo "test.RAW size OK"'
     expected_output_contains: "test.RAW size OK"
 
   - name: 3T basis set size check
     description: Verify 3T basis set has expected size (>1MB)
-    command: test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te30_3t_v3.basis) -gt 1000000 && echo "3T basis size OK"
+    command: bash -lc 'test $(stat -c%s /opt/lcmodel-6.3/.lcmodel/basis-sets/3t/press_te30_3t_v3.basis) -gt 1000000 && echo "3T basis size OK"'
     expected_output_contains: "3T basis size OK"
 
   # ==========================================================================
@@ -610,12 +610,12 @@ tests:
 
   - name: Container labels exist
     description: Verify Singularity container labels
-    command: cat /.singularity.d/labels.json
+    command: "bash -lc 'cat /.singularity.d/labels.json'"
     expected_output_contains: "NeuroDesk"
 
   - name: Singularity runscript exists
     description: Verify container runscript
-    command: test -f /.singularity.d/runscript && echo "runscript found"
+    command: bash -lc 'test -f /.singularity.d/runscript && echo "runscript found"'
     expected_output_contains: "runscript found"
 
 cleanup:

--- a/recipes/mgltools/fulltest.yaml
+++ b/recipes/mgltools/fulltest.yaml
@@ -39,27 +39,27 @@ tests:
 
   - name: MGLTools installation directory
     description: Verify MGLTools is installed in expected location
-    command: ls -la /opt/mgltools/
+    command: "bash -lc 'ls -la /opt/mgltools/'"
     expected_output_contains: "MGLToolsPckgs"
 
   - name: AutoDockTools package exists
     description: Verify AutoDockTools Python package is available
-    command: ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/
+    command: "bash -lc 'ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/'"
     expected_output_contains: "__init__.py"
 
   - name: MolKit package exists
     description: Verify MolKit molecular toolkit package is available
-    command: ls /opt/mgltools/MGLToolsPckgs/MolKit/
+    command: "bash -lc 'ls /opt/mgltools/MGLToolsPckgs/MolKit/'"
     expected_output_contains: "molecule.py"
 
   - name: PyAutoDock package exists
     description: Verify PyAutoDock scoring package is available
-    command: ls /opt/mgltools/MGLToolsPckgs/PyAutoDock/
+    command: "bash -lc 'ls /opt/mgltools/MGLToolsPckgs/PyAutoDock/'"
     expected_output_contains: "AutoDockScorer.py"
 
   - name: Utilities24 directory exists
     description: Verify AutoDock Utilities24 scripts are available
-    command: ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/
+    command: "bash -lc 'ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/'"
     expected_output_contains: "prepare_ligand4.py"
 
   # ==========================================================================
@@ -67,32 +67,32 @@ tests:
   # ==========================================================================
   - name: prepare_ligand4.py help
     description: Test prepare_ligand4.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py -h 2>&1'"
     expected_output_contains: "ligand_filename"
 
   - name: prepare_ligand4.py options A
     description: Verify repair options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py -h 2>&1'"
     expected_output_contains: "bonds_hydrogens"
 
   - name: prepare_ligand4.py options C
     description: Verify charge options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py -h 2>&1'"
     expected_output_contains: "gasteiger"
 
   - name: prepare_ligand.py help
     description: Test prepare_ligand.py (AutoDock 3) shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand.py -h 2>&1'"
     expected_output_contains: "ligand_filename"
 
   - name: write_rigid_ligand.py help
     description: Test write_rigid_ligand.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_rigid_ligand.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_rigid_ligand.py 2>&1'"
     expected_output_contains: "rigid ligandfile"
 
   - name: repair_ligand4.py help
     description: Test repair_ligand4.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/repair_ligand4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/repair_ligand4.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -100,33 +100,33 @@ tests:
   # ==========================================================================
   - name: prepare_receptor4.py help
     description: Test prepare_receptor4.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor4.py -h 2>&1'"
     expected_output_contains: "receptor_filename"
 
   - name: prepare_receptor4.py repair options
     description: Verify receptor repair options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor4.py -h 2>&1'"
     expected_output_contains: "bonds_hydrogens"
 
   - name: prepare_receptor4.py cleanup options
     description: Verify receptor cleanup options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor4.py -h 2>&1'"
     expected_output_contains: "nphs_lps_waters"
 
   - name: prepare_receptor.py help
     description: Test prepare_receptor.py (AutoDock 3) shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_receptor.py -h 2>&1'"
     expected_exit_code: 2
     expected_output_contains: "prepare_receptor.py"
 
   - name: prepare_flexreceptor4.py help
     description: Test prepare_flexreceptor4.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_flexreceptor4.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_flexreceptor4.py -h 2>&1'"
     expected_output_contains: "flex residues"
 
   - name: prepare_pdb_split_alt_confs.py help
     description: Test prepare_pdb_split_alt_confs.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_pdb_split_alt_confs.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_pdb_split_alt_confs.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -134,27 +134,27 @@ tests:
   # ==========================================================================
   - name: prepare_gpf4.py help
     description: Test prepare_gpf4.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_gpf4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_gpf4.py 2>&1'"
     expected_output_contains: "grid parameter file"
 
   - name: prepare_gpf4.py options
     description: Verify GPF parameter options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_gpf4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_gpf4.py 2>&1'"
     expected_output_contains: "ligand_types"
 
   - name: prepare_gpf.py help
     description: Test prepare_gpf.py (AutoDock 3) shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_gpf.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_gpf.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: gpf3_to_gpf4.py help
     description: Test GPF version conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/gpf3_to_gpf4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/gpf3_to_gpf4.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: gpf4_to_gpf3.py help
     description: Test GPF4 to GPF3 conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/gpf4_to_gpf3.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/gpf4_to_gpf3.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -162,27 +162,27 @@ tests:
   # ==========================================================================
   - name: prepare_dpf4.py help
     description: Test prepare_dpf4.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf4.py 2>&1'"
     expected_output_contains: "docking parameter file"
 
   - name: prepare_dpf41.py help
     description: Test prepare_dpf41.py (AutoDock 4.1) shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf41.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf41.py 2>&1'"
     expected_output_contains: "docking parameter file"
 
   - name: prepare_dpf42.py help
     description: Test prepare_dpf42.py (AutoDock 4.2) shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf42.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf42.py 2>&1'"
     expected_output_contains: "AutoDock42"
 
   - name: prepare_dpf.py help
     description: Test prepare_dpf.py (AutoDock 3) shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_dpf.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: dpf3_to_dpf4.py help
     description: Test DPF version conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/dpf3_to_dpf4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/dpf3_to_dpf4.py 2>&1'"
     expected_output_contains: "dpf3_stem"
 
   # ==========================================================================
@@ -190,17 +190,17 @@ tests:
   # ==========================================================================
   - name: prepare_configFile.py help
     description: Test AutoDock Vina config file preparation
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_configFile.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_configFile.py 2>&1'"
     expected_output_contains: "AutoDock vina"
 
   - name: prepare_configFile.py grid options
     description: Verify Vina grid center options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_configFile.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_configFile.py 2>&1'"
     expected_output_contains: "center_x"
 
   - name: prepare_configFile.py size options
     description: Verify Vina grid size options are documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_configFile.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_configFile.py 2>&1'"
     expected_output_contains: "size_x"
 
   # ==========================================================================
@@ -208,27 +208,27 @@ tests:
   # ==========================================================================
   - name: summarize_docking.py help
     description: Test summarize_docking.py shows usage information
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_docking.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_docking.py -h 2>&1'"
     expected_output_contains: "docking_logfile"
 
   - name: summarize_docking.py rmsd option
     description: Verify RMSD tolerance option is documented
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_docking.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_docking.py -h 2>&1'"
     expected_output_contains: "rmsd tolerance"
 
   - name: summarize_results4.py help
     description: Test summarize_results4.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_results4.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_results4.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: summarize_results41.py help
     description: Test summarize_results41.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_results41.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_results41.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: summarize_docking_directory.py help
     description: Test summarize_docking_directory.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_docking_directory.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_docking_directory.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -236,23 +236,23 @@ tests:
   # ==========================================================================
   - name: write_conformations_from_dlg.py help
     description: Test write_conformations_from_dlg.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_conformations_from_dlg.py -h 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_conformations_from_dlg.py -h 2>&1'"
     expected_output_contains: "docking filename"
 
   - name: write_lowest_energy_ligand.py help
     description: Test write_lowest_energy_ligand.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_lowest_energy_ligand.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_lowest_energy_ligand.py 2>&1'"
     expected_output_contains: "dlgfilename"
 
   - name: write_each_cluster_LE_conf.py help
     description: Test write_each_cluster_LE_conf.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_each_cluster_LE_conf.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_each_cluster_LE_conf.py 2>&1'"
     ignore_exit_code: true
     expected_output_contains: "write_each_cluster_LE_conf"
 
   - name: write_all_complexes.py help
     description: Test write_all_complexes.py shows usage
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_all_complexes.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_all_complexes.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -260,27 +260,27 @@ tests:
   # ==========================================================================
   - name: pdbqt_to_pdb.py help
     description: Test PDBQT to PDB conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqt_to_pdb.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqt_to_pdb.py 2>&1'"
     expected_output_contains: "pdbqt_filename"
 
   - name: pdbq_to_pdbqt.py help
     description: Test PDBQ to PDBQT conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbq_to_pdbqt.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbq_to_pdbqt.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: pdbqt_to_pdbq.py help
     description: Test PDBQT to PDBQ conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqt_to_pdbq.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqt_to_pdbq.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: pdbqs_to_pdbqt.py help
     description: Test PDBQS to PDBQT conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqs_to_pdbqt.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqs_to_pdbqt.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: pdbqt_to_pdbqs.py help
     description: Test PDBQT to PDBQS conversion utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqt_to_pdbqs.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/pdbqt_to_pdbqs.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -288,22 +288,22 @@ tests:
   # ==========================================================================
   - name: compute_rms_between_conformations.py help
     description: Test RMSD calculation utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_rms_between_conformations.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_rms_between_conformations.py 2>&1'"
     expected_output_contains: "reference"
 
   - name: compute_interatomic_distance_per_pose.py help
     description: Test interatomic distance calculation
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_interatomic_distance_per_pose.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_interatomic_distance_per_pose.py 2>&1'"
     expected_output_contains: "receptor atom"
 
   - name: superpose_molecules.py help
     description: Test molecule superposition utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/superpose_molecules.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/superpose_molecules.py 2>&1'"
     expected_output_contains: "superimposed"
 
   - name: rotate_molecule.py help
     description: Test molecule rotation utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/rotate_molecule.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/rotate_molecule.py 2>&1'"
     expected_output_contains: "rotate"
 
   # ==========================================================================
@@ -311,17 +311,17 @@ tests:
   # ==========================================================================
   - name: compute_AutoDock41_score.py help
     description: Test AutoDock 4.1 scoring utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_AutoDock41_score.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_AutoDock41_score.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: calc_energy_breakdown_from_results.py help
     description: Test energy breakdown calculation
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/calc_energy_breakdown_from_results.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/calc_energy_breakdown_from_results.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: write_component_energies.py help
     description: Test component energy writer
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_component_energies.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_component_energies.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -329,12 +329,12 @@ tests:
   # ==========================================================================
   - name: process_VinaResult.py help
     description: Test Vina result processing utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/process_VinaResult.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/process_VinaResult.py 2>&1'"
     expected_output_contains: "vina_resultfile"
 
   - name: compute_interatomic_distance_per_vina_pose.py help
     description: Test Vina pose distance calculation
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_interatomic_distance_per_vina_pose.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_interatomic_distance_per_vina_pose.py 2>&1'"
     expected_output_contains: "Usage"
 
   # ==========================================================================
@@ -450,27 +450,27 @@ tests:
   # ==========================================================================
   - name: write_clustering_histogram_postscript.py help
     description: Test clustering histogram utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_clustering_histogram_postscript.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/write_clustering_histogram_postscript.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: summarize_time.py help
     description: Test timing summarization utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_time.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/summarize_time.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: get_trilinterp_values.py help
     description: Test trilinear interpolation utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/get_trilinterp_values.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/get_trilinterp_values.py 2>&1'"
     expected_output_contains: "Usage"
 
   - name: compute_water_map.py help
     description: Test water map computation utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_water_map.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/compute_water_map.py 2>&1'"
     expected_output_contains: "map"
 
   - name: energy_average_maps.py help
     description: Test energy map averaging utility
-    command: pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/energy_average_maps.py 2>&1
+    command: "bash -lc 'pythonsh /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/energy_average_maps.py 2>&1'"
     ignore_exit_code: true
     expected_output_contains: "energy_average_maps"
 
@@ -479,22 +479,22 @@ tests:
   # ==========================================================================
   - name: adt script exists
     description: Verify AutoDockTools main script exists
-    command: ls -la /opt/mgltools/bin/adt
+    command: "bash -lc 'ls -la /opt/mgltools/bin/adt'"
     expected_output_contains: "adt"
 
   - name: pmv script exists
     description: Verify Python Molecular Viewer script exists
-    command: ls -la /opt/mgltools/bin/pmv
+    command: "bash -lc 'ls -la /opt/mgltools/bin/pmv'"
     expected_output_contains: "pmv"
 
   - name: vision script exists
     description: Verify Vision visual programming script exists
-    command: ls -la /opt/mgltools/bin/vision
+    command: "bash -lc 'ls -la /opt/mgltools/bin/vision'"
     expected_output_contains: "vision"
 
   - name: pythonsh script exists
     description: Verify MGLTools Python shell script exists
-    command: ls -la /opt/mgltools/bin/pythonsh
+    command: "bash -lc 'ls -la /opt/mgltools/bin/pythonsh'"
     expected_output_contains: "pythonsh"
 
   # ==========================================================================
@@ -502,17 +502,17 @@ tests:
   # ==========================================================================
   - name: AD4 parameters file exists
     description: Verify AutoDock 4 parameter file exists
-    command: ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/AD4_parameters.dat
+    command: "bash -lc 'ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/AD4_parameters.dat'"
     expected_output_contains: "AD4_parameters.dat"
 
   - name: AD4.1 bound parameters file exists
     description: Verify AutoDock 4.1 bound parameter file exists
-    command: ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/AD4.1_bound.dat
+    command: "bash -lc 'ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/AD4.1_bound.dat'"
     expected_output_contains: "AD4.1_bound.dat"
 
   - name: Reference DPF files exist
     description: Verify reference DPF templates exist
-    command: ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/ref*.dpf
+    command: bash -lc 'ls /opt/mgltools/MGLToolsPckgs/AutoDockTools/Utilities24/ref*.dpf'
     expected_output_contains: ".dpf"
 
 cleanup:

--- a/recipes/mne/fulltest.yaml
+++ b/recipes/mne/fulltest.yaml
@@ -30,12 +30,12 @@ tests:
   # ==========================================================================
   - name: MNE version check
     description: Verify MNE-Python version
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne; print('MNE version:', mne.__version__)\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne; print('\"'\"'MNE version:'\"'\"', mne.__version__)\\\"\"'"
     expected_output_contains: "1.1.1"
 
   - name: System info
     description: Display MNE system information
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne; mne.sys_info()\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne; mne.sys_info()\\\"\"'"
     expected_output_contains: "Platform"
 
   # ==========================================================================
@@ -43,62 +43,62 @@ tests:
   # ==========================================================================
   - name: Import mne core
     description: Test core mne module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne; print('mne imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne; print('\"'\"'mne imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.io
     description: Test mne.io module import for file I/O
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.io; print('mne.io imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.io; print('\"'\"'mne.io imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.preprocessing
     description: Test mne.preprocessing module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.preprocessing; print('mne.preprocessing imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.preprocessing; print('\"'\"'mne.preprocessing imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.time_frequency
     description: Test mne.time_frequency module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.time_frequency; print('mne.time_frequency imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.time_frequency; print('\"'\"'mne.time_frequency imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.stats
     description: Test mne.stats module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.stats; print('mne.stats imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.stats; print('\"'\"'mne.stats imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.decoding
     description: Test mne.decoding module import for machine learning
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.decoding; print('mne.decoding imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.decoding; print('\"'\"'mne.decoding imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.simulation
     description: Test mne.simulation module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.simulation; print('mne.simulation imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.simulation; print('\"'\"'mne.simulation imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.minimum_norm
     description: Test mne.minimum_norm module import for source localization
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.minimum_norm; print('mne.minimum_norm imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.minimum_norm; print('\"'\"'mne.minimum_norm imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.beamformer
     description: Test mne.beamformer module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.beamformer; print('mne.beamformer imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.beamformer; print('\"'\"'mne.beamformer imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.forward
     description: Test mne.forward module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.forward; print('mne.forward imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.forward; print('\"'\"'mne.forward imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.filter
     description: Test mne.filter module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.filter; print('mne.filter imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.filter; print('\"'\"'mne.filter imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   - name: Import mne.channels
     description: Test mne.channels module import
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import mne.channels; print('mne.channels imported successfully')\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import mne.channels; print('\"'\"'mne.channels imported successfully'\"'\"')\\\"\"'"
     expected_output_contains: "imported successfully"
 
   # ==========================================================================
@@ -106,22 +106,22 @@ tests:
   # ==========================================================================
   - name: Import numpy
     description: Test numpy availability (core dependency)
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import numpy as np; print('numpy version:', np.__version__)\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import numpy as np; print('\"'\"'numpy version:'\"'\"', np.__version__)\\\"\"'"
     expected_output_contains: "numpy version"
 
   - name: Import scipy
     description: Test scipy availability (core dependency)
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import scipy; print('scipy version:', scipy.__version__)\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import scipy; print('\"'\"'scipy version:'\"'\"', scipy.__version__)\\\"\"'"
     expected_output_contains: "scipy version"
 
   - name: Import sklearn
     description: Test scikit-learn availability (for decoding)
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import sklearn; print('sklearn version:', sklearn.__version__)\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import sklearn; print('\"'\"'sklearn version:'\"'\"', sklearn.__version__)\\\"\"'"
     expected_output_contains: "sklearn version"
 
   - name: Import matplotlib
     description: Test matplotlib availability (for visualization)
-    command: bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"import matplotlib; print('matplotlib version:', matplotlib.__version__)\""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"import matplotlib; print('\"'\"'matplotlib version:'\"'\"', matplotlib.__version__)\\\"\"'"
     expected_output_contains: "matplotlib version"
 
   # ==========================================================================
@@ -129,47 +129,22 @@ tests:
   # ==========================================================================
   - name: Create Info object
     description: Test creating measurement info structure
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      info = mne.create_info(ch_names=['Fz', 'Cz', 'Pz'], sfreq=1000, ch_types='eeg')
-      print('Info created with', len(info['ch_names']), 'channels')
-      print('Sampling frequency:', info['sfreq'], 'Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\ninfo = mne.create_info(ch_names=['\"'\"'Fz'\"'\"', '\"'\"'Cz'\"'\"', '\"'\"'Pz'\"'\"'], sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nprint('\"'\"'Info created with'\"'\"', len(info['\"'\"'ch_names'\"'\"']), '\"'\"'channels'\"'\"')\nprint('\"'\"'Sampling frequency:'\"'\"', info['\"'\"'sfreq'\"'\"'], '\"'\"'Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "3 channels"
 
   - name: Create Info with multiple channel types
     description: Test creating info with MEG and EEG channels
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      ch_names = ['MEG001', 'MEG002', 'EEG001', 'EEG002', 'EOG001', 'ECG001']
-      ch_types = ['mag', 'grad', 'eeg', 'eeg', 'eog', 'ecg']
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types=ch_types)
-      print('Info created with channel types:', set(ch_types))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\nch_names = ['\"'\"'MEG001'\"'\"', '\"'\"'MEG002'\"'\"', '\"'\"'EEG001'\"'\"', '\"'\"'EEG002'\"'\"', '\"'\"'EOG001'\"'\"', '\"'\"'ECG001'\"'\"']\nch_types = ['\"'\"'mag'\"'\"', '\"'\"'grad'\"'\"', '\"'\"'eeg'\"'\"', '\"'\"'eeg'\"'\"', '\"'\"'eog'\"'\"', '\"'\"'ecg'\"'\"']\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types=ch_types)\nprint('\"'\"'Info created with channel types:'\"'\"', set(ch_types))\n\\\"\"'"
     expected_output_contains: "mag"
 
   - name: Standard montage loading
     description: Test loading standard EEG montage
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      montage = mne.channels.make_standard_montage('standard_1020')
-      print('Montage:', montage)
-      print('Number of positions:', len(montage.ch_names))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\nmontage = mne.channels.make_standard_montage('\"'\"'standard_1020'\"'\"')\nprint('\"'\"'Montage:'\"'\"', montage)\nprint('\"'\"'Number of positions:'\"'\"', len(montage.ch_names))\n\\\"\"'"
     expected_output_contains: "DigMontage"
 
   - name: List available montages
     description: Test listing available standard montages
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      montages = mne.channels.get_builtin_montages()
-      print('Available montages:', len(montages))
-      print('First 5:', montages[:5])
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\nmontages = mne.channels.get_builtin_montages()\nprint('\"'\"'Available montages:'\"'\"', len(montages))\nprint('\"'\"'First 5:'\"'\"', montages[:5])\n\\\"\"'"
     expected_output_contains: "Available montages"
 
   # ==========================================================================
@@ -177,67 +152,22 @@ tests:
   # ==========================================================================
   - name: Create RawArray
     description: Test creating Raw object from numpy array
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_channels, n_times = 32, 10000
-      data = np.random.randn(n_channels, n_times) * 1e-6  # microvolts to volts
-      ch_names = ['EEG%03d' % i for i in range(n_channels)]
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      print('Raw object created:', raw)
-      print('Duration:', raw.times[-1], 'seconds')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_channels, n_times = 32, 10000\ndata = np.random.randn(n_channels, n_times) * 1e-6  # microvolts to volts\nch_names = ['\"'\"'EEG%03d'\"'\"' % i for i in range(n_channels)]\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nprint('\"'\"'Raw object created:'\"'\"', raw)\nprint('\"'\"'Duration:'\"'\"', raw.times[-1], '\"'\"'seconds'\"'\"')\n\\\"\"'"
     expected_output_contains: "RawArray"
 
   - name: Raw data slicing
     description: Test slicing raw data by time
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 5000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_cropped = raw.copy().crop(tmin=1.0, tmax=3.0)
-      print('Original duration:', raw.times[-1], 's')
-      print('Cropped duration:', raw_cropped.times[-1], 's')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 5000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_cropped = raw.copy().crop(tmin=1.0, tmax=3.0)\nprint('\"'\"'Original duration:'\"'\"', raw.times[-1], '\"'\"'s'\"'\"')\nprint('\"'\"'Cropped duration:'\"'\"', raw_cropped.times[-1], '\"'\"'s'\"'\"')\n\\\"\"'"
     expected_output_contains: "Cropped duration: 2.0"
 
   - name: Raw channel selection
     description: Test picking channels from raw data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      ch_names = ['Fp1', 'Fp2', 'F3', 'F4', 'C3', 'C4', 'P3', 'P4', 'O1', 'O2']
-      data = np.random.randn(10, 5000) * 1e-6
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_picked = raw.copy().pick_channels(['Fp1', 'Fp2', 'F3', 'F4'])
-      print('Original channels:', len(raw.ch_names))
-      print('Picked channels:', len(raw_picked.ch_names))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nch_names = ['\"'\"'Fp1'\"'\"', '\"'\"'Fp2'\"'\"', '\"'\"'F3'\"'\"', '\"'\"'F4'\"'\"', '\"'\"'C3'\"'\"', '\"'\"'C4'\"'\"', '\"'\"'P3'\"'\"', '\"'\"'P4'\"'\"', '\"'\"'O1'\"'\"', '\"'\"'O2'\"'\"']\ndata = np.random.randn(10, 5000) * 1e-6\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_picked = raw.copy().pick_channels(['\"'\"'Fp1'\"'\"', '\"'\"'Fp2'\"'\"', '\"'\"'F3'\"'\"', '\"'\"'F4'\"'\"'])\nprint('\"'\"'Original channels:'\"'\"', len(raw.ch_names))\nprint('\"'\"'Picked channels:'\"'\"', len(raw_picked.ch_names))\n\\\"\"'"
     expected_output_contains: "Picked channels: 4"
 
   - name: Rename channels
     description: Test renaming channels in raw data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(3, 1000) * 1e-6
-      info = mne.create_info(ch_names=['ch1', 'ch2', 'ch3'], sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw.rename_channels({'ch1': 'Fz', 'ch2': 'Cz', 'ch3': 'Pz'})
-      print('Renamed channels:', raw.ch_names)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(3, 1000) * 1e-6\ninfo = mne.create_info(ch_names=['\"'\"'ch1'\"'\"', '\"'\"'ch2'\"'\"', '\"'\"'ch3'\"'\"'], sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw.rename_channels({'\"'\"'ch1'\"'\"': '\"'\"'Fz'\"'\"', '\"'\"'ch2'\"'\"': '\"'\"'Cz'\"'\"', '\"'\"'ch3'\"'\"': '\"'\"'Pz'\"'\"'})\nprint('\"'\"'Renamed channels:'\"'\"', raw.ch_names)\n\\\"\"'"
     expected_output_contains: "Fz"
 
   # ==========================================================================
@@ -245,91 +175,32 @@ tests:
   # ==========================================================================
   - name: Bandpass filter
     description: Test bandpass filtering raw data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_filt = raw.copy().filter(l_freq=1, h_freq=40)
-      print('Bandpass filtered: 1-40 Hz')
-      print('Filtered raw:', raw_filt)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_filt = raw.copy().filter(l_freq=1, h_freq=40)\nprint('\"'\"'Bandpass filtered: 1-40 Hz'\"'\"')\nprint('\"'\"'Filtered raw:'\"'\"', raw_filt)\n\\\"\"'"
     expected_output_contains: "Bandpass filtered"
 
   - name: Lowpass filter
     description: Test lowpass filtering
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_filt = raw.copy().filter(l_freq=None, h_freq=30)
-      print('Lowpass filtered: <30 Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_filt = raw.copy().filter(l_freq=None, h_freq=30)\nprint('\"'\"'Lowpass filtered: <30 Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "Lowpass filtered"
 
   - name: Highpass filter
     description: Test highpass filtering
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_filt = raw.copy().filter(l_freq=0.5, h_freq=None)
-      print('Highpass filtered: >0.5 Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_filt = raw.copy().filter(l_freq=0.5, h_freq=None)\nprint('\"'\"'Highpass filtered: >0.5 Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "Highpass filtered"
 
   - name: Notch filter
     description: Test notch filtering for line noise
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_notch = raw.copy().notch_filter(freqs=[50, 60])
-      print('Notch filtered at 50 and 60 Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_notch = raw.copy().notch_filter(freqs=[50, 60])\nprint('\"'\"'Notch filtered at 50 and 60 Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "Notch filtered"
 
   - name: Resampling
     description: Test downsampling raw data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_resampled = raw.copy().resample(sfreq=250)
-      print('Original sfreq:', raw.info['sfreq'], 'Hz')
-      print('Resampled sfreq:', raw_resampled.info['sfreq'], 'Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_resampled = raw.copy().resample(sfreq=250)\nprint('\"'\"'Original sfreq:'\"'\"', raw.info['\"'\"'sfreq'\"'\"'], '\"'\"'Hz'\"'\"')\nprint('\"'\"'Resampled sfreq:'\"'\"', raw_resampled.info['\"'\"'sfreq'\"'\"'], '\"'\"'Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "Resampled sfreq: 250"
 
   - name: Create filter design
     description: Test creating custom filter design
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      fir_coefs = mne.filter.create_filter(
-          data=None, sfreq=1000, l_freq=1, h_freq=40,
-          fir_design='firwin', verbose=False)
-      print('FIR filter created with', len(fir_coefs), 'coefficients')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\nfir_coefs = mne.filter.create_filter(\n    data=None, sfreq=1000, l_freq=1, h_freq=40,\n    fir_design='\"'\"'firwin'\"'\"', verbose=False)\nprint('\"'\"'FIR filter created with'\"'\"', len(fir_coefs), '\"'\"'coefficients'\"'\"')\n\\\"\"'"
     expected_output_contains: "FIR filter created"
 
   # ==========================================================================
@@ -337,123 +208,37 @@ tests:
   # ==========================================================================
   - name: Create events array
     description: Test creating events array manually
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      # Events: [sample, previous_event_id, event_id]
-      events = np.array([
-          [100, 0, 1],
-          [200, 0, 2],
-          [300, 0, 1],
-          [400, 0, 2]
-      ])
-      print('Events shape:', events.shape)
-      print('Event IDs:', np.unique(events[:, 2]))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\n# Events: [sample, previous_event_id, event_id]\nevents = np.array([\n    [100, 0, 1],\n    [200, 0, 2],\n    [300, 0, 1],\n    [400, 0, 2]\n])\nprint('\"'\"'Events shape:'\"'\"', events.shape)\nprint('\"'\"'Event IDs:'\"'\"', np.unique(events[:, 2]))\n\\\"\"'"
     expected_output_contains: "Events shape: (4, 3)"
 
   - name: Make fixed length events
     description: Test creating fixed-length pseudo-events
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 30000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      events = mne.make_fixed_length_events(raw, duration=2.0)
-      print('Fixed length events:', len(events))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 30000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nevents = mne.make_fixed_length_events(raw, duration=2.0)\nprint('\"'\"'Fixed length events:'\"'\"', len(events))\n\\\"\"'"
     expected_output_contains: "Fixed length events:"
 
   - name: Create Epochs from Raw
     description: Test creating epochs from raw data and events
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      events = np.array([[1000, 0, 1], [3000, 0, 2], [5000, 0, 1], [7000, 0, 2]])
-      epochs = mne.Epochs(raw, events, event_id={'cond1': 1, 'cond2': 2},
-                          tmin=-0.2, tmax=0.5, baseline=(None, 0), preload=True)
-      print('Epochs created:', epochs)
-      print('Number of epochs:', len(epochs))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nevents = np.array([[1000, 0, 1], [3000, 0, 2], [5000, 0, 1], [7000, 0, 2]])\nepochs = mne.Epochs(raw, events, event_id={'\"'\"'cond1'\"'\"': 1, '\"'\"'cond2'\"'\"': 2},\n                    tmin=-0.2, tmax=0.5, baseline=(None, 0), preload=True)\nprint('\"'\"'Epochs created:'\"'\"', epochs)\nprint('\"'\"'Number of epochs:'\"'\"', len(epochs))\n\\\"\"'"
     expected_output_contains: "Number of epochs:"
 
   - name: Create EpochsArray
     description: Test creating epochs from numpy array
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 20, 10, 700  # 700 samples = 0.7s at 1000Hz
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      print('EpochsArray created:', epochs)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 20, 10, 700  # 700 samples = 0.7s at 1000Hz\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nprint('\"'\"'EpochsArray created:'\"'\"', epochs)\n\\\"\"'"
     expected_output_contains: "EpochsArray"
 
   - name: Epochs indexing
     description: Test selecting epochs by condition
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      events = np.array([[1000, 0, 1], [2000, 0, 2], [3000, 0, 1], [4000, 0, 2],
-                         [5000, 0, 1], [6000, 0, 2], [7000, 0, 1], [8000, 0, 2]])
-      epochs = mne.Epochs(raw, events, event_id={'target': 1, 'standard': 2},
-                          tmin=-0.1, tmax=0.3, baseline=None, preload=True)
-      epochs_target = epochs['target']
-      print('All epochs:', len(epochs))
-      print('Target epochs:', len(epochs_target))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nevents = np.array([[1000, 0, 1], [2000, 0, 2], [3000, 0, 1], [4000, 0, 2],\n                   [5000, 0, 1], [6000, 0, 2], [7000, 0, 1], [8000, 0, 2]])\nepochs = mne.Epochs(raw, events, event_id={'\"'\"'target'\"'\"': 1, '\"'\"'standard'\"'\"': 2},\n                    tmin=-0.1, tmax=0.3, baseline=None, preload=True)\nepochs_target = epochs['\"'\"'target'\"'\"']\nprint('\"'\"'All epochs:'\"'\"', len(epochs))\nprint('\"'\"'Target epochs:'\"'\"', len(epochs_target))\n\\\"\"'"
     expected_output_contains: "Target epochs: 4"
 
   - name: Epochs baseline correction
     description: Test applying baseline correction
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 10, 5, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6 + 1e-6  # add offset
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      epochs.apply_baseline(baseline=(None, 0))
-      print('Baseline correction applied from tmin to 0')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 10, 5, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6 + 1e-6  # add offset\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nepochs.apply_baseline(baseline=(None, 0))\nprint('\"'\"'Baseline correction applied from tmin to 0'\"'\"')\n\\\"\"'"
     expected_output_contains: "Baseline correction applied"
 
   - name: Drop bad epochs
     description: Test dropping epochs by rejection criteria
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 20, 10, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      # Make some epochs bad
-      data[5] *= 10
-      data[15] *= 10
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      epochs.drop_bad(reject=dict(eeg=50e-6))  # reject >50uV
-      print('Original epochs:', n_epochs)
-      print('Epochs after rejection:', len(epochs))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 20, 10, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\n# Make some epochs bad\ndata[5] *= 10\ndata[15] *= 10\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nepochs.drop_bad(reject=dict(eeg=50e-6))  # reject >50uV\nprint('\"'\"'Original epochs:'\"'\"', n_epochs)\nprint('\"'\"'Epochs after rejection:'\"'\"', len(epochs))\n\\\"\"'"
     expected_output_contains: "Epochs after rejection:"
 
   # ==========================================================================
@@ -461,65 +246,22 @@ tests:
   # ==========================================================================
   - name: Create Evoked from Epochs
     description: Test averaging epochs to create evoked response
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 30, 10, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      evoked = epochs.average()
-      print('Evoked created:', evoked)
-      print('Nave:', evoked.nave)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 30, 10, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nevoked = epochs.average()\nprint('\"'\"'Evoked created:'\"'\"', evoked)\nprint('\"'\"'Nave:'\"'\"', evoked.nave)\n\\\"\"'"
     expected_output_contains: "Nave: 30"
 
   - name: Create EvokedArray
     description: Test creating evoked directly from array
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_channels, n_times = 10, 500
-      data = np.random.randn(n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      evoked = mne.EvokedArray(data, info, tmin=-0.2, nave=30)
-      print('EvokedArray created:', evoked)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_channels, n_times = 10, 500\ndata = np.random.randn(n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nevoked = mne.EvokedArray(data, info, tmin=-0.2, nave=30)\nprint('\"'\"'EvokedArray created:'\"'\"', evoked)\n\\\"\"'"
     expected_output_contains: "EvokedArray"
 
   - name: Combine evoked responses
     description: Test combining multiple evoked responses
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_channels, n_times = 10, 500
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      evoked1 = mne.EvokedArray(np.random.randn(n_channels, n_times) * 1e-6, info, tmin=-0.2, nave=20)
-      evoked2 = mne.EvokedArray(np.random.randn(n_channels, n_times) * 1e-6, info, tmin=-0.2, nave=20)
-      evoked_combined = mne.combine_evoked([evoked1, evoked2], weights='nave')
-      print('Combined evoked nave:', evoked_combined.nave)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_channels, n_times = 10, 500\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nevoked1 = mne.EvokedArray(np.random.randn(n_channels, n_times) * 1e-6, info, tmin=-0.2, nave=20)\nevoked2 = mne.EvokedArray(np.random.randn(n_channels, n_times) * 1e-6, info, tmin=-0.2, nave=20)\nevoked_combined = mne.combine_evoked([evoked1, evoked2], weights='\"'\"'nave'\"'\"')\nprint('\"'\"'Combined evoked nave:'\"'\"', evoked_combined.nave)\n\\\"\"'"
     expected_output_contains: "Combined evoked nave: 40"
 
   - name: Grand average
     description: Test computing grand average across subjects
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_channels, n_times = 10, 500
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      evokeds = [mne.EvokedArray(np.random.randn(n_channels, n_times) * 1e-6, info, tmin=-0.2, nave=30) for _ in range(5)]
-      grand_avg = mne.grand_average(evokeds)
-      print('Grand average computed from', len(evokeds), 'subjects')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_channels, n_times = 10, 500\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nevokeds = [mne.EvokedArray(np.random.randn(n_channels, n_times) * 1e-6, info, tmin=-0.2, nave=30) for _ in range(5)]\ngrand_avg = mne.grand_average(evokeds)\nprint('\"'\"'Grand average computed from'\"'\"', len(evokeds), '\"'\"'subjects'\"'\"')\n\\\"\"'"
     expected_output_contains: "Grand average computed from 5 subjects"
 
   # ==========================================================================
@@ -527,44 +269,17 @@ tests:
   # ==========================================================================
   - name: ICA initialization
     description: Test initializing ICA object
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      from mne.preprocessing import ICA
-      ica = ICA(n_components=15, method='fastica', random_state=42)
-      print('ICA initialized:', ica)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nfrom mne.preprocessing import ICA\nica = ICA(n_components=15, method='\"'\"'fastica'\"'\"', random_state=42)\nprint('\"'\"'ICA initialized:'\"'\"', ica)\n\\\"\"'"
     expected_output_contains: "ICA"
 
   - name: ICA fit and apply
     description: Test fitting ICA on raw data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.preprocessing import ICA
-      np.random.seed(42)
-      data = np.random.randn(20, 50000) * 1e-6
-      info = mne.create_info(ch_names=20, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw.filter(1, 40)
-      ica = ICA(n_components=10, method='fastica', random_state=42)
-      ica.fit(raw)
-      print('ICA fitted with', ica.n_components_, 'components')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.preprocessing import ICA\nnp.random.seed(42)\ndata = np.random.randn(20, 50000) * 1e-6\ninfo = mne.create_info(ch_names=20, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw.filter(1, 40)\nica = ICA(n_components=10, method='\"'\"'fastica'\"'\"', random_state=42)\nica.fit(raw)\nprint('\"'\"'ICA fitted with'\"'\"', ica.n_components_, '\"'\"'components'\"'\"')\n\\\"\"'"
     expected_output_contains: "ICA fitted with 10 components"
 
   - name: ICA methods available
     description: Test available ICA methods
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      from mne.preprocessing import ICA
-      for method in ['fastica', 'infomax', 'picard']:
-          try:
-              ica = ICA(n_components=5, method=method, random_state=42)
-              print(f'{method}: available')
-          except Exception as e:
-              print(f'{method}: not available')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nfrom mne.preprocessing import ICA\nfor method in ['\"'\"'fastica'\"'\"', '\"'\"'infomax'\"'\"', '\"'\"'picard'\"'\"']:\n    try:\n        ica = ICA(n_components=5, method=method, random_state=42)\n        print(f'\"'\"'{method}: available'\"'\"')\n    except Exception as e:\n        print(f'\"'\"'{method}: not available'\"'\"')\n\\\"\"'"
     expected_output_contains: "fastica: available"
 
   # ==========================================================================
@@ -572,33 +287,12 @@ tests:
   # ==========================================================================
   - name: Xdawn initialization
     description: Test Xdawn spatial filter for artifact detection
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      from mne.preprocessing import Xdawn
-      xdawn = Xdawn(n_components=2)
-      print('Xdawn initialized:', xdawn)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nfrom mne.preprocessing import Xdawn\nxdawn = Xdawn(n_components=2)\nprint('\"'\"'Xdawn initialized:'\"'\"', xdawn)\n\\\"\"'"
     expected_output_contains: "Xdawn"
 
   - name: Current source density
     description: Test computing surface Laplacian (CSD)
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.preprocessing import compute_current_source_density
-      np.random.seed(42)
-      montage = mne.channels.make_standard_montage('biosemi64')
-      ch_names = montage.ch_names
-      n_channels = len(ch_names)
-      n_times = 5000
-      data = np.random.randn(n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='eeg')
-      info.set_montage(montage)
-      raw = mne.io.RawArray(data, info)
-      raw_csd = compute_current_source_density(raw)
-      print('CSD computed:', raw_csd)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.preprocessing import compute_current_source_density\nnp.random.seed(42)\nmontage = mne.channels.make_standard_montage('\"'\"'biosemi64'\"'\"')\nch_names = montage.ch_names\nn_channels = len(ch_names)\nn_times = 5000\ndata = np.random.randn(n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\ninfo.set_montage(montage)\nraw = mne.io.RawArray(data, info)\nraw_csd = compute_current_source_density(raw)\nprint('\"'\"'CSD computed:'\"'\"', raw_csd)\n\\\"\"'"
     expected_output_contains: "CSD computed"
 
   # ==========================================================================
@@ -606,85 +300,27 @@ tests:
   # ==========================================================================
   - name: Morlet wavelets
     description: Test creating Morlet wavelets
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne.time_frequency as tfr
-      import numpy as np
-      freqs = np.arange(5, 30, 1)
-      wavelets = tfr.morlet(sfreq=1000, freqs=freqs, n_cycles=freqs/2)
-      print('Created', len(wavelets), 'Morlet wavelets')
-      print('Frequencies:', freqs[0], 'to', freqs[-1], 'Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne.time_frequency as tfr\nimport numpy as np\nfreqs = np.arange(5, 30, 1)\nwavelets = tfr.morlet(sfreq=1000, freqs=freqs, n_cycles=freqs/2)\nprint('\"'\"'Created'\"'\"', len(wavelets), '\"'\"'Morlet wavelets'\"'\"')\nprint('\"'\"'Frequencies:'\"'\"', freqs[0], '\"'\"'to'\"'\"', freqs[-1], '\"'\"'Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "Created 25 Morlet wavelets"
 
   - name: Time-frequency representation
     description: Test computing TFR with Morlet wavelets
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.time_frequency import tfr_morlet
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 10, 5, 2000
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.5)
-      freqs = np.arange(5, 30, 2)
-      power = tfr_morlet(epochs, freqs=freqs, n_cycles=freqs/2, return_itc=False, average=True)
-      print('TFR computed:', power)
-      print('Shape:', power.data.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.time_frequency import tfr_morlet\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 10, 5, 2000\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.5)\nfreqs = np.arange(5, 30, 2)\npower = tfr_morlet(epochs, freqs=freqs, n_cycles=freqs/2, return_itc=False, average=True)\nprint('\"'\"'TFR computed:'\"'\"', power)\nprint('\"'\"'Shape:'\"'\"', power.data.shape)\n\\\"\"'"
     expected_output_contains: "TFR computed"
 
   - name: Multitaper PSD
     description: Test computing multitaper power spectral density
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.time_frequency import psd_multitaper
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      psds, freqs = psd_multitaper(raw, fmin=1, fmax=50)
-      print('PSD computed with multitaper')
-      print('Frequencies:', freqs[0], 'to', freqs[-1], 'Hz')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.time_frequency import psd_multitaper\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\npsds, freqs = psd_multitaper(raw, fmin=1, fmax=50)\nprint('\"'\"'PSD computed with multitaper'\"'\"')\nprint('\"'\"'Frequencies:'\"'\"', freqs[0], '\"'\"'to'\"'\"', freqs[-1], '\"'\"'Hz'\"'\"')\n\\\"\"'"
     expected_output_contains: "PSD computed with multitaper"
 
   - name: Welch PSD
     description: Test computing Welch power spectral density
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.time_frequency import psd_welch
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      psds, freqs = psd_welch(raw, fmin=1, fmax=50)
-      print('PSD computed with Welch method')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.time_frequency import psd_welch\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\npsds, freqs = psd_welch(raw, fmin=1, fmax=50)\nprint('\"'\"'PSD computed with Welch method'\"'\"')\n\\\"\"'"
     expected_output_contains: "PSD computed with Welch"
 
   - name: Cross-spectral density
     description: Test computing cross-spectral density matrix
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.time_frequency import csd_morlet
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 10, 5, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      freqs = np.arange(8, 13, 1)  # alpha band
-      csd = csd_morlet(epochs, frequencies=freqs, n_cycles=freqs/2)
-      print('CSD computed:', csd)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.time_frequency import csd_morlet\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 10, 5, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nfreqs = np.arange(8, 13, 1)  # alpha band\ncsd = csd_morlet(epochs, frequencies=freqs, n_cycles=freqs/2)\nprint('\"'\"'CSD computed:'\"'\"', csd)\n\\\"\"'"
     expected_output_contains: "CrossSpectralDensity"
 
   # ==========================================================================
@@ -692,46 +328,17 @@ tests:
   # ==========================================================================
   - name: Compute covariance from epochs
     description: Test computing noise covariance from epochs
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 30, 10, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      cov = mne.compute_covariance(epochs, method='empirical')
-      print('Covariance computed:', cov)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 30, 10, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\ncov = mne.compute_covariance(epochs, method='\"'\"'empirical'\"'\"')\nprint('\"'\"'Covariance computed:'\"'\"', cov)\n\\\"\"'"
     expected_output_contains: "Covariance"
 
   - name: Covariance regularization methods
     description: Test different covariance regularization methods
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 50, 10, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      for method in ['empirical', 'shrunk', 'diagonal_fixed']:
-          cov = mne.compute_covariance(epochs, method=method)
-          print(f'{method}: computed')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 50, 10, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nfor method in ['\"'\"'empirical'\"'\"', '\"'\"'shrunk'\"'\"', '\"'\"'diagonal_fixed'\"'\"']:\n    cov = mne.compute_covariance(epochs, method=method)\n    print(f'\"'\"'{method}: computed'\"'\"')\n\\\"\"'"
     expected_output_contains: "shrunk: computed"
 
   - name: Ad-hoc covariance
     description: Test creating ad-hoc diagonal covariance
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      info = mne.create_info(ch_names=['EEG001', 'EEG002', 'EEG003'], sfreq=1000, ch_types='eeg')
-      cov = mne.make_ad_hoc_cov(info)
-      print('Ad-hoc covariance created:', cov)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\ninfo = mne.create_info(ch_names=['\"'\"'EEG001'\"'\"', '\"'\"'EEG002'\"'\"', '\"'\"'EEG003'\"'\"'], sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\ncov = mne.make_ad_hoc_cov(info)\nprint('\"'\"'Ad-hoc covariance created:'\"'\"', cov)\n\\\"\"'"
     expected_output_contains: "Covariance"
 
   # ==========================================================================
@@ -739,47 +346,17 @@ tests:
   # ==========================================================================
   - name: Source estimate class
     description: Test SourceEstimate data structure
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_vertices = [500, 500]  # left and right hemisphere
-      n_times = 100
-      data = np.random.randn(sum(n_vertices), n_times) * 1e-9
-      vertices = [np.arange(n_vertices[0]), np.arange(n_vertices[1])]
-      stc = mne.SourceEstimate(data, vertices, tmin=0, tstep=0.001)
-      print('SourceEstimate created')
-      print('Shape:', stc.data.shape)
-      print('Times:', stc.times[0], 'to', stc.times[-1], 's')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_vertices = [500, 500]  # left and right hemisphere\nn_times = 100\ndata = np.random.randn(sum(n_vertices), n_times) * 1e-9\nvertices = [np.arange(n_vertices[0]), np.arange(n_vertices[1])]\nstc = mne.SourceEstimate(data, vertices, tmin=0, tstep=0.001)\nprint('\"'\"'SourceEstimate created'\"'\"')\nprint('\"'\"'Shape:'\"'\"', stc.data.shape)\nprint('\"'\"'Times:'\"'\"', stc.times[0], '\"'\"'to'\"'\"', stc.times[-1], '\"'\"'s'\"'\"')\n\\\"\"'"
     expected_output_contains: "SourceEstimate created"
 
   - name: Volume source estimate
     description: Test VolSourceEstimate data structure
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_vertices = 1000
-      n_times = 100
-      data = np.random.randn(n_vertices, n_times) * 1e-9
-      vertices = np.arange(n_vertices)
-      stc = mne.VolSourceEstimate(data, [vertices], tmin=0, tstep=0.001)
-      print('VolSourceEstimate created')
-      print('Shape:', stc.data.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_vertices = 1000\nn_times = 100\ndata = np.random.randn(n_vertices, n_times) * 1e-9\nvertices = np.arange(n_vertices)\nstc = mne.VolSourceEstimate(data, [vertices], tmin=0, tstep=0.001)\nprint('\"'\"'VolSourceEstimate created'\"'\"')\nprint('\"'\"'Shape:'\"'\"', stc.data.shape)\n\\\"\"'"
     expected_output_contains: "VolSourceEstimate created"
 
   - name: Sphere model
     description: Test creating simple sphere head model
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      sphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.09)
-      print('Sphere model created:', sphere)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\nsphere = mne.make_sphere_model(r0=(0., 0., 0.), head_radius=0.09)\nprint('\"'\"'Sphere model created:'\"'\"', sphere)\n\\\"\"'"
     expected_output_contains: "ConductorModel"
 
   # ==========================================================================
@@ -787,11 +364,7 @@ tests:
   # ==========================================================================
   - name: Inverse methods available
     description: Test available inverse methods
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      from mne.minimum_norm import INVERSE_METHODS
-      print('Available inverse methods:', list(INVERSE_METHODS))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nfrom mne.minimum_norm import INVERSE_METHODS\nprint('\"'\"'Available inverse methods:'\"'\"', list(INVERSE_METHODS))\n\\\"\"'"
     expected_output_contains: "MNE"
 
   # ==========================================================================
@@ -799,115 +372,37 @@ tests:
   # ==========================================================================
   - name: CSP initialization
     description: Test Common Spatial Patterns initialization
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      from mne.decoding import CSP
-      csp = CSP(n_components=4, reg=None, log=True)
-      print('CSP initialized:', csp)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nfrom mne.decoding import CSP\ncsp = CSP(n_components=4, reg=None, log=True)\nprint('\"'\"'CSP initialized:'\"'\"', csp)\n\\\"\"'"
     expected_output_contains: "CSP"
 
   - name: CSP fit and transform
     description: Test CSP on simulated data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.decoding import CSP
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 100, 20, 500
-      X = np.random.randn(n_epochs, n_channels, n_times)
-      y = np.concatenate([np.zeros(50), np.ones(50)])
-      csp = CSP(n_components=4)
-      X_csp = csp.fit_transform(X, y)
-      print('CSP transformed shape:', X_csp.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.decoding import CSP\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 100, 20, 500\nX = np.random.randn(n_epochs, n_channels, n_times)\ny = np.concatenate([np.zeros(50), np.ones(50)])\ncsp = CSP(n_components=4)\nX_csp = csp.fit_transform(X, y)\nprint('\"'\"'CSP transformed shape:'\"'\"', X_csp.shape)\n\\\"\"'"
     expected_output_contains: "CSP transformed shape: (100, 4)"
 
   - name: Vectorizer
     description: Test Vectorizer for sklearn pipeline
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.decoding import Vectorizer
-      np.random.seed(42)
-      X = np.random.randn(50, 10, 100)  # epochs x channels x times
-      vectorizer = Vectorizer()
-      X_vec = vectorizer.fit_transform(X)
-      print('Vectorized shape:', X_vec.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.decoding import Vectorizer\nnp.random.seed(42)\nX = np.random.randn(50, 10, 100)  # epochs x channels x times\nvectorizer = Vectorizer()\nX_vec = vectorizer.fit_transform(X)\nprint('\"'\"'Vectorized shape:'\"'\"', X_vec.shape)\n\\\"\"'"
     expected_output_contains: "Vectorized shape: (50, 1000)"
 
   - name: Scaler
     description: Test MNE Scaler for data normalization
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      from mne.decoding import Scaler
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 50, 10, 100
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      scaler = Scaler(info)
-      X_scaled = scaler.fit_transform(data)
-      print('Scaled data shape:', X_scaled.shape)
-      print('Mean close to 0:', np.abs(X_scaled.mean()) < 0.1)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nfrom mne.decoding import Scaler\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 50, 10, 100\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nscaler = Scaler(info)\nX_scaled = scaler.fit_transform(data)\nprint('\"'\"'Scaled data shape:'\"'\"', X_scaled.shape)\nprint('\"'\"'Mean close to 0:'\"'\"', np.abs(X_scaled.mean()) < 0.1)\n\\\"\"'"
     expected_output_contains: "Scaled data shape:"
 
   - name: SlidingEstimator
     description: Test time-resolved decoding with SlidingEstimator
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from sklearn.linear_model import LogisticRegression
-      from mne.decoding import SlidingEstimator, cross_val_multiscore
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 100, 20, 50
-      X = np.random.randn(n_epochs, n_channels, n_times)
-      y = np.concatenate([np.zeros(50), np.ones(50)])
-      clf = LogisticRegression(solver='lbfgs')
-      slider = SlidingEstimator(clf, scoring='accuracy')
-      scores = cross_val_multiscore(slider, X, y, cv=3)
-      print('Sliding estimator scores shape:', scores.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom sklearn.linear_model import LogisticRegression\nfrom mne.decoding import SlidingEstimator, cross_val_multiscore\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 100, 20, 50\nX = np.random.randn(n_epochs, n_channels, n_times)\ny = np.concatenate([np.zeros(50), np.ones(50)])\nclf = LogisticRegression(solver='\"'\"'lbfgs'\"'\"')\nslider = SlidingEstimator(clf, scoring='\"'\"'accuracy'\"'\"')\nscores = cross_val_multiscore(slider, X, y, cv=3)\nprint('\"'\"'Sliding estimator scores shape:'\"'\"', scores.shape)\n\\\"\"'"
     expected_output_contains: "Sliding estimator scores shape:"
 
   - name: GeneralizingEstimator
     description: Test temporal generalization with GeneralizingEstimator
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from sklearn.linear_model import LogisticRegression
-      from mne.decoding import GeneralizingEstimator
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 100, 10, 20
-      X = np.random.randn(n_epochs, n_channels, n_times)
-      y = np.concatenate([np.zeros(50), np.ones(50)])
-      clf = LogisticRegression(solver='lbfgs', max_iter=500)
-      gen = GeneralizingEstimator(clf, scoring='accuracy')
-      gen.fit(X, y)
-      scores = gen.score(X, y)
-      print('Generalization matrix shape:', scores.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom sklearn.linear_model import LogisticRegression\nfrom mne.decoding import GeneralizingEstimator\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 100, 10, 20\nX = np.random.randn(n_epochs, n_channels, n_times)\ny = np.concatenate([np.zeros(50), np.ones(50)])\nclf = LogisticRegression(solver='\"'\"'lbfgs'\"'\"', max_iter=500)\ngen = GeneralizingEstimator(clf, scoring='\"'\"'accuracy'\"'\"')\ngen.fit(X, y)\nscores = gen.score(X, y)\nprint('\"'\"'Generalization matrix shape:'\"'\"', scores.shape)\n\\\"\"'"
     expected_output_contains: "Generalization matrix shape:"
 
   - name: LinearModel
     description: Test LinearModel for interpretable weights
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from sklearn.linear_model import LogisticRegression
-      from mne.decoding import LinearModel, get_coef
-      np.random.seed(42)
-      n_samples, n_features = 100, 20
-      X = np.random.randn(n_samples, n_features)
-      y = np.concatenate([np.zeros(50), np.ones(50)])
-      clf = LinearModel(LogisticRegression(solver='lbfgs'))
-      clf.fit(X, y)
-      coef = get_coef(clf, 'patterns_')
-      print('Pattern coefficients shape:', coef.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom sklearn.linear_model import LogisticRegression\nfrom mne.decoding import LinearModel, get_coef\nnp.random.seed(42)\nn_samples, n_features = 100, 20\nX = np.random.randn(n_samples, n_features)\ny = np.concatenate([np.zeros(50), np.ones(50)])\nclf = LinearModel(LogisticRegression(solver='\"'\"'lbfgs'\"'\"'))\nclf.fit(X, y)\ncoef = get_coef(clf, '\"'\"'patterns_'\"'\"')\nprint('\"'\"'Pattern coefficients shape:'\"'\"', coef.shape)\n\\\"\"'"
     expected_output_contains: "Pattern coefficients shape: (20,)"
 
   # ==========================================================================
@@ -915,73 +410,27 @@ tests:
   # ==========================================================================
   - name: Permutation t-test
     description: Test permutation-based t-test
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.stats import permutation_t_test
-      np.random.seed(42)
-      X = np.random.randn(20, 100) + 0.5  # 20 subjects, 100 time points
-      T_obs, p_values, H0 = permutation_t_test(X, n_permutations=1000)
-      print('T-statistic shape:', T_obs.shape)
-      print('Significant points:', np.sum(p_values < 0.05))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.stats import permutation_t_test\nnp.random.seed(42)\nX = np.random.randn(20, 100) + 0.5  # 20 subjects, 100 time points\nT_obs, p_values, H0 = permutation_t_test(X, n_permutations=1000)\nprint('\"'\"'T-statistic shape:'\"'\"', T_obs.shape)\nprint('\"'\"'Significant points:'\"'\"', np.sum(p_values < 0.05))\n\\\"\"'"
     expected_output_contains: "T-statistic shape:"
 
   - name: Cluster permutation test
     description: Test spatio-temporal cluster permutation test
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.stats import permutation_cluster_1samp_test
-      np.random.seed(42)
-      X = np.random.randn(15, 50) + 0.3
-      T_obs, clusters, p_values, H0 = permutation_cluster_1samp_test(X, n_permutations=100, tail=0)
-      print('Number of clusters found:', len(clusters))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.stats import permutation_cluster_1samp_test\nnp.random.seed(42)\nX = np.random.randn(15, 50) + 0.3\nT_obs, clusters, p_values, H0 = permutation_cluster_1samp_test(X, n_permutations=100, tail=0)\nprint('\"'\"'Number of clusters found:'\"'\"', len(clusters))\n\\\"\"'"
     expected_output_contains: "Number of clusters found:"
 
   - name: FDR correction
     description: Test false discovery rate correction
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.stats import fdr_correction
-      np.random.seed(42)
-      p_values = np.random.rand(100)
-      p_values[:10] = 0.001  # some significant
-      reject, p_corrected = fdr_correction(p_values, alpha=0.05)
-      print('Original significant:', np.sum(p_values < 0.05))
-      print('After FDR correction:', np.sum(reject))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.stats import fdr_correction\nnp.random.seed(42)\np_values = np.random.rand(100)\np_values[:10] = 0.001  # some significant\nreject, p_corrected = fdr_correction(p_values, alpha=0.05)\nprint('\"'\"'Original significant:'\"'\"', np.sum(p_values < 0.05))\nprint('\"'\"'After FDR correction:'\"'\"', np.sum(reject))\n\\\"\"'"
     expected_output_contains: "After FDR correction:"
 
   - name: Bonferroni correction
     description: Test Bonferroni multiple comparison correction
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.stats import bonferroni_correction
-      np.random.seed(42)
-      p_values = np.random.rand(50)
-      p_values[:5] = 0.0001
-      reject, p_corrected = bonferroni_correction(p_values, alpha=0.05)
-      print('After Bonferroni correction:', np.sum(reject))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.stats import bonferroni_correction\nnp.random.seed(42)\np_values = np.random.rand(50)\np_values[:5] = 0.0001\nreject, p_corrected = bonferroni_correction(p_values, alpha=0.05)\nprint('\"'\"'After Bonferroni correction:'\"'\"', np.sum(reject))\n\\\"\"'"
     expected_output_contains: "After Bonferroni correction:"
 
   - name: F-test (one-way)
     description: Test one-way F-test for ANOVA
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.stats import f_oneway
-      np.random.seed(42)
-      X1 = np.random.randn(20, 50)
-      X2 = np.random.randn(20, 50) + 0.5
-      X3 = np.random.randn(20, 50) + 1.0
-      F_obs = f_oneway(X1, X2, X3)
-      print('F-statistic shape:', F_obs.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.stats import f_oneway\nnp.random.seed(42)\nX1 = np.random.randn(20, 50)\nX2 = np.random.randn(20, 50) + 0.5\nX3 = np.random.randn(20, 50) + 1.0\nF_obs = f_oneway(X1, X2, X3)\nprint('\"'\"'F-statistic shape:'\"'\"', F_obs.shape)\n\\\"\"'"
     expected_output_contains: "F-statistic shape:"
 
   # ==========================================================================
@@ -989,41 +438,12 @@ tests:
   # ==========================================================================
   - name: Simulate sparse STC
     description: Test simulating sparse source time course
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_vertices = [500, 500]
-      n_times = 100
-      data = np.zeros((sum(n_vertices), n_times))
-      vertices = [np.arange(n_vertices[0]), np.arange(n_vertices[1])]
-      for idx in [42, 700]:
-          data[idx] = np.sin(2 * np.pi * 10 * np.arange(n_times) / 1000.)
-      stc = mne.SourceEstimate(data, vertices, tmin=0, tstep=0.001)
-      print('Simulated sparse STC:', stc)
-      print('Active vertices:', np.sum(np.any(stc.data != 0, axis=1)))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_vertices = [500, 500]\nn_times = 100\ndata = np.zeros((sum(n_vertices), n_times))\nvertices = [np.arange(n_vertices[0]), np.arange(n_vertices[1])]\nfor idx in [42, 700]:\n    data[idx] = np.sin(2 * np.pi * 10 * np.arange(n_times) / 1000.)\nstc = mne.SourceEstimate(data, vertices, tmin=0, tstep=0.001)\nprint('\"'\"'Simulated sparse STC:'\"'\"', stc)\nprint('\"'\"'Active vertices:'\"'\"', np.sum(np.any(stc.data != 0, axis=1)))\n\\\"\"'"
     expected_output_contains: "SourceEstimate"
 
   - name: Simulate evoked response
     description: Test simulating evoked data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_channels, n_times = 10, 500
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      # Simulate simple evoked with additive noise
-      data = np.zeros((n_channels, n_times))
-      times = np.arange(n_times) / 1000.
-      for ch in range(n_channels):
-          data[ch] = np.sin(2 * np.pi * 10 * times) * np.exp(-times * 5) * 1e-6
-      data += np.random.randn(n_channels, n_times) * 0.1e-6
-      evoked = mne.EvokedArray(data, info, tmin=-0.1)
-      print('Simulated evoked:', evoked)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_channels, n_times = 10, 500\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\n# Simulate simple evoked with additive noise\ndata = np.zeros((n_channels, n_times))\ntimes = np.arange(n_times) / 1000.\nfor ch in range(n_channels):\n    data[ch] = np.sin(2 * np.pi * 10 * times) * np.exp(-times * 5) * 1e-6\ndata += np.random.randn(n_channels, n_times) * 0.1e-6\nevoked = mne.EvokedArray(data, info, tmin=-0.1)\nprint('\"'\"'Simulated evoked:'\"'\"', evoked)\n\\\"\"'"
     expected_output_contains: "Simulated evoked"
 
   # ==========================================================================
@@ -1031,60 +451,17 @@ tests:
   # ==========================================================================
   - name: Check available readers
     description: Test that file readers are available
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne.io
-      readers = [
-          'read_raw_fif', 'read_raw_edf', 'read_raw_bdf',
-          'read_raw_eeglab', 'read_raw_brainvision', 'read_raw_cnt',
-          'read_raw_egi', 'read_raw_kit', 'read_raw_ctf'
-      ]
-      for reader in readers:
-          if hasattr(mne.io, reader):
-              print(f'{reader}: available')
-          else:
-              print(f'{reader}: not found')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne.io\nreaders = [\n    '\"'\"'read_raw_fif'\"'\"', '\"'\"'read_raw_edf'\"'\"', '\"'\"'read_raw_bdf'\"'\"',\n    '\"'\"'read_raw_eeglab'\"'\"', '\"'\"'read_raw_brainvision'\"'\"', '\"'\"'read_raw_cnt'\"'\"',\n    '\"'\"'read_raw_egi'\"'\"', '\"'\"'read_raw_kit'\"'\"', '\"'\"'read_raw_ctf'\"'\"'\n]\nfor reader in readers:\n    if hasattr(mne.io, reader):\n        print(f'\"'\"'{reader}: available'\"'\"')\n    else:\n        print(f'\"'\"'{reader}: not found'\"'\"')\n\\\"\"'"
     expected_output_contains: "read_raw_fif: available"
 
   - name: Save and load epochs
     description: Test saving and loading epochs to FIF
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      import os
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 10, 5, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      fname = 'test_output/test_epochs-epo.fif'
-      epochs.save(fname, overwrite=True)
-      epochs_loaded = mne.read_epochs(fname, preload=True)
-      print('Saved and loaded epochs:', epochs_loaded)
-      os.remove(fname)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nimport os\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 10, 5, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nfname = '\"'\"'test_output/test_epochs-epo.fif'\"'\"'\nepochs.save(fname, overwrite=True)\nepochs_loaded = mne.read_epochs(fname, preload=True)\nprint('\"'\"'Saved and loaded epochs:'\"'\"', epochs_loaded)\nos.remove(fname)\n\\\"\"'"
     expected_output_contains: "Saved and loaded epochs"
 
   - name: Save and load evoked
     description: Test saving and loading evoked to FIF
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      import os
-      np.random.seed(42)
-      n_channels, n_times = 10, 500
-      data = np.random.randn(n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      evoked = mne.EvokedArray(data, info, tmin=-0.2, nave=30, comment='test')
-      fname = 'test_output/test_evoked-ave.fif'
-      mne.write_evokeds(fname, evoked, overwrite=True)
-      evoked_loaded = mne.read_evokeds(fname)[0]
-      print('Saved and loaded evoked:', evoked_loaded)
-      os.remove(fname)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nimport os\nnp.random.seed(42)\nn_channels, n_times = 10, 500\ndata = np.random.randn(n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nevoked = mne.EvokedArray(data, info, tmin=-0.2, nave=30, comment='\"'\"'test'\"'\"')\nfname = '\"'\"'test_output/test_evoked-ave.fif'\"'\"'\nmne.write_evokeds(fname, evoked, overwrite=True)\nevoked_loaded = mne.read_evokeds(fname)[0]\nprint('\"'\"'Saved and loaded evoked:'\"'\"', evoked_loaded)\nos.remove(fname)\n\\\"\"'"
     expected_output_contains: "Saved and loaded evoked"
 
   # ==========================================================================
@@ -1092,51 +469,17 @@ tests:
   # ==========================================================================
   - name: Create SSP projectors
     description: Test creating signal-space projectors
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      n_epochs, n_channels, n_times = 50, 10, 500
-      data = np.random.randn(n_epochs, n_channels, n_times) * 1e-6
-      info = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='eeg')
-      epochs = mne.EpochsArray(data, info, tmin=-0.2)
-      projs = mne.compute_proj_epochs(epochs, n_eeg=2)
-      print('Created', len(projs), 'SSP projectors')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nn_epochs, n_channels, n_times = 50, 10, 500\ndata = np.random.randn(n_epochs, n_channels, n_times) * 1e-6\ninfo = mne.create_info(ch_names=n_channels, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nepochs = mne.EpochsArray(data, info, tmin=-0.2)\nprojs = mne.compute_proj_epochs(epochs, n_eeg=2)\nprint('\"'\"'Created'\"'\"', len(projs), '\"'\"'SSP projectors'\"'\"')\n\\\"\"'"
     expected_output_contains: "Created 2 SSP projectors"
 
   - name: Set EEG reference
     description: Test setting EEG reference (average)
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 5000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_reref = raw.copy().set_eeg_reference('average', projection=True)
-      print('EEG reference set to average')
-      print('Projectors:', len(raw_reref.info['projs']))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 5000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_reref = raw.copy().set_eeg_reference('\"'\"'average'\"'\"', projection=True)\nprint('\"'\"'EEG reference set to average'\"'\"')\nprint('\"'\"'Projectors:'\"'\"', len(raw_reref.info['\"'\"'projs'\"'\"']))\n\\\"\"'"
     expected_output_contains: "EEG reference set to average"
 
   - name: Add reference channel
     description: Test adding reference channel back
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      ch_names = ['Fp1', 'Fp2', 'F3', 'F4', 'C3', 'C4']
-      data = np.random.randn(6, 5000) * 1e-6
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      raw_with_ref = mne.add_reference_channels(raw, ref_channels='Cz')
-      print('Channels before:', len(ch_names))
-      print('Channels after adding ref:', len(raw_with_ref.ch_names))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nch_names = ['\"'\"'Fp1'\"'\"', '\"'\"'Fp2'\"'\"', '\"'\"'F3'\"'\"', '\"'\"'F4'\"'\"', '\"'\"'C3'\"'\"', '\"'\"'C4'\"'\"']\ndata = np.random.randn(6, 5000) * 1e-6\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nraw_with_ref = mne.add_reference_channels(raw, ref_channels='\"'\"'Cz'\"'\"')\nprint('\"'\"'Channels before:'\"'\"', len(ch_names))\nprint('\"'\"'Channels after adding ref:'\"'\"', len(raw_with_ref.ch_names))\n\\\"\"'"
     expected_output_contains: "Channels after adding ref: 7"
 
   # ==========================================================================
@@ -1144,32 +487,12 @@ tests:
   # ==========================================================================
   - name: Create annotations
     description: Test creating annotations for bad segments
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      annot = mne.Annotations(onset=[0.5, 2.0, 5.0],
-                              duration=[0.2, 0.5, 1.0],
-                              description=['bad_artifact', 'bad_blink', 'bad_movement'])
-      print('Annotations created:', annot)
-      print('Number of annotations:', len(annot))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nannot = mne.Annotations(onset=[0.5, 2.0, 5.0],\n                        duration=[0.2, 0.5, 1.0],\n                        description=['\"'\"'bad_artifact'\"'\"', '\"'\"'bad_blink'\"'\"', '\"'\"'bad_movement'\"'\"'])\nprint('\"'\"'Annotations created:'\"'\"', annot)\nprint('\"'\"'Number of annotations:'\"'\"', len(annot))\n\\\"\"'"
     expected_output_contains: "Number of annotations: 3"
 
   - name: Set annotations on raw
     description: Test setting annotations on raw data
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      data = np.random.randn(10, 10000) * 1e-6
-      info = mne.create_info(ch_names=10, sfreq=1000, ch_types='eeg')
-      raw = mne.io.RawArray(data, info)
-      annot = mne.Annotations(onset=[1.0, 3.0], duration=[0.5, 0.5], description='BAD_artifact')
-      raw.set_annotations(annot)
-      print('Annotations set on raw:', len(raw.annotations))
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\ndata = np.random.randn(10, 10000) * 1e-6\ninfo = mne.create_info(ch_names=10, sfreq=1000, ch_types='\"'\"'eeg'\"'\"')\nraw = mne.io.RawArray(data, info)\nannot = mne.Annotations(onset=[1.0, 3.0], duration=[0.5, 0.5], description='\"'\"'BAD_artifact'\"'\"')\nraw.set_annotations(annot)\nprint('\"'\"'Annotations set on raw:'\"'\"', len(raw.annotations))\n\\\"\"'"
     expected_output_contains: "Annotations set on raw: 2"
 
   # ==========================================================================
@@ -1177,35 +500,12 @@ tests:
   # ==========================================================================
   - name: Pick types
     description: Test picking channels by type
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      import mne
-      np.random.seed(42)
-      ch_names = ['MEG001', 'MEG002', 'EEG001', 'EEG002', 'EOG001', 'ECG001']
-      ch_types = ['mag', 'grad', 'eeg', 'eeg', 'eog', 'ecg']
-      data = np.random.randn(6, 5000) * 1e-6
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types=ch_types)
-      raw = mne.io.RawArray(data, info)
-      picks_eeg = mne.pick_types(raw.info, meg=False, eeg=True)
-      picks_meg = mne.pick_types(raw.info, meg=True, eeg=False)
-      print('EEG picks:', picks_eeg)
-      print('MEG picks:', picks_meg)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nimport mne\nnp.random.seed(42)\nch_names = ['\"'\"'MEG001'\"'\"', '\"'\"'MEG002'\"'\"', '\"'\"'EEG001'\"'\"', '\"'\"'EEG002'\"'\"', '\"'\"'EOG001'\"'\"', '\"'\"'ECG001'\"'\"']\nch_types = ['\"'\"'mag'\"'\"', '\"'\"'grad'\"'\"', '\"'\"'eeg'\"'\"', '\"'\"'eeg'\"'\"', '\"'\"'eog'\"'\"', '\"'\"'ecg'\"'\"']\ndata = np.random.randn(6, 5000) * 1e-6\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types=ch_types)\nraw = mne.io.RawArray(data, info)\npicks_eeg = mne.pick_types(raw.info, meg=False, eeg=True)\npicks_meg = mne.pick_types(raw.info, meg=True, eeg=False)\nprint('\"'\"'EEG picks:'\"'\"', picks_eeg)\nprint('\"'\"'MEG picks:'\"'\"', picks_meg)\n\\\"\"'"
     expected_output_contains: "EEG picks:"
 
   - name: Channel type info
     description: Test getting channel type information
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import mne
-      ch_names = ['MEG001', 'MEG002', 'EEG001', 'EEG002', 'STIM001']
-      ch_types = ['mag', 'grad', 'eeg', 'eeg', 'stim']
-      info = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types=ch_types)
-      for name in ch_names:
-          ch_type = mne.channel_type(info, info['ch_names'].index(name))
-          print(f'{name}: {ch_type}')
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport mne\nch_names = ['\"'\"'MEG001'\"'\"', '\"'\"'MEG002'\"'\"', '\"'\"'EEG001'\"'\"', '\"'\"'EEG002'\"'\"', '\"'\"'STIM001'\"'\"']\nch_types = ['\"'\"'mag'\"'\"', '\"'\"'grad'\"'\"', '\"'\"'eeg'\"'\"', '\"'\"'eeg'\"'\"', '\"'\"'stim'\"'\"']\ninfo = mne.create_info(ch_names=ch_names, sfreq=1000, ch_types=ch_types)\nfor name in ch_names:\n    ch_type = mne.channel_type(info, info['\"'\"'ch_names'\"'\"'].index(name))\n    print(f'\"'\"'{name}: {ch_type}'\"'\"')\n\\\"\"'"
     expected_output_contains: "MEG001: mag"
 
   # ==========================================================================
@@ -1213,20 +513,7 @@ tests:
   # ==========================================================================
   - name: Combine adjacency
     description: Test creating adjacency matrix for clustering
-    command: |
-      bash -c "source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \"
-      import numpy as np
-      from mne.stats import combine_adjacency
-      from scipy import sparse
-      n_times = 50
-      n_channels = 10
-      temporal_adj = sparse.eye(n_times, format='csr')
-      temporal_adj.setdiag(1, k=1)
-      temporal_adj.setdiag(1, k=-1)
-      spatial_adj = sparse.eye(n_channels, format='csr')
-      adjacency = combine_adjacency(temporal_adj, spatial_adj)
-      print('Combined adjacency shape:', adjacency.shape)
-      \""
+    command: "bash -lc 'bash -c \"source /opt/miniconda-4.7.12/etc/profile.d/conda.sh && conda activate mne-1.1.1 && python -c \\\"\nimport numpy as np\nfrom mne.stats import combine_adjacency\nfrom scipy import sparse\nn_times = 50\nn_channels = 10\ntemporal_adj = sparse.eye(n_times, format='\"'\"'csr'\"'\"')\ntemporal_adj.setdiag(1, k=1)\ntemporal_adj.setdiag(1, k=-1)\nspatial_adj = sparse.eye(n_channels, format='\"'\"'csr'\"'\"')\nadjacency = combine_adjacency(temporal_adj, spatial_adj)\nprint('\"'\"'Combined adjacency shape:'\"'\"', adjacency.shape)\n\\\"\"'"
     expected_output_contains: "Combined adjacency shape:"
 
 cleanup:

--- a/recipes/mricrogl/fulltest.yaml
+++ b/recipes/mricrogl/fulltest.yaml
@@ -46,17 +46,17 @@ tests:
 
   - name: MRIcroGL binary exists
     description: Verify MRIcroGL executable is installed
-    command: ls -la /opt/MRIcroGL/MRIcroGL
+    command: "bash -lc 'ls -la /opt/MRIcroGL/MRIcroGL'"
     expected_output_contains: "MRIcroGL"
 
   - name: MRIcroGL QT binary exists
     description: Verify alternative QT5-based MRIcroGL is available
-    command: ls -la /opt/MRIcroGL/MRIcroGL_QT
+    command: "bash -lc 'ls -la /opt/MRIcroGL/MRIcroGL_QT'"
     expected_output_contains: "MRIcroGL_QT"
 
   - name: dcm2niix binary exists
     description: Verify dcm2niix is available in Resources
-    command: ls -la /opt/MRIcroGL/Resources/dcm2niix
+    command: "bash -lc 'ls -la /opt/MRIcroGL/Resources/dcm2niix'"
     expected_output_contains: "dcm2niix"
 
   - name: MRIcroGL in PATH
@@ -117,52 +117,52 @@ tests:
   # ==========================================================================
   - name: Resources directory exists
     description: Verify MRIcroGL Resources directory is present
-    command: ls -la /opt/MRIcroGL/Resources/ | wc -l
+    command: "bash -lc 'ls -la /opt/MRIcroGL/Resources/ | wc -l'"
     expected_exit_code: 0
 
   - name: Script directory exists
     description: Verify scripting examples are available
-    command: ls /opt/MRIcroGL/Resources/script/ | wc -l
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/ | wc -l'"
     expected_exit_code: 0
 
   - name: Standard images available
     description: Verify standard reference images are included
-    command: ls /opt/MRIcroGL/Resources/standard/
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/'"
     expected_output_contains: "mni152.nii.gz"
 
   - name: SPM152 template available
     description: Verify SPM152 template is included
-    command: ls /opt/MRIcroGL/Resources/standard/spm152.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/spm152.nii.gz'"
     expected_output_contains: "spm152.nii.gz"
 
   - name: Chris T1 sample image available
     description: Verify sample T1 image is included
-    command: ls /opt/MRIcroGL/Resources/standard/chris_t1.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/chris_t1.nii.gz'"
     expected_output_contains: "chris_t1.nii.gz"
 
   - name: Chris T2 sample image available
     description: Verify sample T2 image is included
-    command: ls /opt/MRIcroGL/Resources/standard/chris_t2.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/chris_t2.nii.gz'"
     expected_output_contains: "chris_t2.nii.gz"
 
   - name: CT abdomen sample available
     description: Verify CT sample images are included
-    command: ls /opt/MRIcroGL/Resources/standard/CT_Abdo.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/CT_Abdo.nii.gz'"
     expected_output_contains: "CT_Abdo.nii.gz"
 
   - name: fMRI sample image available
     description: Verify fMRI statistical map sample is included
-    command: ls /opt/MRIcroGL/Resources/standard/spmMotor.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/spmMotor.nii.gz'"
     expected_output_contains: "spmMotor.nii.gz"
 
   - name: MRA sample available
     description: Verify MRA sample image is included
-    command: ls /opt/MRIcroGL/Resources/standard/chris_MRA.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/chris_MRA.nii.gz'"
     expected_output_contains: "chris_MRA.nii.gz"
 
   - name: Visible human sample available
     description: Verify visible human dataset is included
-    command: ls /opt/MRIcroGL/Resources/standard/visiblehuman.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/standard/visiblehuman.nii.gz'"
     expected_output_contains: "visiblehuman.nii.gz"
 
   # ==========================================================================
@@ -170,22 +170,22 @@ tests:
   # ==========================================================================
   - name: Atlas directory exists
     description: Verify atlas resources are available
-    command: ls /opt/MRIcroGL/Resources/atlas/
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/atlas/'"
     expected_exit_code: 0
 
   - name: AAL atlas available
     description: Verify AAL atlas is included
-    command: ls /opt/MRIcroGL/Resources/atlas/aal.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/atlas/aal.nii.gz'"
     expected_output_contains: "aal.nii.gz"
 
   - name: AICHA atlas available
     description: Verify AICHA atlas is included
-    command: ls /opt/MRIcroGL/Resources/atlas/AICHA.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/atlas/AICHA.nii.gz'"
     expected_output_contains: "AICHA.nii.gz"
 
   - name: NatBrainLab atlas available
     description: Verify natbrainlab atlas is included
-    command: ls /opt/MRIcroGL/Resources/atlas/natbrainlab.nii.gz
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/atlas/natbrainlab.nii.gz'"
     expected_output_contains: "natbrainlab.nii.gz"
 
   # ==========================================================================
@@ -193,47 +193,47 @@ tests:
   # ==========================================================================
   - name: LUT directory exists
     description: Verify color lookup tables are available
-    command: ls /opt/MRIcroGL/Resources/lut/ | wc -l
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/ | wc -l'"
     expected_exit_code: 0
 
   - name: Hot colormap available
     description: Verify hot colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/4hot.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/4hot.clut'"
     expected_output_contains: "4hot.clut"
 
   - name: Viridis colormap available
     description: Verify viridis colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/Viridis.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/Viridis.clut'"
     expected_output_contains: "Viridis.clut"
 
   - name: Inferno colormap available
     description: Verify inferno colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/Inferno.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/Inferno.clut'"
     expected_output_contains: "Inferno.clut"
 
   - name: Plasma colormap available
     description: Verify plasma colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/Plasma.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/Plasma.clut'"
     expected_output_contains: "Plasma.clut"
 
   - name: CT Bones colormap available
     description: Verify CT bone colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/CT_Bones.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/CT_Bones.clut'"
     expected_output_contains: "CT_Bones.clut"
 
   - name: CT Soft Tissue colormap available
     description: Verify CT soft tissue colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/CT_Soft_Tissue.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/CT_Soft_Tissue.clut'"
     expected_output_contains: "CT_Soft_Tissue.clut"
 
   - name: Jet colormap available
     description: Verify jet colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/jet.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/jet.clut'"
     expected_output_contains: "jet.clut"
 
   - name: Blue to red colormap available
     description: Verify diverging colormap is included
-    command: ls /opt/MRIcroGL/Resources/lut/blue2red.clut
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/lut/blue2red.clut'"
     expected_output_contains: "blue2red.clut"
 
   # ==========================================================================
@@ -241,7 +241,7 @@ tests:
   # ==========================================================================
   - name: Shader directory exists
     description: Verify shader resources are available
-    command: ls /opt/MRIcroGL/Resources/shader/ | wc -l
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/shader/ | wc -l'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -249,57 +249,57 @@ tests:
   # ==========================================================================
   - name: Basic script example exists
     description: Verify basic.py script example is present
-    command: cat /opt/MRIcroGL/Resources/script/basic.py | head -5
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/script/basic.py | head -5'"
     expected_output_contains: "import gl"
 
   - name: Mosaic script example exists
     description: Verify mosaic.py script example is present
-    command: cat /opt/MRIcroGL/Resources/script/mosaic.py
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/script/mosaic.py'"
     expected_output_contains: "mosaic"
 
   - name: CT abdomen script exists
     description: Verify CT visualization script is present
-    command: cat /opt/MRIcroGL/Resources/script/ct_abdomen.py | head -3
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/script/ct_abdomen.py | head -3'"
     expected_output_contains: "import gl"
 
   - name: CT head script exists
     description: Verify CT head visualization script is present
-    command: cat /opt/MRIcroGL/Resources/script/ct_head.py | head -3
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/script/ct_head.py | head -3'"
     expected_output_contains: "import gl"
 
   - name: Help script exists
     description: Verify help documentation script is present
-    command: cat /opt/MRIcroGL/Resources/script/help.py | head -3
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/script/help.py | head -3'"
     expected_output_contains: "import"
 
   - name: Glass effect script exists
     description: Verify glass rendering script is present
-    command: ls /opt/MRIcroGL/Resources/script/glass.py
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/glass.py'"
     expected_output_contains: "glass.py"
 
   - name: Cutout script exists
     description: Verify cutout visualization script is present
-    command: ls /opt/MRIcroGL/Resources/script/cutout.py
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/cutout.py'"
     expected_output_contains: "cutout.py"
 
   - name: Clip script exists
     description: Verify clipping plane script is present
-    command: ls /opt/MRIcroGL/Resources/script/clip.py
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/clip.py'"
     expected_output_contains: "clip.py"
 
   - name: Cluster script exists
     description: Verify cluster visualization script is present
-    command: ls /opt/MRIcroGL/Resources/script/cluster.py
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/cluster.py'"
     expected_output_contains: "cluster.py"
 
   - name: Invert script exists
     description: Verify invert script is present
-    command: ls /opt/MRIcroGL/Resources/script/invert.py
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/invert.py'"
     expected_output_contains: "invert.py"
 
   - name: MIP script exists
     description: Verify Maximum Intensity Projection script is present
-    command: ls /opt/MRIcroGL/Resources/script/mip.py
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/script/mip.py'"
     expected_output_contains: "mip.py"
 
   # ==========================================================================
@@ -626,27 +626,27 @@ tests:
   # ==========================================================================
   - name: MNI152 template readable
     description: Verify MNI152 template is a valid NIfTI file
-    command: test -f /opt/MRIcroGL/Resources/standard/mni152.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/mni152.nii.gz | head -1
+    command: bash -lc 'test -f /opt/MRIcroGL/Resources/standard/mni152.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/mni152.nii.gz | head -1'
     expected_output_contains: "1f 8b"
 
   - name: SPM152 template readable
     description: Verify SPM152 template is a valid NIfTI file
-    command: test -f /opt/MRIcroGL/Resources/standard/spm152.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/spm152.nii.gz | head -1
+    command: bash -lc 'test -f /opt/MRIcroGL/Resources/standard/spm152.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/spm152.nii.gz | head -1'
     expected_output_contains: "1f 8b"
 
   - name: AAL atlas readable
     description: Verify AAL atlas is a valid NIfTI file
-    command: test -f /opt/MRIcroGL/Resources/atlas/aal.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/atlas/aal.nii.gz | head -1
+    command: bash -lc 'test -f /opt/MRIcroGL/Resources/atlas/aal.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/atlas/aal.nii.gz | head -1'
     expected_output_contains: "1f 8b"
 
   - name: CT Abdo readable
     description: Verify CT abdomen sample is a valid NIfTI file
-    command: test -f /opt/MRIcroGL/Resources/standard/CT_Abdo.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/CT_Abdo.nii.gz | head -1
+    command: bash -lc 'test -f /opt/MRIcroGL/Resources/standard/CT_Abdo.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/CT_Abdo.nii.gz | head -1'
     expected_output_contains: "1f 8b"
 
   - name: Visible human readable
     description: Verify visible human sample is a valid NIfTI file
-    command: test -f /opt/MRIcroGL/Resources/standard/visiblehuman.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/visiblehuman.nii.gz | head -1
+    command: bash -lc 'test -f /opt/MRIcroGL/Resources/standard/visiblehuman.nii.gz && od -N4 -An -tx1 /opt/MRIcroGL/Resources/standard/visiblehuman.nii.gz | head -1'
     expected_output_contains: "1f 8b"
 
   # ==========================================================================
@@ -654,17 +654,17 @@ tests:
   # ==========================================================================
   - name: Installation instructions exist
     description: Verify Linux installation guide is present
-    command: cat /opt/MRIcroGL/MRIcroGL_Linux_Installation.txt | head -5
+    command: "bash -lc 'cat /opt/MRIcroGL/MRIcroGL_Linux_Installation.txt | head -5'"
     expected_output_contains: "MRIcroGL"
 
   - name: GTK2 instructions documented
     description: Verify GTK2 version documentation exists
-    command: cat /opt/MRIcroGL/MRIcroGL_Linux_Installation.txt
+    command: "bash -lc 'cat /opt/MRIcroGL/MRIcroGL_Linux_Installation.txt'"
     expected_output_contains: "GTK2"
 
   - name: QT5 instructions documented
     description: Verify QT5 version documentation exists
-    command: cat /opt/MRIcroGL/MRIcroGL_Linux_Installation.txt
+    command: "bash -lc 'cat /opt/MRIcroGL/MRIcroGL_Linux_Installation.txt'"
     expected_output_contains: "QT5"
 
   # ==========================================================================
@@ -672,17 +672,17 @@ tests:
   # ==========================================================================
   - name: Standard images README exists
     description: Verify standard images documentation is present
-    command: cat /opt/MRIcroGL/Resources/standard/README.md | head -10
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/standard/README.md | head -10'"
     expected_output_contains: "Licenses"
 
   - name: BSD license documented
     description: Verify BSD license is documented for source code
-    command: cat /opt/MRIcroGL/Resources/standard/README.md
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/standard/README.md'"
     expected_output_contains: "BSD license"
 
   - name: MNI template license documented
     description: Verify MNI template license information is present
-    command: cat /opt/MRIcroGL/Resources/standard/README.md
+    command: "bash -lc 'cat /opt/MRIcroGL/Resources/standard/README.md'"
     expected_output_contains: "ICBM 152"
 
   # ==========================================================================
@@ -690,27 +690,27 @@ tests:
   # ==========================================================================
   - name: Roboto font exists
     description: Verify Roboto font resources are present
-    command: ls /opt/MRIcroGL/Resources/Roboto.json
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/Roboto.json'"
     expected_output_contains: "Roboto.json"
 
   - name: Roboto font texture exists
     description: Verify Roboto font texture is present
-    command: ls /opt/MRIcroGL/Resources/Roboto.png
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/Roboto.png'"
     expected_output_contains: "Roboto.png"
 
   - name: Desktop file exists
     description: Verify desktop integration file is present
-    command: ls /opt/MRIcroGL/Resources/mricrogl.desktop
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/mricrogl.desktop'"
     expected_output_contains: "mricrogl.desktop"
 
   - name: Icon file exists
     description: Verify application icon is present
-    command: ls /opt/MRIcroGL/Resources/mricrogl.png
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/mricrogl.png'"
     expected_output_contains: "mricrogl.png"
 
   - name: SVG icon exists
     description: Verify scalable icon is present
-    command: ls /opt/MRIcroGL/Resources/mricrogl.svg
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/mricrogl.svg'"
     expected_output_contains: "mricrogl.svg"
 
   # ==========================================================================
@@ -718,7 +718,7 @@ tests:
   # ==========================================================================
   - name: Matcap directory exists
     description: Verify matcap rendering resources are available
-    command: ls /opt/MRIcroGL/Resources/matcap/ | wc -l
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/matcap/ | wc -l'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -726,7 +726,7 @@ tests:
   # ==========================================================================
   - name: Python37 resources exist
     description: Verify Python 3.7 resources are included
-    command: ls /opt/MRIcroGL/Resources/python37/
+    command: "bash -lc 'ls /opt/MRIcroGL/Resources/python37/'"
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/mricron/fulltest.yaml
+++ b/recipes/mricron/fulltest.yaml
@@ -546,52 +546,52 @@ tests:
   # ==========================================================================
   - name: Verify AAL atlas exists
     description: Check AAL brain atlas template is present
-    command: ls -la /opt/mricron/Resources/templates/aal.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/aal.nii.gz'"
     expected_output_contains: "aal.nii.gz"
 
   - name: Verify Brodmann atlas exists
     description: Check Brodmann areas template is present
-    command: ls -la /opt/mricron/Resources/templates/brodmann.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/brodmann.nii.gz'"
     expected_output_contains: "brodmann.nii.gz"
 
   - name: Verify ch2 template exists
     description: Check Colin27 (ch2) MRI template is present
-    command: ls -la /opt/mricron/Resources/templates/ch2.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/ch2.nii.gz'"
     expected_output_contains: "ch2.nii.gz"
 
   - name: Verify ch2bet template exists
     description: Check Colin27 brain-extracted template is present
-    command: ls -la /opt/mricron/Resources/templates/ch2bet.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/ch2bet.nii.gz'"
     expected_output_contains: "ch2bet.nii.gz"
 
   - name: Verify ch2better template exists
     description: Check enhanced Colin27 template is present
-    command: ls -la /opt/mricron/Resources/templates/ch2better.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/ch2better.nii.gz'"
     expected_output_contains: "ch2better.nii.gz"
 
   - name: Verify Harvard-Oxford atlas exists
     description: Check Harvard-Oxford cortical atlas is present
-    command: ls -la /opt/mricron/Resources/templates/HarvardOxford-cort-maxprob-thr0-1mm.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/HarvardOxford-cort-maxprob-thr0-1mm.nii.gz'"
     expected_output_contains: "HarvardOxford"
 
   - name: Verify JHU white matter atlas exists
     description: Check JHU white matter labels are present
-    command: ls -la /opt/mricron/Resources/templates/JHU-WhiteMatter-labels-1mm.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/JHU-WhiteMatter-labels-1mm.nii.gz'"
     expected_output_contains: "JHU-WhiteMatter"
 
   - name: Verify INIA19 template exists
     description: Check INIA19 primate template is present
-    command: ls -la /opt/mricron/Resources/templates/inia19-t1-brain.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/inia19-t1-brain.nii.gz'"
     expected_output_contains: "inia19"
 
   - name: Verify AICHA atlas exists
     description: Check AICHA atlas is present
-    command: ls -la /opt/mricron/Resources/templates/AICHAmc.nii.gz
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/AICHAmc.nii.gz'"
     expected_output_contains: "AICHAmc"
 
   - name: List all templates
     description: Enumerate all available templates
-    command: ls /opt/mricron/Resources/templates/*.nii.gz | wc -l
+    command: bash -lc 'ls /opt/mricron/Resources/templates/*.nii.gz | wc -l'
     expected_output_contains: "1"
 
   # ==========================================================================
@@ -599,37 +599,37 @@ tests:
   # ==========================================================================
   - name: Verify hot LUT exists
     description: Check hot colormap lookup table
-    command: ls -la /opt/mricron/Resources/lut/1hot.lut
+    command: "bash -lc 'ls -la /opt/mricron/Resources/lut/1hot.lut'"
     expected_output_contains: "1hot.lut"
 
   - name: Verify winter LUT exists
     description: Check winter colormap lookup table
-    command: ls -la /opt/mricron/Resources/lut/2winter.lut
+    command: "bash -lc 'ls -la /opt/mricron/Resources/lut/2winter.lut'"
     expected_output_contains: "2winter.lut"
 
   - name: Verify warm LUT exists
     description: Check warm colormap lookup table
-    command: ls -la /opt/mricron/Resources/lut/3warm.lut
+    command: "bash -lc 'ls -la /opt/mricron/Resources/lut/3warm.lut'"
     expected_output_contains: "3warm.lut"
 
   - name: Verify cool LUT exists
     description: Check cool colormap lookup table
-    command: ls -la /opt/mricron/Resources/lut/4cool.lut
+    command: "bash -lc 'ls -la /opt/mricron/Resources/lut/4cool.lut'"
     expected_output_contains: "4cool.lut"
 
   - name: Verify bone LUT exists
     description: Check bone colormap lookup table
-    command: ls -la /opt/mricron/Resources/lut/bone.lut
+    command: "bash -lc 'ls -la /opt/mricron/Resources/lut/bone.lut'"
     expected_output_contains: "bone.lut"
 
   - name: Verify NIH colormaps exist
     description: Check NIH-style colormaps are present
-    command: ls /opt/mricron/Resources/lut/NIH*.lut | wc -l
+    command: bash -lc 'ls /opt/mricron/Resources/lut/NIH*.lut | wc -l'
     expected_output_contains: "3"
 
   - name: List all LUTs
     description: Enumerate all available lookup tables
-    command: ls /opt/mricron/Resources/lut/*.lut | wc -l
+    command: bash -lc 'ls /opt/mricron/Resources/lut/*.lut | wc -l'
     expected_output_contains: "3"
 
   # ==========================================================================
@@ -637,27 +637,27 @@ tests:
   # ==========================================================================
   - name: Verify AAL labels exist
     description: Check AAL region labels text file
-    command: ls -la /opt/mricron/Resources/templates/aal.nii.txt
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/aal.nii.txt'"
     expected_output_contains: "aal.nii.txt"
 
   - name: Verify JHU labels exist
     description: Check JHU white matter labels text file
-    command: ls -la /opt/mricron/Resources/templates/JHU-WhiteMatter-labels-1mm.nii.txt
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/JHU-WhiteMatter-labels-1mm.nii.txt'"
     expected_output_contains: "JHU-WhiteMatter"
 
   - name: Verify AICHA labels exist
     description: Check AICHA region labels text file
-    command: ls -la /opt/mricron/Resources/templates/AICHAmc.nii.txt
+    command: "bash -lc 'ls -la /opt/mricron/Resources/templates/AICHAmc.nii.txt'"
     expected_output_contains: "AICHAmc.nii.txt"
 
   - name: AAL labels content check
     description: Verify AAL labels file contains region names
-    command: head -20 /opt/mricron/Resources/templates/aal.nii.txt
+    command: "bash -lc 'head -20 /opt/mricron/Resources/templates/aal.nii.txt'"
     expected_output_contains: "Frontal"
 
   - name: JHU labels content check
     description: Verify JHU labels file contains tract names
-    command: head -20 /opt/mricron/Resources/templates/JHU-WhiteMatter-labels-1mm.nii.txt
+    command: "bash -lc 'head -20 /opt/mricron/Resources/templates/JHU-WhiteMatter-labels-1mm.nii.txt'"
     expected_output_contains: "tract"
 
   # ==========================================================================
@@ -665,22 +665,22 @@ tests:
   # ==========================================================================
   - name: MRIcron binary exists
     description: Verify MRIcron GUI binary is present
-    command: ls -la /opt/mricron/MRIcron
+    command: "bash -lc 'ls -la /opt/mricron/MRIcron'"
     expected_output_contains: "MRIcron"
 
   - name: MRIcron executable permissions
     description: Verify MRIcron has execute permissions
-    command: test -x /opt/mricron/MRIcron && echo "executable"
+    command: bash -lc 'test -x /opt/mricron/MRIcron && echo "executable"'
     expected_output_contains: "executable"
 
   - name: dcm2niix executable permissions
     description: Verify dcm2niix has execute permissions
-    command: test -x /opt/mricron/dcm2niix && echo "executable"
+    command: bash -lc 'test -x /opt/mricron/dcm2niix && echo "executable"'
     expected_output_contains: "executable"
 
   - name: MRIcron icon exists
     description: Check MRIcron SVG icon is present
-    command: ls -la /opt/mricron/Resources/mricron.svg
+    command: "bash -lc 'ls -la /opt/mricron/Resources/mricron.svg'"
     expected_output_contains: "mricron.svg"
 
   # ==========================================================================
@@ -712,7 +712,7 @@ tests:
   # ==========================================================================
   - name: Render resources exist
     description: Check render resources directory exists
-    command: test -d /opt/mricron/Resources/render/ && echo "render directory exists"
+    command: bash -lc 'test -d /opt/mricron/Resources/render/ && echo "render directory exists"'
     expected_output_contains: "render directory exists"
 
   # ==========================================================================

--- a/recipes/mritools/fulltest.yaml
+++ b/recipes/mritools/fulltest.yaml
@@ -75,37 +75,37 @@ tests:
   # ==========================================================================
   - name: ROMEO version check
     description: Verify ROMEO binary runs and reports version
-    command: romeo --version
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo --version'\"'\"''"
     expected_output_contains: "3"
 
   - name: ROMEO help
     description: Display ROMEO help message
-    command: romeo --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo --help 2>&1'\"'\"''"
     expected_output_contains: "phase"
 
   - name: CLEARSWI version check
     description: Verify CLEARSWI binary runs
-    command: clearswi --version 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi --version 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: CLEARSWI help
     description: Display CLEARSWI help message
-    command: clearswi --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi --help 2>&1'\"'\"''"
     expected_output_contains: "magnitude"
 
   - name: MCPC3DS version check
     description: Verify MCPC3DS binary runs
-    command: mcpc3ds --version 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --version 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: MCPC3DS help
     description: Display MCPC3DS help message
-    command: mcpc3ds --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --help 2>&1'\"'\"''"
     expected_output_contains: "phase"
 
   - name: Julia version check
     description: Verify Julia runtime is available
-    command: julia --version
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'julia --version'\"'\"''"
     expected_output_contains: "julia version"
 
   # ==========================================================================
@@ -115,19 +115,19 @@ tests:
   # ==========================================================================
   - name: Create synthetic phase image from T1w
     description: Verify synthetic wrapped phase was created in setup
-    command: ls -la test_output/synthetic/phase_3d.nii
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'ls -la test_output/synthetic/phase_3d.nii'\"'\"''"
     validate:
       - output_exists: ${output_dir}/synthetic/phase_3d.nii.gz
 
   - name: Create synthetic magnitude for testing
     description: Verify synthetic magnitude was created in setup (uncompressed for mmap)
-    command: ls -la test_output/synthetic/mag_3d.nii
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'ls -la test_output/synthetic/mag_3d.nii'\"'\"''"
     validate:
       - output_exists: ${output_dir}/synthetic/mag_3d.nii
 
   - name: Create 4D synthetic phase from BOLD
     description: Verify synthetic 4D wrapped phase was created in setup
-    command: ls -la test_output/synthetic/phase_4d_mean.nii
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'ls -la test_output/synthetic/phase_4d_mean.nii'\"'\"''"
     validate:
       - output_exists: ${output_dir}/synthetic/phase_4d_mean.nii.gz
 
@@ -136,177 +136,98 @@ tests:
   # ==========================================================================
   - name: ROMEO single-echo unwrapping (nomask)
     description: Test ROMEO unwrapping on synthetic 3D phase without mask
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -o test_output/romeo/unwrapped_nomask.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -o test_output/romeo/unwrapped_nomask.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_nomask.nii.gz
 
   - name: ROMEO single-echo with robustmask
     description: Test ROMEO unwrapping with automatic robust masking
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k robustmask \
-            -o test_output/romeo/unwrapped_robustmask.nii \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k robustmask \\\n      -o test_output/romeo/unwrapped_robustmask.nii \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_robustmask.nii
 
   - name: ROMEO with quality mask threshold
     description: Test ROMEO with quality mask at specific threshold
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k qualitymask 0.5 \
-            -o test_output/romeo/unwrapped_qualitymask.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k qualitymask 0.5 \\\n      -o test_output/romeo/unwrapped_qualitymask.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_qualitymask.nii.gz
 
   - name: ROMEO with mask unwrapped option
     description: Test ROMEO applying mask on the unwrapped result
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k robustmask \
-            -u \
-            -o test_output/romeo/unwrapped_masked_result.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k robustmask \\\n      -u \\\n      -o test_output/romeo/unwrapped_masked_result.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_masked_result.nii.gz
 
   - name: ROMEO write quality map
     description: Test ROMEO outputting quality map
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -q \
-            -o test_output/romeo/unwrapped_quality/ \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -q \\\n      -o test_output/romeo/unwrapped_quality/ \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_quality/
 
   - name: ROMEO write all quality maps
     description: Test ROMEO outputting all individual quality maps
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -Q \
-            -o test_output/romeo/unwrapped_quality_all/ \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -Q \\\n      -o test_output/romeo/unwrapped_quality_all/ \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_quality_all/
 
   - name: ROMEO correct global phase offset
     description: Test ROMEO with global phase correction
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k robustmask \
-            -g \
-            -o test_output/romeo/unwrapped_global_corrected.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k robustmask \\\n      -g \\\n      -o test_output/romeo/unwrapped_global_corrected.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_global_corrected.nii.gz
 
   - name: ROMEO with phase threshold
     description: Test ROMEO with maximum wrap threshold
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            --threshold 10 \
-            -o test_output/romeo/unwrapped_threshold.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      --threshold 10 \\\n      -o test_output/romeo/unwrapped_threshold.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_threshold.nii.gz
 
   - name: ROMEO with romeo2 weights
     description: Test ROMEO using romeo2 weight algorithm
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -w romeo2 \
-            -o test_output/romeo/unwrapped_romeo2.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -w romeo2 \\\n      -o test_output/romeo/unwrapped_romeo2.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_romeo2.nii.gz
 
   - name: ROMEO with romeo3 weights
     description: Test ROMEO using romeo3 weight algorithm
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -w romeo3 \
-            -o test_output/romeo/unwrapped_romeo3.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -w romeo3 \\\n      -o test_output/romeo/unwrapped_romeo3.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_romeo3.nii.gz
 
   - name: ROMEO with bestpath weights
     description: Test ROMEO using bestpath weight algorithm
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -w bestpath \
-            -o test_output/romeo/unwrapped_bestpath.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -w bestpath \\\n      -o test_output/romeo/unwrapped_bestpath.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_bestpath.nii.gz
 
   - name: ROMEO with custom weight flags
     description: Test ROMEO using custom weight bit flags
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -w "1010" \
-            -o test_output/romeo/unwrapped_custom_weights.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -w \"1010\" \\\n      -o test_output/romeo/unwrapped_custom_weights.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_custom_weights.nii.gz
 
   - name: ROMEO no memory mapping
     description: Test ROMEO with memory mapping disabled
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k nomask \
-            -N \
-            -o test_output/romeo/unwrapped_nommap.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k nomask \\\n      -N \\\n      -o test_output/romeo/unwrapped_nommap.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_nommap.nii.gz
 
   - name: ROMEO phase only (no magnitude)
     description: Test ROMEO unwrapping without magnitude guidance
-    command: |
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -k nomask \
-            -o test_output/romeo/unwrapped_phase_only.nii.gz \
-            -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p test_output/synthetic/phase_3d.nii \\\n      -k nomask \\\n      -o test_output/romeo/unwrapped_phase_only.nii.gz \\\n      -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/romeo/unwrapped_phase_only.nii.gz
@@ -316,203 +237,119 @@ tests:
   # ==========================================================================
   - name: CLEARSWI basic processing
     description: Test CLEARSWI with default parameters
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               -o test_output/clearswi/clearswi_basic.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         -o test_output/clearswi/clearswi_basic.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_basic.nii.gz
 
   - name: CLEARSWI with laplacian unwrapping
     description: Test CLEARSWI using laplacian unwrapping algorithm
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --unwrapping-algorithm laplacian \
-               -o test_output/clearswi/clearswi_laplacian.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --unwrapping-algorithm laplacian \\\n         -o test_output/clearswi/clearswi_laplacian.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_laplacian.nii.gz
 
   - name: CLEARSWI with romeo unwrapping
     description: Test CLEARSWI using ROMEO unwrapping algorithm
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --unwrapping-algorithm romeo \
-               -o test_output/clearswi/clearswi_romeo.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --unwrapping-algorithm romeo \\\n         -o test_output/clearswi/clearswi_romeo.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_romeo.nii.gz
 
   - name: CLEARSWI with custom filter size
     description: Test CLEARSWI with modified high-pass filter size
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --filter-size "[8,8,0]" \
-               -o test_output/clearswi/clearswi_filter8.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --filter-size \"[8,8,0]\" \\\n         -o test_output/clearswi/clearswi_filter8.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_filter8.nii.gz
 
   - name: CLEARSWI with 3D filter
     description: Test CLEARSWI with 3D high-pass filter
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --filter-size "[4,4,2]" \
-               -o test_output/clearswi/clearswi_filter3d.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --filter-size \"[4,4,2]\" \\\n         -o test_output/clearswi/clearswi_filter3d.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_filter3d.nii.gz
 
   - name: CLEARSWI positive phase scaling
     description: Test CLEARSWI with positive phase scaling type
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --phase-scaling-type positive \
-               -o test_output/clearswi/clearswi_positive.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --phase-scaling-type positive \\\n         -o test_output/clearswi/clearswi_positive.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_positive.nii.gz
 
   - name: CLEARSWI negative phase scaling
     description: Test CLEARSWI with negative phase scaling type
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --phase-scaling-type negative \
-               -o test_output/clearswi/clearswi_negative.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --phase-scaling-type negative \\\n         -o test_output/clearswi/clearswi_negative.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_negative.nii.gz
 
   - name: CLEARSWI negativetanh phase scaling
     description: Test CLEARSWI with negativetanh phase scaling type
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --phase-scaling-type negativetanh \
-               -o test_output/clearswi/clearswi_negativetanh.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --phase-scaling-type negativetanh \\\n         -o test_output/clearswi/clearswi_negativetanh.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_negativetanh.nii.gz
 
   - name: CLEARSWI triangular phase scaling
     description: Test CLEARSWI with triangular phase scaling type
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --phase-scaling-type triangular \
-               -o test_output/clearswi/clearswi_triangular.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --phase-scaling-type triangular \\\n         -o test_output/clearswi/clearswi_triangular.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_triangular.nii.gz
 
   - name: CLEARSWI with phase scaling strength
     description: Test CLEARSWI with modified phase scaling strength
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --phase-scaling-strength 6 \
-               -o test_output/clearswi/clearswi_strength6.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --phase-scaling-strength 6 \\\n         -o test_output/clearswi/clearswi_strength6.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_strength6.nii.gz
 
   - name: CLEARSWI SNR magnitude combination
     description: Test CLEARSWI with SNR magnitude combination
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --mag-combine SNR \
-               -o test_output/clearswi/clearswi_snr.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --mag-combine SNR \\\n         -o test_output/clearswi/clearswi_snr.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_snr.nii.gz
 
   - name: CLEARSWI average magnitude combination
     description: Test CLEARSWI with average magnitude combination
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --mag-combine average \
-               -o test_output/clearswi/clearswi_average.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --mag-combine average \\\n         -o test_output/clearswi/clearswi_average.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_average.nii.gz
 
   - name: CLEARSWI sensitivity correction off
     description: Test CLEARSWI with sensitivity correction disabled
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --mag-sensitivity-correction off \
-               -o test_output/clearswi/clearswi_nosens.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --mag-sensitivity-correction off \\\n         -o test_output/clearswi/clearswi_nosens.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_nosens.nii.gz
 
   - name: CLEARSWI softplus scaling off
     description: Test CLEARSWI with softplus scaling disabled
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --mag-softplus-scaling off \
-               -o test_output/clearswi/clearswi_nosoftplus.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --mag-softplus-scaling off \\\n         -o test_output/clearswi/clearswi_nosoftplus.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_nosoftplus.nii.gz
 
   - name: CLEARSWI no memory mapping
     description: Test CLEARSWI with memory mapping disabled
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               -N \
-               -o test_output/clearswi/clearswi_nommap.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         -N \\\n         -o test_output/clearswi/clearswi_nommap.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_nommap.nii.gz
 
   - name: CLEARSWI no phase rescale
     description: Test CLEARSWI without automatic phase rescaling
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --no-phase-rescale \
-               -o test_output/clearswi/clearswi_norescale.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --no-phase-rescale \\\n         -o test_output/clearswi/clearswi_norescale.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_norescale.nii.gz
 
   - name: CLEARSWI write intermediate steps
     description: Test CLEARSWI saving intermediate processing steps
-    command: |
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --writesteps test_output/clearswi/steps/ \
-               -o test_output/clearswi/clearswi_steps.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --writesteps test_output/clearswi/steps/ \\\n         -o test_output/clearswi/clearswi_steps.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_steps.nii.gz
@@ -525,39 +362,39 @@ tests:
   # MCPC3DS accepts inputs and processes arguments correctly before the data check.
   - name: MCPC3DS argument parsing
     description: Test MCPC3DS accepts echo times and standard arguments
-    command: mcpc3ds -m test_output/synthetic/mag_3d.nii -p test_output/synthetic/phase_3d.nii -t 20 -o test_output/mcpc3ds/combined_basic -v 2>&1 || true
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds -m test_output/synthetic/mag_3d.nii -p test_output/synthetic/phase_3d.nii -t 20 -o test_output/mcpc3ds/combined_basic -v 2>&1 || true'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     ignore_exit_code: true
     expected_output_contains: ""
 
   - name: MCPC3DS smoothing argument
     description: Test MCPC3DS accepts smoothing sigma argument
-    command: mcpc3ds --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --help 2>&1'\"'\"''"
     expected_output_contains: "smooth"
 
   - name: MCPC3DS phase offsets argument
     description: Test MCPC3DS supports write-phase-offsets flag
-    command: mcpc3ds --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --help 2>&1'\"'\"''"
     expected_output_contains: "phase"
 
   - name: MCPC3DS no-mmap argument
     description: Test MCPC3DS supports no-mmap flag
-    command: mcpc3ds --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --help 2>&1'\"'\"''"
     expected_output_contains: "no-mmap"
 
   - name: MCPC3DS no-rescale argument
     description: Test MCPC3DS supports no-phase-rescale flag
-    command: mcpc3ds --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --help 2>&1'\"'\"''"
     expected_output_contains: "rescale"
 
   - name: MCPC3DS writesteps argument
     description: Test MCPC3DS supports writesteps flag
-    command: mcpc3ds --help 2>&1
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds --help 2>&1'\"'\"''"
     expected_output_contains: "writesteps"
 
   - name: MCPC3DS echo time validation
     description: Verify MCPC3DS requires echo times
-    command: mcpc3ds -m test_output/synthetic/mag_3d.nii -p test_output/synthetic/phase_3d.nii -o test_output/mcpc3ds/noecho 2>&1 || true
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'mcpc3ds -m test_output/synthetic/mag_3d.nii -p test_output/synthetic/phase_3d.nii -o test_output/mcpc3ds/noecho 2>&1 || true'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     ignore_exit_code: true
     expected_output_contains: "echo times"
@@ -567,12 +404,12 @@ tests:
   # ==========================================================================
   - name: ROMEO missing phase file error
     description: Test ROMEO error handling with non-existent file
-    command: romeo -p nonexistent_file.nii.gz -o test_output/romeo/error_test.nii.gz 2>&1 || true
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'romeo -p nonexistent_file.nii.gz -o test_output/romeo/error_test.nii.gz 2>&1 || true'\"'\"''"
     expected_output_contains: ""
 
   - name: CLEARSWI missing magnitude error
     description: Test CLEARSWI error handling without magnitude
-    command: clearswi -p test_output/synthetic/phase_3d.nii -o test_output/clearswi/error_test.nii.gz 2>&1 || true
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'clearswi -p test_output/synthetic/phase_3d.nii -o test_output/clearswi/error_test.nii.gz 2>&1 || true'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -580,37 +417,14 @@ tests:
   # ==========================================================================
   - name: ROMEO to CLEARSWI pipeline
     description: Use ROMEO unwrapped phase as input to CLEARSWI
-    command: |
-      # First unwrap with ROMEO, then process with CLEARSWI
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/romeo/unwrapped_robustmask.nii \
-               --no-phase-rescale \
-               -o test_output/clearswi/clearswi_from_romeo.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'# First unwrap with ROMEO, then process with CLEARSWI\nclearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/romeo/unwrapped_robustmask.nii \\\n         --no-phase-rescale \\\n         -o test_output/clearswi/clearswi_from_romeo.nii.gz \\\n         -v'\"'\"''"
     depends_on: ROMEO single-echo with robustmask
     validate:
       - output_exists: ${output_dir}/clearswi/clearswi_from_romeo.nii.gz
 
   - name: Complete SWI processing workflow
     description: Full pipeline from synthetic data to SWI output
-    command: |
-      # Run ROMEO phase unwrapping
-      romeo -p test_output/synthetic/phase_3d.nii \
-            -m test_output/synthetic/mag_3d.nii \
-            -k robustmask \
-            -q \
-            -o test_output/romeo/workflow_unwrapped/ \
-            -v && \
-      # Run CLEARSWI on the result
-      clearswi -m test_output/synthetic/mag_3d.nii \
-               -p test_output/synthetic/phase_3d.nii \
-               --unwrapping-algorithm romeo \
-               --phase-scaling-type tanh \
-               --phase-scaling-strength 4 \
-               --filter-size "[4,4,0]" \
-               --writesteps test_output/clearswi/workflow_steps/ \
-               -o test_output/clearswi/workflow_final.nii.gz \
-               -v
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'# Run ROMEO phase unwrapping\nromeo -p test_output/synthetic/phase_3d.nii \\\n      -m test_output/synthetic/mag_3d.nii \\\n      -k robustmask \\\n      -q \\\n      -o test_output/romeo/workflow_unwrapped/ \\\n      -v && \\\n# Run CLEARSWI on the result\nclearswi -m test_output/synthetic/mag_3d.nii \\\n         -p test_output/synthetic/phase_3d.nii \\\n         --unwrapping-algorithm romeo \\\n         --phase-scaling-type tanh \\\n         --phase-scaling-strength 4 \\\n         --filter-size \"[4,4,0]\" \\\n         --writesteps test_output/clearswi/workflow_steps/ \\\n         -o test_output/clearswi/workflow_final.nii.gz \\\n         -v'\"'\"''"
     depends_on: Create synthetic phase image from T1w
     validate:
       - output_exists: ${output_dir}/clearswi/workflow_final.nii.gz
@@ -621,12 +435,12 @@ tests:
   # ==========================================================================
   - name: Julia basic execution
     description: Verify Julia can execute simple commands
-    command: julia -e 'println("Julia works!")'
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'julia -e '\"'\"'\"'\"'\"'\"'\"'\"'println(\"Julia works!\")'\"'\"'\"'\"'\"'\"'\"'\"''\"'\"''"
     expected_output_contains: "Julia works!"
 
   - name: Julia package check
     description: Verify ROMEO Julia package is loadable
-    command: julia -e 'using MriResearchTools; println("MriResearchTools loaded")'
+    command: "bash -lc 'env JULIA_PROJECT=/opt/mritools-3.3.0/share/julia bash -lc '\"'\"'julia -e '\"'\"'\"'\"'\"'\"'\"'\"'using MriResearchTools; println(\"MriResearchTools loaded\")'\"'\"'\"'\"'\"'\"'\"'\"''\"'\"''"
     expected_output_contains: "loaded"
 
 cleanup:

--- a/recipes/mrsiproc/fulltest.yaml
+++ b/recipes/mrsiproc/fulltest.yaml
@@ -41,12 +41,12 @@ tests:
   # ==========================================================================
   - name: Container README exists
     description: Verify container README is present
-    command: cat /README.md | head -5
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'cat /README.md | head -5'\"'\"''"
     expected_output_contains: "mrsiproc"
 
   - name: Container labels accessible
     description: Verify container metadata labels
-    command: cat /.singularity.d/labels.json
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'cat /.singularity.d/labels.json'\"'\"''"
     expected_output_contains: "NeuroDesk/neurocontainers"
 
   # ==========================================================================
@@ -54,32 +54,32 @@ tests:
   # ==========================================================================
   - name: Python version check
     description: Verify Python 3.11 is installed
-    command: python3 --version
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 --version'\"'\"''"
     expected_output_contains: "Python 3.11"
 
   - name: NumPy available
     description: Verify NumPy is installed
-    command: python3 -c "import numpy; print(numpy.__version__)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import numpy; print(numpy.__version__)\"'\"'\"''"
     expected_exit_code: 0
 
   - name: SciPy available
     description: Verify SciPy is installed
-    command: python3 -c "import scipy; print(scipy.__version__)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import scipy; print(scipy.__version__)\"'\"'\"''"
     expected_exit_code: 0
 
   - name: PyTorch available
     description: Verify PyTorch is installed
-    command: python3 -c "import torch; print(torch.__version__)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import torch; print(torch.__version__)\"'\"'\"''"
     expected_exit_code: 0
 
   - name: SimpleITK available
     description: Verify SimpleITK is installed for medical image processing
-    command: python3 -c "import SimpleITK; print(SimpleITK.__version__)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import SimpleITK; print(SimpleITK.__version__)\"'\"'\"''"
     expected_exit_code: 0
 
   - name: scikit-image available
     description: Verify scikit-image is installed
-    command: python3 -c "import skimage; print(skimage.__version__)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import skimage; print(skimage.__version__)\"'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -87,12 +87,12 @@ tests:
   # ==========================================================================
   - name: Julia version check
     description: Verify Julia 1.9.3 is installed
-    command: julia --version
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'julia --version'\"'\"''"
     expected_output_contains: "julia version 1.9"
 
   - name: Julia can run basic script
     description: Verify Julia can execute basic commands
-    command: julia -e 'println("Julia works")'
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'julia -e '\"'\"'\"'\"'\"'\"'\"'\"'println(\"Julia works\")'\"'\"'\"'\"'\"'\"'\"'\"''\"'\"''"
     expected_output_contains: "Julia works"
 
   # ==========================================================================
@@ -100,47 +100,47 @@ tests:
   # ==========================================================================
   - name: MATLAB Runtime directory exists
     description: Verify MATLAB Runtime R2021b is installed
-    command: ls /opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64 | head -5
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64 | head -5'\"'\"''"
     expected_exit_code: 0
 
   - name: MRSI_Reconstruction compiled binary exists
     description: Verify main MRSI reconstruction tool is present
-    command: ls -la /opt/mrsi_pipeline_neurodesk/matlab_compiled/MRSI_Reconstruction
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/matlab_compiled/MRSI_Reconstruction'\"'\"''"
     expected_exit_code: 0
 
   - name: MRSI_Reconstruction responds without input
     description: Verify MRSI_Reconstruction compiled MATLAB tool loads
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/MRSI_Reconstruction 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/MRSI_Reconstruction 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   - name: extract_met_maps binary exists
     description: Verify metabolite map extraction tool is present
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/extract_met_maps 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/extract_met_maps 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   - name: extract_spectra binary exists
     description: Verify spectra extraction tool is present
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/extract_spectra 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/extract_spectra 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   - name: CreateSpectralNiftiMap binary exists
     description: Verify spectral NIfTI map creation tool is present
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/CreateSpectralNiftiMap 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/CreateSpectralNiftiMap 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   - name: GetPar_CreateTempl_MaskPart1 binary exists
     description: Verify parameter/template/mask tool is present
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/GetPar_CreateTempl_MaskPart1 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/GetPar_CreateTempl_MaskPart1 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   - name: julia_write_lcm_files binary exists
     description: Verify LCModel file writer tool is present
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/julia_write_lcm_files 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/julia_write_lcm_files 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   - name: segmentation_simple binary exists
     description: Verify simple segmentation tool is present
-    command: /opt/mrsi_pipeline_neurodesk/matlab_compiled/segmentation_simple 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/mrsi_pipeline_neurodesk/matlab_compiled/segmentation_simple 2>&1 || true'\"'\"''"
     expected_output_contains: "input arguments"
 
   # ==========================================================================
@@ -148,32 +148,32 @@ tests:
   # ==========================================================================
   - name: Part1_ProcessMRSI.sh exists
     description: Verify main MRSI processing script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/Part1_ProcessMRSI.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/Part1_ProcessMRSI.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: Part2_EvaluateMRSI.sh exists
     description: Verify MRSI evaluation script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part2/Part2_EvaluateMRSI.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part2/Part2_EvaluateMRSI.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: update_mrsi.sh exists
     description: Verify MRSI update script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/update_mrsi.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/update_mrsi.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: InstallProgramPaths.sh Part1 exists
     description: Verify program paths configuration for Part1
-    command: cat /opt/mrsi_pipeline_neurodesk/Part1/InstallProgramPaths.sh | head -10
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'cat /opt/mrsi_pipeline_neurodesk/Part1/InstallProgramPaths.sh | head -10'\"'\"''"
     expected_output_contains: "aliases and paths"
 
   - name: LCModel basis file exists
     description: Verify LCModel basis file is present
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/fid_1.300000ms.basis | head -1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/fid_1.300000ms.basis | head -1'\"'\"''"
     expected_exit_code: 0
 
   - name: Julia reconstruction script exists
     description: Verify Julia reconstruction script is present
-    command: cat /opt/mrsi_pipeline_neurodesk/Part1/julia_reco.jl | head -5
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'cat /opt/mrsi_pipeline_neurodesk/Part1/julia_reco.jl | head -5'\"'\"''"
     expected_output_contains: "using MAT"
 
   # ==========================================================================
@@ -181,27 +181,27 @@ tests:
   # ==========================================================================
   - name: LCModel binary exists
     description: Verify LCModel executable is present
-    command: ls -la /opt/lcmodel-6.3/.lcmodel/bin/lcmodel
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/lcmodel-6.3/.lcmodel/bin/lcmodel'\"'\"''"
     expected_exit_code: 0
 
   - name: LCModel responds
     description: Verify LCModel binary can be invoked (errors without input expected)
-    command: /opt/lcmodel-6.3/.lcmodel/bin/lcmodel 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/lcmodel-6.3/.lcmodel/bin/lcmodel 2>&1 || true'\"'\"''"
     expected_output_contains: "FATAL ERROR"
 
   - name: makebasis exists
     description: Verify LCModel makebasis tool is present
-    command: ls -la /opt/lcmodel-6.3/.lcmodel/bin/makebasis
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/lcmodel-6.3/.lcmodel/bin/makebasis'\"'\"''"
     expected_exit_code: 0
 
   - name: plotraw exists
     description: Verify LCModel plotraw tool is present
-    command: ls -la /opt/lcmodel-6.3/.lcmodel/bin/plotraw
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/lcmodel-6.3/.lcmodel/bin/plotraw'\"'\"''"
     expected_exit_code: 0
 
   - name: LCModel manual exists
     description: Verify LCModel documentation is present
-    command: ls -la /opt/lcmodel-6.3/manual.pdf
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/lcmodel-6.3/manual.pdf'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -209,18 +209,18 @@ tests:
   # ==========================================================================
   - name: dcm2niix version
     description: Verify dcm2niix is installed and check version
-    command: dcm2niix --version 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'dcm2niix --version 2>&1'\"'\"''"
     expected_output_contains: "v1.0"
     ignore_exit_code: true
 
   - name: dcm2niix help
     description: Verify dcm2niix help is accessible
-    command: dcm2niix -h 2>&1 | head -20
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'dcm2niix -h 2>&1 | head -20'\"'\"''"
     expected_output_contains: "Convert DICOM"
 
   - name: dcm2niix BIDS support
     description: Verify dcm2niix supports BIDS sidecars
-    command: dcm2niix -h 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'dcm2niix -h 2>&1'\"'\"''"
     expected_output_contains: "BIDS sidecar"
 
   # ==========================================================================
@@ -228,17 +228,17 @@ tests:
   # ==========================================================================
   - name: hd-bet help
     description: Verify HD-BET help is accessible
-    command: hd-bet --help 2>&1 | head -20
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'hd-bet --help 2>&1 | head -20'\"'\"''"
     expected_output_contains: "brain extraction"
 
   - name: hd-bet citation info
     description: Verify HD-BET shows citation information
-    command: hd-bet --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'hd-bet --help 2>&1'\"'\"''"
     expected_output_contains: "Isensee"
 
   - name: hd-bet mode options
     description: Verify HD-BET supports fast and accurate modes
-    command: hd-bet --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'hd-bet --help 2>&1'\"'\"''"
     expected_output_contains: "fast"
 
   # ==========================================================================
@@ -246,72 +246,72 @@ tests:
   # ==========================================================================
   - name: BET help
     description: Verify FSL BET (brain extraction) is available
-    command: bet 2>&1 | head -10
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'bet 2>&1 | head -10'\"'\"''"
     expected_output_contains: "bet <input> <output>"
 
   - name: BET run brain extraction
     description: Run BET on test data
-    command: bet ${t1w} test_output/t1w_brain.nii.gz -m
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'bet ${t1w} test_output/t1w_brain.nii.gz -m'\"'\"''"
     validate:
       - output_exists: ${output_dir}/t1w_brain.nii.gz
       - output_exists: ${output_dir}/t1w_brain_mask.nii.gz
 
   - name: FLIRT help
     description: Verify FSL FLIRT (linear registration) is available
-    command: flirt 2>&1 | head -10
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'flirt 2>&1 | head -10'\"'\"''"
     expected_output_contains: "FLIRT version"
 
   - name: FAST help
     description: Verify FSL FAST (tissue segmentation) is available
-    command: fast 2>&1 | head -10
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fast 2>&1 | head -10'\"'\"''"
     expected_output_contains: "tissue-type classes"
 
   - name: fslinfo help
     description: Verify fslinfo is available
-    command: fslinfo 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslinfo 2>&1'\"'\"''"
     expected_output_contains: "Usage"
     ignore_exit_code: true
 
   - name: fslinfo on test data
     description: Run fslinfo on test NIfTI
-    command: fslinfo ${t1w}
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslinfo ${t1w}'\"'\"''"
     expected_output_contains: "dim1"
 
   - name: fslhd help
     description: Verify fslhd (header display) is available
-    command: fslhd 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslhd 2>&1'\"'\"''"
     expected_output_contains: "Usage"
     ignore_exit_code: true
 
   - name: fslhd on test data
     description: Display NIfTI header
-    command: fslhd ${t1w} | head -20
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslhd ${t1w} | head -20'\"'\"''"
     expected_output_contains: "sizeof_hdr"
 
   - name: fslstats exists
     description: Verify fslstats is available
-    command: which fslstats
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslstats'\"'\"''"
     expected_output_contains: "fslstats"
 
   - name: fslmaths exists
     description: Verify fslmaths is available
-    command: which fslmaths
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslmaths'\"'\"''"
     expected_output_contains: "fslmaths"
 
   - name: fslmaths binarize
     description: Test fslmaths binarization
-    command: fslmaths ${t1w} -bin test_output/t1w_fsl_bin.nii.gz
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslmaths ${t1w} -bin test_output/t1w_fsl_bin.nii.gz'\"'\"''"
     validate:
       - output_exists: ${output_dir}/t1w_fsl_bin.nii.gz
 
   - name: fslsplit exists
     description: Verify fslsplit is available
-    command: which fslsplit
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslsplit'\"'\"''"
     expected_output_contains: "fslsplit"
 
   - name: fslmerge exists
     description: Verify fslmerge is available
-    command: which fslmerge
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslmerge'\"'\"''"
     expected_output_contains: "fslmerge"
 
   # ==========================================================================
@@ -319,56 +319,56 @@ tests:
   # ==========================================================================
   - name: mincinfo help
     description: Verify mincinfo is available
-    command: /opt/minc/1.9.15/bin/mincinfo 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mincinfo 2>&1'\"'\"''"
     expected_output_contains: "Usage"
     ignore_exit_code: true
 
   - name: mincconvert help
     description: Verify mincconvert is available
-    command: /opt/minc/1.9.15/bin/mincconvert 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mincconvert 2>&1'\"'\"''"
     expected_output_contains: "Usage"
     ignore_exit_code: true
 
   - name: mincmath help
     description: Verify mincmath is available
-    command: /opt/minc/1.9.15/bin/mincmath 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mincmath 2>&1'\"'\"''"
     expected_output_contains: "Usage"
     ignore_exit_code: true
 
   - name: mincresample help
     description: Verify mincresample is available
-    command: /opt/minc/1.9.15/bin/mincresample 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mincresample 2>&1'\"'\"''"
     expected_output_contains: "Usage"
     ignore_exit_code: true
 
   - name: mincstats exists
     description: Verify mincstats is available
-    command: ls /opt/minc/1.9.15/bin/mincstats
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/mincstats'\"'\"''"
     expected_exit_code: 0
 
   - name: mincaverage exists
     description: Verify mincaverage is available
-    command: ls /opt/minc/1.9.15/bin/mincaverage
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/mincaverage'\"'\"''"
     expected_exit_code: 0
 
   - name: mincblur exists
     description: Verify mincblur is available
-    command: ls /opt/minc/1.9.15/bin/mincblur
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/mincblur'\"'\"''"
     expected_exit_code: 0
 
   - name: mnc2nii help
     description: Verify mnc2nii converter is available
-    command: /opt/minc/1.9.15/bin/mnc2nii 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mnc2nii 2>&1 || true'\"'\"''"
     expected_output_contains: "Convert MINC files to NIfTI"
 
   - name: nii2mnc help
     description: Verify nii2mnc converter is available
-    command: /opt/minc/1.9.15/bin/nii2mnc 2>&1 || true
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/nii2mnc 2>&1 || true'\"'\"''"
     expected_output_contains: "Convert NIfTI-1 files to MINC"
 
   - name: minctracc exists
     description: Verify minctracc registration tool is available
-    command: ls /opt/minc/1.9.15/bin/minctracc
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/minctracc'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -376,47 +376,47 @@ tests:
   # ==========================================================================
   - name: antsRegistration help
     description: Verify ANTs registration is available
-    command: /opt/minc/1.9.15/bin/antsRegistration --help 2>&1 | head -10
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/antsRegistration --help 2>&1 | head -10'\"'\"''"
     expected_output_contains: "antsRegistration"
 
   - name: antsApplyTransforms exists
     description: Verify ANTs transform application is available
-    command: ls /opt/minc/1.9.15/bin/antsApplyTransforms
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/antsApplyTransforms'\"'\"''"
     expected_exit_code: 0
 
   - name: N4BiasFieldCorrection exists
     description: Verify N4 bias correction is available
-    command: ls /opt/minc/1.9.15/bin/N4BiasFieldCorrection
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/N4BiasFieldCorrection'\"'\"''"
     expected_exit_code: 0
 
   - name: antsMotionCorr exists
     description: Verify ANTs motion correction is available
-    command: ls /opt/minc/1.9.15/bin/antsMotionCorr
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/antsMotionCorr'\"'\"''"
     expected_exit_code: 0
 
   - name: Atropos exists
     description: Verify Atropos segmentation is available
-    command: ls /opt/minc/1.9.15/bin/Atropos
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/Atropos'\"'\"''"
     expected_exit_code: 0
 
   - name: ImageMath exists
     description: Verify ANTs ImageMath is available
-    command: ls /opt/minc/1.9.15/bin/ImageMath
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/ImageMath'\"'\"''"
     expected_exit_code: 0
 
   - name: antsRegistrationSyN.sh exists
     description: Verify ANTs SyN registration script is available
-    command: ls /opt/minc/1.9.15/bin/antsRegistrationSyN.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/antsRegistrationSyN.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: antsBrainExtraction.sh exists
     description: Verify ANTs brain extraction script is available
-    command: ls /opt/minc/1.9.15/bin/antsBrainExtraction.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/antsBrainExtraction.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: antsJointFusion exists
     description: Verify ANTs joint fusion is available
-    command: ls /opt/minc/1.9.15/bin/antsJointFusion
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/antsJointFusion'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -424,27 +424,27 @@ tests:
   # ==========================================================================
   - name: create_mask.sh exists
     description: Verify mask creation script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/create_mask.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/create_mask.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: create_mask_iterative.sh exists
     description: Verify iterative mask creation script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/create_mask_iterative.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/create_mask_iterative.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: RunLCModel.sh exists
     description: Verify LCModel runner script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/RunLCModel.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/RunLCModel.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: write_InitialParameters.sh exists
     description: Verify initial parameters script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/write_InitialParameters.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/write_InitialParameters.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: LCModel_Control_Template.m exists
     description: Verify LCModel control template exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part1/LCModel_Control_Template.m
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/LCModel_Control_Template.m'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -452,27 +452,27 @@ tests:
   # ==========================================================================
   - name: coregistration.sh exists
     description: Verify coregistration script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part2/coregistration.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part2/coregistration.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: segmentation.sh exists
     description: Verify segmentation script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part2/segmentation.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part2/segmentation.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: raw2mnc.sh exists
     description: Verify raw to MINC conversion script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part2/raw2mnc.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part2/raw2mnc.sh'\"'\"''"
     expected_exit_code: 0
 
   - name: mnc2nii_wholefolder exists
     description: Verify MINC to NIfTI folder conversion script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part2/mnc2nii_wholefolder
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part2/mnc2nii_wholefolder'\"'\"''"
     expected_exit_code: 0
 
   - name: write_parameter2.sh exists
     description: Verify parameter writing script exists
-    command: ls -la /opt/mrsi_pipeline_neurodesk/Part2/write_parameter2.sh
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part2/write_parameter2.sh'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -480,17 +480,17 @@ tests:
   # ==========================================================================
   - name: Pillow available
     description: Verify Pillow image library is installed
-    command: python3 -c "from PIL import Image; print('Pillow OK')"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"from PIL import Image; print('\"'\"'\"'\"'\"'\"'\"'\"'Pillow OK'\"'\"'\"'\"'\"'\"'\"'\"')\"'\"'\"''"
     expected_output_contains: "Pillow OK"
 
   - name: tqdm available
     description: Verify tqdm progress bar is installed
-    command: python3 -c "import tqdm; print(tqdm.__version__)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import tqdm; print(tqdm.__version__)\"'\"'\"''"
     expected_exit_code: 0
 
   - name: nibabel check
     description: Check if nibabel is available for NIfTI processing
-    command: python3 -c "import nibabel; print(nibabel.__version__)" 2>&1 || echo "nibabel not installed"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'python3 -c \"import nibabel; print(nibabel.__version__)\" 2>&1 || echo \"nibabel not installed\"'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -498,32 +498,32 @@ tests:
   # ==========================================================================
   - name: fslroi exists
     description: Verify fslroi for ROI extraction is available
-    command: which fslroi
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslroi'\"'\"''"
     expected_output_contains: "fslroi"
 
   - name: fslchfiletype exists
     description: Verify fslchfiletype is available
-    command: which fslchfiletype
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslchfiletype'\"'\"''"
     expected_output_contains: "fslchfiletype"
 
   - name: fslcpgeom exists
     description: Verify fslcpgeom is available
-    command: which fslcpgeom
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslcpgeom'\"'\"''"
     expected_exit_code: 0
 
   - name: fslval exists
     description: Verify fslval is available
-    command: which fslval
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which fslval'\"'\"''"
     expected_output_contains: "fslval"
 
   - name: slicer exists
     description: Verify FSL slicer is available
-    command: which slicer
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which slicer'\"'\"''"
     expected_output_contains: "slicer"
 
   - name: overlay exists
     description: Verify FSL overlay is available
-    command: which overlay
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which overlay'\"'\"''"
     expected_output_contains: "overlay"
 
   # ==========================================================================
@@ -531,27 +531,27 @@ tests:
   # ==========================================================================
   - name: Convert NIfTI to MINC
     description: Test NIfTI to MINC conversion
-    command: /opt/minc/1.9.15/bin/nii2mnc ${t1w} test_output/t1w.mnc
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/nii2mnc ${t1w} test_output/t1w.mnc'\"'\"''"
     expected_exit_code: 0
     validate:
       - output_exists: ${output_dir}/t1w.mnc
 
   - name: MINC file info
     description: Get info from converted MINC file
-    command: /opt/minc/1.9.15/bin/mincinfo test_output/t1w.mnc
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mincinfo test_output/t1w.mnc'\"'\"''"
     depends_on: Convert NIfTI to MINC
     expected_exit_code: 0
 
   - name: Convert MINC back to NIfTI
     description: Test MINC to NIfTI conversion
-    command: /opt/minc/1.9.15/bin/mnc2nii test_output/t1w.mnc test_output/t1w_converted.nii
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'/opt/minc/1.9.15/bin/mnc2nii test_output/t1w.mnc test_output/t1w_converted.nii'\"'\"''"
     depends_on: Convert NIfTI to MINC
     validate:
       - output_exists: ${output_dir}/t1w_converted.nii
 
   - name: FAST tissue segmentation
     description: Run FAST segmentation on brain extracted data
-    command: fast -o test_output/t1w_seg test_output/t1w_brain.nii.gz
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fast -o test_output/t1w_seg test_output/t1w_brain.nii.gz'\"'\"''"
     depends_on: BET run brain extraction
     timeout: 300
     validate:
@@ -559,27 +559,27 @@ tests:
 
   - name: fslstats on brain
     description: Get statistics from brain extracted image
-    command: fslstats test_output/t1w_brain.nii.gz -m -s
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslstats test_output/t1w_brain.nii.gz -m -s'\"'\"''"
     depends_on: BET run brain extraction
     expected_exit_code: 0
 
   - name: fslmaths threshold
     description: Apply threshold to brain image
-    command: fslmaths test_output/t1w_brain.nii.gz -thr 100 test_output/t1w_brain_thr.nii.gz
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslmaths test_output/t1w_brain.nii.gz -thr 100 test_output/t1w_brain_thr.nii.gz'\"'\"''"
     depends_on: BET run brain extraction
     validate:
       - output_exists: ${output_dir}/t1w_brain_thr.nii.gz
 
   - name: fslmaths multiply images
     description: Multiply brain by mask
-    command: fslmaths test_output/t1w_brain.nii.gz -mul test_output/t1w_brain_mask.nii.gz test_output/t1w_brain_masked.nii.gz
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslmaths test_output/t1w_brain.nii.gz -mul test_output/t1w_brain_mask.nii.gz test_output/t1w_brain_masked.nii.gz'\"'\"''"
     depends_on: BET run brain extraction
     validate:
       - output_exists: ${output_dir}/t1w_brain_masked.nii.gz
 
   - name: fslmaths smoothing
     description: Apply Gaussian smoothing
-    command: fslmaths test_output/t1w_brain.nii.gz -s 2 test_output/t1w_brain_smooth.nii.gz
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'fslmaths test_output/t1w_brain.nii.gz -s 2 test_output/t1w_brain_smooth.nii.gz'\"'\"''"
     depends_on: BET run brain extraction
     validate:
       - output_exists: ${output_dir}/t1w_brain_smooth.nii.gz
@@ -589,22 +589,22 @@ tests:
   # ==========================================================================
   - name: mincblob exists
     description: Verify mincblob for blob detection is available
-    command: ls /opt/minc/1.9.15/bin/mincblob
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/mincblob'\"'\"''"
     expected_exit_code: 0
 
   - name: minccalc exists
     description: Verify minccalc for math operations is available
-    command: ls /opt/minc/1.9.15/bin/minccalc
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/minccalc'\"'\"''"
     expected_exit_code: 0
 
   - name: mincmorph exists
     description: Verify mincmorph for morphological operations is available
-    command: ls /opt/minc/1.9.15/bin/mincmorph
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/mincmorph'\"'\"''"
     expected_exit_code: 0
 
   - name: mincpik exists
     description: Verify mincpik for creating PNG images is available
-    command: ls /opt/minc/1.9.15/bin/mincpik
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls /opt/minc/1.9.15/bin/mincpik'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -612,17 +612,17 @@ tests:
   # ==========================================================================
   - name: tar available
     description: Verify tar is available for archive handling
-    command: tar --version | head -1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'tar --version | head -1'\"'\"''"
     expected_output_contains: "tar"
 
   - name: gzip available
     description: Verify gzip is available for compression
-    command: gzip --version | head -1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'gzip --version | head -1'\"'\"''"
     expected_output_contains: "gzip"
 
   - name: bash available
     description: Verify bash is available
-    command: bash --version | head -1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'bash --version | head -1'\"'\"''"
     expected_output_contains: "bash"
 
   # ==========================================================================
@@ -630,27 +630,27 @@ tests:
   # ==========================================================================
   - name: FSL path set
     description: Verify FSL binaries are in PATH
-    command: which bet flirt fast | wc -l
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which bet flirt fast | wc -l'\"'\"''"
     expected_output_contains: "3"
 
   - name: dcm2niix in PATH
     description: Verify dcm2niix is accessible
-    command: which dcm2niix
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which dcm2niix'\"'\"''"
     expected_output_contains: "dcm2niix"
 
   - name: Julia in PATH
     description: Verify Julia is accessible
-    command: which julia
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which julia'\"'\"''"
     expected_output_contains: "julia"
 
   - name: Python3 in PATH
     description: Verify Python3 is accessible
-    command: which python3
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which python3'\"'\"''"
     expected_output_contains: "python"
 
   - name: hd-bet in PATH
     description: Verify hd-bet is accessible
-    command: which hd-bet
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'which hd-bet'\"'\"''"
     expected_output_contains: "hd-bet"
 
 cleanup:

--- a/recipes/networkcorrespondancetoolkit/fulltest.yaml
+++ b/recipes/networkcorrespondancetoolkit/fulltest.yaml
@@ -663,53 +663,25 @@ tests:
   - name: NCT grab_data_info module
     description: Test NCT configuration parsing module (import triggers data download which fails - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence import grab_data_info
-      args = grab_data_info.MyClass()
-      args.category = 'parcellation'
-      args.name = 'TestAtlas'
-      print('Config class created')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence import grab_data_info\nargs = grab_data_info.MyClass()\nargs.category = '\"'\"'parcellation'\"'\"'\nargs.name = '\"'\"'TestAtlas'\"'\"'\nprint('\"'\"'Config class created'\"'\"')\n\"'"
     expected_output_contains: "Download data"
 
   - name: NCT str2bool function
     description: Test NCT string to boolean conversion (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.grab_data_info import str2bool
-      print('yes ->', str2bool('yes'))
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.grab_data_info import str2bool\nprint('\"'\"'yes ->'\"'\"', str2bool('\"'\"'yes'\"'\"'))\n\"'"
     expected_output_contains: "Download data"
 
   - name: NCT str2num function
     description: Test NCT string to number conversion (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.grab_data_info import str2num
-      print('42 ->', str2num('42'))
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.grab_data_info import str2num\nprint('\"'\"'42 ->'\"'\"', str2num('\"'\"'42'\"'\"'))\n\"'"
     expected_output_contains: "Download data"
 
   - name: NCT thresh_str_to_num function
     description: Test NCT threshold string parsing (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.grab_data_info import thresh_str_to_num
-      result = thresh_str_to_num('[0, Inf]')
-      print('Threshold [0, Inf]:', result)
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.grab_data_info import thresh_str_to_num\nresult = thresh_str_to_num('\"'\"'[0, Inf]'\"'\"')\nprint('\"'\"'Threshold [0, Inf]:'\"'\"', result)\n\"'"
     expected_output_contains: "Download data"
 
   # ==========================================================================
@@ -718,25 +690,13 @@ tests:
   - name: NCT pair_match function
     description: Test NCT network pair matching algorithm (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.visualize_overlap_lib import pair_match
-      print('pair_match imported')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.visualize_overlap_lib import pair_match\nprint('\"'\"'pair_match imported'\"'\"')\n\"'"
     expected_output_contains: "Download data"
 
   - name: NCT construct_network_name function
     description: Test NCT network name construction (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.visualize_overlap_lib import construct_network_name
-      print('construct_network_name imported')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.visualize_overlap_lib import construct_network_name\nprint('\"'\"'construct_network_name imported'\"'\"')\n\"'"
     expected_output_contains: "Download data"
 
   # ==========================================================================
@@ -889,13 +849,7 @@ tests:
   - name: Parse NCT config file
     description: Parse config file with NCT functions (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.grab_data_info import read_config
-      print('read_config imported')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.grab_data_info import read_config\nprint('\"'\"'read_config imported'\"'\"')\n\"'"
     expected_output_contains: "Download data"
 
   # ==========================================================================
@@ -1088,13 +1042,7 @@ tests:
   - name: Handle invalid config gracefully
     description: Test error handling for invalid config (import triggers data download - container bug)
     ignore_exit_code: true
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages')
-      from cbig_network_correspondence.grab_data_info import read_config, MyClass, check_args_format
-      print('check_args_format imported')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/miniconda/envs/NCT_env/lib/python3.9/site-packages'\"'\"')\nfrom cbig_network_correspondence.grab_data_info import read_config, MyClass, check_args_format\nprint('\"'\"'check_args_format imported'\"'\"')\n\"'"
     expected_output_contains: "Download data"
 
   # ==========================================================================

--- a/recipes/nibabies/fulltest.yaml
+++ b/recipes/nibabies/fulltest.yaml
@@ -480,9 +480,9 @@ tests:
   - name: BOLD to T1 preparation
     description: Prepare BOLD for registration (extract middle volume)
     command: |
-      nvols=$(fslnvols ${bold}) && \
+      bash -lc 'nvols=$(fslnvols ${bold}) && \
       midvol=$((nvols / 2)) && \
-      fslroi ${bold} test_output/bold_ref.nii.gz $midvol 1
+      fslroi ${bold} test_output/bold_ref.nii.gz $midvol 1'
     validate:
       - output_exists: ${output_dir}/bold_ref.nii.gz
 

--- a/recipes/nighres/fulltest.yaml
+++ b/recipes/nighres/fulltest.yaml
@@ -110,77 +110,77 @@ tests:
   # ==========================================================================
   - name: Nighres source directory
     description: Verify nighres source code is present
-    command: ls -la /opt/nighres/nighres/ | head -20
+    command: "bash -lc 'ls -la /opt/nighres/nighres/ | head -20'"
     expected_output_contains: "__init__.py"
 
   - name: Nighres brain module present
     description: Verify brain module source files exist
-    command: ls /opt/nighres/nighres/brain/
+    command: "bash -lc 'ls /opt/nighres/nighres/brain/'"
     expected_output_contains: "mgdm_segmentation.py"
 
   - name: Nighres cortex module present
     description: Verify cortex module source files exist
-    command: ls /opt/nighres/nighres/cortex/
+    command: "bash -lc 'ls /opt/nighres/nighres/cortex/'"
     expected_output_contains: "cruise_cortex_extraction.py"
 
   - name: Nighres laminar module present
     description: Verify laminar module source files exist
-    command: ls /opt/nighres/nighres/laminar/
+    command: "bash -lc 'ls /opt/nighres/nighres/laminar/'"
     expected_output_contains: "volumetric_layering.py"
 
   - name: Nighres intensity module present
     description: Verify intensity module source files exist
-    command: ls /opt/nighres/nighres/intensity/
+    command: "bash -lc 'ls /opt/nighres/nighres/intensity/'"
     expected_output_contains: "mp2rage_t1_mapping.py"
 
   - name: Nighres segmentation module present
     description: Verify segmentation module source files exist
-    command: ls /opt/nighres/nighres/segmentation/
+    command: "bash -lc 'ls /opt/nighres/nighres/segmentation/'"
     expected_output_contains: "conditional_shape.py"
 
   - name: Nighres registration module present
     description: Verify registration module source files exist
-    command: ls /opt/nighres/nighres/registration/
+    command: "bash -lc 'ls /opt/nighres/nighres/registration/'"
     expected_output_contains: "embedded_antspy.py"
 
   - name: Nighres surface module present
     description: Verify surface module source files exist
-    command: ls /opt/nighres/nighres/surface/
+    command: "bash -lc 'ls /opt/nighres/nighres/surface/'"
     expected_output_contains: "levelset_to_mesh.py"
 
   - name: Nighres shape module present
     description: Verify shape module source files exist
-    command: ls /opt/nighres/nighres/shape/
+    command: "bash -lc 'ls /opt/nighres/nighres/shape/'"
     expected_output_contains: "spectral_embedding.py"
 
   - name: Nighres parcellation module present
     description: Verify parcellation module source files exist
-    command: ls /opt/nighres/nighres/parcellation/
+    command: "bash -lc 'ls /opt/nighres/nighres/parcellation/'"
     expected_output_contains: "massp.py"
 
   - name: Nighres filtering module present
     description: Verify filtering module source files exist
-    command: ls /opt/nighres/nighres/filtering/
+    command: "bash -lc 'ls /opt/nighres/nighres/filtering/'"
     expected_output_contains: "recursive_ridge_diffusion.py"
 
   - name: Nighres microscopy module present
     description: Verify microscopy module source files exist
-    command: ls /opt/nighres/nighres/microscopy/
+    command: "bash -lc 'ls /opt/nighres/nighres/microscopy/'"
     expected_output_contains: "mgdm_cells.py"
 
   - name: Nighres io module present
     description: Verify io module source files exist
-    command: ls /opt/nighres/nighres/io/
+    command: "bash -lc 'ls /opt/nighres/nighres/io/'"
     expected_output_contains: "io_volume.py"
 
   - name: Nighres statistics module present
     description: Verify statistics module source files exist
-    command: ls /opt/nighres/nighres/statistics/
+    command: "bash -lc 'ls /opt/nighres/nighres/statistics/'"
     expected_output_contains: "segmentation_statistics.py"
 
   - name: Nighres data module present
     description: Verify data download module exists
-    command: ls /opt/nighres/nighres/data/
+    command: "bash -lc 'ls /opt/nighres/nighres/data/'"
     expected_output_contains: "download_data.py"
 
   # ==========================================================================
@@ -596,27 +596,27 @@ tests:
   # ==========================================================================
   - name: Nighres examples directory
     description: Verify example scripts are present
-    command: ls /opt/nighres/examples/
+    command: "bash -lc 'ls /opt/nighres/examples/'"
     expected_output_contains: "testing_01"
 
   - name: Quantitative MRI example
     description: Check quantitative MRI example script exists
-    command: head -30 /opt/nighres/examples/testing_01_quantitative_mri.py
+    command: "bash -lc 'head -30 /opt/nighres/examples/testing_01_quantitative_mri.py'"
     expected_output_contains: "Quantitative MRI"
 
   - name: Cortical laminar example
     description: Check cortical laminar analysis example exists
-    command: head -30 /opt/nighres/examples/testing_02_cortical_laminar_analysis.py
+    command: "bash -lc 'head -30 /opt/nighres/examples/testing_02_cortical_laminar_analysis.py'"
     expected_output_contains: "Cortical laminar"
 
   - name: Brain slab coregistration example
     description: Check brain slab coregistration example exists
-    command: head -30 /opt/nighres/examples/testing_03_brain_slab_coregistration.py
+    command: "bash -lc 'head -30 /opt/nighres/examples/testing_03_brain_slab_coregistration.py'"
     expected_output_contains: "registration"
 
   - name: MASSP subcortex example
     description: Check MASSP subcortex parcellation example exists
-    command: head -30 /opt/nighres/examples/testing_04_massp_subcortex_parcellation.py
+    command: "bash -lc 'head -30 /opt/nighres/examples/testing_04_massp_subcortex_parcellation.py'"
     expected_output_contains: "MASSP"
 
   # ==========================================================================
@@ -960,7 +960,7 @@ tests:
 
   - name: Nighres documentation
     description: Check nighres documentation directory exists
-    command: ls /opt/nighres/doc/
+    command: "bash -lc 'ls /opt/nighres/doc/'"
     expected_output_contains: "index.rst"
 
 cleanup:

--- a/recipes/niistat/fulltest.yaml
+++ b/recipes/niistat/fulltest.yaml
@@ -72,29 +72,29 @@ tests:
   # ==========================================================================
   - name: SPM12 path exists
     description: Verify SPM12 installation directory exists
-    command: ls -la /opt/spm12-r7771/spm.m 2>&1
+    command: "bash -lc 'ls -la /opt/spm12-r7771/spm.m 2>&1'"
     expected_output_contains: "spm.m"
 
   - name: SPM12 version check
     description: Verify SPM12 loads and reports correct version
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); v = spm('Version'); disp(v); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); v = spm('\"'\"'Version'\"'\"'); disp(v); exit(0);\" 2>&1'"
     expected_output_contains: "SPM12"
     expected_exit_code: 0
 
   - name: SPM12 nifti functions available
     description: Test SPM12 NIfTI file handling functions are accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); which spm_vol; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); which spm_vol; exit(0);\" 2>&1'"
     expected_output_contains: "spm_vol"
     expected_exit_code: 0
 
   - name: SPM12 file_array class
     description: Verify SPM12 file_array class is functional
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); exist('file_array'); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); exist('\"'\"'file_array'\"'\"'); exit(0);\" 2>&1'"
     expected_exit_code: 0
 
   - name: SPM12 matrix functions
     description: Test SPM matrix/transformation functions
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); M = spm_matrix([0 0 0]); disp(size(M)); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); M = spm_matrix([0 0 0]); disp(size(M)); exit(0);\" 2>&1'"
     expected_output_contains: "4"
     expected_exit_code: 0
 
@@ -103,30 +103,30 @@ tests:
   # ==========================================================================
   - name: NiiStat path exists
     description: Verify NiiStat installation directory exists
-    command: ls -la /opt/niistat-1.0.20191216/NiiStat.m 2>&1
+    command: "bash -lc 'ls -la /opt/niistat-1.0.20191216/NiiStat.m 2>&1'"
     expected_output_contains: "NiiStat.m"
 
   - name: NiiStat main function accessible
     description: Test NiiStat main function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which NiiStat; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which NiiStat; exit(0);\" 2>&1'"
     expected_output_contains: "NiiStat"
     expected_exit_code: 0
 
   - name: NiiStat core functions available
     description: Verify nii_stat_core function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_core; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_core; exit(0);\" 2>&1'"
     expected_output_contains: "nii_stat_core"
     expected_exit_code: 0
 
   - name: NiiStat ROI functions available
     description: Verify nii_roi_list function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_roi_list; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_roi_list; exit(0);\" 2>&1'"
     expected_output_contains: "nii_roi_list"
     expected_exit_code: 0
 
   - name: NiiStat modality list available
     description: Verify nii_modality_list function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_modality_list; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_modality_list; exit(0);\" 2>&1'"
     expected_output_contains: "nii_modality_list"
     expected_exit_code: 0
 
@@ -135,47 +135,47 @@ tests:
   # ==========================================================================
   - name: ROI atlas directory exists
     description: Verify ROI atlas files are present
-    command: ls /opt/niistat-1.0.20191216/roi/*.nii 2>&1 | wc -l
+    command: bash -lc 'ls /opt/niistat-1.0.20191216/roi/*.nii 2>&1 | wc -l'
     expected_output_contains: "9"
 
   - name: AAL atlas present
     description: Verify AAL (Automated Anatomical Labeling) atlas is available
-    command: ls /opt/niistat-1.0.20191216/roi/aal.nii 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/aal.nii 2>&1'"
     expected_output_contains: "aal.nii"
 
   - name: JHU atlas present
     description: Verify JHU (Johns Hopkins University) white matter atlas is available
-    command: ls /opt/niistat-1.0.20191216/roi/jhu.nii 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/jhu.nii 2>&1'"
     expected_output_contains: "jhu.nii"
 
   - name: Brodmann atlas present
     description: Verify Brodmann areas atlas is available
-    command: ls /opt/niistat-1.0.20191216/roi/bro.nii 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/bro.nii 2>&1'"
     expected_output_contains: "bro.nii"
 
   - name: AICHA atlas present
     description: Verify AICHA (Atlas of Intrinsic Connectivity of Homotopic Areas) is available
-    command: ls /opt/niistat-1.0.20191216/roi/AICHA.nii 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/AICHA.nii 2>&1'"
     expected_output_contains: "AICHA.nii"
 
   - name: Fox atlas present
     description: Verify Fox atlas for resting state networks is available
-    command: ls /opt/niistat-1.0.20191216/roi/fox.nii 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/fox.nii 2>&1'"
     expected_output_contains: "fox.nii"
 
   - name: Catani atlas present
     description: Verify Catani white matter tract atlas is available
-    command: ls /opt/niistat-1.0.20191216/roi/cat.nii 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/cat.nii 2>&1'"
     expected_output_contains: "cat.nii"
 
   - name: ROI label files present
     description: Verify ROI label text files are present
-    command: ls /opt/niistat-1.0.20191216/roi/*.txt 2>&1 | wc -l
+    command: bash -lc 'ls /opt/niistat-1.0.20191216/roi/*.txt 2>&1 | wc -l'
     expected_output_contains: "8"
 
   - name: ROI node files present
     description: Verify ROI node files for BrainNet Viewer are present
-    command: ls /opt/niistat-1.0.20191216/roi/*.node 2>&1 | wc -l
+    command: bash -lc 'ls /opt/niistat-1.0.20191216/roi/*.node 2>&1 | wc -l'
     expected_output_contains: "7"
 
   # ==========================================================================
@@ -183,25 +183,25 @@ tests:
   # ==========================================================================
   - name: ROI list function
     description: Test nii_roi_list returns available atlases
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [files, nums] = nii_roi_list(); disp(nums); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [files, nums] = nii_roi_list(); disp(nums); exit(0);\" 2>&1'"
     expected_output_contains: "aal"
     expected_exit_code: 0
 
   - name: Modality list function
     description: Test nii_modality_list returns available modalities
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [files, nums] = nii_modality_list(); disp(nums); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [files, nums] = nii_modality_list(); disp(nums); exit(0);\" 2>&1'"
     expected_output_contains: "lesion"
     expected_exit_code: 0
 
   - name: Binary check function
     description: Test nii_isBinary function with binary data
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [isBin, dat] = nii_isBinary([1 0 1 1]); disp(isBin); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [isBin, dat] = nii_isBinary([1 0 1 1]); disp(isBin); exit(0);\" 2>&1'"
     expected_output_contains: "1"
     expected_exit_code: 0
 
   - name: Binary check function non-binary
     description: Test nii_isBinary function with non-binary data
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [isBin, dat] = nii_isBinary([1 2 3 4]); disp(isBin); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [isBin, dat] = nii_isBinary([1 2 3 4]); disp(isBin); exit(0);\" 2>&1'"
     expected_output_contains: "0"
     expected_exit_code: 0
 
@@ -210,27 +210,27 @@ tests:
   # ==========================================================================
   - name: LibSVM directory exists
     description: Verify LibSVM installation directory exists
-    command: ls -la /opt/niistat-1.0.20191216/libsvm/ 2>&1
+    command: "bash -lc 'ls -la /opt/niistat-1.0.20191216/libsvm/ 2>&1'"
     expected_output_contains: "svmtrain"
 
   - name: LibSVM MEX files present
     description: Verify LibSVM compiled MEX files are present
-    command: ls /opt/niistat-1.0.20191216/libsvm/*.mexa64 2>&1 | wc -l
+    command: bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/*.mexa64 2>&1 | wc -l'
     expected_output_contains: "4"
 
   - name: LibSVM svmtrain MEX available
     description: Verify svmtrain MEX file exists
-    command: ls /opt/niistat-1.0.20191216/libsvm/svmtrain.mexa64 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/svmtrain.mexa64 2>&1'"
     expected_output_contains: "svmtrain.mexa64"
 
   - name: LibSVM svmpredict MEX available
     description: Verify svmpredict MEX file exists
-    command: ls /opt/niistat-1.0.20191216/libsvm/svmpredict.mexa64 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/svmpredict.mexa64 2>&1'"
     expected_output_contains: "svmpredict.mexa64"
 
   - name: LibSVM read/write MEX available
     description: Verify libsvmread and libsvmwrite MEX files exist
-    command: ls /opt/niistat-1.0.20191216/libsvm/libsvmread.mexa64 /opt/niistat-1.0.20191216/libsvm/libsvmwrite.mexa64 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/libsvmread.mexa64 /opt/niistat-1.0.20191216/libsvm/libsvmwrite.mexa64 2>&1'"
     expected_output_contains: "libsvmread.mexa64"
 
   # ==========================================================================
@@ -238,17 +238,17 @@ tests:
   # ==========================================================================
   - name: TFCE MEX file present
     description: Verify TFCE compiled MEX file exists
-    command: ls /opt/niistat-1.0.20191216/tfceMex.mexa64 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/tfceMex.mexa64 2>&1'"
     expected_output_contains: "tfceMex.mexa64"
 
   - name: TFCE function file present
     description: Verify TFCE MATLAB function file exists
-    command: ls /opt/niistat-1.0.20191216/tfceMex.m 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/tfceMex.m 2>&1'"
     expected_output_contains: "tfceMex.m"
 
   - name: TFCE C source present
     description: Verify TFCE C source code is included
-    command: ls /opt/niistat-1.0.20191216/tfceMex.c 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/tfceMex.c 2>&1'"
     expected_output_contains: "tfceMex.c"
 
   # ==========================================================================
@@ -256,18 +256,18 @@ tests:
   # ==========================================================================
   - name: GLM directory exists
     description: Verify GLM functions directory exists
-    command: ls -la /opt/niistat-1.0.20191216/glm/ 2>&1
+    command: "bash -lc 'ls -la /opt/niistat-1.0.20191216/glm/ 2>&1'"
     expected_output_contains: "xl_glm.m"
 
   - name: GLM function accessible
     description: Verify xl_glm function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/glm'); which xl_glm; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"'); which xl_glm; exit(0);\" 2>&1'"
     expected_output_contains: "xl_glm"
     expected_exit_code: 0
 
   - name: SPM T-distribution function
     description: Test spm_Tcdf function for T-distribution
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216/glm'); p = spm_Tcdf(2.0, 10); disp(p); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"'); p = spm_Tcdf(2.0, 10); disp(p); exit(0);\" 2>&1'"
     expected_output_contains: "0.9"
     expected_exit_code: 0
 
@@ -276,18 +276,18 @@ tests:
   # ==========================================================================
   - name: FDR function present
     description: Verify FDR correction function is present
-    command: ls /opt/niistat-1.0.20191216/fdr_bh.m 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/fdr_bh.m 2>&1'"
     expected_output_contains: "fdr_bh.m"
 
   - name: FDR function accessible
     description: Verify fdr_bh function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which fdr_bh; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which fdr_bh; exit(0);\" 2>&1'"
     expected_output_contains: "fdr_bh"
     expected_exit_code: 0
 
   - name: FDR Benjamini-Hochberg correction
     description: Test FDR correction on p-values
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); pvals = [0.01 0.02 0.03 0.5 0.6]; [h, crit_p] = fdr_bh(pvals, 0.05); disp(sum(h)); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); pvals = [0.01 0.02 0.03 0.5 0.6]; [h, crit_p] = fdr_bh(pvals, 0.05); disp(sum(h)); exit(0);\" 2>&1'"
     expected_output_contains: "3"
     expected_exit_code: 0
 
@@ -296,12 +296,12 @@ tests:
   # ==========================================================================
   - name: Fisher exact test function present
     description: Verify Fisher exact test function is present
-    command: ls /opt/niistat-1.0.20191216/fexact.m 2>&1
+    command: "bash -lc 'ls /opt/niistat-1.0.20191216/fexact.m 2>&1'"
     expected_output_contains: "fexact.m"
 
   - name: Fisher exact test accessible
     description: Verify fexact function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which fexact; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which fexact; exit(0);\" 2>&1'"
     expected_output_contains: "fexact"
     expected_exit_code: 0
 
@@ -310,32 +310,24 @@ tests:
   # ==========================================================================
   - name: SPM volume read function
     description: Test SPM can read NIfTI header (copy to /tmp since SPM deletes .nii.gz after decompression)
-    command: |
-      cp ${t1w} /tmp/t1w.nii.gz
-      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/t1w.nii.gz'); disp(hdr.dim); exit(0);" 2>&1
+    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"'); disp(hdr.dim); exit(0);\" 2>&1'"
     expected_output_contains: "160"
     expected_exit_code: 0
 
   - name: SPM volume data read
     description: Test SPM can read NIfTI image data
-    command: |
-      cp ${t1w} /tmp/t1w.nii.gz
-      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/t1w.nii.gz'); img = spm_read_vols(hdr); disp(size(img)); exit(0);" 2>&1
+    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"'); img = spm_read_vols(hdr); disp(size(img)); exit(0);\" 2>&1'"
     expected_output_contains: "160"
     expected_exit_code: 0
 
   - name: NIfTI header information
     description: Extract NIfTI header information using SPM
-    command: |
-      cp ${t1w} /tmp/t1w.nii.gz
-      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/t1w.nii.gz'); disp(hdr.mat); exit(0);" 2>&1
+    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"'); disp(hdr.mat); exit(0);\" 2>&1'"
     expected_exit_code: 0
 
   - name: 4D NIfTI read
     description: Test reading 4D functional data (copy to /tmp since SPM deletes .nii.gz after decompression)
-    command: |
-      cp ${bold} /tmp/bold.nii.gz
-      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/bold.nii.gz'); disp(length(hdr)); exit(0);" 2>&1
+    command: "bash -lc 'cp ${bold} /tmp/bold.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/bold.nii.gz'\"'\"'); disp(length(hdr)); exit(0);\" 2>&1'"
     expected_output_contains: "300"
     expected_exit_code: 0
 
@@ -344,31 +336,31 @@ tests:
   # ==========================================================================
   - name: Reslice function accessible
     description: Verify nii_reslice_target function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_reslice_target; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_reslice_target; exit(0);\" 2>&1'"
     expected_output_contains: "nii_reslice_target"
     expected_exit_code: 0
 
   - name: NII to MAT conversion function
     description: Verify nii_nii2mat function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_nii2mat; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_nii2mat; exit(0);\" 2>&1'"
     expected_output_contains: "nii_nii2mat"
     expected_exit_code: 0
 
   - name: MAT to NII conversion function
     description: Verify nii_mat2nii function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_mat2nii; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_mat2nii; exit(0);\" 2>&1'"
     expected_output_contains: "nii_mat2nii"
     expected_exit_code: 0
 
   - name: ROI to stats function
     description: Verify nii_roi2stats function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_roi2stats; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_roi2stats; exit(0);\" 2>&1'"
     expected_output_contains: "nii_roi2stats"
     expected_exit_code: 0
 
   - name: NII to ROI function
     description: Verify nii_nii2roi function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_nii2roi; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_nii2roi; exit(0);\" 2>&1'"
     expected_output_contains: "nii_nii2roi"
     expected_exit_code: 0
 
@@ -377,31 +369,31 @@ tests:
   # ==========================================================================
   - name: SVM analysis function accessible
     description: Verify nii_stat_svm function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_svm; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_svm; exit(0);\" 2>&1'"
     expected_output_contains: "nii_stat_svm"
     expected_exit_code: 0
 
   - name: SVM core function accessible
     description: Verify nii_stat_svm_core function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_svm_core; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_svm_core; exit(0);\" 2>&1'"
     expected_output_contains: "nii_stat_svm_core"
     expected_exit_code: 0
 
   - name: SVR core function accessible
     description: Verify nii_stat_svr_core function for Support Vector Regression
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_svr_core; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_svr_core; exit(0);\" 2>&1'"
     expected_output_contains: "nii_stat_svr_core"
     expected_exit_code: 0
 
   - name: PCA function accessible
     description: Verify nii_pca function for Principal Component Analysis
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_pca; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_pca; exit(0);\" 2>&1'"
     expected_output_contains: "nii_pca"
     expected_exit_code: 0
 
   - name: Power analysis function accessible
     description: Verify nii_power function for statistical power analysis
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_power; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_power; exit(0);\" 2>&1'"
     expected_output_contains: "nii_power"
     expected_exit_code: 0
 
@@ -410,25 +402,25 @@ tests:
   # ==========================================================================
   - name: Design file reader accessible
     description: Verify nii_read_design function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_read_design; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_read_design; exit(0);\" 2>&1'"
     expected_output_contains: "nii_read_design"
     expected_exit_code: 0
 
   - name: Tab to MAT converter accessible
     description: Verify nii_tab2mat function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_tab2mat; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_tab2mat; exit(0);\" 2>&1'"
     expected_output_contains: "nii_tab2mat"
     expected_exit_code: 0
 
   - name: XLS to MAT converter accessible
     description: Verify nii_xls2mat function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_xls2mat; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_xls2mat; exit(0);\" 2>&1'"
     expected_output_contains: "nii_xls2mat"
     expected_exit_code: 0
 
   - name: VAL to MAT converter accessible
     description: Verify nii_val2mat function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_val2mat; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_val2mat; exit(0);\" 2>&1'"
     expected_output_contains: "nii_val2mat"
     expected_exit_code: 0
 
@@ -437,25 +429,25 @@ tests:
   # ==========================================================================
   - name: Plot function accessible
     description: Verify nii_plot function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_plot; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_plot; exit(0);\" 2>&1'"
     expected_output_contains: "nii_plot"
     expected_exit_code: 0
 
   - name: Power map function accessible
     description: Verify nii_powermap function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_powermap; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_powermap; exit(0);\" 2>&1'"
     expected_output_contains: "nii_powermap"
     expected_exit_code: 0
 
   - name: Node file save function accessible
     description: Verify nii_save_nodz function for BrainNet Viewer output
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_save_nodz; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_save_nodz; exit(0);\" 2>&1'"
     expected_output_contains: "nii_save_nodz"
     expected_exit_code: 0
 
   - name: Array to node conversion accessible
     description: Verify nii_array2node function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_array2node; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_array2node; exit(0);\" 2>&1'"
     expected_output_contains: "nii_array2node"
     expected_exit_code: 0
 
@@ -464,31 +456,31 @@ tests:
   # ==========================================================================
   - name: Sphere creation function accessible
     description: Verify nii_sphere function for creating spherical ROIs
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_sphere; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_sphere; exit(0);\" 2>&1'"
     expected_output_contains: "nii_sphere"
     expected_exit_code: 0
 
   - name: Custom ROI function accessible
     description: Verify nii_custom_roi function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_custom_roi; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_custom_roi; exit(0);\" 2>&1'"
     expected_output_contains: "nii_custom_roi"
     expected_exit_code: 0
 
   - name: Make ROI function accessible
     description: Verify nii_make_roi function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_make_roi; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_make_roi; exit(0);\" 2>&1'"
     expected_output_contains: "nii_make_roi"
     expected_exit_code: 0
 
   - name: ROI to mm conversion accessible
     description: Verify nii_roi2mm function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_roi2mm; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_roi2mm; exit(0);\" 2>&1'"
     expected_output_contains: "nii_roi2mm"
     expected_exit_code: 0
 
   - name: Array to ROI conversion accessible
     description: Verify nii_array2roi function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_array2roi; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_array2roi; exit(0);\" 2>&1'"
     expected_output_contains: "nii_array2roi"
     expected_exit_code: 0
 
@@ -497,7 +489,7 @@ tests:
   # ==========================================================================
   - name: Fiber QA function accessible
     description: Verify nii_fiberQA function for DTI quality assessment
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_fiberQA; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_fiberQA; exit(0);\" 2>&1'"
     expected_output_contains: "nii_fiberQA"
     expected_exit_code: 0
 
@@ -506,19 +498,19 @@ tests:
   # ==========================================================================
   - name: Structure merge function accessible
     description: Verify nii_mergestruct function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_mergestruct; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_mergestruct; exit(0);\" 2>&1'"
     expected_output_contains: "nii_mergestruct"
     expected_exit_code: 0
 
   - name: MAT purge ROIs function accessible
     description: Verify nii_matPurgeRois function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_matPurgeRois; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_matPurgeRois; exit(0);\" 2>&1'"
     expected_output_contains: "nii_matPurgeRois"
     expected_exit_code: 0
 
   - name: MAT version function accessible
     description: Verify nii_matver function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_matver; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_matver; exit(0);\" 2>&1'"
     expected_output_contains: "nii_matver"
     expected_exit_code: 0
 
@@ -527,19 +519,19 @@ tests:
   # ==========================================================================
   - name: SPM normal CDF available
     description: Test SPM normal cumulative distribution function
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); p = spm_Ncdf(1.96); disp(p); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); p = spm_Ncdf(1.96); disp(p); exit(0);\" 2>&1'"
     expected_output_contains: "0.97"
     expected_exit_code: 0
 
   - name: SPM inverse normal CDF available
     description: Test SPM inverse normal CDF function
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); z = spm_invNcdf(0.95); disp(z); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); z = spm_invNcdf(0.95); disp(z); exit(0);\" 2>&1'"
     expected_output_contains: "1.64"
     expected_exit_code: 0
 
   - name: SPM F-distribution CDF available
     description: Test SPM F-distribution function
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); p = spm_Fcdf(4.0, 1, 10); disp(p); exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); p = spm_Fcdf(4.0, 1, 10); disp(p); exit(0);\" 2>&1'"
     expected_output_contains: "0.9"
     expected_exit_code: 0
 
@@ -548,51 +540,19 @@ tests:
   # ==========================================================================
   - name: Create binary mask from T1
     description: Test creating a binary mask using SPM (copy to /tmp since SPM deletes .nii.gz)
-    command: |
-      cp ${t1w} /tmp/t1w.nii.gz
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        hdr = spm_vol('/tmp/t1w.nii.gz');
-        img = spm_read_vols(hdr);
-        mask = img > mean(img(:));
-        hdr.fname = 'test_output/t1w_mask.nii';
-        spm_write_vol(hdr, double(mask));
-        disp('Mask created successfully');
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"');\n  img = spm_read_vols(hdr);\n  mask = img > mean(img(:));\n  hdr.fname = '\"'\"'test_output/t1w_mask.nii'\"'\"';\n  spm_write_vol(hdr, double(mask));\n  disp('\"'\"'Mask created successfully'\"'\"');\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "Mask created successfully"
     validate:
       - output_exists: ${output_dir}/t1w_mask.nii
 
   - name: Extract ROI statistics
     description: Test extracting mean value from image using mask
-    command: |
-      cp ${t1w} /tmp/t1w.nii.gz
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        hdr = spm_vol('/tmp/t1w.nii.gz');
-        img = spm_read_vols(hdr);
-        mask = img > mean(img(:));
-        roi_mean = mean(img(mask));
-        disp(['ROI mean: ' num2str(roi_mean)]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"');\n  img = spm_read_vols(hdr);\n  mask = img > mean(img(:));\n  roi_mean = mean(img(mask));\n  disp(['\"'\"'ROI mean: '\"'\"' num2str(roi_mean)]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "ROI mean:"
 
   - name: Compute image statistics
     description: Calculate basic image statistics
-    command: |
-      cp ${t1w} /tmp/t1w.nii.gz
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        hdr = spm_vol('/tmp/t1w.nii.gz');
-        img = spm_read_vols(hdr);
-        disp(['Min: ' num2str(min(img(:)))]);
-        disp(['Max: ' num2str(max(img(:)))]);
-        disp(['Mean: ' num2str(mean(img(:)))]);
-        disp(['Std: ' num2str(std(img(:)))]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"');\n  img = spm_read_vols(hdr);\n  disp(['\"'\"'Min: '\"'\"' num2str(min(img(:)))]);\n  disp(['\"'\"'Max: '\"'\"' num2str(max(img(:)))]);\n  disp(['\"'\"'Mean: '\"'\"' num2str(mean(img(:)))]);\n  disp(['\"'\"'Std: '\"'\"' num2str(std(img(:)))]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "Mean:"
 
   # ==========================================================================
@@ -600,52 +560,17 @@ tests:
   # ==========================================================================
   - name: T-test computation
     description: Test two-sample t-statistic using base Octave (ttest2 requires statistics package)
-    command: |
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        addpath('/opt/niistat-1.0.20191216');
-        x1 = [1 2 3 4 5];
-        x2 = [6 7 8 9 10];
-        mean_diff = mean(x2) - mean(x1);
-        pooled_se = sqrt(var(x1)/length(x1) + var(x2)/length(x2));
-        t_stat = mean_diff / pooled_se;
-        disp(['T-statistic: ' num2str(t_stat)]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"');\n  x1 = [1 2 3 4 5];\n  x2 = [6 7 8 9 10];\n  mean_diff = mean(x2) - mean(x1);\n  pooled_se = sqrt(var(x1)/length(x1) + var(x2)/length(x2));\n  t_stat = mean_diff / pooled_se;\n  disp(['\"'\"'T-statistic: '\"'\"' num2str(t_stat)]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "T-statistic:"
 
   - name: Correlation computation
     description: Test Pearson correlation computation
-    command: |
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        x = [1 2 3 4 5];
-        y = [2 4 5 4 5];
-        r = corr(x', y');
-        disp(['Correlation: ' num2str(r)]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  x = [1 2 3 4 5];\n  y = [2 4 5 4 5];\n  r = corr(x'\"'\"', y'\"'\"');\n  disp(['\"'\"'Correlation: '\"'\"' num2str(r)]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "Correlation:"
 
   - name: Permutation test setup
     description: Test permutation testing infrastructure
-    command: |
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        rng(42);
-        x = randn(10, 1);
-        y = randn(10, 1);
-        nperm = 100;
-        orig_corr = corr(x, y);
-        perm_corrs = zeros(nperm, 1);
-        for i = 1:nperm
-          perm_y = y(randperm(length(y)));
-          perm_corrs(i) = corr(x, perm_y);
-        end
-        p = sum(abs(perm_corrs) >= abs(orig_corr)) / nperm;
-        disp(['Permutation p-value: ' num2str(p)]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  rng(42);\n  x = randn(10, 1);\n  y = randn(10, 1);\n  nperm = 100;\n  orig_corr = corr(x, y);\n  perm_corrs = zeros(nperm, 1);\n  for i = 1:nperm\n    perm_y = y(randperm(length(y)));\n    perm_corrs(i) = corr(x, perm_y);\n  end\n  p = sum(abs(perm_corrs) >= abs(orig_corr)) / nperm;\n  disp(['\"'\"'Permutation p-value: '\"'\"' num2str(p)]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "Permutation p-value:"
 
   # ==========================================================================
@@ -653,18 +578,18 @@ tests:
   # ==========================================================================
   - name: GUI helper functions present
     description: Verify NiiStatGUI helper functions are present
-    command: ls /opt/niistat-1.0.20191216/NiiStatGUI/*.m 2>&1 | wc -l
+    command: bash -lc 'ls /opt/niistat-1.0.20191216/NiiStatGUI/*.m 2>&1 | wc -l'
     expected_output_contains: "5"
 
   - name: GetROIFilesGivenDirectory accessible
     description: Verify GetROIFilesGivenDirectory function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/NiiStatGUI'); which GetROIFilesGivenDirectory; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/NiiStatGUI'\"'\"'); which GetROIFilesGivenDirectory; exit(0);\" 2>&1'"
     expected_output_contains: "GetROIFilesGivenDirectory"
     expected_exit_code: 0
 
   - name: GetROINamesFromFile accessible
     description: Verify GetROINamesFromFile function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/NiiStatGUI'); which GetROINamesFromFile; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/NiiStatGUI'\"'\"'); which GetROINamesFromFile; exit(0);\" 2>&1'"
     expected_output_contains: "GetROINamesFromFile"
     expected_exit_code: 0
 
@@ -673,7 +598,7 @@ tests:
   # ==========================================================================
   - name: MAT to ortho function accessible
     description: Verify nii_mat2ortho function for visualization
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_mat2ortho; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_mat2ortho; exit(0);\" 2>&1'"
     expected_output_contains: "nii_mat2ortho"
     expected_exit_code: 0
 
@@ -682,13 +607,13 @@ tests:
   # ==========================================================================
   - name: XL to ROI function accessible
     description: Verify nii_xl2roi function for Excel-based ROI definition
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_xl2roi; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_xl2roi; exit(0);\" 2>&1'"
     expected_output_contains: "nii_xl2roi"
     expected_exit_code: 0
 
   - name: xl_xls2mat function accessible
     description: Verify xl_xls2mat function in glm directory
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/glm'); which xl_xls2mat; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"'); which xl_xls2mat; exit(0);\" 2>&1'"
     expected_output_contains: "xl_xls2mat"
     expected_exit_code: 0
 
@@ -697,7 +622,7 @@ tests:
   # ==========================================================================
   - name: Modality table function accessible
     description: Verify nii_modality_table function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_modality_table; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_modality_table; exit(0);\" 2>&1'"
     expected_output_contains: "nii_modality_table"
     expected_exit_code: 0
 
@@ -706,7 +631,7 @@ tests:
   # ==========================================================================
   - name: NII to MAT report function accessible
     description: Verify nii_nii2matReport function is accessible
-    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_nii2matReport; exit(0);" 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_nii2matReport; exit(0);\" 2>&1'"
     expected_output_contains: "nii_nii2matReport"
     expected_exit_code: 0
 
@@ -715,38 +640,12 @@ tests:
   # ==========================================================================
   - name: Full environment setup test
     description: Test that all paths can be added and NiiStat reports version
-    command: |
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        addpath('/opt/niistat-1.0.20191216');
-        addpath('/opt/niistat-1.0.20191216/glm');
-        addpath('/opt/niistat-1.0.20191216/libsvm');
-        disp('All paths added successfully');
-        spm_ver = spm('Version');
-        disp(['SPM version: ' spm_ver]);
-        [~, mods] = nii_modality_list();
-        disp(['Modalities: ' mods]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216/libsvm'\"'\"');\n  disp('\"'\"'All paths added successfully'\"'\"');\n  spm_ver = spm('\"'\"'Version'\"'\"');\n  disp(['\"'\"'SPM version: '\"'\"' spm_ver]);\n  [~, mods] = nii_modality_list();\n  disp(['\"'\"'Modalities: '\"'\"' mods]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "All paths added successfully"
 
   - name: Memory and matrix operations test
     description: Test large matrix operations typical in neuroimaging
-    command: |
-      octave --no-gui --eval "
-        addpath('/opt/spm12-r7771');
-        % Create a moderate-sized matrix (simulating voxel data)
-        X = randn(50, 1000);  % 50 subjects, 1000 voxels
-        Y = randn(50, 1);     % behavioral scores
-        % Compute correlation for each voxel
-        r = zeros(1, 1000);
-        for v = 1:1000
-          r(v) = corr(X(:,v), Y);
-        end
-        disp(['Max correlation: ' num2str(max(r))]);
-        disp(['Min correlation: ' num2str(min(r))]);
-        exit(0);
-      " 2>&1
+    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  % Create a moderate-sized matrix (simulating voxel data)\n  X = randn(50, 1000);  % 50 subjects, 1000 voxels\n  Y = randn(50, 1);     % behavioral scores\n  % Compute correlation for each voxel\n  r = zeros(1, 1000);\n  for v = 1:1000\n    r(v) = corr(X(:,v), Y);\n  end\n  disp(['\"'\"'Max correlation: '\"'\"' num2str(max(r))]);\n  disp(['\"'\"'Min correlation: '\"'\"' num2str(min(r))]);\n  exit(0);\n\" 2>&1'"
     expected_output_contains: "Max correlation:"
 
 cleanup:

--- a/recipes/oshyx/fulltest.yaml
+++ b/recipes/oshyx/fulltest.yaml
@@ -40,67 +40,67 @@ tests:
   # ==========================================================================
   - name: OSHy.py version and banner
     description: Verify OSHy.py runs and displays version banner
-    command: python -u /OSHy/OSHy.py 2>&1 | head -5
+    command: "bash -lc 'python -u /OSHy/OSHy.py 2>&1 | head -5'"
     expected_output_contains: "OSHy-X v0.4"
 
   - name: OSHy.py help message
     description: Display OSHy.py command-line help
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--target"
 
   - name: OSHy.py help contains all options
     description: Verify all command line options are documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--outdir"
 
   - name: OSHy.py crop option documentation
     description: Verify crop option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--crop"
 
   - name: OSHy.py weighting option documentation
     description: Verify weighting option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--weighting"
 
   - name: OSHy.py denoise option documentation
     description: Verify denoise option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--denoise"
 
   - name: OSHy.py field correction option documentation
     description: Verify field correction option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--fieldCorrection"
 
   - name: OSHy.py mosaic option documentation
     description: Verify mosaic option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--mosaic"
 
   - name: OSHy.py tesla option documentation
     description: Verify tesla/field strength option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--tesla"
 
   - name: OSHy.py bimodal option documentation
     description: Verify bimodal priors option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--bimodal"
 
   - name: OSHy.py threads option documentation
     description: Verify threads option is documented
-    command: python -u /OSHy/OSHy.py --help 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py --help 2>&1'"
     expected_output_contains: "--nthreads"
 
   - name: OSHy.py copyright notice
     description: Verify copyright is displayed
-    command: python -u /OSHy/OSHy.py 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py 2>&1'"
     expected_output_contains: "Copyright"
 
   - name: OSHy.py missing arguments message
     description: Verify helpful message when required args missing
-    command: python -u /OSHy/OSHy.py 2>&1
+    command: "bash -lc 'python -u /OSHy/OSHy.py 2>&1'"
     expected_output_contains: "required"
 
   # ==========================================================================
@@ -108,52 +108,52 @@ tests:
   # ==========================================================================
   - name: Test T1w image exists
     description: Verify bundled T1w test image is present
-    command: 'python -c "import os; print(''exists'' if os.path.exists(''/OSHy/sub-test.nii.gz'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.exists('\"'\"'/OSHy/sub-test.nii.gz'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: Test T2w image exists
     description: Verify bundled T2w test image is present
-    command: 'python -c "import os; print(''exists'' if os.path.exists(''/OSHy/test_T2w.nii.gz'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.exists('\"'\"'/OSHy/test_T2w.nii.gz'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 3T template exists
     description: Verify 3T template is present
-    command: 'python -c "import os; print(''exists'' if os.path.exists(''/OSHy/templates/3T_template.nii.gz'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.exists('\"'\"'/OSHy/templates/3T_template.nii.gz'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 7T template exists
     description: Verify 7T template is present
-    command: 'python -c "import os; print(''exists'' if os.path.exists(''/OSHy/templates/7T_template.nii.gz'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.exists('\"'\"'/OSHy/templates/7T_template.nii.gz'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 3T bounding box exists
     description: Verify 3T bounding box is present
-    command: 'python -c "import os; print(''exists'' if os.path.exists(''/OSHy/templates/3T_box.nii.gz'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.exists('\"'\"'/OSHy/templates/3T_box.nii.gz'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 7T bounding box exists
     description: Verify 7T bounding box is present
-    command: 'python -c "import os; print(''exists'' if os.path.exists(''/OSHy/templates/7T_box.nii.gz'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.exists('\"'\"'/OSHy/templates/7T_box.nii.gz'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 3T atlases directory exists
     description: Verify 3T atlases directory is present
-    command: 'python -c "import os; print(''exists'' if os.path.isdir(''/OSHy/atlases/3T'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.isdir('\"'\"'/OSHy/atlases/3T'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 7T atlases directory exists
     description: Verify 7T atlases directory is present
-    command: 'python -c "import os; print(''exists'' if os.path.isdir(''/OSHy/atlases/7T'') else ''missing'')"'
+    command: "bash -lc 'python -c \"import os; print('\"'\"'exists'\"'\"' if os.path.isdir('\"'\"'/OSHy/atlases/7T'\"'\"') else '\"'\"'missing'\"'\"')\"'"
     expected_output_contains: "exists"
 
   - name: 3T atlas count
     description: Verify sufficient 3T atlases are present
-    command: 'python -c "import glob; files=glob.glob(''/OSHy/atlases/3T/*.nii.gz''); print(str(len(files)) + '' atlas files'')"'
+    command: "bash -lc 'python -c \"import glob; files=glob.glob('\"'\"'/OSHy/atlases/3T/*.nii.gz'\"'\"'); print(str(len(files)) + '\"'\"' atlas files'\"'\"')\"'"
     expected_output_contains: "atlas files"
 
   - name: 7T atlas count
     description: Verify sufficient 7T atlases are present
-    command: 'python -c "import glob; files=glob.glob(''/OSHy/atlases/7T/*.nii.gz''); print(str(len(files)) + '' atlas files'')"'
+    command: "bash -lc 'python -c \"import glob; files=glob.glob('\"'\"'/OSHy/atlases/7T/*.nii.gz'\"'\"'); print(str(len(files)) + '\"'\"' atlas files'\"'\"')\"'"
     expected_output_contains: "atlas files"
 
   # ==========================================================================
@@ -196,22 +196,22 @@ tests:
 
   - name: antsJointLabelFusion script available
     description: Verify Joint Label Fusion script is available
-    command: ls /opt/ants-2.3.1/antsJointLabelFusion.sh 2>&1
+    command: "bash -lc 'ls /opt/ants-2.3.1/antsJointLabelFusion.sh 2>&1'"
     expected_output_contains: "antsJointLabelFusion.sh"
 
   - name: antsJointLabelFusion2 script available
     description: Verify Joint Label Fusion 2 script is available
-    command: ls /opt/ants-2.3.1/antsJointLabelFusion2.sh 2>&1
+    command: "bash -lc 'ls /opt/ants-2.3.1/antsJointLabelFusion2.sh 2>&1'"
     expected_output_contains: "antsJointLabelFusion2.sh"
 
   - name: antsBrainExtraction script available
     description: Verify brain extraction script is available
-    command: ls /opt/ants-2.3.1/antsBrainExtraction.sh 2>&1
+    command: "bash -lc 'ls /opt/ants-2.3.1/antsBrainExtraction.sh 2>&1'"
     expected_output_contains: "antsBrainExtraction.sh"
 
   - name: antsRegistrationSyN script available
     description: Verify SyN registration script is available
-    command: ls /opt/ants-2.3.1/antsRegistrationSyN.sh 2>&1
+    command: "bash -lc 'ls /opt/ants-2.3.1/antsRegistrationSyN.sh 2>&1'"
     expected_output_contains: "antsRegistrationSyN.sh"
 
   - name: ThresholdImage available
@@ -244,22 +244,22 @@ tests:
 
   - name: ANTsPy image read
     description: Test reading NIfTI with ANTsPy
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); print(''Shape: '' + str(img.shape))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); print('\"'\"'Shape: '\"'\"' + str(img.shape))\"'"
     expected_output_contains: "Shape:"
 
   - name: ANTsPy image dimensions
     description: Verify test image dimensions
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); print(''Dims: '' + str(img.shape))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); print('\"'\"'Dims: '\"'\"' + str(img.shape))\"'"
     expected_output_contains: "(192, 240, 256)"
 
   - name: ANTsPy image spacing
     description: Verify test image spacing
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); print(''Spacing: '' + str(img.spacing))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); print('\"'\"'Spacing: '\"'\"' + str(img.spacing))\"'"
     expected_output_contains: "1.0"
 
   - name: ANTsPy denoise function
     description: Test ANTsPy denoising on downsampled image to avoid timeout
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); small=ants.resample_image(img, (2,2,2), False, 1); result=ants.denoise_image(small); print(''Denoising works'')"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); small=ants.resample_image(img, (2,2,2), False, 1); result=ants.denoise_image(small); print('\"'\"'Denoising works'\"'\"')\"'"
     expected_output_contains: "Denoising works"
 
   - name: ANTsPy registration function exists
@@ -331,7 +331,7 @@ tests:
 
   - name: nibabel load test image
     description: Test loading NIfTI with nibabel
-    command: 'python -c "import nibabel as nib; img=nib.load(''/OSHy/sub-test.nii.gz''); print(''Shape: '' + str(img.shape))"'
+    command: "bash -lc 'python -c \"import nibabel as nib; img=nib.load('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); print('\"'\"'Shape: '\"'\"' + str(img.shape))\"'"
     expected_output_contains: "Shape:"
 
   - name: numpy import
@@ -374,88 +374,88 @@ tests:
   # ==========================================================================
   - name: ANTsPy image write
     description: Test writing NIfTI with ANTsPy
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); ants.image_write(img, 'test_output/ants_write_test.nii.gz'); print('Write successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); ants.image_write(img, '\"'\"'test_output/ants_write_test.nii.gz'\"'\"'); print('\"'\"'Write successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/ants_write_test.nii.gz
 
   - name: ANTsPy image smoothing
     description: Test Gaussian smoothing with ANTsPy
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); smoothed=ants.smooth_image(img, 2.0); ants.image_write(smoothed, 'test_output/smoothed.nii.gz'); print('Smoothing successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); smoothed=ants.smooth_image(img, 2.0); ants.image_write(smoothed, '\"'\"'test_output/smoothed.nii.gz'\"'\"'); print('\"'\"'Smoothing successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/smoothed.nii.gz
 
   - name: ANTsPy image thresholding
     description: Test image thresholding with ANTsPy
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); thresh=ants.threshold_image(img, 100, 500); ants.image_write(thresh, 'test_output/thresholded.nii.gz'); print('Thresholding successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); thresh=ants.threshold_image(img, 100, 500); ants.image_write(thresh, '\"'\"'test_output/thresholded.nii.gz'\"'\"'); print('\"'\"'Thresholding successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/thresholded.nii.gz
 
   - name: ANTsPy Otsu thresholding
     description: Test Otsu automatic thresholding
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); ants.image_write(mask, 'test_output/otsu_mask.nii.gz'); print('Otsu successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); ants.image_write(mask, '\"'\"'test_output/otsu_mask.nii.gz'\"'\"'); print('\"'\"'Otsu successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/otsu_mask.nii.gz
 
   - name: ANTsPy mask application
     description: Test masking an image
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); masked=ants.mask_image(img, mask); ants.image_write(masked, 'test_output/masked.nii.gz'); print('Masking successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); masked=ants.mask_image(img, mask); ants.image_write(masked, '\"'\"'test_output/masked.nii.gz'\"'\"'); print('\"'\"'Masking successful'\"'\"')\"'"
     depends_on: ANTsPy Otsu thresholding
     validate:
       - output_exists: ${output_dir}/masked.nii.gz
 
   - name: ANTsPy image resampling
     description: Test image resampling
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); resampled=ants.resample_image(img, (2,2,2), False, 1); ants.image_write(resampled, 'test_output/resampled.nii.gz'); print('Resampling successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); resampled=ants.resample_image(img, (2,2,2), False, 1); ants.image_write(resampled, '\"'\"'test_output/resampled.nii.gz'\"'\"'); print('\"'\"'Resampling successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/resampled.nii.gz
 
   - name: ANTsPy N4 bias correction
     description: Test N4 bias field correction
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); corrected=ants.n4_bias_field_correction(img); ants.image_write(corrected, 'test_output/n4_corrected.nii.gz'); print('N4 successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); corrected=ants.n4_bias_field_correction(img); ants.image_write(corrected, '\"'\"'test_output/n4_corrected.nii.gz'\"'\"'); print('\"'\"'N4 successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/n4_corrected.nii.gz
 
   - name: ANTsPy histogram matching
     description: Test histogram matching between images
-    command: python -c "import ants; img1=ants.image_read('/OSHy/sub-test.nii.gz'); img2=ants.image_read('/OSHy/templates/3T_template.nii.gz'); matched=ants.histogram_match_image(img1, img2); print('Histogram matching successful')"
+    command: "bash -lc 'python -c \"import ants; img1=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); img2=ants.image_read('\"'\"'/OSHy/templates/3T_template.nii.gz'\"'\"'); matched=ants.histogram_match_image(img1, img2); print('\"'\"'Histogram matching successful'\"'\"')\"'"
     expected_output_contains: "successful"
 
   - name: ANTsPy iMath operations gradient
     description: Test iMath gradient operation
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); grad=ants.iMath_grad(img); ants.image_write(grad, 'test_output/gradient.nii.gz'); print('Gradient successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); grad=ants.iMath_grad(img); ants.image_write(grad, '\"'\"'test_output/gradient.nii.gz'\"'\"'); print('\"'\"'Gradient successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/gradient.nii.gz
 
   - name: ANTsPy iMath operations Laplacian
     description: Test iMath Laplacian operation
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); lap=ants.iMath_laplacian(img, 1.5); ants.image_write(lap, 'test_output/laplacian.nii.gz'); print('Laplacian successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); lap=ants.iMath_laplacian(img, 1.5); ants.image_write(lap, '\"'\"'test_output/laplacian.nii.gz'\"'\"'); print('\"'\"'Laplacian successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/laplacian.nii.gz
 
   - name: ANTsPy morphological dilation
     description: Test morphological dilation
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); dilated=ants.iMath_MD(mask, 2); ants.image_write(dilated, 'test_output/dilated.nii.gz'); print('Dilation successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); dilated=ants.iMath_MD(mask, 2); ants.image_write(dilated, '\"'\"'test_output/dilated.nii.gz'\"'\"'); print('\"'\"'Dilation successful'\"'\"')\"'"
     depends_on: ANTsPy Otsu thresholding
     validate:
       - output_exists: ${output_dir}/dilated.nii.gz
 
   - name: ANTsPy morphological erosion
     description: Test morphological erosion
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); eroded=ants.iMath_ME(mask, 2); ants.image_write(eroded, 'test_output/eroded.nii.gz'); print('Erosion successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); eroded=ants.iMath_ME(mask, 2); ants.image_write(eroded, '\"'\"'test_output/eroded.nii.gz'\"'\"'); print('\"'\"'Erosion successful'\"'\"')\"'"
     depends_on: ANTsPy Otsu thresholding
     validate:
       - output_exists: ${output_dir}/eroded.nii.gz
 
   - name: ANTsPy fill holes
     description: Test hole filling in mask
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); filled=ants.iMath_fill_holes(mask); ants.image_write(filled, 'test_output/filled.nii.gz'); print('Fill holes successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); filled=ants.iMath_fill_holes(mask); ants.image_write(filled, '\"'\"'test_output/filled.nii.gz'\"'\"'); print('\"'\"'Fill holes successful'\"'\"')\"'"
     depends_on: ANTsPy Otsu thresholding
     validate:
       - output_exists: ${output_dir}/filled.nii.gz
 
   - name: ANTsPy get largest component
     description: Test extracting largest connected component
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); largest=ants.iMath_get_largest_component(mask); ants.image_write(largest, 'test_output/largest_component.nii.gz'); print('Largest component successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); largest=ants.iMath_get_largest_component(mask); ants.image_write(largest, '\"'\"'test_output/largest_component.nii.gz'\"'\"'); print('\"'\"'Largest component successful'\"'\"')\"'"
     depends_on: ANTsPy Otsu thresholding
     validate:
       - output_exists: ${output_dir}/largest_component.nii.gz
@@ -465,32 +465,32 @@ tests:
   # ==========================================================================
   - name: 3T template dimensions
     description: Verify 3T template has correct dimensions
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/templates/3T_template.nii.gz''); print(''Shape: '' + str(img.shape))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/templates/3T_template.nii.gz'\"'\"'); print('\"'\"'Shape: '\"'\"' + str(img.shape))\"'"
     expected_output_contains: "Shape:"
 
   - name: 7T template dimensions
     description: Verify 7T template has correct dimensions
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/templates/7T_template.nii.gz''); print(''Shape: '' + str(img.shape))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/templates/7T_template.nii.gz'\"'\"'); print('\"'\"'Shape: '\"'\"' + str(img.shape))\"'"
     expected_output_contains: "Shape:"
 
   - name: 3T bounding box is binary
     description: Verify 3T bounding box contains only 0 and 1
-    command: 'python -c "import ants; import numpy as np; img=ants.image_read(''/OSHy/templates/3T_box.nii.gz''); data=img.numpy(); unique=np.unique(data); print(''Unique values: '' + str(unique))"'
+    command: "bash -lc 'python -c \"import ants; import numpy as np; img=ants.image_read('\"'\"'/OSHy/templates/3T_box.nii.gz'\"'\"'); data=img.numpy(); unique=np.unique(data); print('\"'\"'Unique values: '\"'\"' + str(unique))\"'"
     expected_output_contains: "Unique values:"
 
   - name: 7T bounding box is binary
     description: Verify 7T bounding box contains only 0 and 1
-    command: 'python -c "import ants; import numpy as np; img=ants.image_read(''/OSHy/templates/7T_box.nii.gz''); data=img.numpy(); unique=np.unique(data); print(''Unique values: '' + str(unique))"'
+    command: "bash -lc 'python -c \"import ants; import numpy as np; img=ants.image_read('\"'\"'/OSHy/templates/7T_box.nii.gz'\"'\"'); data=img.numpy(); unique=np.unique(data); print('\"'\"'Unique values: '\"'\"' + str(unique))\"'"
     expected_output_contains: "Unique values:"
 
   - name: 3T atlas labels check
     description: Verify 3T atlases contain correct labels (1-4)
-    command: 'python -c "import glob; import ants; import numpy as np; labels=glob.glob(''/OSHy/atlases/3T/*label*.nii.gz''); img=ants.image_read(labels[0]); unique=np.unique(img.numpy()); print(''Labels: '' + str(unique))"'
+    command: "bash -lc 'python -c \"import glob; import ants; import numpy as np; labels=glob.glob('\"'\"'/OSHy/atlases/3T/*label*.nii.gz'\"'\"'); img=ants.image_read(labels[0]); unique=np.unique(img.numpy()); print('\"'\"'Labels: '\"'\"' + str(unique))\"'"
     expected_output_contains: "Labels:"
 
   - name: 7T atlas labels check
     description: Verify 7T atlases contain correct labels (1-4)
-    command: 'python -c "import glob; import ants; import numpy as np; labels=glob.glob(''/OSHy/atlases/7T/*label*.nii.gz''); img=ants.image_read(labels[0]); unique=np.unique(img.numpy()); print(''Labels: '' + str(unique))"'
+    command: "bash -lc 'python -c \"import glob; import ants; import numpy as np; labels=glob.glob('\"'\"'/OSHy/atlases/7T/*label*.nii.gz'\"'\"'); img=ants.image_read(labels[0]); unique=np.unique(img.numpy()); print('\"'\"'Labels: '\"'\"' + str(unique))\"'"
     expected_output_contains: "Labels:"
 
   # ==========================================================================
@@ -498,12 +498,12 @@ tests:
   # ==========================================================================
   - name: ANTsPy affine registration
     description: Test affine registration capability
-    command: python -c "import ants; fixed=ants.image_read('/OSHy/templates/3T_template.nii.gz'); moving=ants.image_read('/OSHy/sub-test.nii.gz'); reg=ants.registration(fixed, moving, type_of_transform='Affine'); print('Affine registration successful')"
+    command: "bash -lc 'python -c \"import ants; fixed=ants.image_read('\"'\"'/OSHy/templates/3T_template.nii.gz'\"'\"'); moving=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); reg=ants.registration(fixed, moving, type_of_transform='\"'\"'Affine'\"'\"'); print('\"'\"'Affine registration successful'\"'\"')\"'"
     expected_output_contains: "successful"
 
   - name: ANTsPy transform application
     description: Test applying transforms to images
-    command: "python -c \"import ants; fixed=ants.image_read('/OSHy/templates/3T_template.nii.gz'); moving=ants.image_read('/OSHy/sub-test.nii.gz'); reg=ants.registration(fixed, moving, type_of_transform='Affine'); warped=ants.apply_transforms(fixed, moving, reg['fwdtransforms']); print('Transform application successful')\""
+    command: "bash -lc 'python -c \"import ants; fixed=ants.image_read('\"'\"'/OSHy/templates/3T_template.nii.gz'\"'\"'); moving=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); reg=ants.registration(fixed, moving, type_of_transform='\"'\"'Affine'\"'\"'); warped=ants.apply_transforms(fixed, moving, reg['\"'\"'fwdtransforms'\"'\"']); print('\"'\"'Transform application successful'\"'\"')\"'"
     expected_output_contains: "successful"
 
   # ==========================================================================
@@ -511,14 +511,12 @@ tests:
   # ==========================================================================
   - name: ANTsPy label geometry measures
     description: Test computing label geometry measures
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); mask=ants.otsu_segmentation(img, 2); stats=ants.label_geometry_measures(mask, img); print(''Measures computed: '' + str(len(stats)) + '' rows'')"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); stats=ants.label_geometry_measures(mask, img); print('\"'\"'Measures computed: '\"'\"' + str(len(stats)) + '\"'\"' rows'\"'\"')\"'"
     expected_output_contains: "Measures computed:"
 
   - name: ImageMath label stats
     description: Test ImageMath LabelStats operation
-    command: |
-      python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); ants.image_write(mask, 'test_output/temp_mask.nii.gz')" && \
-      ImageMath 3 test_output/label_stats.csv LabelStats test_output/temp_mask.nii.gz /OSHy/sub-test.nii.gz 2>&1 | head -5
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); ants.image_write(mask, '\"'\"'test_output/temp_mask.nii.gz'\"'\"')\" && \\\nImageMath 3 test_output/label_stats.csv LabelStats test_output/temp_mask.nii.gz /OSHy/sub-test.nii.gz 2>&1 | head -5'"
     validate:
       - output_exists: ${output_dir}/label_stats.csv
 
@@ -527,28 +525,28 @@ tests:
   # ==========================================================================
   - name: Read compressed NIfTI
     description: Test reading .nii.gz files
-    command: 'python -c "import nibabel as nib; img=nib.load(''/OSHy/sub-test.nii.gz''); print(''Loaded: '' + str(img.shape))"'
+    command: "bash -lc 'python -c \"import nibabel as nib; img=nib.load('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); print('\"'\"'Loaded: '\"'\"' + str(img.shape))\"'"
     expected_output_contains: "Loaded:"
 
   - name: Write uncompressed NIfTI
     description: Test writing .nii files
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); ants.image_write(img, 'test_output/uncompressed.nii'); print('Uncompressed write successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); ants.image_write(img, '\"'\"'test_output/uncompressed.nii'\"'\"'); print('\"'\"'Uncompressed write successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/uncompressed.nii
 
   - name: Header information extraction
     description: Test extracting header information
-    command: "python -c \"import ants; info=ants.image_header_info('/OSHy/sub-test.nii.gz'); print('Dimensions: ' + str(info['dimensions']))\""
+    command: "bash -lc 'python -c \"import ants; info=ants.image_header_info('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); print('\"'\"'Dimensions: '\"'\"' + str(info['\"'\"'dimensions'\"'\"']))\"'"
     expected_output_contains: "Dimensions:"
 
   - name: Image orientation check
     description: Test getting image orientation
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); orient=ants.get_orientation(img); print(''Orientation: '' + str(orient))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); orient=ants.get_orientation(img); print('\"'\"'Orientation: '\"'\"' + str(orient))\"'"
     expected_output_contains: "Orientation:"
 
   - name: Image direction matrix
     description: Test getting direction matrix
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); direction=ants.get_direction(img); print(''Direction shape: '' + str(direction.shape))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); direction=ants.get_direction(img); print('\"'\"'Direction shape: '\"'\"' + str(direction.shape))\"'"
     expected_output_contains: "Direction shape:"
 
   # ==========================================================================
@@ -581,7 +579,7 @@ tests:
 
   - name: glob available
     description: Verify glob for file pattern matching
-    command: 'python -c "import glob; files=glob.glob(''/OSHy/*.py''); print(''Found '' + str(len(files)) + '' Python files'')"'
+    command: "bash -lc 'python -c \"import glob; files=glob.glob('\"'\"'/OSHy/*.py'\"'\"'); print('\"'\"'Found '\"'\"' + str(len(files)) + '\"'\"' Python files'\"'\"')\"'"
     expected_output_contains: "Found"
 
   # ==========================================================================
@@ -589,52 +587,52 @@ tests:
   # ==========================================================================
   - name: OSHy module import
     description: Test importing OSHy module
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import Target_img, OSHy_data, convert_to_bool; print(''OSHy module imported'')"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import Target_img, OSHy_data, convert_to_bool; print('\"'\"'OSHy module imported'\"'\"')\"'"
     expected_output_contains: "OSHy module imported"
 
   - name: convert_to_bool True
     description: Test convert_to_bool with True string
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import convert_to_bool; print(convert_to_bool(''True''))"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import convert_to_bool; print(convert_to_bool('\"'\"'True'\"'\"'))\"'"
     expected_output_contains: "True"
 
   - name: convert_to_bool False
     description: Test convert_to_bool with False string
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import convert_to_bool; print(convert_to_bool(''False''))"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import convert_to_bool; print(convert_to_bool('\"'\"'False'\"'\"'))\"'"
     expected_output_contains: "False"
 
   - name: convert_to_bool case insensitive
     description: Test convert_to_bool case insensitivity
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import convert_to_bool; print(convert_to_bool(''TRUE''), convert_to_bool(''false''))"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import convert_to_bool; print(convert_to_bool('\"'\"'TRUE'\"'\"'), convert_to_bool('\"'\"'false'\"'\"'))\"'"
     expected_output_contains: "True False"
 
   - name: OSHy_data class instantiation
     description: Test creating OSHy_data object
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import OSHy_data; data=OSHy_data(''3'', ''T1w'', False, True); print(''OSHy_data created'')"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import OSHy_data; data=OSHy_data('\"'\"'3'\"'\"', '\"'\"'T1w'\"'\"', False, True); print('\"'\"'OSHy_data created'\"'\"')\"'"
     expected_output_contains: "OSHy_data created"
 
   - name: OSHy_data get_template
     description: Test getting template from OSHy_data
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import OSHy_data; data=OSHy_data(''3'', ''T1w'', False, True); template=data.get_template(); print(''Template shape: '' + str(template.shape))"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import OSHy_data; data=OSHy_data('\"'\"'3'\"'\"', '\"'\"'T1w'\"'\"', False, True); template=data.get_template(); print('\"'\"'Template shape: '\"'\"' + str(template.shape))\"'"
     expected_output_contains: "Template shape:"
 
   - name: OSHy_data get_template_box
     description: Test getting template box from OSHy_data
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import OSHy_data; data=OSHy_data(''3'', ''T1w'', False, True); box=data.get_template_box(); print(''Box shape: '' + str(box.shape))"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import OSHy_data; data=OSHy_data('\"'\"'3'\"'\"', '\"'\"'T1w'\"'\"', False, True); box=data.get_template_box(); print('\"'\"'Box shape: '\"'\"' + str(box.shape))\"'"
     expected_output_contains: "Box shape:"
 
   - name: OSHy_data get_atlases 3T T1w
     description: Test getting 3T T1w atlases
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import OSHy_data; data=OSHy_data(''3'', ''T1w'', False, True); atlases=data.get_atlases(); print(''Found '' + str(len(atlases)) + '' atlases'')"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import OSHy_data; data=OSHy_data('\"'\"'3'\"'\"', '\"'\"'T1w'\"'\"', False, True); atlases=data.get_atlases(); print('\"'\"'Found '\"'\"' + str(len(atlases)) + '\"'\"' atlases'\"'\"')\"'"
     expected_output_contains: "Found"
 
   - name: OSHy_data get_atlases 7T T1w
     description: Test getting 7T T1w atlases
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import OSHy_data; data=OSHy_data(''7'', ''T1w'', False, True); atlases=data.get_atlases(); print(''Found '' + str(len(atlases)) + '' atlases'')"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import OSHy_data; data=OSHy_data('\"'\"'7'\"'\"', '\"'\"'T1w'\"'\"', False, True); atlases=data.get_atlases(); print('\"'\"'Found '\"'\"' + str(len(atlases)) + '\"'\"' atlases'\"'\"')\"'"
     expected_output_contains: "Found"
 
   - name: OSHy_data get_labels
     description: Test getting atlas labels
-    command: 'python -c "import sys; sys.path.insert(0, ''/OSHy''); from OSHy import OSHy_data; data=OSHy_data(''3'', ''T1w'', False, True); labels=data.get_labels(); print(''Found '' + str(len(labels)) + '' label files'')"'
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/OSHy'\"'\"'); from OSHy import OSHy_data; data=OSHy_data('\"'\"'3'\"'\"', '\"'\"'T1w'\"'\"', False, True); labels=data.get_labels(); print('\"'\"'Found '\"'\"' + str(len(labels)) + '\"'\"' label files'\"'\"')\"'"
     expected_output_contains: "Found"
 
   # ==========================================================================
@@ -642,57 +640,57 @@ tests:
   # ==========================================================================
   - name: ANTsPy crop image
     description: Test image cropping with ANTsPy
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.otsu_segmentation(img, 2); cropped=ants.crop_image(img, mask); ants.image_write(cropped, 'test_output/cropped.nii.gz'); print('Cropping successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.otsu_segmentation(img, 2); cropped=ants.crop_image(img, mask); ants.image_write(cropped, '\"'\"'test_output/cropped.nii.gz'\"'\"'); print('\"'\"'Cropping successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/cropped.nii.gz
 
   - name: ANTsPy pad image
     description: Test image padding
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); padded=ants.pad_image(img, pad_width=(10,10,10)); ants.image_write(padded, 'test_output/padded.nii.gz'); print('Padding successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); padded=ants.pad_image(img, pad_width=(10,10,10)); ants.image_write(padded, '\"'\"'test_output/padded.nii.gz'\"'\"'); print('\"'\"'Padding successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/padded.nii.gz
 
   - name: ANTsPy slice image
     description: Test extracting 2D slice from 3D
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); sliced=ants.slice_image(img, axis=2, idx=100); print(''Slice shape: '' + str(sliced.shape))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); sliced=ants.slice_image(img, axis=2, idx=100); print('\"'\"'Slice shape: '\"'\"' + str(sliced.shape))\"'"
     expected_output_contains: "Slice shape:"
 
   - name: ANTsPy get mask
     description: Test getting mask from image
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); mask=ants.get_mask(img); ants.image_write(mask, 'test_output/get_mask.nii.gz'); print('Get mask successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); mask=ants.get_mask(img); ants.image_write(mask, '\"'\"'test_output/get_mask.nii.gz'\"'\"'); print('\"'\"'Get mask successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/get_mask.nii.gz
 
   - name: ANTsPy image clone
     description: Test image cloning
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); clone=ants.image_clone(img); print('Clone successful' if clone.shape == img.shape else 'Clone failed')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); clone=ants.image_clone(img); print('\"'\"'Clone successful'\"'\"' if clone.shape == img.shape else '\"'\"'Clone failed'\"'\"')\"'"
     expected_output_contains: "Clone successful"
 
   - name: ANTsPy reflect image
     description: Test image reflection
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); reflected=ants.reflect_image(img, axis=0); ants.image_write(reflected, 'test_output/reflected.nii.gz'); print('Reflection successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); reflected=ants.reflect_image(img, axis=0); ants.image_write(reflected, '\"'\"'test_output/reflected.nii.gz'\"'\"'); print('\"'\"'Reflection successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/reflected.nii.gz
 
   - name: ANTsPy multiply images
     description: Test image multiplication
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); result=ants.multiply_images(img, img); ants.image_write(result, 'test_output/multiplied.nii.gz'); print('Multiply successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); result=ants.multiply_images(img, img); ants.image_write(result, '\"'\"'test_output/multiplied.nii.gz'\"'\"'); print('\"'\"'Multiply successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/multiplied.nii.gz
 
   - name: ANTsPy copy image info
     description: Test copying image information
-    command: python -c "import ants; img1=ants.image_read('/OSHy/sub-test.nii.gz'); img2=ants.image_clone(img1); ants.copy_image_info(img1, img2); print('Copy info successful')"
+    command: "bash -lc 'python -c \"import ants; img1=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); img2=ants.image_clone(img1); ants.copy_image_info(img1, img2); print('\"'\"'Copy info successful'\"'\"')\"'"
     expected_output_contains: "successful"
 
   - name: ANTsPy image similarity
     description: Test computing image similarity
-    command: 'python -c "import ants; img=ants.image_read(''/OSHy/sub-test.nii.gz''); sim=ants.image_similarity(img, img, metric_type=''Correlation''); print(''Similarity: '' + str(sim))"'
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); sim=ants.image_similarity(img, img, metric_type='\"'\"'Correlation'\"'\"'); print('\"'\"'Similarity: '\"'\"' + str(sim))\"'"
     expected_output_contains: "Similarity:"
 
   - name: ANTsPy rank intensity
     description: Test rank intensity normalization
-    command: python -c "import ants; img=ants.image_read('/OSHy/sub-test.nii.gz'); ranked=ants.rank_intensity(img); ants.image_write(ranked, 'test_output/ranked.nii.gz'); print('Rank intensity successful')"
+    command: "bash -lc 'python -c \"import ants; img=ants.image_read('\"'\"'/OSHy/sub-test.nii.gz'\"'\"'); ranked=ants.rank_intensity(img); ants.image_write(ranked, '\"'\"'test_output/ranked.nii.gz'\"'\"'); print('\"'\"'Rank intensity successful'\"'\"')\"'"
     validate:
       - output_exists: ${output_dir}/ranked.nii.gz
 

--- a/recipes/osprey/fulltest.yaml
+++ b/recipes/osprey/fulltest.yaml
@@ -77,12 +77,12 @@ tests:
   # ==========================================================================
   - name: MATLAB Runtime installed
     description: Verify MATLAB Compiler Runtime R2023a is present
-    command: ls -d /opt/MCR/R2023a/
+    command: "bash -lc 'ls -d /opt/MCR/R2023a/'"
     expected_output_contains: "/opt/MCR/R2023a/"
 
   - name: MCR library path accessible
     description: Verify MCR runtime libraries exist
-    command: ls /opt/MCR/R2023a/runtime/glnxa64/ | head -5
+    command: "bash -lc 'ls /opt/MCR/R2023a/runtime/glnxa64/ | head -5'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -95,7 +95,7 @@ tests:
 
   - name: MEGA-PRESS SPAR header exists (sub-01)
     description: Verify MEGA-PRESS parameter file exists alongside SDAT
-    command: ls -la /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'ls -la /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "sub-01_megapress_act.spar"
 
   - name: MEGA-PRESS reference data exists (sub-01)
@@ -130,7 +130,7 @@ tests:
 
   - name: Example data directory structure
     description: Verify BIDS-like directory structure of example data
-    command: ls -la /opt/exampledata/
+    command: "bash -lc 'ls -la /opt/exampledata/'"
     expected_output_contains: "MEGA"
 
   # ==========================================================================
@@ -138,27 +138,27 @@ tests:
   # ==========================================================================
   - name: SPAR file readable (MEGA-PRESS sub-01)
     description: Verify SPAR header file contains expected parameters
-    command: head -20 /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'head -20 /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "GYROSCAN spectro parameter file"
 
   - name: SPAR contains samples parameter
     description: Verify SPAR header has number of samples
-    command: grep "samples" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"samples\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "samples"
 
   - name: SPAR contains echo_time parameter
     description: Verify SPAR header has echo time (68ms for MEGA-PRESS GABA)
-    command: grep "echo_time" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"echo_time\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "68"
 
   - name: SPAR contains synthesizer_frequency
     description: Verify SPAR header has field strength indicator
-    command: grep "synthesizer_frequency" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"synthesizer_frequency\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "127750920"
 
   - name: SPAR contains voxel dimensions
     description: Verify SPAR header has voxel size parameters
-    command: grep "_size" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"_size\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "30"
 
   - name: SDAT file size check (MEGA-PRESS)
@@ -168,7 +168,7 @@ tests:
 
   - name: Unedited PRESS SPAR header check
     description: Verify unedited PRESS SPAR file is readable
-    command: cat /opt/exampledata/UnEdited/sub-01/ses-01/mrs/sub-01_ses-01_press/sub-01_PRESS_35_act.spar
+    command: "bash -lc 'cat /opt/exampledata/UnEdited/sub-01/ses-01/mrs/sub-01_ses-01_press/sub-01_PRESS_35_act.spar'"
     expected_output_contains: "GYROSCAN"
 
   # ==========================================================================
@@ -176,12 +176,12 @@ tests:
   # ==========================================================================
   - name: Basis sets directory structure
     description: Verify basis sets organized by field strength
-    command: ls /opt/basissets/
+    command: "bash -lc 'ls /opt/basissets/'"
     expected_output_contains: "3T"
 
   - name: 3T basis sets by vendor
     description: Verify basis sets available for all major vendors
-    command: ls /opt/basissets/3T/
+    command: "bash -lc 'ls /opt/basissets/3T/'"
     expected_output_contains: "philips"
 
   - name: Philips MEGA-PRESS basis set exists (GABA 68ms)
@@ -191,7 +191,7 @@ tests:
 
   - name: Philips MEGA-PRESS basis set exists (GABA 80ms)
     description: Verify Philips MEGA-PRESS GABA basis set for TE=80ms
-    command: ls -la /opt/basissets/3T/philips/mega/press/gaba80/
+    command: "bash -lc 'ls -la /opt/basissets/3T/philips/mega/press/gaba80/'"
     expected_output_contains: "basis_philips_megapress_gaba80.mat"
 
   - name: Philips unedited PRESS basis set exists (TE=35ms)
@@ -201,52 +201,52 @@ tests:
 
   - name: Philips HERMES basis set exists
     description: Verify Philips HERMES editing basis set
-    command: ls -la /opt/basissets/3T/philips/hermes/gabagsh/
+    command: "bash -lc 'ls -la /opt/basissets/3T/philips/hermes/gabagsh/'"
     expected_output_contains: "basis_philips_hermes.mat"
 
   - name: Philips HERCULES basis set exists
     description: Verify Philips HERCULES editing basis set
-    command: ls -la /opt/basissets/3T/philips/hercules-press/
+    command: "bash -lc 'ls -la /opt/basissets/3T/philips/hercules-press/'"
     expected_output_contains: "basis_philips_hercules-press.mat"
 
   - name: Siemens MEGA-PRESS basis set exists (GABA 68ms)
     description: Verify Siemens MEGA-PRESS GABA basis set
-    command: ls -la /opt/basissets/3T/siemens/mega/press/gaba68/
+    command: "bash -lc 'ls -la /opt/basissets/3T/siemens/mega/press/gaba68/'"
     expected_output_contains: "basis_siemens_megapress_gaba68.mat"
 
   - name: Siemens unedited PRESS basis set exists (TE=30ms)
     description: Verify Siemens unedited PRESS basis set for TE=30ms
-    command: ls -la /opt/basissets/3T/siemens/unedited/press/30/
+    command: "bash -lc 'ls -la /opt/basissets/3T/siemens/unedited/press/30/'"
     expected_output_contains: "basis_siemens_press30.mat"
 
   - name: Siemens sLASER basis set exists
     description: Verify Siemens sLASER basis set
-    command: ls -la /opt/basissets/3T/siemens/unedited/slaser/30/
+    command: "bash -lc 'ls -la /opt/basissets/3T/siemens/unedited/slaser/30/'"
     expected_output_contains: "basis_siemens_slaser30.mat"
 
   - name: GE MEGA-PRESS basis set exists (GABA 68ms)
     description: Verify GE MEGA-PRESS GABA basis set
-    command: ls -la /opt/basissets/3T/ge/mega/press/gaba68/
+    command: "bash -lc 'ls -la /opt/basissets/3T/ge/mega/press/gaba68/'"
     expected_output_contains: "basis_ge_megapress_gaba68.mat"
 
   - name: GE unedited PRESS basis set exists (TE=35ms)
     description: Verify GE unedited PRESS basis set
-    command: ls -la /opt/basissets/3T/ge/unedited/press/35/
+    command: "bash -lc 'ls -la /opt/basissets/3T/ge/unedited/press/35/'"
     expected_output_contains: "basis_ge_press35.mat"
 
   - name: 7T basis sets available
     description: Verify 7T basis sets directory exists
-    command: ls /opt/basissets/7T/
+    command: "bash -lc 'ls /opt/basissets/7T/'"
     expected_exit_code: 0
 
   - name: 9.4T basis sets available
     description: Verify 9.4T basis sets directory exists
-    command: ls /opt/basissets/9-4T/
+    command: "bash -lc 'ls /opt/basissets/9-4T/'"
     expected_exit_code: 0
 
   - name: User basis sets directory
     description: Verify user-customizable basis sets directory exists
-    command: ls /opt/basissets/user/
+    command: "bash -lc 'ls /opt/basissets/user/'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -254,12 +254,12 @@ tests:
   # ==========================================================================
   - name: LCModel BASIS file format available (Philips)
     description: Verify LCModel-compatible BASIS format file exists
-    command: ls -la /opt/basissets/3T/philips/unedited/press/35/3T_PRESS_Philips_35ms_noMM.BASIS 2>/dev/null || echo "No LCModel BASIS file"
+    command: "bash -lc 'ls -la /opt/basissets/3T/philips/unedited/press/35/3T_PRESS_Philips_35ms_noMM.BASIS 2>/dev/null || echo \"No LCModel BASIS file\"'"
     expected_exit_code: 0
 
   - name: LCModel BASIS file format available (Siemens)
     description: Verify LCModel-compatible BASIS format file exists for Siemens
-    command: ls -la /opt/basissets/3T/siemens/unedited/press/35/3T_PRESS_Siemens_35ms_noMM.BASIS 2>/dev/null || echo "Checked"
+    command: "bash -lc 'ls -la /opt/basissets/3T/siemens/unedited/press/35/3T_PRESS_Siemens_35ms_noMM.BASIS 2>/dev/null || echo \"Checked\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -267,32 +267,32 @@ tests:
   # ==========================================================================
   - name: ospreyCMD wrapper script content
     description: Verify ospreyCMD wrapper script calls correct binary
-    command: cat /opt/ospreyCMD
+    command: "bash -lc 'cat /opt/ospreyCMD'"
     expected_output_contains: "run_OspreyCMD.sh"
 
   - name: ospreyCMD wrapper uses correct MCR path
     description: Verify ospreyCMD wrapper uses R2023a runtime
-    command: cat /opt/ospreyCMD
+    command: "bash -lc 'cat /opt/ospreyCMD'"
     expected_output_contains: "/opt/MCR/R2023a/"
 
   - name: ospreyGUI wrapper script content
     description: Verify ospreyGUI wrapper script calls correct binary
-    command: cat /opt/ospreyGUI
+    command: "bash -lc 'cat /opt/ospreyGUI'"
     expected_output_contains: "run_Osprey.sh"
 
   - name: ospreyGUI wrapper uses correct MCR path
     description: Verify ospreyGUI wrapper uses R2023a runtime
-    command: cat /opt/ospreyGUI
+    command: "bash -lc 'cat /opt/ospreyGUI'"
     expected_output_contains: "/opt/MCR/R2023a/"
 
   - name: Underlying OspreyCMD binary exists
     description: Verify compiled MATLAB binary exists
-    command: ls -la /opt/UbuntuCMD/OspreyCMD
+    command: "bash -lc 'ls -la /opt/UbuntuCMD/OspreyCMD'"
     expected_output_contains: "OspreyCMD"
 
   - name: Underlying Osprey GUI binary exists
     description: Verify compiled MATLAB GUI binary exists
-    command: ls -la /opt/UbuntuGUI/
+    command: "bash -lc 'ls -la /opt/UbuntuGUI/'"
     expected_output_contains: "Osprey"
 
   # ==========================================================================
@@ -300,12 +300,12 @@ tests:
   # ==========================================================================
   - name: Osprey license file present
     description: Verify Osprey MIT license is included
-    command: cat /opt/UbuntuCMD/OSPREY_LICENSE.md
+    command: "bash -lc 'cat /opt/UbuntuCMD/OSPREY_LICENSE.md'"
     expected_output_contains: "MIT"
 
   - name: SPM12 license present
     description: Verify SPM12 license is included (used for coregistration)
-    command: head -20 /opt/UbuntuCMD/SPM12_LICENCE.txt
+    command: "bash -lc 'head -20 /opt/UbuntuCMD/SPM12_LICENCE.txt'"
     expected_output_contains: "SPM"
 
   - name: Container README present
@@ -336,12 +336,12 @@ tests:
   # ==========================================================================
   - name: Statistics CSV exists (MEGA)
     description: Verify statistics CSV for group analysis exists
-    command: cat /opt/exampledata/MEGA/stat.csv
+    command: "bash -lc 'cat /opt/exampledata/MEGA/stat.csv'"
     expected_exit_code: 0
 
   - name: Statistics CSV exists (UnEdited)
     description: Verify statistics CSV for unedited data exists
-    command: cat /opt/exampledata/UnEdited/stat.csv
+    command: "bash -lc 'cat /opt/exampledata/UnEdited/stat.csv'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -354,12 +354,12 @@ tests:
 
   - name: ospreyCMD executable permissions
     description: Verify ospreyCMD has execute permissions
-    command: ls -la /opt/ospreyCMD | awk '{print $1}'
+    command: "bash -lc 'ls -la /opt/ospreyCMD | awk '\"'\"'{print $1}'\"'\"''"
     expected_output_contains: "x"
 
   - name: ospreyGUI executable permissions
     description: Verify ospreyGUI has execute permissions
-    command: ls -la /opt/ospreyGUI | awk '{print $1}'
+    command: "bash -lc 'ls -la /opt/ospreyGUI | awk '\"'\"'{print $1}'\"'\"''"
     expected_output_contains: "x"
 
   # ==========================================================================
@@ -367,17 +367,17 @@ tests:
   # ==========================================================================
   - name: MCR runtime libraries present
     description: Verify MATLAB Runtime shared libraries exist
-    command: ls /opt/MCR/R2023a/runtime/glnxa64/*.so | head -3
+    command: bash -lc 'ls /opt/MCR/R2023a/runtime/glnxa64/*.so | head -3'
     expected_exit_code: 0
 
   - name: MCR bin directory present
     description: Verify MATLAB Runtime binaries directory
-    command: ls /opt/MCR/R2023a/bin/glnxa64/ | head -3
+    command: "bash -lc 'ls /opt/MCR/R2023a/bin/glnxa64/ | head -3'"
     expected_exit_code: 0
 
   - name: Required MCR products file
     description: Verify required MCR products specification
-    command: cat /opt/UbuntuCMD/requiredMCRProducts.txt
+    command: "bash -lc 'cat /opt/UbuntuCMD/requiredMCRProducts.txt'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -385,27 +385,27 @@ tests:
   # ==========================================================================
   - name: Both MEGA subjects present
     description: Verify MEGA data for both subjects exists
-    command: ls /opt/exampledata/MEGA/ | grep sub
+    command: "bash -lc 'ls /opt/exampledata/MEGA/ | grep sub'"
     expected_output_contains: "sub-01"
 
   - name: Both UnEdited subjects present
     description: Verify unedited data for both subjects exists
-    command: ls /opt/exampledata/UnEdited/ | grep sub
+    command: "bash -lc 'ls /opt/exampledata/UnEdited/ | grep sub'"
     expected_output_contains: "sub-01"
 
   - name: BIDS session structure (sub-01)
     description: Verify BIDS-like session directory structure
-    command: ls /opt/exampledata/MEGA/sub-01/
+    command: "bash -lc 'ls /opt/exampledata/MEGA/sub-01/'"
     expected_output_contains: "ses-01"
 
   - name: MRS directory structure (sub-01)
     description: Verify MRS data organized in mrs subdirectory
-    command: ls /opt/exampledata/MEGA/sub-01/ses-01/
+    command: "bash -lc 'ls /opt/exampledata/MEGA/sub-01/ses-01/'"
     expected_output_contains: "mrs"
 
   - name: Anatomical directory structure (sub-01)
     description: Verify anatomical data organized in anat subdirectory
-    command: ls /opt/exampledata/MEGA/sub-01/ses-01/
+    command: "bash -lc 'ls /opt/exampledata/MEGA/sub-01/ses-01/'"
     expected_output_contains: "anat"
 
   # ==========================================================================
@@ -413,12 +413,12 @@ tests:
   # ==========================================================================
   - name: MEGA-PRESS data for GABA editing
     description: Verify MEGA-PRESS acquisition (320 averages typical for GABA)
-    command: grep "rows" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"rows\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "320"
 
   - name: Reference scan parameters
     description: Verify reference scan has same parameters as metabolite scan
-    command: grep "echo_time" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress-ref/sub-01_megapress_ref.spar
+    command: "bash -lc 'grep \"echo_time\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress-ref/sub-01_megapress_ref.spar'"
     expected_output_contains: "68"
 
   # ==========================================================================
@@ -426,22 +426,22 @@ tests:
   # ==========================================================================
   - name: Voxel AP size
     description: Verify voxel anterior-posterior dimension
-    command: grep "ap_size" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"ap_size\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "30"
 
   - name: Voxel LR size
     description: Verify voxel left-right dimension
-    command: grep "lr_size" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"lr_size\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "30"
 
   - name: Voxel CC size
     description: Verify voxel cranio-caudal dimension
-    command: grep "cc_size" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"cc_size\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "30"
 
   - name: Voxel position (AP offset)
     description: Verify voxel anterior-posterior offset position
-    command: grep "ap_off_center" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar
+    command: "bash -lc 'grep \"ap_off_center\" /opt/exampledata/MEGA/sub-01/ses-01/mrs/sub-01_ses-01_megapress/sub-01_megapress_act.spar'"
     expected_output_contains: "45"
 
   # ==========================================================================
@@ -449,12 +449,12 @@ tests:
   # ==========================================================================
   - name: Unedited PRESS echo time
     description: Verify unedited PRESS has short TE (35ms)
-    command: grep "echo_time" /opt/exampledata/UnEdited/sub-01/ses-01/mrs/sub-01_ses-01_press/sub-01_PRESS_35_act.spar
+    command: "bash -lc 'grep \"echo_time\" /opt/exampledata/UnEdited/sub-01/ses-01/mrs/sub-01_ses-01_press/sub-01_PRESS_35_act.spar'"
     expected_output_contains: "35"
 
   - name: Unedited PRESS sample frequency
     description: Verify unedited PRESS spectral bandwidth
-    command: grep "sample_frequency" /opt/exampledata/UnEdited/sub-01/ses-01/mrs/sub-01_ses-01_press/sub-01_PRESS_35_act.spar
+    command: "bash -lc 'grep \"sample_frequency\" /opt/exampledata/UnEdited/sub-01/ses-01/mrs/sub-01_ses-01_press/sub-01_PRESS_35_act.spar'"
     expected_output_contains: "2000"
 
   # ==========================================================================
@@ -475,27 +475,27 @@ tests:
   # ==========================================================================
   - name: MEGA sequence basis sets present
     description: Verify MEGA editing basis sets available
-    command: ls /opt/basissets/3T/philips/mega/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/mega/'"
     expected_output_contains: "press"
 
   - name: HERMES sequence basis sets present
     description: Verify HERMES editing basis sets available
-    command: ls /opt/basissets/3T/philips/hermes/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/hermes/'"
     expected_output_contains: "gabagsh"
 
   - name: HERCULES sequence basis sets present
     description: Verify HERCULES editing basis sets available
-    command: ls /opt/basissets/3T/philips/hercules-press/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/hercules-press/'"
     expected_output_contains: "basis_philips"
 
   - name: Unedited sequence basis sets present
     description: Verify unedited sequence basis sets available
-    command: ls /opt/basissets/3T/philips/unedited/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/'"
     expected_output_contains: "press"
 
   - name: sLASER sequence basis sets present
     description: Verify sLASER sequence basis sets available
-    command: ls /opt/basissets/3T/philips/unedited/slaser/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/slaser/'"
     expected_output_contains: "30"
 
   # ==========================================================================
@@ -503,17 +503,17 @@ tests:
   # ==========================================================================
   - name: All major vendors supported (3T)
     description: Verify basis sets for GE, Philips, and Siemens
-    command: ls /opt/basissets/3T/ | sort
+    command: "bash -lc 'ls /opt/basissets/3T/ | sort'"
     expected_output_contains: "ge"
 
   - name: GE basis sets structure
     description: Verify GE basis sets organization
-    command: ls /opt/basissets/3T/ge/
+    command: "bash -lc 'ls /opt/basissets/3T/ge/'"
     expected_output_contains: "mega"
 
   - name: Siemens basis sets structure
     description: Verify Siemens basis sets organization
-    command: ls /opt/basissets/3T/siemens/
+    command: "bash -lc 'ls /opt/basissets/3T/siemens/'"
     expected_output_contains: "mega"
 
   # ==========================================================================
@@ -521,27 +521,27 @@ tests:
   # ==========================================================================
   - name: Philips PRESS TE=20ms basis
     description: Verify short TE basis set available
-    command: ls /opt/basissets/3T/philips/unedited/press/20/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/press/20/'"
     expected_output_contains: "basis_philips_press20.mat"
 
   - name: Philips PRESS TE=30ms basis
     description: Verify TE=30ms basis set available
-    command: ls /opt/basissets/3T/philips/unedited/press/30/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/press/30/'"
     expected_output_contains: "basis_philips_press30.mat"
 
   - name: Philips PRESS TE=35ms basis
     description: Verify TE=35ms basis set available
-    command: ls /opt/basissets/3T/philips/unedited/press/35/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/press/35/'"
     expected_output_contains: "basis_philips_press35.mat"
 
   - name: Philips PRESS TE=80ms basis
     description: Verify intermediate TE basis set available
-    command: ls /opt/basissets/3T/philips/unedited/press/80/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/press/80/'"
     expected_output_contains: "basis_philips_press80.mat"
 
   - name: Philips PRESS TE=140ms basis
     description: Verify long TE basis set available
-    command: ls /opt/basissets/3T/philips/unedited/press/140/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/unedited/press/140/'"
     expected_output_contains: "basis_philips_press140.mat"
 
   # ==========================================================================
@@ -549,17 +549,17 @@ tests:
   # ==========================================================================
   - name: Philips MEGA-PRESS GABA TE=68ms
     description: Verify GABA editing basis for TE=68ms
-    command: ls /opt/basissets/3T/philips/mega/press/gaba68/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/mega/press/gaba68/'"
     expected_output_contains: "basis_philips_megapress_gaba68.mat"
 
   - name: Philips MEGA-PRESS GABA TE=80ms
     description: Verify GABA editing basis for TE=80ms
-    command: ls /opt/basissets/3T/philips/mega/press/gaba80/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/mega/press/gaba80/'"
     expected_output_contains: "basis_philips_megapress_gaba80.mat"
 
   - name: Philips MEGA-PRESS GSH TE=120ms
     description: Verify GSH editing basis for TE=120ms
-    command: ls /opt/basissets/3T/philips/mega/press/gsh120/
+    command: "bash -lc 'ls /opt/basissets/3T/philips/mega/press/gsh120/'"
     expected_output_contains: "basis_philips_megapress_gsh120.mat"
 
   # ==========================================================================
@@ -567,12 +567,12 @@ tests:
   # ==========================================================================
   - name: Siemens SPECIAL sequence basis
     description: Verify SPECIAL sequence basis set available
-    command: ls /opt/basissets/3T/siemens/unedited/special/
+    command: "bash -lc 'ls /opt/basissets/3T/siemens/unedited/special/'"
     expected_output_contains: "8_5"
 
   - name: SPECIAL control file present
     description: Verify LCModel control file for SPECIAL
-    command: ls /opt/basissets/3T/siemens/unedited/special/8_5/
+    command: "bash -lc 'ls /opt/basissets/3T/siemens/unedited/special/8_5/'"
     expected_output_contains: ".control"
 
 cleanup:

--- a/recipes/ospreybids/fulltest.yaml
+++ b/recipes/ospreybids/fulltest.yaml
@@ -124,7 +124,7 @@ tests:
 
   - name: OspreyHBCD executable permissions
     description: Verify OspreyHBCD has executable permissions
-    command: test -x /code/OspreyHBCD && echo "executable"
+    command: bash -lc 'test -x /code/OspreyHBCD && echo "executable"'
     expected_output_contains: "executable"
 
   - name: run_compiled.sh exists
@@ -248,12 +248,12 @@ tests:
 
   - name: Basis sets directory exists
     description: Verify HBCD_basissets directory exists
-    command: ls -d /HBCD_basissets 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets 2>&1'"
     expected_output_contains: "/HBCD_basissets"
 
   - name: 3T basis sets directory exists
     description: Verify 3T basis sets directory exists
-    command: ls -d /HBCD_basissets/3T 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T 2>&1'"
     expected_output_contains: "3T"
 
   # ==========================================================================
@@ -261,27 +261,27 @@ tests:
   # ==========================================================================
   - name: Siemens basis sets directory exists
     description: Verify Siemens basis sets directory exists
-    command: ls -d /HBCD_basissets/3T/siemens 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/siemens 2>&1'"
     expected_output_contains: "siemens"
 
   - name: Siemens HERCULES-PRESS basis set directory
     description: Verify Siemens HERCULES-PRESS basis set directory exists
-    command: ls -d /HBCD_basissets/3T/siemens/hercules-press 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/siemens/hercules-press 2>&1'"
     expected_output_contains: "hercules-press"
 
   - name: Siemens HERCULES-PRESS basis set file
     description: Verify Siemens HERCULES-PRESS basis set .mat file exists
-    command: ls /HBCD_basissets/3T/siemens/hercules-press/*.mat 2>&1
+    command: bash -lc 'ls /HBCD_basissets/3T/siemens/hercules-press/*.mat 2>&1'
     expected_output_contains: ".mat"
 
   - name: Siemens unedited basis set directory
     description: Verify Siemens unedited basis set directory exists
-    command: ls -d /HBCD_basissets/3T/siemens/unedited 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/siemens/unedited 2>&1'"
     expected_output_contains: "unedited"
 
   - name: Siemens unedited PRESS basis set directory
     description: Verify Siemens unedited PRESS basis set directory exists
-    command: ls -d /HBCD_basissets/3T/siemens/unedited/press 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/siemens/unedited/press 2>&1'"
     expected_output_contains: "press"
 
   # ==========================================================================
@@ -289,17 +289,17 @@ tests:
   # ==========================================================================
   - name: GE basis sets directory exists
     description: Verify GE basis sets directory exists
-    command: ls -d /HBCD_basissets/3T/ge 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/ge 2>&1'"
     expected_output_contains: "ge"
 
   - name: GE HERCULES-PRESS basis set directory
     description: Verify GE HERCULES-PRESS basis set directory exists
-    command: ls -d /HBCD_basissets/3T/ge/hercules-press 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/ge/hercules-press 2>&1'"
     expected_output_contains: "hercules-press"
 
   - name: GE unedited basis set directory
     description: Verify GE unedited basis set directory exists
-    command: ls -d /HBCD_basissets/3T/ge/unedited 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/ge/unedited 2>&1'"
     expected_output_contains: "unedited"
 
   # ==========================================================================
@@ -307,17 +307,17 @@ tests:
   # ==========================================================================
   - name: Philips basis sets directory exists
     description: Verify Philips basis sets directory exists
-    command: ls -d /HBCD_basissets/3T/philips 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/philips 2>&1'"
     expected_output_contains: "philips"
 
   - name: Philips HERCULES-PRESS basis set directory
     description: Verify Philips HERCULES-PRESS basis set directory exists
-    command: ls -d /HBCD_basissets/3T/philips/hercules-press 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/philips/hercules-press 2>&1'"
     expected_output_contains: "hercules-press"
 
   - name: Philips unedited basis set directory
     description: Verify Philips unedited basis set directory exists
-    command: ls -d /HBCD_basissets/3T/philips/unedited 2>&1
+    command: "bash -lc 'ls -d /HBCD_basissets/3T/philips/unedited 2>&1'"
     expected_output_contains: "unedited"
 
   # ==========================================================================
@@ -412,17 +412,17 @@ tests:
   # ==========================================================================
   - name: Singularity labels exist
     description: Verify container has Singularity labels
-    command: cat /.singularity.d/labels.json 2>&1
+    command: "bash -lc 'cat /.singularity.d/labels.json 2>&1'"
     expected_output_contains: "org.label-schema"
 
   - name: Container build date in labels
     description: Verify container build date is recorded
-    command: cat /.singularity.d/labels.json 2>&1
+    command: "bash -lc 'cat /.singularity.d/labels.json 2>&1'"
     expected_output_contains: "build-date"
 
   - name: Container architecture in labels
     description: Verify container architecture is recorded
-    command: cat /.singularity.d/labels.json 2>&1
+    command: "bash -lc 'cat /.singularity.d/labels.json 2>&1'"
     expected_output_contains: "amd64"
 
   - name: README.md exists
@@ -621,7 +621,7 @@ tests:
 
   - name: OspreyHBCD job file error
     description: Verify OspreyHBCD shows appropriate error for missing job file
-    command: /code/OspreyHBCD 2>&1 || true
+    command: bash -lc '/code/OspreyHBCD 2>&1 || true'
     expected_output_contains: "Not enough"
 
 cleanup:

--- a/recipes/palmettobug/fulltest.yaml
+++ b/recipes/palmettobug/fulltest.yaml
@@ -702,7 +702,7 @@ tests:
 
   - name: Palmettobug package files
     description: List palmettobug package contents
-    command: ls /opt/miniconda-latest/lib/python3.9/site-packages/palmettobug/
+    command: "bash -lc 'ls /opt/miniconda-latest/lib/python3.9/site-packages/palmettobug/'"
     expected_output_contains: "Executable.py"
     expected_exit_code: 0
 

--- a/recipes/physio/fulltest.yaml
+++ b/recipes/physio/fulltest.yaml
@@ -42,32 +42,32 @@ tests:
   # ==========================================================================
   - name: SPM12 help command
     description: Verify SPM12 standalone runs and displays help
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 help 2>&1'\"'\"''"
     expected_output_contains: "Usage: spm12"
 
   - name: SPM12 verbose help
     description: List all available SPM12 batch nodes
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 help --verbose 2>&1 | head -20
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 help --verbose 2>&1 | head -20'\"'\"''"
     expected_output_contains: "spm.temporal.st"
 
   - name: PhysIO toolbox presence
     description: Verify PhysIO toolbox is available in SPM tools
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 help --verbose 2>&1 | grep physio
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 help --verbose 2>&1 | grep physio'\"'\"''"
     expected_output_contains: "spm.tools.physio"
 
   - name: PhysIO help command
     description: Verify PhysIO help displays available options
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.physio help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.physio help 2>&1'\"'\"''"
     expected_output_contains: "save_dir"
 
   - name: MCR directory exists
     description: Verify MATLAB Compiler Runtime is installed
-    command: ls -la /opt/mcr/v99 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls -la /opt/mcr/v99 2>&1'\"'\"''"
     expected_output_contains: "runtime"
 
   - name: SPM12 directory exists
     description: Verify SPM12 standalone is installed
-    command: ls -la /opt/spm12 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls -la /opt/spm12 2>&1'\"'\"''"
     expected_output_contains: "run_spm12.sh"
 
   # ==========================================================================
@@ -75,27 +75,27 @@ tests:
   # ==========================================================================
   - name: PhysIO main function exists
     description: Verify main PhysIO regressor creation function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_main_create_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_main_create_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_main_create_regressors.m"
 
   - name: PhysIO initialization function exists
     description: Verify PhysIO initialization function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_init.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_init.m'\"'\"''"
     expected_output_contains: "tapas_physio_init.m"
 
   - name: PhysIO new structure function exists
     description: Verify PhysIO structure creation function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_new.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_new.m'\"'\"''"
     expected_output_contains: "tapas_physio_new.m"
 
   - name: PhysIO version function exists
     description: Verify PhysIO version function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_version.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_version.m'\"'\"''"
     expected_output_contains: "tapas_physio_version.m"
 
   - name: PhysIO batch configuration exists
     description: Verify PhysIO matlabbatch configuration
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_cfg_matlabbatch.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/tapas_physio_cfg_matlabbatch.m'\"'\"''"
     expected_output_contains: "tapas_physio_cfg_matlabbatch.m"
 
   # ==========================================================================
@@ -103,57 +103,57 @@ tests:
   # ==========================================================================
   - name: PhysIO BIDS reader exists
     description: Verify BIDS format physiological data reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_bids.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_bids.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_bids.m"
 
   - name: PhysIO Siemens reader exists
     description: Verify Siemens physiological log reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_siemens.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_siemens.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_siemens.m"
 
   - name: PhysIO Siemens TICS reader exists
     description: Verify Siemens TICS format reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_siemens_tics.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_siemens_tics.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_siemens_tics.m"
 
   - name: PhysIO Siemens HCP reader exists
     description: Verify Siemens HCP format reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_siemens_hcp.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_siemens_hcp.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_siemens_hcp.m"
 
   - name: PhysIO Philips reader exists
     description: Verify Philips physiological log reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_philips.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_philips.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_philips.m"
 
   - name: PhysIO GE reader exists
     description: Verify GE physiological log reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_GE.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_GE.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_GE.m"
 
   - name: PhysIO Biopac MAT reader exists
     description: Verify Biopac .mat file reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_biopac_mat.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_biopac_mat.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_biopac_mat.m"
 
   - name: PhysIO Biopac TXT reader exists
     description: Verify Biopac text file reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_biopac_txt.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_biopac_txt.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_biopac_txt.m"
 
   - name: PhysIO BrainProducts reader exists
     description: Verify BrainProducts physiological log reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_brainproducts.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_brainproducts.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_brainproducts.m"
 
   - name: PhysIO custom reader exists
     description: Verify custom format reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_custom.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_physlogfiles_custom.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_physlogfiles_custom.m"
 
   - name: PhysIO columnar text reader exists
     description: Verify columnar text file reader
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_columnar_textfiles.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/readin/tapas_physio_read_columnar_textfiles.m'\"'\"''"
     expected_output_contains: "tapas_physio_read_columnar_textfiles.m"
 
   # ==========================================================================
@@ -161,52 +161,52 @@ tests:
   # ==========================================================================
   - name: PhysIO cardiac filtering exists
     description: Verify cardiac signal filtering function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_filter_cardiac.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_filter_cardiac.m'\"'\"''"
     expected_output_contains: "tapas_physio_filter_cardiac.m"
 
   - name: PhysIO respiratory filtering exists
     description: Verify respiratory signal filtering function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_filter_respiratory.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_filter_respiratory.m'\"'\"''"
     expected_output_contains: "tapas_physio_filter_respiratory.m"
 
   - name: PhysIO ECG R-peak detection exists
     description: Verify ECG R-peak detection function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_find_ecg_r_peaks.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_find_ecg_r_peaks.m'\"'\"''"
     expected_output_contains: "tapas_physio_find_ecg_r_peaks.m"
 
   - name: PhysIO cardiac pulse detection exists
     description: Verify cardiac pulse detection function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_cardiac_pulses.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_cardiac_pulses.m'\"'\"''"
     expected_output_contains: "tapas_physio_get_cardiac_pulses.m"
 
   - name: PhysIO cardiac phase extraction exists
     description: Verify cardiac phase extraction function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_cardiac_phase.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_cardiac_phase.m'\"'\"''"
     expected_output_contains: "tapas_physio_get_cardiac_phase.m"
 
   - name: PhysIO respiratory phase extraction exists
     description: Verify respiratory phase extraction function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_respiratory_phase.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_respiratory_phase.m'\"'\"''"
     expected_output_contains: "tapas_physio_get_respiratory_phase.m"
 
   - name: PhysIO cardiac template extraction exists
     description: Verify cardiac pulse template function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_cardiac_pulse_template.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_get_cardiac_pulse_template.m'\"'\"''"
     expected_output_contains: "tapas_physio_get_cardiac_pulse_template.m"
 
   - name: PhysIO cardiac outlier detection exists
     description: Verify cardiac outlier detection function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_cardiac_detect_outliers.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_cardiac_detect_outliers.m'\"'\"''"
     expected_output_contains: "tapas_physio_cardiac_detect_outliers.m"
 
   - name: PhysIO manual pulse correction exists
     description: Verify manual cardiac pulse correction function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_correct_cardiac_pulses_manually.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_correct_cardiac_pulses_manually.m'\"'\"''"
     expected_output_contains: "tapas_physio_correct_cardiac_pulses_manually.m"
 
   - name: PhysIO constant detection exists
     description: Verify constant value detection in physiological data
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_detect_constants.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/preproc/tapas_physio_detect_constants.m'\"'\"''"
     expected_output_contains: "tapas_physio_detect_constants.m"
 
   # ==========================================================================
@@ -214,62 +214,62 @@ tests:
   # ==========================================================================
   - name: PhysIO RETROICOR regressor creation exists
     description: Verify RETROICOR model regressor creation
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_retroicor_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_retroicor_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_retroicor_regressors.m"
 
   - name: PhysIO HRV regressor creation exists
     description: Verify heart rate variability regressor creation
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_hrv_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_hrv_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_hrv_regressors.m"
 
   - name: PhysIO RVT regressor creation exists
     description: Verify respiratory volume per time regressor creation
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_rvt_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_rvt_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_rvt_regressors.m"
 
   - name: PhysIO noise ROI regressor creation exists
     description: Verify noise ROI (aCompCor-style) regressor creation
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_noise_rois_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_noise_rois_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_noise_rois_regressors.m"
 
   - name: PhysIO movement regressor creation exists
     description: Verify movement regressor creation
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_movement_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_create_movement_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_movement_regressors.m"
 
   - name: PhysIO Fourier expansion exists
     description: Verify Fourier basis set expansion function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_get_fourier_expansion.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_get_fourier_expansion.m'\"'\"''"
     expected_output_contains: "tapas_physio_get_fourier_expansion.m"
 
   - name: PhysIO cardiac response function exists
     description: Verify cardiac response function (CRF)
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_crf.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_crf.m'\"'\"''"
     expected_output_contains: "tapas_physio_crf.m"
 
   - name: PhysIO respiratory response function exists
     description: Verify respiratory response function (RRF)
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_rrf.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_rrf.m'\"'\"''"
     expected_output_contains: "tapas_physio_rrf.m"
 
   - name: PhysIO heart rate calculation exists
     description: Verify heart rate calculation function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_hr.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_hr.m'\"'\"''"
     expected_output_contains: "tapas_physio_hr.m"
 
   - name: PhysIO RVT Hilbert calculation exists
     description: Verify RVT calculation using Hilbert transform
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_rvt_hilbert.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_rvt_hilbert.m'\"'\"''"
     expected_output_contains: "tapas_physio_rvt_hilbert.m"
 
   - name: PhysIO RVT peaks calculation exists
     description: Verify RVT calculation using peak detection
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_rvt_peaks.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_rvt_peaks.m'\"'\"''"
     expected_output_contains: "tapas_physio_rvt_peaks.m"
 
   - name: PhysIO orthogonalization exists
     description: Verify regressor orthogonalization function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_orthogonalise_physiological_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/model/tapas_physio_orthogonalise_physiological_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_orthogonalise_physiological_regressors.m"
 
   # ==========================================================================
@@ -277,27 +277,27 @@ tests:
   # ==========================================================================
   - name: PhysIO scan timing creation exists
     description: Verify scan timing creation function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_scan_timing.m"
 
   - name: PhysIO nominal scan timing exists
     description: Verify nominal scan timing creation
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_nominal.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_nominal.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_scan_timing_nominal.m"
 
   - name: PhysIO gradient-based timing (Philips) exists
     description: Verify Philips gradient-based scan timing
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_from_gradients_philips.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_from_gradients_philips.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_scan_timing_from_gradients_philips.m"
 
   - name: PhysIO TICS-based timing (Siemens) exists
     description: Verify Siemens TICS-based scan timing
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_from_tics_siemens.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_from_tics_siemens.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_scan_timing_from_tics_siemens.m"
 
   - name: PhysIO acquisition code timing exists
     description: Verify acquisition code-based scan timing
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_from_acq_codes.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/sync/tapas_physio_create_scan_timing_from_acq_codes.m'\"'\"''"
     expected_output_contains: "tapas_physio_create_scan_timing_from_acq_codes.m"
 
   # ==========================================================================
@@ -305,32 +305,32 @@ tests:
   # ==========================================================================
   - name: PhysIO efficacy check exists
     description: Verify physiological noise model efficacy assessment
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_check_efficacy.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_check_efficacy.m'\"'\"''"
     expected_output_contains: "tapas_physio_check_efficacy.m"
 
   - name: PhysIO tSNR computation exists
     description: Verify temporal SNR computation function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_compute_tsnr_spm.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_compute_tsnr_spm.m'\"'\"''"
     expected_output_contains: "tapas_physio_compute_tsnr_spm.m"
 
   - name: PhysIO tSNR gains computation exists
     description: Verify tSNR gains computation function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_compute_tsnr_gains.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_compute_tsnr_gains.m'\"'\"''"
     expected_output_contains: "tapas_physio_compute_tsnr_gains.m"
 
   - name: PhysIO review function exists
     description: Verify PhysIO results review function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_review.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_review.m'\"'\"''"
     expected_output_contains: "tapas_physio_review.m"
 
   - name: PhysIO cardiac phase sorting exists
     description: Verify cardiac phase image sorting function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_sort_images_by_cardiac_phase.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_sort_images_by_cardiac_phase.m'\"'\"''"
     expected_output_contains: "tapas_physio_sort_images_by_cardiac_phase.m"
 
   - name: PhysIO respiratory phase sorting exists
     description: Verify respiratory phase image sorting function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_sort_images_by_respiratory_phase.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/assess/tapas_physio_sort_images_by_respiratory_phase.m'\"'\"''"
     expected_output_contains: "tapas_physio_sort_images_by_respiratory_phase.m"
 
   # ==========================================================================
@@ -338,22 +338,22 @@ tests:
   # ==========================================================================
   - name: PhysIO raw data plotting exists
     description: Verify raw physiological data plotting function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_plot_raw_physdata.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_plot_raw_physdata.m'\"'\"''"
     expected_output_contains: "tapas_physio_plot_raw_physdata.m"
 
   - name: PhysIO RETROICOR plotting exists
     description: Verify RETROICOR regressor plotting function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_plot_retroicor_regressors.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_plot_retroicor_regressors.m'\"'\"''"
     expected_output_contains: "tapas_physio_plot_retroicor_regressors.m"
 
   - name: PhysIO RVT plotting exists
     description: Verify RVT plotting function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_plot_rvt.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_plot_rvt.m'\"'\"''"
     expected_output_contains: "tapas_physio_plot_rvt.m"
 
   - name: PhysIO figure output exists
     description: Verify figure printing function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_print_figs_to_file.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/plot/tapas_physio_print_figs_to_file.m'\"'\"''"
     expected_output_contains: "tapas_physio_print_figs_to_file.m"
 
   # ==========================================================================
@@ -361,32 +361,32 @@ tests:
   # ==========================================================================
   - name: PhysIO peak finding exists
     description: Verify peak finding utility function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_findpeaks.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_findpeaks.m'\"'\"''"
     expected_output_contains: "tapas_physio_findpeaks.m"
 
   - name: PhysIO template correlation peak finding exists
     description: Verify template correlation peak finding
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_findpeaks_template_correlation.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_findpeaks_template_correlation.m'\"'\"''"
     expected_output_contains: "tapas_physio_findpeaks_template_correlation.m"
 
   - name: PhysIO PCA utility exists
     description: Verify PCA utility function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_pca.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_pca.m'\"'\"''"
     expected_output_contains: "tapas_physio_pca.m"
 
   - name: PhysIO Gaussian window exists
     description: Verify Gaussian window function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_gausswin.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_gausswin.m'\"'\"''"
     expected_output_contains: "tapas_physio_gausswin.m"
 
   - name: PhysIO convolution utility exists
     description: Verify convolution utility function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_conv.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_conv.m'\"'\"''"
     expected_output_contains: "tapas_physio_conv.m"
 
   - name: PhysIO logging utility exists
     description: Verify logging utility function
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_log.m
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/PhysIO/utils/tapas_physio_log.m'\"'\"''"
     expected_output_contains: "tapas_physio_log.m"
 
   # ==========================================================================
@@ -394,52 +394,52 @@ tests:
   # ==========================================================================
   - name: SPM smooth help
     description: Verify SPM smooth function parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.smooth help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.smooth help 2>&1'\"'\"''"
     expected_output_contains: "--fwhm"
 
   - name: SPM realign help
     description: Verify SPM realign function parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.realign.estimate help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.realign.estimate help 2>&1'\"'\"''"
     expected_output_contains: "--data"
 
   - name: SPM coregister help
     description: Verify SPM coregistration function parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.coreg.estimate help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.coreg.estimate help 2>&1'\"'\"''"
     expected_output_contains: "--ref"
 
   - name: SPM segment help
     description: Verify SPM segmentation function parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.preproc help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.preproc help 2>&1'\"'\"''"
     expected_output_contains: "--channel"
 
   - name: SPM normalize help
     description: Verify SPM normalization function parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.normalise.write help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.spatial.normalise.write help 2>&1'\"'\"''"
     expected_output_contains: "--subj"
 
   - name: SPM slice timing help
     description: Verify SPM slice timing correction parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.temporal.st help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.temporal.st help 2>&1'\"'\"''"
     expected_output_contains: "--scans"
 
   - name: SPM fMRI specification help
     description: Verify SPM fMRI design specification parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.fmri_spec help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.fmri_spec help 2>&1'\"'\"''"
     expected_output_contains: "--dir"
 
   - name: SPM estimation help
     description: Verify SPM model estimation parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.fmri_est help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.fmri_est help 2>&1'\"'\"''"
     expected_output_contains: "--spmmat"
 
   - name: SPM contrast help
     description: Verify SPM contrast specification parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.con help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.con help 2>&1'\"'\"''"
     expected_output_contains: "--spmmat"
 
   - name: SPM results help
     description: Verify SPM results module is recognized (help errors due to SPM results cfg bug)
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.results help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.stats.results help 2>&1'\"'\"''"
     expected_output_contains: "spm.stats.results"
     ignore_exit_code: true
 
@@ -448,22 +448,22 @@ tests:
   # ==========================================================================
   - name: SPM DARTEL help
     description: Verify DARTEL warp function parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.dartel.warp help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.dartel.warp help 2>&1'\"'\"''"
     expected_output_contains: "--images"
 
   - name: SPM FieldMap help
     description: Verify FieldMap VDM calculation parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.fieldmap.calculatevdm help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.fieldmap.calculatevdm help 2>&1'\"'\"''"
     expected_output_contains: "--subj"
 
   - name: SPM Longitudinal help
     description: Verify longitudinal registration parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.longit.pairwise help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.longit.pairwise help 2>&1'\"'\"''"
     expected_output_contains: "--vols"
 
   - name: SPM Shoot help
     description: Verify Shoot geodesic registration parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.shoot.warp help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.tools.shoot.warp help 2>&1'\"'\"''"
     expected_output_contains: "--images"
 
   # ==========================================================================
@@ -471,32 +471,32 @@ tests:
   # ==========================================================================
   - name: SPM image calculator help
     description: Verify SPM image calculator parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.imcalc help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.imcalc help 2>&1'\"'\"''"
     expected_output_contains: "--input"
 
   - name: SPM DICOM import help
     description: Verify DICOM import parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.import.dicom help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.import.dicom help 2>&1'\"'\"''"
     expected_output_contains: "--data"
 
   - name: SPM deface help
     description: Verify deface utility parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.deface help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.deface help 2>&1'\"'\"''"
     expected_output_contains: "--images"
 
   - name: SPM 4D concatenation help
     description: Verify 4D volume concatenation parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.cat help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.cat help 2>&1'\"'\"''"
     expected_output_contains: "--vols"
 
   - name: SPM 4D split help
     description: Verify 4D volume split parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.split help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.split help 2>&1'\"'\"''"
     expected_output_contains: "--vol"
 
   - name: SPM VOI extraction help
     description: Verify VOI time-series extraction parameters
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.voi help 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99 spm.util.voi help 2>&1'\"'\"''"
     expected_output_contains: "--spmmat"
 
   # ==========================================================================
@@ -504,32 +504,32 @@ tests:
   # ==========================================================================
   - name: SPM12 DARTEL toolbox exists
     description: Verify DARTEL toolbox is present
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/DARTEL 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/DARTEL 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 FieldMap toolbox exists
     description: Verify FieldMap toolbox is present
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/FieldMap 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/FieldMap 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 Longitudinal toolbox exists
     description: Verify Longitudinal toolbox is present
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/Longitudinal 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/Longitudinal 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 DEM toolbox exists
     description: Verify Dynamic Expectation Maximization toolbox is present
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/DEM 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/DEM 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 Neural_Models toolbox exists
     description: Verify Neural Models toolbox is present
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/Neural_Models 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/Neural_Models 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 Shoot toolbox exists
     description: Verify Shoot toolbox is present
-    command: ls /opt/spm12/spm12_mcr/spm12/toolbox/Shoot 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/toolbox/Shoot 2>&1'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -537,32 +537,32 @@ tests:
   # ==========================================================================
   - name: SPM12 main function exists
     description: Verify SPM main function file
-    command: ls /opt/spm12/spm12_mcr/spm12/spm.m 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/spm.m 2>&1'\"'\"''"
     expected_output_contains: "spm.m"
 
   - name: SPM12 BIDS function exists
     description: Verify SPM BIDS handling function
-    command: ls /opt/spm12/spm12_mcr/spm12/spm_BIDS.m 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/spm_BIDS.m 2>&1'\"'\"''"
     expected_output_contains: "spm_BIDS.m"
 
   - name: SPM12 NIfTI class exists
     description: Verify SPM NIfTI class directory
-    command: ls /opt/spm12/spm12_mcr/spm12/@nifti 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/@nifti 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 GIfTI class exists
     description: Verify SPM GIfTI class directory
-    command: ls /opt/spm12/spm12_mcr/spm12/@gifti 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/@gifti 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 matlabbatch exists
     description: Verify matlabbatch directory
-    command: ls /opt/spm12/spm12_mcr/spm12/matlabbatch 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/matlabbatch 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: SPM12 canonical templates exist
     description: Verify SPM canonical template directory
-    command: ls /opt/spm12/spm12_mcr/spm12/canonical 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/spm12/spm12_mcr/spm12/canonical 2>&1'\"'\"''"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -570,17 +570,17 @@ tests:
   # ==========================================================================
   - name: MCR runtime libraries exist
     description: Verify MCR runtime library directory
-    command: ls /opt/mcr/v99/runtime/glnxa64 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/mcr/v99/runtime/glnxa64 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: MCR bin directory exists
     description: Verify MCR bin directory
-    command: ls /opt/mcr/v99/bin/glnxa64 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/mcr/v99/bin/glnxa64 2>&1'\"'\"''"
     expected_exit_code: 0
 
   - name: MCR toolbox exists
     description: Verify MCR toolbox directory
-    command: ls /opt/mcr/v99/toolbox 2>&1
+    command: "bash -lc 'env MCR_ROOT=/opt/mcr/v99 SPM_CMD='\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v99'\"'\"' bash -lc '\"'\"'ls /opt/mcr/v99/toolbox 2>&1'\"'\"''"
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/pydeface/fulltest.yaml
+++ b/recipes/pydeface/fulltest.yaml
@@ -421,22 +421,22 @@ tests:
   # ==========================================================================
   - name: Check default template exists
     description: Verify default registration template is present
-    command: ls -la /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/mean_reg2mean.nii.gz
+    command: "bash -lc 'ls -la /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/mean_reg2mean.nii.gz'"
     expected_output_contains: "mean_reg2mean.nii.gz"
 
   - name: Check default facemask exists
     description: Verify default face mask is present
-    command: ls -la /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/facemask.nii.gz
+    command: "bash -lc 'ls -la /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/facemask.nii.gz'"
     expected_output_contains: "facemask.nii.gz"
 
   - name: Inspect default template
     description: Get info about default template image
-    command: nib-ls /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/mean_reg2mean.nii.gz
+    command: "bash -lc 'nib-ls /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/mean_reg2mean.nii.gz'"
     expected_output_contains: ""
 
   - name: Inspect default facemask
     description: Get info about default face mask image
-    command: nib-ls /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/facemask.nii.gz
+    command: "bash -lc 'nib-ls /opt/miniconda-4.6.14/lib/python3.7/site-packages/pydeface/data/facemask.nii.gz'"
     expected_output_contains: ""
 
   # ==========================================================================

--- a/recipes/qsiprep/fulltest.yaml
+++ b/recipes/qsiprep/fulltest.yaml
@@ -355,68 +355,68 @@ tests:
   # ==========================================================================
   - name: Convert3D version
     description: Verify Convert3D (c3d) is available
-    command: /opt/convert3d-nightly/bin/c3d -version 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d -version 2>&1'
     expected_output_contains: "Version"
 
   - name: Convert3D image info
     description: Test c3d for displaying image info
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -info 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -info 2>&1'
     expected_output_contains: "dim"
 
   - name: Convert3D resample
     description: Test c3d for resampling image
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -resample 50% -o test_output/t1w_c3d_resample.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -resample 50% -o test_output/t1w_c3d_resample.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_resample.nii.gz
 
   - name: Convert3D smooth
     description: Test c3d for Gaussian smoothing
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -smooth 2mm -o test_output/t1w_c3d_smooth.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -smooth 2mm -o test_output/t1w_c3d_smooth.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_smooth.nii.gz
 
   - name: Convert3D threshold
     description: Test c3d for thresholding
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -threshold 100 inf 1 0 -o test_output/t1w_c3d_thresh.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -threshold 100 inf 1 0 -o test_output/t1w_c3d_thresh.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_thresh.nii.gz
 
   - name: Convert3D arithmetic
     description: Test c3d for voxelwise arithmetic
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -scale 2 -o test_output/t1w_c3d_scale.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -scale 2 -o test_output/t1w_c3d_scale.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_scale.nii.gz
 
   - name: Convert3D statistics
     description: Test c3d for computing voxel statistics
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -voxel-sum 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -voxel-sum 2>&1'
     expected_exit_code: 0
 
   - name: Convert3D pad
     description: Test c3d for image padding
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -pad 5x5x5 5x5x5 0 -o test_output/t1w_c3d_pad.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -pad 5x5x5 5x5x5 0 -o test_output/t1w_c3d_pad.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_pad.nii.gz
 
   - name: Convert3D trim
     description: Test c3d for automatic trimming
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -trim 10vox -o test_output/t1w_c3d_trim.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -trim 10vox -o test_output/t1w_c3d_trim.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_trim.nii.gz
 
   - name: Convert3D dilate
     description: Test c3d for morphological dilation
     command: |
-      /opt/convert3d-nightly/bin/c3d ${t1w} -threshold 100 inf 1 0 \
-      -dilate 1 3x3x3vox -o test_output/t1w_c3d_dilate.nii.gz 2>&1
+      bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -threshold 100 inf 1 0 \
+      -dilate 1 3x3x3vox -o test_output/t1w_c3d_dilate.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_dilate.nii.gz
 
   - name: Convert3D erode
     description: Test c3d for morphological erosion
     command: |
-      /opt/convert3d-nightly/bin/c3d ${t1w} -threshold 100 inf 1 0 \
-      -erode 1 3x3x3vox -o test_output/t1w_c3d_erode.nii.gz 2>&1
+      bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -threshold 100 inf 1 0 \
+      -erode 1 3x3x3vox -o test_output/t1w_c3d_erode.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_erode.nii.gz
 
@@ -425,12 +425,12 @@ tests:
   # ==========================================================================
   - name: FreeSurfer mri_info help
     description: Verify FreeSurfer mri_info is available
-    command: /opt/freesurfer/bin/mri_info --help 2>&1 | head -10
+    command: bash -lc '/opt/freesurfer/bin/mri_info --help 2>&1 | head -10'
     expected_output_contains: "mri_info"
 
   - name: FreeSurfer mri_convert help
     description: Verify FreeSurfer mri_convert is available
-    command: /opt/freesurfer/bin/mri_convert --help 2>&1 | head -10
+    command: bash -lc '/opt/freesurfer/bin/mri_convert --help 2>&1 | head -10'
     expected_output_contains: "mri_convert"
 
   # ==========================================================================
@@ -438,7 +438,7 @@ tests:
   # ==========================================================================
   - name: 3Tissue ss3t_csd_beta1 help
     description: Verify 3Tissue single-shell 3-tissue CSD is available
-    command: /opt/3Tissue/bin/ss3t_csd_beta1 --help 2>&1 | head -10
+    command: bash -lc '/opt/3Tissue/bin/ss3t_csd_beta1 --help 2>&1 | head -10'
     expected_output_contains: "ss3t"
 
   # ==========================================================================
@@ -473,12 +473,12 @@ tests:
   - name: Convert3D pipeline - preprocess structural
     description: Chain c3d operations for basic preprocessing
     command: |
-      /opt/convert3d-nightly/bin/c3d ${t1w} \
+      bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} \
       -smooth 1mm \
       -threshold 50 inf 1 0 \
       -dilate 1 2x2x2vox \
       -erode 1 2x2x2vox \
-      -o test_output/t1w_c3d_pipeline.nii.gz 2>&1
+      -o test_output/t1w_c3d_pipeline.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_pipeline.nii.gz
 
@@ -503,8 +503,8 @@ tests:
   - name: Cross-tool - c3d to AFNI
     description: Resample with c3d, process with AFNI
     command: |
-      /opt/convert3d-nightly/bin/c3d ${t1w} -resample 64x64x64 -o test_output/t1w_c3d_64.nii.gz 2>&1 && \
-      3dcalc -a test_output/t1w_c3d_64.nii.gz -expr 'a/1000' -prefix test_output/t1w_cross_scaled.nii.gz 2>&1
+      bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -resample 64x64x64 -o test_output/t1w_c3d_64.nii.gz 2>&1 && \
+      3dcalc -a test_output/t1w_c3d_64.nii.gz -expr '\''a/1000'\'' -prefix test_output/t1w_cross_scaled.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_cross_scaled.nii.gz
 
@@ -570,7 +570,7 @@ tests:
 
   - name: Convert3D 4D operations
     description: Extract single volume from 4D using c3d (c3d cannot write 4D slices - ITK region mismatch)
-    command: /opt/convert3d-nightly/bin/c3d ${bold} -slice w 0 -o test_output/bold_c3d_vol0.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${bold} -slice w 0 -o test_output/bold_c3d_vol0.nii.gz 2>&1'
     expected_exit_code: 255
 
   # ==========================================================================
@@ -590,7 +590,7 @@ tests:
 
   - name: Convert3D reorient
     description: Reorient image using c3d
-    command: /opt/convert3d-nightly/bin/c3d ${t1w} -orient RAI -o test_output/t1w_c3d_rai.nii.gz 2>&1
+    command: bash -lc '/opt/convert3d-nightly/bin/c3d ${t1w} -orient RAI -o test_output/t1w_c3d_rai.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_c3d_rai.nii.gz
 

--- a/recipes/qsirecon/fulltest.yaml
+++ b/recipes/qsirecon/fulltest.yaml
@@ -440,17 +440,17 @@ tests:
   # ==========================================================================
   - name: ANTs antsRegistration version
     description: Check ANTs registration version
-    command: /opt/ants/bin/antsRegistration --version 2>&1
+    command: bash -lc '/opt/ants/bin/antsRegistration --version 2>&1'
     expected_output_contains: "ANTs Version"
 
   - name: ANTs N4BiasFieldCorrection version
     description: Check N4 bias correction version
-    command: /opt/ants/bin/N4BiasFieldCorrection --version 2>&1
+    command: bash -lc '/opt/ants/bin/N4BiasFieldCorrection --version 2>&1'
     expected_output_contains: "ANTs Version"
 
   - name: ANTs antsApplyTransforms version
     description: Check antsApplyTransforms version
-    command: /opt/ants/bin/antsApplyTransforms --help 2>&1 | head -5
+    command: bash -lc '/opt/ants/bin/antsApplyTransforms --help 2>&1 | head -5'
     expected_output_contains: "antsApplyTransforms"
 
   # ==========================================================================
@@ -458,17 +458,17 @@ tests:
   # ==========================================================================
   - name: PrintHeader origin
     description: Print image origin information
-    command: /opt/ants/bin/PrintHeader ${t1w} 0 2>&1
+    command: bash -lc '/opt/ants/bin/PrintHeader ${t1w} 0 2>&1'
     expected_exit_code: 0
 
   - name: PrintHeader spacing
     description: Print image voxel spacing
-    command: /opt/ants/bin/PrintHeader ${t1w} 1 2>&1
+    command: bash -lc '/opt/ants/bin/PrintHeader ${t1w} 1 2>&1'
     expected_exit_code: 0
 
   - name: PrintHeader size
     description: Print image dimensions
-    command: /opt/ants/bin/PrintHeader ${t1w} 2 2>&1
+    command: bash -lc '/opt/ants/bin/PrintHeader ${t1w} 2 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -476,13 +476,13 @@ tests:
   # ==========================================================================
   - name: N4 bias field correction basic
     description: Run N4 bias field correction with default parameters
-    command: /opt/ants/bin/N4BiasFieldCorrection -d 3 -i ${t1w} -o test_output/t1w_n4.nii.gz -s 4 -c [50x50x50,0.0] -v 0 2>&1
+    command: bash -lc '/opt/ants/bin/N4BiasFieldCorrection -d 3 -i ${t1w} -o test_output/t1w_n4.nii.gz -s 4 -c [50x50x50,0.0] -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_n4.nii.gz
 
   - name: N4 with bias field output
     description: Run N4 and output the estimated bias field
-    command: /opt/ants/bin/N4BiasFieldCorrection -d 3 -i ${t1w} -o [test_output/t1w_n4_with_bias.nii.gz,test_output/t1w_biasfield.nii.gz] -s 4 -c [50x50x50,0.0] -v 0 2>&1
+    command: bash -lc '/opt/ants/bin/N4BiasFieldCorrection -d 3 -i ${t1w} -o [test_output/t1w_n4_with_bias.nii.gz,test_output/t1w_biasfield.nii.gz] -s 4 -c [50x50x50,0.0] -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_n4_with_bias.nii.gz
       - output_exists: ${output_dir}/t1w_biasfield.nii.gz
@@ -492,13 +492,13 @@ tests:
   # ==========================================================================
   - name: Denoise image Rician model
     description: Denoise image using Rician noise model
-    command: /opt/ants/bin/DenoiseImage -d 3 -i ${t1w} -n Rician -o test_output/t1w_denoise_rician.nii.gz -v 0 2>&1
+    command: bash -lc '/opt/ants/bin/DenoiseImage -d 3 -i ${t1w} -n Rician -o test_output/t1w_denoise_rician.nii.gz -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_denoise_rician.nii.gz
 
   - name: Denoise image Gaussian model
     description: Denoise image using Gaussian noise model
-    command: /opt/ants/bin/DenoiseImage -d 3 -i ${t1w} -n Gaussian -o test_output/t1w_denoise_gaussian.nii.gz -v 0 2>&1
+    command: bash -lc '/opt/ants/bin/DenoiseImage -d 3 -i ${t1w} -n Gaussian -o test_output/t1w_denoise_gaussian.nii.gz -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_denoise_gaussian.nii.gz
 
@@ -507,19 +507,19 @@ tests:
   # ==========================================================================
   - name: ANTs threshold basic
     description: Binary threshold with low and high values
-    command: /opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_ants_thresh.nii.gz 100 500 2>&1
+    command: bash -lc '/opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_ants_thresh.nii.gz 100 500 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_ants_thresh.nii.gz
 
   - name: ANTs Otsu thresholding single class
     description: Otsu automatic thresholding with 1 threshold
-    command: /opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_otsu1.nii.gz Otsu 1 2>&1
+    command: bash -lc '/opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_otsu1.nii.gz Otsu 1 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_otsu1.nii.gz
 
   - name: ANTs Otsu thresholding multi-class
     description: Otsu automatic thresholding with 3 classes
-    command: /opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_otsu3.nii.gz Otsu 3 2>&1
+    command: bash -lc '/opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_otsu3.nii.gz Otsu 3 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_otsu3.nii.gz
 
@@ -528,7 +528,7 @@ tests:
   # ==========================================================================
   - name: ANTs smooth image Gaussian
     description: Gaussian smoothing with sigma in mm
-    command: /opt/ants/bin/SmoothImage 3 ${t1w} 2 test_output/t1w_ants_smooth2mm.nii.gz 2>&1
+    command: bash -lc '/opt/ants/bin/SmoothImage 3 ${t1w} 2 test_output/t1w_ants_smooth2mm.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_ants_smooth2mm.nii.gz
 
@@ -537,13 +537,13 @@ tests:
   # ==========================================================================
   - name: ANTs resample by spacing
     description: Resample image to new voxel spacing
-    command: /opt/ants/bin/ResampleImage 3 ${t1w} test_output/t1w_resample_2mm.nii.gz 2x2x2 0 2>&1
+    command: bash -lc '/opt/ants/bin/ResampleImage 3 ${t1w} test_output/t1w_resample_2mm.nii.gz 2x2x2 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_resample_2mm.nii.gz
 
   - name: ANTs resample nearest neighbor
     description: Resample using nearest neighbor interpolation
-    command: /opt/ants/bin/ResampleImage 3 ${t1w} test_output/t1w_resample_nn.nii.gz 80x96x96 1 1 2>&1
+    command: bash -lc '/opt/ants/bin/ResampleImage 3 ${t1w} test_output/t1w_resample_nn.nii.gz 80x96x96 1 1 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_resample_nn.nii.gz
 
@@ -552,19 +552,19 @@ tests:
   # ==========================================================================
   - name: ImageMath multiply by scalar
     description: Multiply image by a scalar value
-    command: /opt/ants/bin/ImageMath 3 test_output/t1w_imgmath_mul2.nii.gz m ${t1w} 2 2>&1
+    command: bash -lc '/opt/ants/bin/ImageMath 3 test_output/t1w_imgmath_mul2.nii.gz m ${t1w} 2 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_imgmath_mul2.nii.gz
 
   - name: ImageMath add scalar
     description: Add a scalar value to image
-    command: /opt/ants/bin/ImageMath 3 test_output/t1w_imgmath_add100.nii.gz + ${t1w} 100 2>&1
+    command: bash -lc '/opt/ants/bin/ImageMath 3 test_output/t1w_imgmath_add100.nii.gz + ${t1w} 100 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_imgmath_add100.nii.gz
 
   - name: ImageMath Gaussian smoothing
     description: Smooth image using ImageMath
-    command: /opt/ants/bin/ImageMath 3 test_output/t1w_imgmath_smooth.nii.gz G ${t1w} 2 2>&1
+    command: bash -lc '/opt/ants/bin/ImageMath 3 test_output/t1w_imgmath_smooth.nii.gz G ${t1w} 2 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_imgmath_smooth.nii.gz
 
@@ -574,28 +574,28 @@ tests:
   - name: ImageMath morphological dilation
     description: Dilate binary image using ImageMath
     command: |
-      /opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_mask_for_morph.nii.gz Otsu 1 && \
-      /opt/ants/bin/ImageMath 3 test_output/ants_mask_dilate.nii.gz MD test_output/t1w_mask_for_morph.nii.gz 2
+      bash -lc '/opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_mask_for_morph.nii.gz Otsu 1 && \
+      /opt/ants/bin/ImageMath 3 test_output/ants_mask_dilate.nii.gz MD test_output/t1w_mask_for_morph.nii.gz 2'
     validate:
       - output_exists: ${output_dir}/ants_mask_dilate.nii.gz
 
   - name: ImageMath morphological erosion
     description: Erode binary image using ImageMath
-    command: /opt/ants/bin/ImageMath 3 test_output/ants_mask_erode.nii.gz ME test_output/t1w_mask_for_morph.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants/bin/ImageMath 3 test_output/ants_mask_erode.nii.gz ME test_output/t1w_mask_for_morph.nii.gz 2 2>&1'
     depends_on: ImageMath morphological dilation
     validate:
       - output_exists: ${output_dir}/ants_mask_erode.nii.gz
 
   - name: ImageMath morphological opening
     description: Open binary image (erosion then dilation)
-    command: /opt/ants/bin/ImageMath 3 test_output/ants_mask_open.nii.gz MO test_output/t1w_mask_for_morph.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants/bin/ImageMath 3 test_output/ants_mask_open.nii.gz MO test_output/t1w_mask_for_morph.nii.gz 2 2>&1'
     depends_on: ImageMath morphological dilation
     validate:
       - output_exists: ${output_dir}/ants_mask_open.nii.gz
 
   - name: ImageMath morphological closing
     description: Close binary image (dilation then erosion)
-    command: /opt/ants/bin/ImageMath 3 test_output/ants_mask_close.nii.gz MC test_output/t1w_mask_for_morph.nii.gz 2 2>&1
+    command: bash -lc '/opt/ants/bin/ImageMath 3 test_output/ants_mask_close.nii.gz MC test_output/t1w_mask_for_morph.nii.gz 2 2>&1'
     depends_on: ImageMath morphological dilation
     validate:
       - output_exists: ${output_dir}/ants_mask_close.nii.gz
@@ -606,16 +606,16 @@ tests:
   - name: Atropos Kmeans 3 classes
     description: Tissue segmentation with Kmeans initialization
     command: |
-      /opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_atropos_mask.nii.gz Otsu 1 && \
-      /opt/ants/bin/Atropos -d 3 -a ${t1w} -i KMeans[3] -x test_output/t1w_atropos_mask.nii.gz -o test_output/t1w_atropos_seg.nii.gz -v 0 2>&1
+      bash -lc '/opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_atropos_mask.nii.gz Otsu 1 && \
+      /opt/ants/bin/Atropos -d 3 -a ${t1w} -i KMeans[3] -x test_output/t1w_atropos_mask.nii.gz -o test_output/t1w_atropos_seg.nii.gz -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_atropos_seg.nii.gz
 
   - name: Atropos Otsu initialization
     description: Tissue segmentation with Otsu initialization
     command: |
-      /opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_atropos_otsu_mask.nii.gz Otsu 1 && \
-      /opt/ants/bin/Atropos -d 3 -a ${t1w} -i Otsu[3] -x test_output/t1w_atropos_otsu_mask.nii.gz -o test_output/t1w_atropos_otsu.nii.gz -v 0 2>&1
+      bash -lc '/opt/ants/bin/ThresholdImage 3 ${t1w} test_output/t1w_atropos_otsu_mask.nii.gz Otsu 1 && \
+      /opt/ants/bin/Atropos -d 3 -a ${t1w} -i Otsu[3] -x test_output/t1w_atropos_otsu_mask.nii.gz -o test_output/t1w_atropos_otsu.nii.gz -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_atropos_otsu.nii.gz
 
@@ -624,21 +624,21 @@ tests:
   # ==========================================================================
   - name: Affine initializer
     description: Initialize affine transform between two images
-    command: /opt/ants/bin/antsAffineInitializer 3 ${t1w} ${t2} test_output/affine_init.mat 15 0.1 0 10 2>&1
+    command: bash -lc '/opt/ants/bin/antsAffineInitializer 3 ${t1w} ${t2} test_output/affine_init.mat 15 0.1 0 10 2>&1'
     validate:
       - output_exists: ${output_dir}/affine_init.mat
 
   - name: Rigid registration
     description: Rigid registration between T1w and T2
     command: |
-      /opt/ants/bin/antsRegistration -d 3 \
+      bash -lc '/opt/ants/bin/antsRegistration -d 3 \
         --output [test_output/rigid_,test_output/rigid_warped.nii.gz] \
         --metric MI[${t1w},${t2},1,32,Regular,0.25] \
         --transform Rigid[0.1] \
         --convergence [100x50x25,1e-6,10] \
         --shrink-factors 4x2x1 \
         --smoothing-sigmas 2x1x0vox \
-        -v 0
+        -v 0'
     validate:
       - output_exists: ${output_dir}/rigid_warped.nii.gz
       - output_exists: ${output_dir}/rigid_0GenericAffine.mat
@@ -646,14 +646,14 @@ tests:
   - name: Affine registration
     description: Affine registration between T1w and T2
     command: |
-      /opt/ants/bin/antsRegistration -d 3 \
+      bash -lc '/opt/ants/bin/antsRegistration -d 3 \
         --output [test_output/affine_,test_output/affine_warped.nii.gz] \
         --metric MI[${t1w},${t2},1,32,Regular,0.25] \
         --transform Affine[0.1] \
         --convergence [100x50x25,1e-6,10] \
         --shrink-factors 4x2x1 \
         --smoothing-sigmas 2x1x0vox \
-        -v 0
+        -v 0'
     validate:
       - output_exists: ${output_dir}/affine_warped.nii.gz
       - output_exists: ${output_dir}/affine_0GenericAffine.mat
@@ -664,13 +664,13 @@ tests:
   - name: Apply affine transform
     description: Apply affine transform to image
     command: |
-      /opt/ants/bin/antsApplyTransforms -d 3 \
+      bash -lc '/opt/ants/bin/antsApplyTransforms -d 3 \
         -i ${t2} \
         -r ${t1w} \
         -o test_output/t2_to_t1w_affine.nii.gz \
         -t test_output/affine_0GenericAffine.mat \
         -n Linear \
-        -v 0
+        -v 0'
     depends_on: Affine registration
     validate:
       - output_exists: ${output_dir}/t2_to_t1w_affine.nii.gz
@@ -678,13 +678,13 @@ tests:
   - name: Apply transform nearest neighbor
     description: Apply transform with nearest neighbor interpolation
     command: |
-      /opt/ants/bin/antsApplyTransforms -d 3 \
+      bash -lc '/opt/ants/bin/antsApplyTransforms -d 3 \
         -i test_output/t1w_atropos_seg.nii.gz \
         -r ${t2} \
         -o test_output/seg_to_t2_nn.nii.gz \
         -t [test_output/affine_0GenericAffine.mat,1] \
         -n NearestNeighbor \
-        -v 0
+        -v 0'
     depends_on: Atropos Kmeans 3 classes
     validate:
       - output_exists: ${output_dir}/seg_to_t2_nn.nii.gz
@@ -694,7 +694,7 @@ tests:
   # ==========================================================================
   - name: Measure similarity MI
     description: Measure mutual information similarity
-    command: /opt/ants/bin/MeasureImageSimilarity -d 3 -m MI[${t1w},${t2},1,32] 2>&1
+    command: bash -lc '/opt/ants/bin/MeasureImageSimilarity -d 3 -m MI[${t1w},${t2},1,32] 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -702,7 +702,7 @@ tests:
   # ==========================================================================
   - name: Transform info
     description: Get information about a transform
-    command: /opt/ants/bin/antsTransformInfo test_output/affine_0GenericAffine.mat 2>&1
+    command: bash -lc '/opt/ants/bin/antsTransformInfo test_output/affine_0GenericAffine.mat 2>&1'
     depends_on: Affine registration
     expected_exit_code: 0
 
@@ -711,30 +711,30 @@ tests:
   # ==========================================================================
   - name: AFNI 3dcalc version
     description: Check AFNI 3dcalc version
-    command: /opt/afni-latest/3dcalc -help 2>&1 | head -3
+    command: bash -lc '/opt/afni-latest/3dcalc -help 2>&1 | head -3'
     expected_output_contains: "3dcalc"
 
   - name: AFNI 3dcalc add constant
     description: Add constant value using 3dcalc
-    command: /opt/afni-latest/3dcalc -a ${t1w} -expr 'a+100' -prefix test_output/t1w_afni_add100.nii.gz 2>&1
+    command: bash -lc '/opt/afni-latest/3dcalc -a ${t1w} -expr '\''a+100'\'' -prefix test_output/t1w_afni_add100.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_add100.nii.gz
 
   - name: AFNI 3dcalc multiply
     description: Multiply image by constant using 3dcalc
-    command: /opt/afni-latest/3dcalc -a ${t1w} -expr 'a*2' -prefix test_output/t1w_afni_mul2.nii.gz 2>&1
+    command: bash -lc '/opt/afni-latest/3dcalc -a ${t1w} -expr '\''a*2'\'' -prefix test_output/t1w_afni_mul2.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_mul2.nii.gz
 
   - name: AFNI 3dcalc threshold
     description: Threshold image using 3dcalc
-    command: /opt/afni-latest/3dcalc -a ${t1w} -expr 'step(a-100)*a' -prefix test_output/t1w_afni_thr100.nii.gz 2>&1
+    command: bash -lc '/opt/afni-latest/3dcalc -a ${t1w} -expr '\''step(a-100)*a'\'' -prefix test_output/t1w_afni_thr100.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_thr100.nii.gz
 
   - name: AFNI 3dcalc square root
     description: Compute square root using 3dcalc
-    command: /opt/afni-latest/3dcalc -a ${t1w} -expr 'sqrt(a)' -prefix test_output/t1w_afni_sqrt.nii.gz 2>&1
+    command: bash -lc '/opt/afni-latest/3dcalc -a ${t1w} -expr '\''sqrt(a)'\'' -prefix test_output/t1w_afni_sqrt.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_sqrt.nii.gz
 
@@ -743,19 +743,19 @@ tests:
   # ==========================================================================
   - name: AFNI 3dTstat mean
     description: Compute temporal mean of BOLD data
-    command: /opt/afni-latest/3dTstat -mean -prefix test_output/bold_afni_tmean.nii.gz ${bold} 2>&1
+    command: bash -lc '/opt/afni-latest/3dTstat -mean -prefix test_output/bold_afni_tmean.nii.gz ${bold} 2>&1'
     validate:
       - output_exists: ${output_dir}/bold_afni_tmean.nii.gz
 
   - name: AFNI 3dTstat stdev
     description: Compute temporal standard deviation of BOLD data
-    command: /opt/afni-latest/3dTstat -stdev -prefix test_output/bold_afni_tstd.nii.gz ${bold} 2>&1
+    command: bash -lc '/opt/afni-latest/3dTstat -stdev -prefix test_output/bold_afni_tstd.nii.gz ${bold} 2>&1'
     validate:
       - output_exists: ${output_dir}/bold_afni_tstd.nii.gz
 
   - name: AFNI 3dTstat max
     description: Compute temporal maximum of BOLD data
-    command: /opt/afni-latest/3dTstat -max -prefix test_output/bold_afni_tmax.nii.gz ${bold} 2>&1
+    command: bash -lc '/opt/afni-latest/3dTstat -max -prefix test_output/bold_afni_tmax.nii.gz ${bold} 2>&1'
     validate:
       - output_exists: ${output_dir}/bold_afni_tmax.nii.gz
 
@@ -764,7 +764,7 @@ tests:
   # ==========================================================================
   - name: AFNI 3dAutomask basic
     description: Create brain mask using 3dAutomask
-    command: /opt/afni-latest/3dAutomask -prefix test_output/t1w_afni_automask.nii.gz ${t1w} 2>&1
+    command: bash -lc '/opt/afni-latest/3dAutomask -prefix test_output/t1w_afni_automask.nii.gz ${t1w} 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_automask.nii.gz
 
@@ -773,7 +773,7 @@ tests:
   # ==========================================================================
   - name: AFNI 3dresample orientation
     description: Resample to different orientation
-    command: /opt/afni-latest/3dresample -orient RPI -prefix test_output/t1w_afni_rpi.nii.gz -inset ${t1w} 2>&1
+    command: bash -lc '/opt/afni-latest/3dresample -orient RPI -prefix test_output/t1w_afni_rpi.nii.gz -inset ${t1w} 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_rpi.nii.gz
 
@@ -782,7 +782,7 @@ tests:
   # ==========================================================================
   - name: AFNI 3dAutobox crop
     description: Automatically crop image to brain
-    command: /opt/afni-latest/3dAutobox -prefix test_output/t1w_afni_autobox.nii.gz -input ${t1w} 2>&1
+    command: bash -lc '/opt/afni-latest/3dAutobox -prefix test_output/t1w_afni_autobox.nii.gz -input ${t1w} 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_autobox.nii.gz
 
@@ -792,8 +792,8 @@ tests:
   - name: AFNI 3drefit space
     description: Set image space attribute (copy then modify)
     command: |
-      cp ${t1w} test_output/t1w_afni_refit.nii.gz && \
-      /opt/afni-latest/3drefit -space ORIG test_output/t1w_afni_refit.nii.gz 2>&1
+      bash -lc 'cp ${t1w} test_output/t1w_afni_refit.nii.gz && \
+      /opt/afni-latest/3drefit -space ORIG test_output/t1w_afni_refit.nii.gz 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_afni_refit.nii.gz
 
@@ -802,7 +802,7 @@ tests:
   # ==========================================================================
   - name: AFNI 3dTcat extract volumes
     description: Extract first 5 volumes from BOLD data
-    command: /opt/afni-latest/3dTcat -prefix test_output/bold_afni_first5.nii.gz "${bold}[0..4]" 2>&1
+    command: bash -lc '/opt/afni-latest/3dTcat -prefix test_output/bold_afni_first5.nii.gz "${bold}[0..4]" 2>&1'
     validate:
       - output_exists: ${output_dir}/bold_afni_first5.nii.gz
 
@@ -811,7 +811,7 @@ tests:
   # ==========================================================================
   - name: DSI Studio version check
     description: Check DSI Studio version
-    command: /opt/dsi-studio/dsi_studio --action=rec 2>&1 | head -1
+    command: bash -lc '/opt/dsi-studio/dsi_studio --action=rec 2>&1 | head -1'
     expected_output_contains: "DSI Studio"
 
   # ==========================================================================
@@ -819,7 +819,7 @@ tests:
   # ==========================================================================
   - name: 3Tissue ss3t_csd_beta1 help
     description: Check 3Tissue-specific command availability
-    command: /opt/3Tissue/bin/ss3t_csd_beta1 --help 2>&1 | head -3
+    command: bash -lc '/opt/3Tissue/bin/ss3t_csd_beta1 --help 2>&1 | head -3'
     expected_output_contains: "ss3t_csd_beta1"
 
   # ==========================================================================
@@ -827,7 +827,7 @@ tests:
   # ==========================================================================
   - name: Workbench version check
     description: Check Connectome Workbench version
-    command: /opt/workbench/bin_linux64/wb_command -version 2>&1 | head -3
+    command: bash -lc '/opt/workbench/bin_linux64/wb_command -version 2>&1 | head -3'
     expected_output_contains: "Connectome Workbench"
 
   # ==========================================================================
@@ -895,17 +895,17 @@ tests:
   - name: Pipeline N4 then denoise
     description: Chain N4 bias correction followed by denoising
     command: |
-      /opt/ants/bin/N4BiasFieldCorrection -d 3 -i ${t1w} -o test_output/t1w_n4_pipeline.nii.gz -s 4 -c [50x50x50,0.0] -v 0 2>&1 && \
-      /opt/ants/bin/DenoiseImage -d 3 -i test_output/t1w_n4_pipeline.nii.gz -n Rician -o test_output/t1w_n4_denoise_pipeline.nii.gz -v 0 2>&1
+      bash -lc '/opt/ants/bin/N4BiasFieldCorrection -d 3 -i ${t1w} -o test_output/t1w_n4_pipeline.nii.gz -s 4 -c [50x50x50,0.0] -v 0 2>&1 && \
+      /opt/ants/bin/DenoiseImage -d 3 -i test_output/t1w_n4_pipeline.nii.gz -n Rician -o test_output/t1w_n4_denoise_pipeline.nii.gz -v 0 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_n4_denoise_pipeline.nii.gz
 
   - name: Pipeline preprocessing chain
     description: Full preprocessing chain (denoise, N4, threshold)
     command: |
-      /opt/ants/bin/DenoiseImage -d 3 -i ${t1w} -n Rician -o test_output/t1w_preproc_denoise.nii.gz -v 0 2>&1 && \
+      bash -lc '/opt/ants/bin/DenoiseImage -d 3 -i ${t1w} -n Rician -o test_output/t1w_preproc_denoise.nii.gz -v 0 2>&1 && \
       /opt/ants/bin/N4BiasFieldCorrection -d 3 -i test_output/t1w_preproc_denoise.nii.gz -o test_output/t1w_preproc_n4.nii.gz -s 4 -c [50x50x50,0.0] -v 0 2>&1 && \
-      /opt/ants/bin/ThresholdImage 3 test_output/t1w_preproc_n4.nii.gz test_output/t1w_preproc_mask.nii.gz Otsu 1 2>&1
+      /opt/ants/bin/ThresholdImage 3 test_output/t1w_preproc_n4.nii.gz test_output/t1w_preproc_mask.nii.gz Otsu 1 2>&1'
     validate:
       - output_exists: ${output_dir}/t1w_preproc_denoise.nii.gz
       - output_exists: ${output_dir}/t1w_preproc_n4.nii.gz
@@ -916,22 +916,22 @@ tests:
   # ==========================================================================
   - name: List available pipeline specs
     description: List QSIRecon built-in pipeline specifications
-    command: ls /opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/ 2>&1
+    command: "bash -lc 'ls /opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/ 2>&1'"
     expected_output_contains: "mrtrix"
 
   - name: Check mrtrix multishell pipeline spec
     description: Verify mrtrix multishell pipeline spec exists and is valid YAML
-    command: python -c "import yaml; yaml.safe_load(open('/opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/mrtrix_multishell_msmt_noACT.yaml')); print('Valid YAML')"
+    command: "bash -lc 'python -c \"import yaml; yaml.safe_load(open('\"'\"'/opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/mrtrix_multishell_msmt_noACT.yaml'\"'\"')); print('\"'\"'Valid YAML'\"'\"')\"'"
     expected_output_contains: "Valid YAML"
 
   - name: Check dipy dki pipeline spec
     description: Verify dipy DKI pipeline spec exists and is valid YAML
-    command: python -c "import yaml; yaml.safe_load(open('/opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/dipy_dki.yaml')); print('Valid YAML')"
+    command: "bash -lc 'python -c \"import yaml; yaml.safe_load(open('\"'\"'/opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/dipy_dki.yaml'\"'\"')); print('\"'\"'Valid YAML'\"'\"')\"'"
     expected_output_contains: "Valid YAML"
 
   - name: Check dsi_studio_gqi pipeline spec
     description: Verify DSI Studio GQI pipeline spec exists
-    command: python -c "import yaml; yaml.safe_load(open('/opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/dsi_studio_gqi.yaml')); print('Valid YAML')"
+    command: "bash -lc 'python -c \"import yaml; yaml.safe_load(open('\"'\"'/opt/conda/envs/qsiprep/lib/python3.10/site-packages/qsirecon/data/pipelines/dsi_studio_gqi.yaml'\"'\"')); print('\"'\"'Valid YAML'\"'\"')\"'"
     expected_output_contains: "Valid YAML"
 
   # ==========================================================================
@@ -939,7 +939,7 @@ tests:
   # ==========================================================================
   - name: FreeSurfer mri_convert check
     description: Check FreeSurfer mri_convert availability
-    command: /opt/freesurfer/bin/mri_convert --help 2>&1 | head -5
+    command: bash -lc '/opt/freesurfer/bin/mri_convert --help 2>&1 | head -5'
     expected_output_contains: "mri_convert"
 
 cleanup:

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -526,19 +526,19 @@ tests:
   # ==========================================================================
   - name: FastSurfer script exists
     description: Verify FastSurfer run script exists
-    command: ls -la /opt/FastSurfer/run_fastsurfer.sh 2>&1
+    command: "bash -lc 'ls -la /opt/FastSurfer/run_fastsurfer.sh 2>&1'"
     expected_output_contains: "run_fastsurfer.sh"
     expected_exit_code: 0
 
   - name: FastSurfer help
     description: Verify FastSurfer help is accessible
-    command: /opt/FastSurfer/run_fastsurfer.sh --help 2>&1 | head -10
+    command: bash -lc '/opt/FastSurfer/run_fastsurfer.sh --help 2>&1 | head -10'
     expected_output_contains: "run_fastsurfer.sh"
     expected_exit_code: 0
 
   - name: FastSurfer checkpoints exist
     description: Verify FastSurfer model checkpoints are available
-    command: ls /opt/FastSurfer/checkpoints/ 2>&1
+    command: "bash -lc 'ls /opt/FastSurfer/checkpoints/ 2>&1'"
     expected_output_contains: "Weights"
     expected_exit_code: 0
 
@@ -547,7 +547,7 @@ tests:
   # ==========================================================================
   - name: QSMxT-UI exists
     description: Verify QSMxT-UI directory exists
-    command: ls -la /opt/QSMxT-UI/ 2>&1
+    command: "bash -lc 'ls -la /opt/QSMxT-UI/ 2>&1'"
     expected_output_contains: "qsmxt-gui"
     expected_exit_code: 0
 

--- a/recipes/quickshear/fulltest.yaml
+++ b/recipes/quickshear/fulltest.yaml
@@ -53,27 +53,27 @@ tests:
   # ==========================================================================
   - name: mri_synthstrip help
     description: Verify mri_synthstrip binary shows help (exits 1 with --help)
-    command: /freesurfer/mri_synthstrip --help 2>&1
+    command: mri_synthstrip --help 2>&1 || true
     expected_output_contains: "Robust, universal skull-stripping"
     ignore_exit_code: true
 
   - name: Skull strip T1w - generate mask only
     description: Generate brain mask using SynthStrip for T1w image
-    command: /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_brain_mask.nii.gz
+    command: mri_synthstrip -i ${t1w} -m test_output/t1w_brain_mask.nii.gz
     validate:
       - output_exists: ${output_dir}/t1w_brain_mask.nii.gz
     timeout: 300
 
   - name: Skull strip T1w - generate stripped brain
     description: Generate stripped brain image using SynthStrip
-    command: /freesurfer/mri_synthstrip -i ${t1w} -o test_output/t1w_stripped.nii.gz
+    command: mri_synthstrip -i ${t1w} -o test_output/t1w_stripped.nii.gz
     validate:
       - output_exists: ${output_dir}/t1w_stripped.nii.gz
     timeout: 300
 
   - name: Skull strip T1w - mask and stripped together
     description: Generate both brain mask and stripped image in single run
-    command: /freesurfer/mri_synthstrip -i ${t1w} -o test_output/t1w_stripped_full.nii.gz -m test_output/t1w_mask_full.nii.gz
+    command: mri_synthstrip -i ${t1w} -o test_output/t1w_stripped_full.nii.gz -m test_output/t1w_mask_full.nii.gz
     validate:
       - output_exists: ${output_dir}/t1w_stripped_full.nii.gz
       - output_exists: ${output_dir}/t1w_mask_full.nii.gz
@@ -81,7 +81,7 @@ tests:
 
   - name: Skull strip T1w - with distance transform
     description: Generate brain mask with signed distance transform output
-    command: /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_mask_sdt.nii.gz -d test_output/t1w_sdt.nii.gz
+    command: mri_synthstrip -i ${t1w} -m test_output/t1w_mask_sdt.nii.gz -d test_output/t1w_sdt.nii.gz
     validate:
       - output_exists: ${output_dir}/t1w_mask_sdt.nii.gz
       - output_exists: ${output_dir}/t1w_sdt.nii.gz
@@ -89,28 +89,28 @@ tests:
 
   - name: Skull strip with custom border
     description: Generate brain mask with larger border (2mm)
-    command: /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_mask_border2.nii.gz -b 2
+    command: mri_synthstrip -i ${t1w} -m test_output/t1w_mask_border2.nii.gz -b 2
     validate:
       - output_exists: ${output_dir}/t1w_mask_border2.nii.gz
     timeout: 300
 
   - name: Skull strip with zero border
     description: Generate tight brain mask with no border expansion
-    command: /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_mask_border0.nii.gz -b 0
+    command: mri_synthstrip -i ${t1w} -m test_output/t1w_mask_border0.nii.gz -b 0
     validate:
       - output_exists: ${output_dir}/t1w_mask_border0.nii.gz
     timeout: 300
 
   - name: Skull strip excluding CSF
     description: Generate brain mask excluding CSF from border
-    command: /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_mask_nocsf.nii.gz --no-csf
+    command: mri_synthstrip -i ${t1w} -m test_output/t1w_mask_nocsf.nii.gz --no-csf
     validate:
       - output_exists: ${output_dir}/t1w_mask_nocsf.nii.gz
     timeout: 300
 
   - name: Skull strip T2 image
     description: Generate brain mask from inplane T2 image
-    command: /freesurfer/mri_synthstrip -i ${t2} -m test_output/t2_mask.nii.gz
+    command: mri_synthstrip -i ${t2} -m test_output/t2_mask.nii.gz
     validate:
       - output_exists: ${output_dir}/t2_mask.nii.gz
     timeout: 300
@@ -188,8 +188,8 @@ tests:
   - name: Full pipeline - T1w defacing (single command)
     description: Complete pipeline - skull strip then deface in sequence
     command: |
-      /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_pipe_mask.nii.gz && \
-      quickshear ${t1w} test_output/t1w_pipe_mask.nii.gz test_output/t1w_pipe_defaced.nii.gz
+      bash -lc 'mri_synthstrip -i ${t1w} -m test_output/t1w_pipe_mask.nii.gz && \
+      quickshear ${t1w} test_output/t1w_pipe_mask.nii.gz test_output/t1w_pipe_defaced.nii.gz'
     validate:
       - output_exists: ${output_dir}/t1w_pipe_mask.nii.gz
       - output_exists: ${output_dir}/t1w_pipe_defaced.nii.gz
@@ -198,8 +198,8 @@ tests:
   - name: Full pipeline - T2 defacing
     description: Complete pipeline for T2 image - skull strip then deface
     command: |
-      /freesurfer/mri_synthstrip -i ${t2} -m test_output/t2_pipe_mask.nii.gz && \
-      quickshear ${t2} test_output/t2_pipe_mask.nii.gz test_output/t2_defaced.nii.gz
+      bash -lc 'mri_synthstrip -i ${t2} -m test_output/t2_pipe_mask.nii.gz && \
+      quickshear ${t2} test_output/t2_pipe_mask.nii.gz test_output/t2_defaced.nii.gz'
     validate:
       - output_exists: ${output_dir}/t2_pipe_mask.nii.gz
       - output_exists: ${output_dir}/t2_defaced.nii.gz
@@ -208,8 +208,8 @@ tests:
   - name: Full pipeline - conservative defacing
     description: Pipeline with conservative settings (large border, large buffer)
     command: |
-      /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_cons_mask.nii.gz -b 3 && \
-      quickshear ${t1w} test_output/t1w_cons_mask.nii.gz test_output/t1w_conservative.nii.gz 30
+      bash -lc 'mri_synthstrip -i ${t1w} -m test_output/t1w_cons_mask.nii.gz -b 3 && \
+      quickshear ${t1w} test_output/t1w_cons_mask.nii.gz test_output/t1w_conservative.nii.gz 30'
     validate:
       - output_exists: ${output_dir}/t1w_cons_mask.nii.gz
       - output_exists: ${output_dir}/t1w_conservative.nii.gz
@@ -218,8 +218,8 @@ tests:
   - name: Full pipeline - aggressive defacing
     description: Pipeline with aggressive settings (tight mask, small buffer)
     command: |
-      /freesurfer/mri_synthstrip -i ${t1w} -m test_output/t1w_agg_mask.nii.gz -b 0 --no-csf && \
-      quickshear ${t1w} test_output/t1w_agg_mask.nii.gz test_output/t1w_aggressive.nii.gz 3
+      bash -lc 'mri_synthstrip -i ${t1w} -m test_output/t1w_agg_mask.nii.gz -b 0 --no-csf && \
+      quickshear ${t1w} test_output/t1w_agg_mask.nii.gz test_output/t1w_aggressive.nii.gz 3'
     validate:
       - output_exists: ${output_dir}/t1w_agg_mask.nii.gz
       - output_exists: ${output_dir}/t1w_aggressive.nii.gz
@@ -382,7 +382,7 @@ tests:
 
   - name: Error - mri_synthstrip missing input
     description: Test error handling for mri_synthstrip without input (shows usage)
-    command: /freesurfer/mri_synthstrip 2>&1 || true
+    command: mri_synthstrip 2>&1 || true
     expected_output_contains: "usage"
 
   # ==========================================================================

--- a/recipes/rabies/fulltest.yaml
+++ b/recipes/rabies/fulltest.yaml
@@ -295,47 +295,47 @@ tests:
   # ==========================================================================
   - name: DSURQE template exists
     description: Verify DSURQE mouse atlas template is available
-    command: ls -la /opt/rabies/share/rabies/DSURQE_40micron_average.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/DSURQE_40micron_average.nii.gz 2>&1'"
     expected_output_contains: "DSURQE_40micron_average.nii.gz"
 
   - name: DSURQE brain mask exists
     description: Verify DSURQE brain mask is available
-    command: ls -la /opt/rabies/share/rabies/DSURQE_40micron_mask.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/DSURQE_40micron_mask.nii.gz 2>&1'"
     expected_output_contains: "DSURQE_40micron_mask.nii.gz"
 
   - name: DSURQE labels exist
     description: Verify DSURQE atlas labels are available
-    command: ls -la /opt/rabies/share/rabies/DSURQE_40micron_labels.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/DSURQE_40micron_labels.nii.gz 2>&1'"
     expected_output_contains: "DSURQE_40micron_labels.nii.gz"
 
   - name: WM mask exists
     description: Verify white matter mask is available
-    command: ls -la /opt/rabies/share/rabies/DSURQE_40micron_eroded_WM_mask.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/DSURQE_40micron_eroded_WM_mask.nii.gz 2>&1'"
     expected_output_contains: "DSURQE_40micron_eroded_WM_mask.nii.gz"
 
   - name: CSF mask exists
     description: Verify CSF mask is available
-    command: ls -la /opt/rabies/share/rabies/DSURQE_40micron_eroded_CSF_mask.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/DSURQE_40micron_eroded_CSF_mask.nii.gz 2>&1'"
     expected_output_contains: "DSURQE_40micron_eroded_CSF_mask.nii.gz"
 
   - name: Vascular mask exists
     description: Verify vascular mask is available
-    command: ls -la /opt/rabies/share/rabies/vascular_mask.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/vascular_mask.nii.gz 2>&1'"
     expected_output_contains: "vascular_mask.nii.gz"
 
   - name: EPI template exists
     description: Verify EPI reference template is available
-    command: ls -la /opt/rabies/share/rabies/EPI_template.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/EPI_template.nii.gz 2>&1'"
     expected_output_contains: "EPI_template.nii.gz"
 
   - name: Melodic ICA priors exist
     description: Verify ICA prior maps for dual regression
-    command: ls -la /opt/rabies/share/rabies/melodic_IC.nii.gz 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/melodic_IC.nii.gz 2>&1'"
     expected_output_contains: "melodic_IC.nii.gz"
 
   - name: ROI mapping CSV exists
     description: Verify ROI label mapping file is available
-    command: ls -la /opt/rabies/share/rabies/DSURQE_40micron_R_mapping.csv 2>&1
+    command: "bash -lc 'ls -la /opt/rabies/share/rabies/DSURQE_40micron_R_mapping.csv 2>&1'"
     expected_output_contains: "DSURQE_40micron_R_mapping.csv"
 
   # ==========================================================================
@@ -541,49 +541,22 @@ tests:
   # ==========================================================================
   - name: Load DSURQE template
     description: Verify DSURQE template can be loaded
-    command: |
-      python -c "
-      import nibabel as nib
-      img = nib.load('/opt/rabies/share/rabies/DSURQE_40micron_average.nii.gz')
-      print('Template shape:', img.shape)
-      print('Voxel size:', img.header.get_zooms())
-      " 2>&1
+    command: "bash -lc 'python -c \"\nimport nibabel as nib\nimg = nib.load('\"'\"'/opt/rabies/share/rabies/DSURQE_40micron_average.nii.gz'\"'\"')\nprint('\"'\"'Template shape:'\"'\"', img.shape)\nprint('\"'\"'Voxel size:'\"'\"', img.header.get_zooms())\n\" 2>&1'"
     expected_output_contains: "Template shape:"
 
   - name: Load DSURQE labels
     description: Verify DSURQE atlas labels
-    command: |
-      python -c "
-      import nibabel as nib
-      import numpy as np
-      img = nib.load('/opt/rabies/share/rabies/DSURQE_40micron_labels.nii.gz')
-      labels = img.get_fdata()
-      unique_labels = np.unique(labels)
-      print('Labels shape:', img.shape)
-      print('Number of unique labels:', len(unique_labels))
-      " 2>&1
+    command: "bash -lc 'python -c \"\nimport nibabel as nib\nimport numpy as np\nimg = nib.load('\"'\"'/opt/rabies/share/rabies/DSURQE_40micron_labels.nii.gz'\"'\"')\nlabels = img.get_fdata()\nunique_labels = np.unique(labels)\nprint('\"'\"'Labels shape:'\"'\"', img.shape)\nprint('\"'\"'Number of unique labels:'\"'\"', len(unique_labels))\n\" 2>&1'"
     expected_output_contains: "Number of unique labels:"
 
   - name: Read ROI mapping
     description: Verify ROI mapping CSV can be read
-    command: |
-      python -c "
-      import pandas as pd
-      df = pd.read_csv('/opt/rabies/share/rabies/DSURQE_40micron_R_mapping.csv')
-      print('ROI mapping columns:', list(df.columns))
-      print('Number of ROIs:', len(df))
-      " 2>&1
+    command: "bash -lc 'python -c \"\nimport pandas as pd\ndf = pd.read_csv('\"'\"'/opt/rabies/share/rabies/DSURQE_40micron_R_mapping.csv'\"'\"')\nprint('\"'\"'ROI mapping columns:'\"'\"', list(df.columns))\nprint('\"'\"'Number of ROIs:'\"'\"', len(df))\n\" 2>&1'"
     expected_output_contains: "Number of ROIs:"
 
   - name: Load melodic ICA priors
     description: Verify ICA prior maps for dual regression
-    command: |
-      python -c "
-      import nibabel as nib
-      img = nib.load('/opt/rabies/share/rabies/melodic_IC.nii.gz')
-      print('ICA priors shape:', img.shape)
-      print('Number of components:', img.shape[3] if len(img.shape) > 3 else 1)
-      " 2>&1
+    command: "bash -lc 'python -c \"\nimport nibabel as nib\nimg = nib.load('\"'\"'/opt/rabies/share/rabies/melodic_IC.nii.gz'\"'\"')\nprint('\"'\"'ICA priors shape:'\"'\"', img.shape)\nprint('\"'\"'Number of components:'\"'\"', img.shape[3] if len(img.shape) > 3 else 1)\n\" 2>&1'"
     expected_output_contains: "ICA priors shape:"
 
   # ==========================================================================

--- a/recipes/relion/fulltest.yaml
+++ b/recipes/relion/fulltest.yaml
@@ -654,24 +654,24 @@ tests:
   # ==========================================================================
   - name: CTFFIND binary exists
     description: Check CTFFIND 4 binary location
-    command: ls /opt/ctffind-4.1.14/bin/ctffind
+    command: "bash -lc 'ls /opt/ctffind-4.1.14/bin/ctffind'"
     expected_output_contains: "ctffind"
 
   - name: CTFFIND usage
     description: Check CTFFIND version and scripted mode
-    command: echo "" | /opt/ctffind-4.1.14/bin/ctffind 2>&1 | head -5
+    command: bash -lc 'echo "" | /opt/ctffind-4.1.14/bin/ctffind 2>&1 | head -5'
     expected_output_contains: "Ctffind"
     ignore_exit_code: true
 
   - name: CTFFIND version info
     description: Verify CTFFIND version displays correctly
-    command: echo "" | /opt/ctffind-4.1.14/bin/ctffind 2>&1
+    command: bash -lc 'echo "" | /opt/ctffind-4.1.14/bin/ctffind 2>&1'
     expected_output_contains: "Version"
     ignore_exit_code: true
 
   - name: CTFFIND plot script exists
     description: Check CTFFIND plot results script
-    command: ls /opt/ctffind-4.1.14/bin/ctffind_plot_results.sh
+    command: "bash -lc 'ls /opt/ctffind-4.1.14/bin/ctffind_plot_results.sh'"
     expected_output_contains: "ctffind_plot_results.sh"
 
   # ==========================================================================
@@ -679,17 +679,17 @@ tests:
   # ==========================================================================
   - name: MotionCor2 binaries exist
     description: Check MotionCor2 CUDA binaries directory
-    command: ls /opt/motioncor2-1.6.4/bin/ | head -5
+    command: "bash -lc 'ls /opt/motioncor2-1.6.4/bin/ | head -5'"
     expected_output_contains: "MotionCor2"
 
   - name: MotionCor2 CUDA 11.8 binary exists
     description: Check MotionCor2 for CUDA 11.8
-    command: ls /opt/motioncor2-1.6.4/bin/MotionCor2_1.6.4_Cuda118_Mar312023
+    command: "bash -lc 'ls /opt/motioncor2-1.6.4/bin/MotionCor2_1.6.4_Cuda118_Mar312023'"
     expected_output_contains: "MotionCor2"
 
   - name: MotionCor2 manual exists
     description: Check MotionCor2 user manual
-    command: ls /opt/motioncor2-1.6.4/bin/MotionCor2-UserManual-02-18-2023.pdf
+    command: "bash -lc 'ls /opt/motioncor2-1.6.4/bin/MotionCor2-UserManual-02-18-2023.pdf'"
     expected_output_contains: "UserManual"
 
   # ==========================================================================
@@ -715,10 +715,10 @@ tests:
   # ==========================================================================
   - name: CUDA toolkit directory exists
     description: Check CUDA 11.8 installation
-    command: ls /usr/local/cuda-11.8/
+    command: "bash -lc 'ls /usr/local/cuda-11.8/'"
     expected_output_contains: "bin"
 
   - name: CUDA nvcc exists
     description: Check CUDA compiler exists
-    command: ls /usr/local/cuda-11.8/bin/nvcc
+    command: "bash -lc 'ls /usr/local/cuda-11.8/bin/nvcc'"
     expected_output_contains: "nvcc"

--- a/recipes/samsrfx/fulltest.yaml
+++ b/recipes/samsrfx/fulltest.yaml
@@ -37,12 +37,12 @@ tests:
 
   - name: Container labels
     description: Verify container metadata labels exist
-    command: cat /.singularity.d/labels.json
+    command: "bash -lc 'cat /.singularity.d/labels.json'"
     expected_output_contains: "NeuroDesk/neurocontainers"
 
   - name: SamSrfX entry script exists
     description: Verify the main samsrfx launcher exists
-    command: cat /opt/samsrfx-v10.004/samsrfx
+    command: "bash -lc 'cat /opt/samsrfx-v10.004/samsrfx'"
     expected_output_contains: "run_SamSrfX.sh"
 
   - name: SamSrfX in PATH
@@ -55,27 +55,27 @@ tests:
   # ==========================================================================
   - name: MCR installation directory
     description: Verify MCR R2023b is installed
-    command: ls -la /opt/MCR-2023b/R2023b/
+    command: "bash -lc 'ls -la /opt/MCR-2023b/R2023b/'"
     expected_output_contains: "runtime"
 
   - name: MCR version info
     description: Check MCR version information file
-    command: cat /opt/MCR-2023b/R2023b/VersionInfo.xml
+    command: "bash -lc 'cat /opt/MCR-2023b/R2023b/VersionInfo.xml'"
     expected_output_contains: "R2023b"
 
   - name: MCR runtime libraries
     description: Verify MCR runtime library directory exists
-    command: ls /opt/MCR-2023b/R2023b/runtime/glnxa64/ | head -10
+    command: "bash -lc 'ls /opt/MCR-2023b/R2023b/runtime/glnxa64/ | head -10'"
     expected_output_contains: "libmw"
 
   - name: MCR bin directory
     description: Verify MCR bin directory exists
-    command: ls /opt/MCR-2023b/R2023b/bin/glnxa64/ | head -10
+    command: "bash -lc 'ls /opt/MCR-2023b/R2023b/bin/glnxa64/ | head -10'"
     expected_output_contains: ".so"
 
   - name: MCR toolbox directory
     description: Verify MCR toolbox directory exists
-    command: ls /opt/MCR-2023b/R2023b/toolbox/
+    command: "bash -lc 'ls /opt/MCR-2023b/R2023b/toolbox/'"
     expected_output_contains: "matlab"
 
   - name: MCR Java runtime
@@ -88,32 +88,32 @@ tests:
   # ==========================================================================
   - name: SamSrfX binary exists
     description: Verify the compiled SamSrfX binary exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/SamSrfX
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/SamSrfX'"
     expected_output_contains: "SamSrfX"
 
   - name: SamSrfX runner script
     description: Verify run_SamSrfX.sh script exists and is executable
-    command: ls -la /opt/samsrfx-v10.004/samsrf/run_SamSrfX.sh
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/run_SamSrfX.sh'"
     expected_output_contains: "rwx"
 
   - name: SamSrfX runner script content
     description: Verify runner script sets up MCR environment
-    command: cat /opt/samsrfx-v10.004/samsrf/run_SamSrfX.sh
+    command: "bash -lc 'cat /opt/samsrfx-v10.004/samsrf/run_SamSrfX.sh'"
     expected_output_contains: "LD_LIBRARY_PATH"
 
   - name: SamSrfX main MATLAB source
     description: Verify main SamSrfX.m source file exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/SamSrfX.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/SamSrfX.m'"
     expected_output_contains: "GUI for running SamSrf"
 
   - name: SamSrf version function
     description: Verify version information
-    command: cat /opt/samsrfx-v10.004/samsrf/Various/samsrf_version.m
+    command: "bash -lc 'cat /opt/samsrfx-v10.004/samsrf/Various/samsrf_version.m'"
     expected_output_contains: "v = 10.003"
 
   - name: SamSrf ReadMe documentation
     description: Verify ReadMe.md documentation exists
-    command: head -30 /opt/samsrfx-v10.004/samsrf/ReadMe.md
+    command: "bash -lc 'head -30 /opt/samsrfx-v10.004/samsrf/ReadMe.md'"
     expected_output_contains: "SamSrf X"
 
   # ==========================================================================
@@ -121,22 +121,22 @@ tests:
   # ==========================================================================
   - name: SamSrf defaults JSON
     description: Verify default configuration file exists
-    command: cat /opt/samsrfx-v10.004/samsrf/SamSrf_defaults.json
+    command: "bash -lc 'cat /opt/samsrfx-v10.004/samsrf/SamSrf_defaults.json'"
     expected_output_contains: "def_cmap_angle"
 
   - name: Default colormap settings
     description: Verify colormap defaults are configured
-    command: cat /opt/samsrfx-v10.004/samsrf/SamSrf_defaults.json
+    command: "bash -lc 'cat /opt/samsrfx-v10.004/samsrf/SamSrf_defaults.json'"
     expected_output_contains: "berlin"
 
   - name: Default ROI list
     description: Verify default ROI list includes visual areas
-    command: cat /opt/samsrfx-v10.004/samsrf/SamSrf_defaults.json
+    command: "bash -lc 'cat /opt/samsrfx-v10.004/samsrf/SamSrf_defaults.json'"
     expected_output_contains: "V1"
 
   - name: Load defaults function
     description: Verify LoadSamSrfDefaults function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/LoadSamSrfDefaults.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/LoadSamSrfDefaults.m'"
     expected_output_contains: "LoadSamSrfDefaults"
 
   # ==========================================================================
@@ -144,47 +144,47 @@ tests:
   # ==========================================================================
   - name: Analysis directory structure
     description: Verify Analysis directory contains functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Analysis/ | wc -l
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Analysis/ | wc -l'"
     expected_output_contains: "25"
 
   - name: pRF backprojection function
     description: Verify samsrf_backproj_prf.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_backproj_prf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_backproj_prf.m'"
     expected_output_contains: "backproj_prf"
 
   - name: Reverse correlation backprojection
     description: Verify samsrf_backproj_revcor.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_backproj_revcor.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_backproj_revcor.m'"
     expected_output_contains: "backproj_revcor"
 
   - name: Heatmap function
     description: Verify samsrf_heatmap.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_heatmap.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_heatmap.m'"
     expected_output_contains: "heatmap"
 
   - name: Polar plot function
     description: Verify samsrf_polarplot.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_polarplot.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_polarplot.m'"
     expected_output_contains: "polarplot"
 
   - name: Plot function
     description: Verify samsrf_plot.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_plot.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_plot.m'"
     expected_output_contains: "samsrf_plot"
 
   - name: Visual field coverage function
     description: Verify samsrf_vfcoverage.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_vfcoverage.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_vfcoverage.m'"
     expected_output_contains: "vfcoverage"
 
   - name: Comet plot function
     description: Verify samsrf_cometplot.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_cometplot.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_cometplot.m'"
     expected_output_contains: "cometplot"
 
   - name: Wedge plot function
     description: Verify samsrf_wedgeplot.m exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_wedgeplot.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Analysis/samsrf_wedgeplot.m'"
     expected_output_contains: "wedgeplot"
 
   # ==========================================================================
@@ -192,42 +192,42 @@ tests:
   # ==========================================================================
   - name: Fitting directory structure
     description: Verify Fitting directory contains functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Fitting/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Fitting/'"
     expected_output_contains: "samsrf_fit_prf.m"
 
   - name: pRF fitting function
     description: Verify main pRF fitting function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_fit_prf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_fit_prf.m'"
     expected_output_contains: "fit_prf"
 
   - name: CF fitting function
     description: Verify connective field fitting function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_fit_cf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_fit_cf.m'"
     expected_output_contains: "fit_cf"
 
   - name: Reverse correlation pRF function
     description: Verify reverse correlation pRF function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_revcor_prf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_revcor_prf.m'"
     expected_output_contains: "revcor_prf"
 
   - name: Reverse correlation CF function
     description: Verify reverse correlation CF function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_revcor_cf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_revcor_cf.m'"
     expected_output_contains: "revcor_cf"
 
   - name: GLM function
     description: Verify GLM analysis function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_glm.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_glm.m'"
     expected_output_contains: "samsrf_glm"
 
   - name: Hooke-Jeeves optimization
     description: Verify Hooke-Jeeves algorithm implementation exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_hookejeeves.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_hookejeeves.m'"
     expected_output_contains: "hookejeeves"
 
   - name: Bandpass filter function
     description: Verify bandpass filtering function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_bandpass.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Fitting/samsrf_bandpass.m'"
     expected_output_contains: "bandpass"
 
   # ==========================================================================
@@ -235,42 +235,42 @@ tests:
   # ==========================================================================
   - name: pRF directory structure
     description: Verify pRF directory contains functions
-    command: ls /opt/samsrfx-v10.004/samsrf/pRF/ | wc -l
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/pRF/ | wc -l'"
     expected_output_contains: "15"
 
   - name: Gaussian pRF function
     description: Verify Gaussian receptive field function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_gaussian_rf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_gaussian_rf.m'"
     expected_output_contains: "gaussian_rf"
 
   - name: DOG pRF function
     description: Verify difference-of-Gaussians pRF function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_dog_rf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_dog_rf.m'"
     expected_output_contains: "dog_rf"
 
   - name: Multivariate pRF function
     description: Verify multivariate pRF function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_multivariate_rf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_multivariate_rf.m'"
     expected_output_contains: "multivariate_rf"
 
   - name: pRF search space generation
     description: Verify search space generation function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_generate_searchspace.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_generate_searchspace.m'"
     expected_output_contains: "searchspace"
 
   - name: pRF prediction function
     description: Verify timecourse prediction function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_predict_timecourse.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_predict_timecourse.m'"
     expected_output_contains: "predict_timecourse"
 
   - name: pRF error function
     description: Verify error function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_errfun.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_errfun.m'"
     expected_output_contains: "errfun"
 
   - name: pRF contour function
     description: Verify contour function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_contour.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/pRF/prf_contour.m'"
     expected_output_contains: "contour"
 
   # ==========================================================================
@@ -278,42 +278,42 @@ tests:
   # ==========================================================================
   - name: Models directory structure
     description: Verify Models directory contains model definitions
-    command: ls /opt/samsrfx-v10.004/samsrf/Models/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Models/'"
     expected_output_contains: "Standard_2d_Gaussian_Prf.m"
 
   - name: Standard 2D Gaussian pRF model
     description: Verify standard 2D Gaussian model exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Models/Standard_2d_Gaussian_Prf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Models/Standard_2d_Gaussian_Prf.m'"
     expected_output_contains: "Standard"
 
   - name: Difference of Gaussians model
     description: Verify DoG model exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Models/Difference_of_Gaussians_Prf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Models/Difference_of_Gaussians_Prf.m'"
     expected_output_contains: "Difference"
 
   - name: Connective Fields model
     description: Verify CF model exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Models/Connective_Fields.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Models/Connective_Fields.m'"
     expected_output_contains: "Connective"
 
   - name: Circular tuning curve model
     description: Verify circular tuning curve model exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Models/Circular_Tuning_Curve.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Models/Circular_Tuning_Curve.m'"
     expected_output_contains: "Circular"
 
   - name: Reverse correlation pRF model
     description: Verify reverse correlation model exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Models/Reverse_Correlation_Prf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Models/Reverse_Correlation_Prf.m'"
     expected_output_contains: "Reverse"
 
   - name: Oriented 2D multivariate model
     description: Verify oriented multivariate model exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Models/Oriented_2d_Multivariate_Prf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Models/Oriented_2d_Multivariate_Prf.m'"
     expected_output_contains: "Oriented"
 
   - name: Model specification files (.mod)
     description: Verify .mod model spec files exist
-    command: ls /opt/samsrfx-v10.004/samsrf/Models/*.mod | wc -l
+    command: bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Models/*.mod | wc -l'
     expected_output_contains: "11"
 
   # ==========================================================================
@@ -321,27 +321,27 @@ tests:
   # ==========================================================================
   - name: HRF directory structure
     description: Verify HRF directory contains functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Hrf/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Hrf/'"
     expected_output_contains: "samsrf_hrf.m"
 
   - name: HRF main function
     description: Verify main HRF function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_hrf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_hrf.m'"
     expected_output_contains: "samsrf_hrf"
 
   - name: Double gamma HRF function
     description: Verify double gamma HRF function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_doublegamma.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_doublegamma.m'"
     expected_output_contains: "doublegamma"
 
   - name: HRF extraction function
     description: Verify HRF extraction function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_extract_hrf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_extract_hrf.m'"
     expected_output_contains: "extract_hrf"
 
   - name: HRF plotting function
     description: Verify HRF plotting function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_plothrf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Hrf/samsrf_plothrf.m'"
     expected_output_contains: "plothrf"
 
   # ==========================================================================
@@ -349,57 +349,57 @@ tests:
   # ==========================================================================
   - name: Surfs directory structure
     description: Verify Surfs directory contains surface functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Surfs/ | wc -l
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Surfs/ | wc -l'"
     expected_output_contains: "44"
 
   - name: GIfTI to Srf conversion
     description: Verify GIfTI conversion function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_gii2srf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_gii2srf.m'"
     expected_output_contains: "gii2srf"
 
   - name: Srf to GIfTI conversion
     description: Verify reverse conversion function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_srf2gii.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_srf2gii.m'"
     expected_output_contains: "srf2gii"
 
   - name: MGH to Srf conversion
     description: Verify MGH conversion function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_mgh2srf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_mgh2srf.m'"
     expected_output_contains: "mgh2srf"
 
   - name: Volume to surface projection
     description: Verify volume to surface function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_vol2srf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_vol2srf.m'"
     expected_output_contains: "vol2srf"
 
   - name: Anatomy to map function
     description: Verify anatomy function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_anat2map.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_anat2map.m'"
     expected_output_contains: "anat2map"
 
   - name: Bilateral surface function
     description: Verify bilateral surface handling exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_bilat_srf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_bilat_srf.m'"
     expected_output_contains: "bilat"
 
   - name: Surface smoothing function
     description: Verify Dijkstra smoothing function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_smooth_dijkstra.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_smooth_dijkstra.m'"
     expected_output_contains: "dijkstra"
 
   - name: Field sign calculation
     description: Verify field sign function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_fieldsign.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_fieldsign.m'"
     expected_output_contains: "fieldsign"
 
   - name: Cortical magnification function
     description: Verify cortical magnification function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_cortmagn.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_cortmagn.m'"
     expected_output_contains: "cortmagn"
 
   - name: Label export function
     description: Verify label export function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_export_labels.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Surfs/samsrf_export_labels.m'"
     expected_output_contains: "export_labels"
 
   # ==========================================================================
@@ -407,62 +407,62 @@ tests:
   # ==========================================================================
   - name: Utils directory structure
     description: Verify Utils directory contains utility functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Utils/ | wc -l
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Utils/ | wc -l'"
     expected_output_contains: "57"
 
   - name: Display maps tool
     description: Verify DisplayMaps function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/DisplayMaps.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/DisplayMaps.m'"
     expected_output_contains: "DisplayMaps"
 
   - name: Delineation tool
     description: Verify DelineationTool function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/DelineationTool.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/DelineationTool.m'"
     expected_output_contains: "DelineationTool"
 
   - name: Auto delineation function
     description: Verify AutoDelineation function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/AutoDelineation.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/AutoDelineation.m'"
     expected_output_contains: "AutoDelineation"
 
   - name: View apertures tool
     description: Verify ViewApertures function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/ViewApertures.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/ViewApertures.m'"
     expected_output_contains: "ViewApertures"
 
   - name: Surface projection tool
     description: Verify SurfaceProjection function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/SurfaceProjection.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/SurfaceProjection.m'"
     expected_output_contains: "SurfaceProjection"
 
   - name: Model help function
     description: Verify ModelHelp function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/ModelHelp.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/ModelHelp.m'"
     expected_output_contains: "ModelHelp"
 
   - name: Function help tool
     description: Verify FuncHelp function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Utils/FuncHelp.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Utils/FuncHelp.m'"
     expected_output_contains: "FuncHelp"
 
   - name: FreeSurfer surface reader
     description: Verify FreeSurfer reader exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Utils/fs_read_surf.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Utils/fs_read_surf.m'"
     expected_output_contains: "read_surf"
 
   - name: Native to template map conversion
     description: Verify Native2TemplateMap exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Utils/Native2TemplateMap.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Utils/Native2TemplateMap.m'"
     expected_output_contains: "Native2TemplateMap"
 
   - name: Template to native map conversion
     description: Verify Template2NativeMap exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Utils/Template2NativeMap.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Utils/Template2NativeMap.m'"
     expected_output_contains: "Template2NativeMap"
 
   - name: Colormap function
     description: Verify colormap function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Utils/samsrf_cmap.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Utils/samsrf_cmap.m'"
     expected_output_contains: "samsrf_cmap"
 
   # ==========================================================================
@@ -470,22 +470,22 @@ tests:
   # ==========================================================================
   - name: Simulations directory structure
     description: Verify Simulations directory exists
-    command: ls /opt/samsrfx-v10.004/samsrf/Simulations/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Simulations/'"
     expected_output_contains: "samsrf_simulate_prfs.m"
 
   - name: pRF simulation function
     description: Verify pRF simulation function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Simulations/samsrf_simulate_prfs.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Simulations/samsrf_simulate_prfs.m'"
     expected_output_contains: "simulate_prfs"
 
   - name: Simulation vs fit comparison
     description: Verify simulation comparison function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Simulations/samsrf_simvsfit.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Simulations/samsrf_simvsfit.m'"
     expected_output_contains: "simvsfit"
 
   - name: Example apertures for simulation
     description: Verify example apertures exist
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Simulations/*.mat
+    command: bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Simulations/*.mat'
     expected_output_contains: "aps_SweepingBars.mat"
 
   # ==========================================================================
@@ -493,27 +493,27 @@ tests:
   # ==========================================================================
   - name: Render directory structure
     description: Verify Render directory contains rendering functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Render/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Render/'"
     expected_output_contains: "samsrf_surf.m"
 
   - name: Surface rendering function
     description: Verify main surface rendering function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Render/samsrf_surf.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Render/samsrf_surf.m'"
     expected_output_contains: "samsrf_surf"
 
   - name: Colour coding function
     description: Verify colour coding function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Render/samsrf_colourcode.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Render/samsrf_colourcode.m'"
     expected_output_contains: "colourcode"
 
   - name: Timecourse movie function
     description: Verify timecourse movie function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Render/samsrf_tcmovie.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Render/samsrf_tcmovie.m'"
     expected_output_contains: "tcmovie"
 
   - name: Aperture movie function
     description: Verify aperture movie function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Render/samsrf_apmovie.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Render/samsrf_apmovie.m'"
     expected_output_contains: "apmovie"
 
   # ==========================================================================
@@ -521,17 +521,17 @@ tests:
   # ==========================================================================
   - name: Vols directory structure
     description: Verify Vols directory contains volume functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Vols/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Vols/'"
     expected_output_contains: "samsrf_vol2mat.m"
 
   - name: Volume to mat function
     description: Verify volume to mat function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Vols/samsrf_vol2mat.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Vols/samsrf_vol2mat.m'"
     expected_output_contains: "vol2mat"
 
   - name: Mat to volume function
     description: Verify mat to volume function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Vols/samsrf_mat2vol.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Vols/samsrf_mat2vol.m'"
     expected_output_contains: "mat2vol"
 
   # ==========================================================================
@@ -539,37 +539,37 @@ tests:
   # ==========================================================================
   - name: Colormaps directory structure
     description: Verify Colours directory contains colormap files
-    command: ls /opt/samsrfx-v10.004/samsrf/Colours/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Colours/'"
     expected_output_contains: "berlin.csv"
 
   - name: Berlin colormap
     description: Verify berlin colormap exists
-    command: head -5 /opt/samsrfx-v10.004/samsrf/Colours/berlin.csv
+    command: "bash -lc 'head -5 /opt/samsrfx-v10.004/samsrf/Colours/berlin.csv'"
     expected_output_contains: ","
 
   - name: Fire colormap
     description: Verify fire colormap exists
-    command: head -5 /opt/samsrfx-v10.004/samsrf/Colours/fire.csv
+    command: "bash -lc 'head -5 /opt/samsrfx-v10.004/samsrf/Colours/fire.csv'"
     expected_output_contains: ","
 
   - name: Hawaii colormap
     description: Verify hawaii colormap exists
-    command: head -5 /opt/samsrfx-v10.004/samsrf/Colours/hawaii.csv
+    command: "bash -lc 'head -5 /opt/samsrfx-v10.004/samsrf/Colours/hawaii.csv'"
     expected_output_contains: ","
 
   - name: Romao colormap for polar angle
     description: Verify romao colormap exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Colours/romao.csv
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Colours/romao.csv'"
     expected_output_contains: "romao.csv"
 
   - name: Eccentricity colorwheel image
     description: Verify eccentricity colorwheel PNG exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Colours/Eccentricity.png
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Colours/Eccentricity.png'"
     expected_output_contains: "Eccentricity.png"
 
   - name: Polar angle colorwheel images
     description: Verify polar angle colorwheel PNGs exist
-    command: ls /opt/samsrfx-v10.004/samsrf/Colours/Polar*.png
+    command: bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Colours/Polar*.png'
     expected_output_contains: "Polar"
 
   # ==========================================================================
@@ -577,27 +577,27 @@ tests:
   # ==========================================================================
   - name: Various directory structure
     description: Verify Various directory contains helper functions
-    command: ls /opt/samsrfx-v10.004/samsrf/Various/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/Various/'"
     expected_output_contains: "samsrf_version.m"
 
   - name: R-squared calculation function
     description: Verify gsr2 function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Various/samsrf_gsr2.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Various/samsrf_gsr2.m'"
     expected_output_contains: "gsr2"
 
   - name: Model defaults function
     description: Verify model defaults function exists
-    command: head -20 /opt/samsrfx-v10.004/samsrf/Various/samsrf_model_defaults.m
+    command: "bash -lc 'head -20 /opt/samsrfx-v10.004/samsrf/Various/samsrf_model_defaults.m'"
     expected_output_contains: "model_defaults"
 
   - name: DOG FWHM calculation
     description: Verify DOG FWHM function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Various/samsrf_dog_fwhm.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Various/samsrf_dog_fwhm.m'"
     expected_output_contains: "dog_fwhm"
 
   - name: Progress bar function
     description: Verify progress bar function exists
-    command: head -10 /opt/samsrfx-v10.004/samsrf/Various/samsrf_progbar.m
+    command: "bash -lc 'head -10 /opt/samsrfx-v10.004/samsrf/Various/samsrf_progbar.m'"
     expected_output_contains: "progbar"
 
   # ==========================================================================
@@ -605,27 +605,27 @@ tests:
   # ==========================================================================
   - name: DisplayMaps GUI figure
     description: Verify DisplayMaps.fig GUI file exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/DisplayMaps.fig
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/DisplayMaps.fig'"
     expected_output_contains: "DisplayMaps.fig"
 
   - name: DelineationTool GUI figure
     description: Verify DelineationTool.fig GUI file exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/DelineationTool.fig
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/DelineationTool.fig'"
     expected_output_contains: "DelineationTool.fig"
 
   - name: ViewApertures GUI figure
     description: Verify ViewApertures.fig GUI file exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/ViewApertures.fig
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/ViewApertures.fig'"
     expected_output_contains: "ViewApertures.fig"
 
   - name: FuncHelp GUI figure
     description: Verify FuncHelp.fig GUI file exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/FuncHelp.fig
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/FuncHelp.fig'"
     expected_output_contains: "FuncHelp.fig"
 
   - name: ModelHelp GUI figure
     description: Verify ModelHelp.fig GUI file exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/ModelHelp.fig
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/ModelHelp.fig'"
     expected_output_contains: "ModelHelp.fig"
 
   # ==========================================================================
@@ -633,17 +633,17 @@ tests:
   # ==========================================================================
   - name: Benson atlas data
     description: Verify Benson atlas delineation data exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/AutoDelinAtlas_Benson.mat
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/AutoDelinAtlas_Benson.mat'"
     expected_output_contains: "AutoDelinAtlas_Benson.mat"
 
   - name: InfernoSerpents atlas data
     description: Verify InfernoSerpents atlas exists
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/AutoDelinAtlas_InfernoSerpents.mat
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/AutoDelinAtlas_InfernoSerpents.mat'"
     expected_output_contains: "InfernoSerpents"
 
   - name: Scalp head model
     description: Verify scalp head model exists for EEG
-    command: ls -la /opt/samsrfx-v10.004/samsrf/Utils/ScalpHeadModel.mat
+    command: "bash -lc 'ls -la /opt/samsrfx-v10.004/samsrf/Utils/ScalpHeadModel.mat'"
     expected_output_contains: "ScalpHeadModel.mat"
 
   # ==========================================================================
@@ -661,7 +661,7 @@ tests:
 
   - name: Samsrfx directory structure
     description: Verify samsrf subdirectory structure
-    command: ls /opt/samsrfx-v10.004/samsrf/
+    command: "bash -lc 'ls /opt/samsrfx-v10.004/samsrf/'"
     expected_output_contains: "SamSrfX.m"
 
   # ==========================================================================
@@ -669,12 +669,12 @@ tests:
   # ==========================================================================
   - name: X11 libraries available
     description: Verify X11 extension library is available
-    command: ldconfig -p | grep libXext || ls /usr/lib/x86_64-linux-gnu/libXext* 2>/dev/null | head -1
+    command: bash -lc 'ldconfig -p | grep libXext || ls /usr/lib/x86_64-linux-gnu/libXext* 2>/dev/null | head -1'
     expected_output_contains: "libXext"
 
   - name: Ncurses library available
     description: Verify ncurses library is available
-    command: ldconfig -p | grep libncurses || ls /usr/lib/x86_64-linux-gnu/libncurses* 2>/dev/null | head -1
+    command: bash -lc 'ldconfig -p | grep libncurses || ls /usr/lib/x86_64-linux-gnu/libncurses* 2>/dev/null | head -1'
     expected_output_contains: "libncurses"
 
 cleanup:

--- a/recipes/sigviewer/fulltest.yaml
+++ b/recipes/sigviewer/fulltest.yaml
@@ -150,7 +150,7 @@ tests:
 
   - name: Libbiosig present
     description: Verify libbiosig library is available
-    command: ls -la /usr/lib/x86_64-linux-gnu/libbiosig.so*
+    command: bash -lc 'ls -la /usr/lib/x86_64-linux-gnu/libbiosig.so*'
     expected_output_contains: "libbiosig.so.3"
 
   - name: Qt libraries present

--- a/recipes/slicersalt/fulltest.yaml
+++ b/recipes/slicersalt/fulltest.yaml
@@ -39,17 +39,17 @@ tests:
   # ==========================================================================
   - name: SlicerSALT executable exists
     description: Verify SlicerSALT main executable is present
-    command: test -x /opt/SlicerSALT-3.0.0-linux-amd64/SlicerSALT && echo "SlicerSALT executable found"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'test -x /opt/SlicerSALT-3.0.0-linux-amd64/SlicerSALT && echo \"SlicerSALT executable found\"'\"'\"''"
     expected_output_contains: "SlicerSALT executable found"
 
   - name: CLI modules directory exists
     description: Verify CLI modules directory is present
-    command: test -d /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules && echo "CLI modules directory found"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'test -d /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules && echo \"CLI modules directory found\"'\"'\"''"
     expected_output_contains: "CLI modules directory found"
 
   - name: Sample mesh file exists
     description: Verify sample VTP mesh file is available for testing
-    command: test -f /opt/SlicerSALT-3.0.0-linux-amd64/share/SlicerSALT-4.11/OrientationMarkers/Human.vtp && echo "Sample mesh found"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'test -f /opt/SlicerSALT-3.0.0-linux-amd64/share/SlicerSALT-4.11/OrientationMarkers/Human.vtp && echo \"Sample mesh found\"'\"'\"''"
     expected_output_contains: "Sample mesh found"
 
   # ==========================================================================
@@ -57,127 +57,127 @@ tests:
   # ==========================================================================
   - name: Decimation module help
     description: Test Decimation CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: Smoothing module help
     description: Test Smoothing CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --help 2>&1'\"'\"''"
     expected_output_contains: "Smoothing"
 
   - name: BordersOut module help
     description: Test BordersOut CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/BordersOut --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/BordersOut --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: Cleaner module help
     description: Test Cleaner CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: Connectivity module help
     description: Test Connectivity CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Connectivity --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Connectivity --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: FillHoles module help
     description: Test FillHoles CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/FillHoles --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/FillHoles --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: MC2Origin module help
     description: Test MC2Origin (mass center to origin) CLI module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MC2Origin --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MC2Origin --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: MergeModels module help
     description: Test MergeModels CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MergeModels --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MergeModels --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: Mirror module help
     description: Test Mirror CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --help 2>&1'\"'\"''"
     expected_output_contains: "Mirror"
 
   - name: Normals module help
     description: Test Normals CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: relaxPolygons module help
     description: Test relaxPolygons CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/relaxPolygons --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/relaxPolygons --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: scaleMesh module help
     description: Test scaleMesh CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/scaleMesh --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/scaleMesh --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: translateMesh module help
     description: Test translateMesh CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/translateMesh --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/translateMesh --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: surfacefeaturesextractor module help
     description: Test surfacefeaturesextractor CLI module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/surfacefeaturesextractor --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/surfacefeaturesextractor --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: ModelToModelDistance module help
     description: Test ModelToModelDistance CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: MeshToMeshRegistration module help
     description: Test MeshToMeshRegistration CLI module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToMeshRegistration --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToMeshRegistration --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: MeshToMeshDiffeoRegistration module help
     description: Test MeshToMeshDiffeoRegistration (diffeomorphic) module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToMeshDiffeoRegistration --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToMeshDiffeoRegistration --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: ModelMaker module help
     description: Test ModelMaker CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelMaker --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelMaker --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: MeshToLabelMap module help
     description: Test MeshToLabelMap CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToLabelMap --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToLabelMap --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: SRemesh module help
     description: Test SRemesh (surface remeshing) CLI module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/SRemesh --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/SRemesh --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: RigidAlignment module help
     description: Test RigidAlignment CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/RigidAlignment --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/RigidAlignment --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: SegPostProcessCLP module help
     description: Test SegPostProcessCLP (segmentation post-processing) module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/SegPostProcessCLP --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/SegPostProcessCLP --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: shape4D module help
     description: Test shape4D (temporal shape analysis) CLI module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/shape4D --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/shape4D --help 2>&1'\"'\"''"
     expected_output_contains: "shape4D"
 
   - name: ResampleDTIVolume module help
     description: Test ResampleDTIVolume CLI module loads and shows help
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ResampleDTIVolume --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ResampleDTIVolume --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   - name: ResampleScalarVectorDWIVolume module help
     description: Test ResampleScalarVectorDWIVolume CLI module loads
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ResampleScalarVectorDWIVolume --help 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ResampleScalarVectorDWIVolume --help 2>&1'\"'\"''"
     expected_output_contains: "USAGE"
 
   # ==========================================================================
@@ -185,17 +185,17 @@ tests:
   # ==========================================================================
   - name: Decimation XML schema
     description: Test Decimation module produces valid XML description
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --xml 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --xml 2>&1'\"'\"''"
     expected_output_contains: "<executable>"
 
   - name: Smoothing XML schema
     description: Test Smoothing module produces valid XML description
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --xml 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --xml 2>&1'\"'\"''"
     expected_output_contains: "<executable>"
 
   - name: ModelToModelDistance XML schema
     description: Test ModelToModelDistance module produces valid XML description
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance --xml 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance --xml 2>&1'\"'\"''"
     expected_output_contains: "<executable>"
 
   # ==========================================================================
@@ -203,27 +203,27 @@ tests:
   # ==========================================================================
   - name: Meta2VTK converter help
     description: Test Meta2VTK format converter displays usage
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/bin/Meta2VTK 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/bin/Meta2VTK 2>&1'\"'\"''"
     expected_output_contains: "Meta2VTK"
 
   - name: VTK2Meta converter help
     description: Test VTK2Meta format converter displays usage
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/bin/VTK2Meta 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/bin/VTK2Meta 2>&1'\"'\"''"
     expected_output_contains: "VTK2Meta"
 
   - name: BYU2VTK converter help
     description: Test BYU2VTK format converter displays usage
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/bin/BYU2VTK 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/bin/BYU2VTK 2>&1'\"'\"''"
     expected_output_contains: "BYU2VTK"
 
   - name: asc2vtk converter help
     description: Test asc2vtk (FreeSurfer ASCII to VTK) converter displays usage
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/bin/asc2vtk 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/bin/asc2vtk 2>&1'\"'\"''"
     expected_output_contains: "asc2vtk"
 
   - name: asc2meta converter help
     description: Test asc2meta (FreeSurfer ASCII to Meta) converter displays usage
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/bin/asc2meta 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/bin/asc2meta 2>&1'\"'\"''"
     expected_output_contains: "asc2vtk"
 
   # ==========================================================================
@@ -231,147 +231,147 @@ tests:
   # ==========================================================================
   - name: Mesh decimation
     description: Reduce mesh polygon count using Decimation module
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.5 test_output/sample_mesh.vtp test_output/mesh_decimated.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.5 test_output/sample_mesh.vtp test_output/mesh_decimated.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_decimated.vtp
 
   - name: Mesh decimation with boundary preservation
     description: Decimate mesh while preserving boundary edges
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.7 --boundary test_output/sample_mesh.vtp test_output/mesh_decimated_boundary.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.7 --boundary test_output/sample_mesh.vtp test_output/mesh_decimated_boundary.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_decimated_boundary.vtp
 
   - name: Laplacian smoothing
     description: Apply Laplacian smoothing to mesh
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Laplace --iterations 50 --relaxation 0.5 test_output/sample_mesh.vtp test_output/mesh_laplace_smooth.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Laplace --iterations 50 --relaxation 0.5 test_output/sample_mesh.vtp test_output/mesh_laplace_smooth.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_laplace_smooth.vtp
 
   - name: Taubin smoothing
     description: Apply Taubin (non-shrinking) smoothing to mesh
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Taubin --iterations 50 --relaxation 0.5 test_output/sample_mesh.vtp test_output/mesh_taubin_smooth.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Taubin --iterations 50 --relaxation 0.5 test_output/sample_mesh.vtp test_output/mesh_taubin_smooth.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_taubin_smooth.vtp
 
   - name: Smoothing with boundary preservation
     description: Apply smoothing while preserving boundary edges
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Laplace --iterations 30 --boundary test_output/sample_mesh.vtp test_output/mesh_smooth_boundary.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Laplace --iterations 30 --boundary test_output/sample_mesh.vtp test_output/mesh_smooth_boundary.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_smooth_boundary.vtp
 
   - name: Extract mesh borders
     description: Extract border edges from mesh using BordersOut
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/BordersOut test_output/sample_mesh.vtp test_output/mesh_borders.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/BordersOut test_output/sample_mesh.vtp test_output/mesh_borders.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_borders.vtp
 
   - name: Clean mesh
     description: Clean mesh topology using Cleaner module
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner test_output/sample_mesh.vtp test_output/mesh_cleaned.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner test_output/sample_mesh.vtp test_output/mesh_cleaned.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_cleaned.vtp
 
   - name: Extract largest connected component
     description: Extract largest connected component from mesh
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Connectivity test_output/sample_mesh.vtp test_output/mesh_connected.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Connectivity test_output/sample_mesh.vtp test_output/mesh_connected.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_connected.vtp
 
   - name: Fill holes in mesh
     description: Fill holes in mesh surface using FillHoles
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/FillHoles --holes 500 test_output/sample_mesh.vtp test_output/mesh_filled.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/FillHoles --holes 500 test_output/sample_mesh.vtp test_output/mesh_filled.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_filled.vtp
 
   - name: Move mesh center to origin
     description: Translate mesh so mass center is at origin
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MC2Origin test_output/sample_mesh.vtp test_output/mesh_centered.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MC2Origin test_output/sample_mesh.vtp test_output/mesh_centered.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_centered.vtp
 
   - name: Mirror mesh over X axis
     description: Mirror/reflect mesh over X axis
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --xAxis test_output/sample_mesh.vtp test_output/mesh_mirror_x.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --xAxis test_output/sample_mesh.vtp test_output/mesh_mirror_x.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_mirror_x.vtp
 
   - name: Mirror mesh over Y axis
     description: Mirror/reflect mesh over Y axis
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --yAxis test_output/sample_mesh.vtp test_output/mesh_mirror_y.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --yAxis test_output/sample_mesh.vtp test_output/mesh_mirror_y.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_mirror_y.vtp
 
   - name: Mirror mesh over Z axis
     description: Mirror/reflect mesh over Z axis
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --zAxis test_output/sample_mesh.vtp test_output/mesh_mirror_z.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Mirror --zAxis test_output/sample_mesh.vtp test_output/mesh_mirror_z.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_mirror_z.vtp
 
   - name: Compute and orient normals
     description: Compute surface normals with consistent orientation
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --orient test_output/sample_mesh.vtp test_output/mesh_normals.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --orient test_output/sample_mesh.vtp test_output/mesh_normals.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_normals.vtp
 
   - name: Flip mesh normals
     description: Flip all surface normals
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --flip test_output/sample_mesh.vtp test_output/mesh_normals_flipped.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --flip test_output/sample_mesh.vtp test_output/mesh_normals_flipped.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_normals_flipped.vtp
 
   - name: Split normals by feature angle
     description: Split normals at sharp feature edges
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --splitting --angle 45 test_output/sample_mesh.vtp test_output/mesh_normals_split.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --splitting --angle 45 test_output/sample_mesh.vtp test_output/mesh_normals_split.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_normals_split.vtp
 
   - name: Relax mesh polygons
     description: Relax polygon distribution using relaxPolygons
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/relaxPolygons --iterations 10 test_output/sample_mesh.vtp test_output/mesh_relaxed.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/relaxPolygons --iterations 10 test_output/sample_mesh.vtp test_output/mesh_relaxed.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_relaxed.vtp
 
   - name: Scale mesh uniformly
     description: Scale mesh uniformly by factor of 2
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/scaleMesh --dimX 2 --dimY 2 --dimZ 2 test_output/sample_mesh.vtp test_output/mesh_scaled_uniform.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/scaleMesh --dimX 2 --dimY 2 --dimZ 2 test_output/sample_mesh.vtp test_output/mesh_scaled_uniform.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_scaled_uniform.vtp
 
   - name: Scale mesh non-uniformly
     description: Scale mesh with different factors per axis
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/scaleMesh --dimX 1.5 --dimY 1.0 --dimZ 2.0 test_output/sample_mesh.vtp test_output/mesh_scaled_nonuniform.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/scaleMesh --dimX 1.5 --dimY 1.0 --dimZ 2.0 test_output/sample_mesh.vtp test_output/mesh_scaled_nonuniform.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_scaled_nonuniform.vtp
 
   - name: Translate mesh
     description: Translate mesh by specified offset
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/translateMesh --dimX 10 --dimY 20 --dimZ 30 test_output/sample_mesh.vtp test_output/mesh_translated.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/translateMesh --dimX 10 --dimY 20 --dimZ 30 test_output/sample_mesh.vtp test_output/mesh_translated.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_translated.vtp
 
   - name: Merge two models
     description: Merge two mesh models into one
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MergeModels test_output/sample_mesh.vtp test_output/mesh_translated.vtp test_output/mesh_merged.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MergeModels test_output/sample_mesh.vtp test_output/mesh_translated.vtp test_output/mesh_merged.vtp 2>&1'\"'\"''"
     depends_on: Translate mesh
     validate:
       - output_exists: ${output_dir}/mesh_merged.vtp
@@ -381,28 +381,28 @@ tests:
   # ==========================================================================
   - name: Model to model distance - signed closest point
     description: Compute signed closest point distance between meshes
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/mesh_scaled_uniform.vtp -o test_output/distance_signed.vtp -d signed_closest_point 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/mesh_scaled_uniform.vtp -o test_output/distance_signed.vtp -d signed_closest_point 2>&1'\"'\"''"
     depends_on: Scale mesh uniformly
     validate:
       - output_exists: ${output_dir}/distance_signed.vtp
 
   - name: Model to model distance - absolute closest point
     description: Compute absolute closest point distance between meshes
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/mesh_scaled_uniform.vtp -o test_output/distance_absolute.vtp -d absolute_closest_point 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/mesh_scaled_uniform.vtp -o test_output/distance_absolute.vtp -d absolute_closest_point 2>&1'\"'\"''"
     depends_on: Scale mesh uniformly
     validate:
       - output_exists: ${output_dir}/distance_absolute.vtp
 
   - name: Model to model distance - point to point
     description: Compute corresponding point-to-point distance between meshes
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/sample_mesh.vtp -o test_output/distance_p2p.vtp -d corresponding_point_to_point 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/sample_mesh.vtp -o test_output/distance_p2p.vtp -d corresponding_point_to_point 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/distance_p2p.vtp
 
   - name: Model to model distance with target field names
     description: Compute distance and save target model name in fields
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/mesh_laplace_smooth.vtp -o test_output/distance_with_fields.vtp -f 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/ModelToModelDistance -s test_output/sample_mesh.vtp -t test_output/mesh_laplace_smooth.vtp -o test_output/distance_with_fields.vtp -f 2>&1'\"'\"''"
     depends_on: Laplacian smoothing
     validate:
       - output_exists: ${output_dir}/distance_with_fields.vtp
@@ -412,12 +412,12 @@ tests:
   # ==========================================================================
   - name: Mesh to mesh registration
     description: Register template mesh to target mesh (skipped - too slow, >300s)
-    command: echo "Skipped - mesh registration too slow (>300s)"
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'echo \"Skipped - mesh registration too slow (>300s)\"'\"'\"''"
     expected_output_contains: "Skipped"
 
   - name: Diffeomorphic mesh registration
     description: Perform diffeomorphic registration between meshes
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToMeshDiffeoRegistration --templateMesh test_output/sample_mesh.vtp --targetMesh test_output/mesh_scaled_uniform.vtp --registeredTemplate test_output/mesh_diffeo_registered.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/MeshToMeshDiffeoRegistration --templateMesh test_output/sample_mesh.vtp --targetMesh test_output/mesh_scaled_uniform.vtp --registeredTemplate test_output/mesh_diffeo_registered.vtp 2>&1'\"'\"''"
     depends_on: Scale mesh uniformly
     validate:
       - output_exists: ${output_dir}/mesh_diffeo_registered.vtp
@@ -427,28 +427,21 @@ tests:
   # ==========================================================================
   - name: Full preprocessing pipeline
     description: Clean, decimate, smooth, and compute normals in sequence
-    command: |
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner test_output/sample_mesh.vtp test_output/pipeline_step1.vtp && \
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.5 test_output/pipeline_step1.vtp test_output/pipeline_step2.vtp && \
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Taubin --iterations 30 test_output/pipeline_step2.vtp test_output/pipeline_step3.vtp && \
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --orient test_output/pipeline_step3.vtp test_output/mesh_preprocessed.vtp
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner test_output/sample_mesh.vtp test_output/pipeline_step1.vtp && \\\n/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.5 test_output/pipeline_step1.vtp test_output/pipeline_step2.vtp && \\\n/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Smoothing --type Taubin --iterations 30 test_output/pipeline_step2.vtp test_output/pipeline_step3.vtp && \\\n/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Normals --orient test_output/pipeline_step3.vtp test_output/mesh_preprocessed.vtp'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_preprocessed.vtp
 
   - name: Mesh simplification pipeline
     description: Decimate and then clean for efficient mesh
-    command: |
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.8 test_output/sample_mesh.vtp test_output/simplified_step1.vtp && \
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner test_output/simplified_step1.vtp test_output/simplified_step2.vtp && \
-      /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Connectivity test_output/simplified_step2.vtp test_output/mesh_simplified.vtp
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Decimation --decimate 0.8 test_output/sample_mesh.vtp test_output/simplified_step1.vtp && \\\n/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Cleaner test_output/simplified_step1.vtp test_output/simplified_step2.vtp && \\\n/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/Connectivity test_output/simplified_step2.vtp test_output/mesh_simplified.vtp'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_simplified.vtp
 
   - name: Surface features extraction
     description: Extract surface features from mesh
-    command: /opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/surfacefeaturesextractor test_output/sample_mesh.vtp test_output/mesh_features.vtp 2>&1
+    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules:/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Python/lib:/opt/SlicerSALT-3.0.0-linux-amd64/lib/QtPlugins:/opt/SlicerSALT-3.0.0-linux-amd64/lib/Teem-1.12.0 bash -lc '\"'\"'/opt/SlicerSALT-3.0.0-linux-amd64/lib/SlicerSALT-4.11/cli-modules/surfacefeaturesextractor test_output/sample_mesh.vtp test_output/mesh_features.vtp 2>&1'\"'\"''"
     depends_on: setup
     validate:
       - output_exists: ${output_dir}/mesh_features.vtp

--- a/recipes/spm12/fulltest.yaml
+++ b/recipes/spm12/fulltest.yaml
@@ -53,22 +53,22 @@ tests:
   # ==========================================================================
   - name: SPM12 runner script exists
     description: Verify the main SPM12 runner script is present
-    command: test -f /opt/spm12/run_spm12.sh && echo "run_spm12.sh exists"
+    command: bash -lc 'test -f /opt/spm12/run_spm12.sh && echo "run_spm12.sh exists"'
     expected_output_contains: "run_spm12.sh exists"
 
   - name: MCR installation exists
     description: Verify MATLAB Compiler Runtime v97 is installed
-    command: test -d /opt/mcr/v97 && echo "MCR v97 installed"
+    command: bash -lc 'test -d /opt/mcr/v97 && echo "MCR v97 installed"'
     expected_output_contains: "MCR v97 installed"
 
   - name: SPM12 binary exists
     description: Verify compiled SPM12 binary is present
-    command: test -x /opt/spm12/spm12 && echo "spm12 binary exists"
+    command: bash -lc 'test -x /opt/spm12/spm12 && echo "spm12 binary exists"'
     expected_output_contains: "spm12 binary exists"
 
   - name: SPM12 CTF archive exists
     description: Verify SPM12 compiled archive is present
-    command: test -f /opt/spm12/spm12.ctf && echo "spm12.ctf exists"
+    command: bash -lc 'test -f /opt/spm12/spm12.ctf && echo "spm12.ctf exists"'
     expected_output_contains: "spm12.ctf exists"
 
   # ==========================================================================
@@ -76,25 +76,25 @@ tests:
   # ==========================================================================
   - name: SPM12 version check
     description: Verify SPM12 reports correct version
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ --version 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ --version 2>&1'
     expected_output_contains: "SPM12"
     timeout: 120
 
   - name: SPM12 help output
     description: Verify SPM12 help displays correctly
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ --help 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ --help 2>&1'
     expected_output_contains: "Usage"
     timeout: 120
 
   - name: MATLAB version check
     description: Verify MCR reports MATLAB version
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ --version 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ --version 2>&1'
     expected_output_contains: "MATLAB"
     timeout: 120
 
   - name: SPM12 revision number
     description: Verify SPM12 revision 7771
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ --version 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ --version 2>&1'
     expected_output_contains: "7771"
     timeout: 120
 
@@ -103,55 +103,55 @@ tests:
   # ==========================================================================
   - name: SPM eval disp command
     description: Test basic MATLAB eval with disp
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp('SPM12 working')" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp('\''SPM12 working'\'')" 2>&1'
     expected_output_contains: "SPM12 working"
     timeout: 180
 
   - name: SPM eval spm version
     description: Get SPM version via spm function
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "spm('ver')" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "spm('\''ver'\'')" 2>&1'
     expected_output_contains: "SPM12"
     timeout: 180
 
   - name: SPM eval get defaults
     description: Verify SPM defaults are accessible
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "d=spm_get_defaults; disp(class(d))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "d=spm_get_defaults; disp(class(d))" 2>&1'
     expected_output_contains: "struct"
     timeout: 180
 
   - name: SPM eval exist spm_vol
     description: Verify spm_vol function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_vol'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_vol'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM eval exist spm_realign
     description: Verify spm_realign function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_realign'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_realign'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM eval exist spm_smooth
     description: Verify spm_smooth function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_smooth'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_smooth'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM eval exist spm_coreg
     description: Verify spm_coreg function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_coreg'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_coreg'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM eval exist spm_preproc
     description: Verify spm_preproc function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_preproc'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_preproc'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM eval exist spm_spm
     description: Verify spm_spm function (GLM estimation) exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_spm'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_spm'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
@@ -160,22 +160,22 @@ tests:
   # ==========================================================================
   - name: SPM12 MCR directory structure
     description: Verify SPM12 MCR unpacked directory exists
-    command: test -d /opt/spm12/spm12_mcr && echo "spm12_mcr directory exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr && echo "spm12_mcr directory exists"'
     expected_output_contains: "spm12_mcr directory exists"
 
   - name: SPM12 canonical directory exists
     description: Verify canonical templates directory
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/canonical && echo "canonical dir exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/canonical && echo "canonical dir exists"'
     expected_output_contains: "canonical dir exists"
 
   - name: SPM12 config directory exists
     description: Verify config batch modules directory
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/config && echo "config dir exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/config && echo "config dir exists"'
     expected_output_contains: "config dir exists"
 
   - name: SPM12 toolbox directory exists
     description: Verify toolbox directory
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox && echo "toolbox dir exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox && echo "toolbox dir exists"'
     expected_output_contains: "toolbox dir exists"
 
   # ==========================================================================
@@ -183,37 +183,37 @@ tests:
   # ==========================================================================
   - name: TPM template exists
     description: Verify Tissue Probability Map template
-    command: find /opt/spm12 -name "TPM.nii" -type f 2>/dev/null | head -1 | xargs test -f && echo "TPM.nii exists"
+    command: "bash -lc 'find /opt/spm12 -name \"TPM.nii\" -type f 2>/dev/null | head -1 | xargs test -f && echo \"TPM.nii exists\"'"
     expected_output_contains: "TPM.nii exists"
 
   - name: T1 canonical template exists
     description: Verify single subject T1 template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/single_subj_T1.nii && echo "single_subj_T1.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/single_subj_T1.nii && echo "single_subj_T1.nii exists"'
     expected_output_contains: "single_subj_T1.nii exists"
 
   - name: avg152T1 template exists
     description: Verify MNI avg152 T1 template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/avg152T1.nii && echo "avg152T1.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/avg152T1.nii && echo "avg152T1.nii exists"'
     expected_output_contains: "avg152T1.nii exists"
 
   - name: avg152T2 template exists
     description: Verify MNI avg152 T2 template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/avg152T2.nii && echo "avg152T2.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/avg152T2.nii && echo "avg152T2.nii exists"'
     expected_output_contains: "avg152T2.nii exists"
 
   - name: avg152PD template exists
     description: Verify MNI avg152 PD template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/avg152PD.nii && echo "avg152PD.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/avg152PD.nii && echo "avg152PD.nii exists"'
     expected_output_contains: "avg152PD.nii exists"
 
   - name: Neuromorphometrics labels exist
     description: Verify Neuromorphometrics atlas labels
-    command: find /opt/spm12 -name "labels_Neuromorphometrics*" -type f 2>/dev/null | wc -l | xargs test 0 -lt && echo "Neuromorphometrics labels exist"
+    command: "bash -lc 'find /opt/spm12 -name \"labels_Neuromorphometrics*\" -type f 2>/dev/null | wc -l | xargs test 0 -lt && echo \"Neuromorphometrics labels exist\"'"
     expected_output_contains: "Neuromorphometrics labels exist"
 
   - name: ICV mask exists
     description: Verify intracranial volume mask template
-    command: find /opt/spm12 -name "mask_ICV.nii" -type f 2>/dev/null | head -1 | xargs test -f && echo "mask_ICV.nii exists"
+    command: "bash -lc 'find /opt/spm12 -name \"mask_ICV.nii\" -type f 2>/dev/null | head -1 | xargs test -f && echo \"mask_ICV.nii exists\"'"
     expected_output_contains: "mask_ICV.nii exists"
 
   # ==========================================================================
@@ -221,37 +221,37 @@ tests:
   # ==========================================================================
   - name: DARTEL toolbox exists
     description: Verify DARTEL diffeomorphic registration toolbox
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL && echo "DARTEL toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL && echo "DARTEL toolbox exists"'
     expected_output_contains: "DARTEL toolbox exists"
 
   - name: FieldMap toolbox exists
     description: Verify FieldMap distortion correction toolbox
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap && echo "FieldMap toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap && echo "FieldMap toolbox exists"'
     expected_output_contains: "FieldMap toolbox exists"
 
   - name: Shoot toolbox exists
     description: Verify Shoot geodesic shooting toolbox
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot && echo "Shoot toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot && echo "Shoot toolbox exists"'
     expected_output_contains: "Shoot toolbox exists"
 
   - name: Longitudinal toolbox exists
     description: Verify Longitudinal registration toolbox
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal && echo "Longitudinal toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal && echo "Longitudinal toolbox exists"'
     expected_output_contains: "Longitudinal toolbox exists"
 
   - name: OldNorm toolbox exists
     description: Verify Old Normalise toolbox (SPM2/5 style)
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/OldNorm && echo "OldNorm toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/OldNorm && echo "OldNorm toolbox exists"'
     expected_output_contains: "OldNorm toolbox exists"
 
   - name: OldSeg toolbox exists
     description: Verify Old Segment toolbox (SPM8 style)
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/OldSeg && echo "OldSeg toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/OldSeg && echo "OldSeg toolbox exists"'
     expected_output_contains: "OldSeg toolbox exists"
 
   - name: DEM toolbox exists
     description: Verify Dynamic Expectation Maximization toolbox
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DEM && echo "DEM toolbox exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DEM && echo "DEM toolbox exists"'
     expected_output_contains: "DEM toolbox exists"
 
   # ==========================================================================
@@ -259,72 +259,72 @@ tests:
   # ==========================================================================
   - name: Realign config module exists
     description: Verify realignment batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_realign.m && echo "spm_cfg_realign.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_realign.m && echo "spm_cfg_realign.m exists"'
     expected_output_contains: "spm_cfg_realign.m exists"
 
   - name: Coregister config module exists
     description: Verify coregistration batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_coreg.m && echo "spm_cfg_coreg.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_coreg.m && echo "spm_cfg_coreg.m exists"'
     expected_output_contains: "spm_cfg_coreg.m exists"
 
   - name: Segment config module exists
     description: Verify unified segmentation batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_preproc8.m && echo "spm_cfg_preproc8.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_preproc8.m && echo "spm_cfg_preproc8.m exists"'
     expected_output_contains: "spm_cfg_preproc8.m exists"
 
   - name: Normalise config module exists
     description: Verify normalise batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_norm.m && echo "spm_cfg_norm.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_norm.m && echo "spm_cfg_norm.m exists"'
     expected_output_contains: "spm_cfg_norm.m exists"
 
   - name: Smooth config module exists
     description: Verify smoothing batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_smooth.m && echo "spm_cfg_smooth.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_smooth.m && echo "spm_cfg_smooth.m exists"'
     expected_output_contains: "spm_cfg_smooth.m exists"
 
   - name: fMRI design config module exists
     description: Verify fMRI model specification batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_fmri_spec.m && echo "spm_cfg_fmri_spec.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_fmri_spec.m && echo "spm_cfg_fmri_spec.m exists"'
     expected_output_contains: "spm_cfg_fmri_spec.m exists"
 
   - name: fMRI estimation config module exists
     description: Verify fMRI model estimation batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_fmri_est.m && echo "spm_cfg_fmri_est.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_fmri_est.m && echo "spm_cfg_fmri_est.m exists"'
     expected_output_contains: "spm_cfg_fmri_est.m exists"
 
   - name: Contrast config module exists
     description: Verify contrast manager batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_con.m && echo "spm_cfg_con.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_con.m && echo "spm_cfg_con.m exists"'
     expected_output_contains: "spm_cfg_con.m exists"
 
   - name: Results config module exists
     description: Verify results batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_results.m && echo "spm_cfg_results.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_results.m && echo "spm_cfg_results.m exists"'
     expected_output_contains: "spm_cfg_results.m exists"
 
   - name: Slice timing config module exists
     description: Verify slice timing correction batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_st.m && echo "spm_cfg_st.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_st.m && echo "spm_cfg_st.m exists"'
     expected_output_contains: "spm_cfg_st.m exists"
 
   - name: ImCalc config module exists
     description: Verify image calculator batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_imcalc.m && echo "spm_cfg_imcalc.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_imcalc.m && echo "spm_cfg_imcalc.m exists"'
     expected_output_contains: "spm_cfg_imcalc.m exists"
 
   - name: DICOM import config module exists
     description: Verify DICOM import batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dicom.m && echo "spm_cfg_dicom.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dicom.m && echo "spm_cfg_dicom.m exists"'
     expected_output_contains: "spm_cfg_dicom.m exists"
 
   - name: Deformations config module exists
     description: Verify deformations batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_deformations.m && echo "spm_cfg_deformations.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_deformations.m && echo "spm_cfg_deformations.m exists"'
     expected_output_contains: "spm_cfg_deformations.m exists"
 
   - name: Factorial design config module exists
     description: Verify factorial design batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_factorial_design.m && echo "spm_cfg_factorial_design.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_factorial_design.m && echo "spm_cfg_factorial_design.m exists"'
     expected_output_contains: "spm_cfg_factorial_design.m exists"
 
   # ==========================================================================
@@ -332,27 +332,27 @@ tests:
   # ==========================================================================
   - name: spm_vol MEX exists
     description: Verify spm_vol MEX compiled function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_vol_nifti.m && echo "spm_vol_nifti.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_vol_nifti.m && echo "spm_vol_nifti.m exists"'
     expected_output_contains: "spm_vol_nifti.m exists"
 
   - name: spm_add MEX exists
     description: Verify spm_add MEX compiled function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_add.mexa64 && echo "spm_add.mexa64 exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_add.mexa64 && echo "spm_add.mexa64 exists"'
     expected_output_contains: "spm_add.mexa64 exists"
 
   - name: spm_conv_vol MEX exists
     description: Verify spm_conv_vol MEX compiled function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_conv_vol.mexa64 && echo "spm_conv_vol.mexa64 exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_conv_vol.mexa64 && echo "spm_conv_vol.mexa64 exists"'
     expected_output_contains: "spm_conv_vol.mexa64 exists"
 
   - name: spm_slice_vol MEX exists
     description: Verify spm_slice_vol MEX compiled function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_slice_vol.mexa64 && echo "spm_slice_vol.mexa64 exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_slice_vol.mexa64 && echo "spm_slice_vol.mexa64 exists"'
     expected_output_contains: "spm_slice_vol.mexa64 exists"
 
   - name: spm_sample_vol MEX exists
     description: Verify spm_sample_vol MEX compiled function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_sample_vol.mexa64 && echo "spm_sample_vol.mexa64 exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_sample_vol.mexa64 && echo "spm_sample_vol.mexa64 exists"'
     expected_output_contains: "spm_sample_vol.mexa64 exists"
 
   # ==========================================================================
@@ -360,57 +360,57 @@ tests:
   # ==========================================================================
   - name: spm_realign function exists
     description: Verify motion correction function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_realign.m && echo "spm_realign.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_realign.m && echo "spm_realign.m exists"'
     expected_output_contains: "spm_realign.m exists"
 
   - name: spm_reslice function exists
     description: Verify reslicing function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_reslice.m && echo "spm_reslice.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_reslice.m && echo "spm_reslice.m exists"'
     expected_output_contains: "spm_reslice.m exists"
 
   - name: spm_coreg function exists
     description: Verify coregistration function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_coreg.m && echo "spm_coreg.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_coreg.m && echo "spm_coreg.m exists"'
     expected_output_contains: "spm_coreg.m exists"
 
   - name: spm_slice_timing function exists
     description: Verify slice timing correction function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_slice_timing.m && echo "spm_slice_timing.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_slice_timing.m && echo "spm_slice_timing.m exists"'
     expected_output_contains: "spm_slice_timing.m exists"
 
   - name: spm_smooth function exists
     description: Verify spatial smoothing function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_smooth.m && echo "spm_smooth.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_smooth.m && echo "spm_smooth.m exists"'
     expected_output_contains: "spm_smooth.m exists"
 
   - name: spm_preproc function exists
     description: Verify preprocessing (segmentation) function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_preproc.m && echo "spm_preproc.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_preproc.m && echo "spm_preproc.m exists"'
     expected_output_contains: "spm_preproc.m exists"
 
   - name: spm_preproc8 function exists
     description: Verify unified segmentation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_preproc8.m && echo "spm_preproc8.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_preproc8.m && echo "spm_preproc8.m exists"'
     expected_output_contains: "spm_preproc8.m exists"
 
   - name: spm_deformations function exists
     description: Verify deformations function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_deformations.m && echo "spm_deformations.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_deformations.m && echo "spm_deformations.m exists"'
     expected_output_contains: "spm_deformations.m exists"
 
   - name: spm_imcalc function exists
     description: Verify image calculator function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_imcalc.m && echo "spm_imcalc.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_imcalc.m && echo "spm_imcalc.m exists"'
     expected_output_contains: "spm_imcalc.m exists"
 
   - name: spm_spm function exists
     description: Verify GLM estimation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_spm.m && echo "spm_spm.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_spm.m && echo "spm_spm.m exists"'
     expected_output_contains: "spm_spm.m exists"
 
   - name: spm_contrasts function exists
     description: Verify contrast computation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_contrasts.m && echo "spm_contrasts.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_contrasts.m && echo "spm_contrasts.m exists"'
     expected_output_contains: "spm_contrasts.m exists"
 
   # ==========================================================================
@@ -465,8 +465,8 @@ tests:
   - name: Run SPM12 smoothing
     description: Execute SPM12 smoothing via batch
     command: |
-      cd test_output && \
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ batch spm_batch/smooth_batch.m 2>&1 | tail -30
+      bash -lc 'cd test_output && \
+      /opt/spm12/run_spm12.sh /opt/mcr/v97/ batch spm_batch/smooth_batch.m 2>&1 | tail -30'
     depends_on: Create smoothing batch file
     timeout: 300
     validate:
@@ -475,7 +475,7 @@ tests:
   - name: Verify smoothed output dimensions
     description: Check that smoothed image has same dimensions as input
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('$(pwd)/test_output/s6sub-01_T1w.nii'); disp(V.dim)" 2>&1 | tail -5
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('\''$(pwd)/test_output/s6sub-01_T1w.nii'\''); disp(V.dim)" 2>&1 | tail -5'
     depends_on: Run SPM12 smoothing
     timeout: 180
     expected_exit_code: 0
@@ -508,8 +508,8 @@ tests:
   - name: Run SPM12 image calculator
     description: Execute SPM12 image calculator (multiply by 2)
     command: |
-      cd test_output && \
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ batch spm_batch/imcalc_batch.m 2>&1 | tail -30
+      bash -lc 'cd test_output && \
+      /opt/spm12/run_spm12.sh /opt/mcr/v97/ batch spm_batch/imcalc_batch.m 2>&1 | tail -30'
     depends_on: Create imcalc batch file
     timeout: 300
     validate:
@@ -541,8 +541,8 @@ tests:
   - name: Run SPM12 imcalc threshold
     description: Execute SPM12 image calculator (threshold)
     command: |
-      cd test_output && \
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ batch spm_batch/imcalc_thr_batch.m 2>&1 | tail -30
+      bash -lc 'cd test_output && \
+      /opt/spm12/run_spm12.sh /opt/mcr/v97/ batch spm_batch/imcalc_thr_batch.m 2>&1 | tail -30'
     depends_on: Create imcalc threshold batch
     timeout: 300
     validate:
@@ -554,7 +554,7 @@ tests:
   - name: SPM12 read volume header
     description: Read NIfTI header using spm_vol
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('$(pwd)/test_output/sub-01_T1w.nii'); disp(V.fname)" 2>&1 | tail -10
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('\''$(pwd)/test_output/sub-01_T1w.nii'\''); disp(V.fname)" 2>&1 | tail -10'
     depends_on: Prepare uncompressed T1w for SPM12
     timeout: 180
     expected_exit_code: 0
@@ -563,7 +563,7 @@ tests:
   - name: SPM12 get image dimensions
     description: Read image dimensions using spm_vol
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('$(pwd)/test_output/sub-01_T1w.nii'); disp(V.dim)" 2>&1 | tail -5
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('\''$(pwd)/test_output/sub-01_T1w.nii'\''); disp(V.dim)" 2>&1 | tail -5'
     depends_on: Prepare uncompressed T1w for SPM12
     timeout: 180
     expected_exit_code: 0
@@ -571,7 +571,7 @@ tests:
   - name: SPM12 get voxel size
     description: Read voxel dimensions from header
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('$(pwd)/test_output/sub-01_T1w.nii'); disp(sqrt(sum(V.mat(1:3,1:3).^2)))" 2>&1 | tail -5
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('\''$(pwd)/test_output/sub-01_T1w.nii'\''); disp(sqrt(sum(V.mat(1:3,1:3).^2)))" 2>&1 | tail -5'
     depends_on: Prepare uncompressed T1w for SPM12
     timeout: 180
     expected_exit_code: 0
@@ -579,7 +579,7 @@ tests:
   - name: SPM12 read image data
     description: Read and report image statistics
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('$(pwd)/test_output/sub-01_T1w.nii'); Y=spm_read_vols(V); disp(['Mean: ' num2str(mean(Y(:)))])" 2>&1 | tail -10
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "V=spm_vol('\''$(pwd)/test_output/sub-01_T1w.nii'\''); Y=spm_read_vols(V); disp(['\''Mean: '\'' num2str(mean(Y(:)))])" 2>&1 | tail -10'
     depends_on: Prepare uncompressed T1w for SPM12
     timeout: 180
     expected_output_contains: "Mean:"
@@ -589,45 +589,45 @@ tests:
   # ==========================================================================
   - name: SPM12 exist spm_P function
     description: Verify p-value function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_P'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_P'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM12 exist spm_P_FDR function
     description: Verify FDR correction function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_P_FDR'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_P_FDR'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM12 exist spm_Tcdf function
     description: Verify T distribution CDF function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_Tcdf'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_Tcdf'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM12 exist spm_Fcdf function
     description: Verify F distribution CDF function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_Fcdf'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_Fcdf'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM12 exist spm_Ncdf function
     description: Verify Normal distribution CDF function exists
-    command: /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('spm_Ncdf'))" 2>&1
+    command: bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "disp(exist('\''spm_Ncdf'\''))" 2>&1'
     expected_output_contains: "2"
     timeout: 180
 
   - name: SPM12 T-statistic calculation
     description: Calculate T-statistic using SPM function
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "p=spm_Tcdf(2.5,20); disp(['p-value: ' num2str(p)])" 2>&1 | tail -5
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "p=spm_Tcdf(2.5,20); disp(['\''p-value: '\'' num2str(p)])" 2>&1 | tail -5'
     timeout: 180
     expected_output_contains: "p-value:"
 
   - name: SPM12 F-statistic calculation
     description: Calculate F-statistic using SPM function
     command: |
-      /opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "p=spm_Fcdf(3.5,[1 20]); disp(['p-value: ' num2str(p)])" 2>&1 | tail -5
+      bash -lc '/opt/spm12/run_spm12.sh /opt/mcr/v97/ eval "p=spm_Fcdf(3.5,[1 20]); disp(['\''p-value: '\'' num2str(p)])" 2>&1 | tail -5'
     timeout: 180
     expected_output_contains: "p-value:"
 
@@ -636,22 +636,22 @@ tests:
   # ==========================================================================
   - name: DARTEL template exists
     description: Verify DARTEL ICBM152 template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/icbm152.nii && echo "icbm152.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/icbm152.nii && echo "icbm152.nii exists"'
     expected_output_contains: "icbm152.nii exists"
 
   - name: spm_dartel_warp function exists
     description: Verify DARTEL warping function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/spm_dartel_warp.m && echo "spm_dartel_warp.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/spm_dartel_warp.m && echo "spm_dartel_warp.m exists"'
     expected_output_contains: "spm_dartel_warp.m exists"
 
   - name: spm_dartel_norm function exists
     description: Verify DARTEL normalization function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/spm_dartel_norm.m && echo "spm_dartel_norm.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/spm_dartel_norm.m && echo "spm_dartel_norm.m exists"'
     expected_output_contains: "spm_dartel_norm.m exists"
 
   - name: spm_dartel_template function exists
     description: Verify DARTEL template creation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/spm_dartel_template.m && echo "spm_dartel_template.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/DARTEL/spm_dartel_template.m && echo "spm_dartel_template.m exists"'
     expected_output_contains: "spm_dartel_template.m exists"
 
   # ==========================================================================
@@ -659,17 +659,17 @@ tests:
   # ==========================================================================
   - name: FieldMap function exists
     description: Verify FieldMap main function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap/FieldMap.m && echo "FieldMap.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap/FieldMap.m && echo "FieldMap.m exists"'
     expected_output_contains: "FieldMap.m exists"
 
   - name: FieldMap templates exist
     description: Verify FieldMap template files
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap/T1.nii && echo "FieldMap T1.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap/T1.nii && echo "FieldMap T1.nii exists"'
     expected_output_contains: "FieldMap T1.nii exists"
 
   - name: FieldMap brain mask exists
     description: Verify FieldMap brain mask template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap/brainmask.nii && echo "FieldMap brainmask.nii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/FieldMap/brainmask.nii && echo "FieldMap brainmask.nii exists"'
     expected_output_contains: "FieldMap brainmask.nii exists"
 
   # ==========================================================================
@@ -677,17 +677,17 @@ tests:
   # ==========================================================================
   - name: spm_shoot_warp function exists
     description: Verify Shoot warping function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot/spm_shoot_warp.m && echo "spm_shoot_warp.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot/spm_shoot_warp.m && echo "spm_shoot_warp.m exists"'
     expected_output_contains: "spm_shoot_warp.m exists"
 
   - name: spm_shoot_template function exists
     description: Verify Shoot template creation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot/spm_shoot_template.m && echo "spm_shoot_template.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot/spm_shoot_template.m && echo "spm_shoot_template.m exists"'
     expected_output_contains: "spm_shoot_template.m exists"
 
   - name: spm_shoot_greens function exists
     description: Verify Shoot Green's function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot/spm_shoot_greens.m && echo "spm_shoot_greens.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Shoot/spm_shoot_greens.m && echo "spm_shoot_greens.m exists"'
     expected_output_contains: "spm_shoot_greens.m exists"
 
   # ==========================================================================
@@ -695,17 +695,17 @@ tests:
   # ==========================================================================
   - name: spm_pairwise function exists
     description: Verify longitudinal pairwise registration function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal/spm_pairwise.m && echo "spm_pairwise.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal/spm_pairwise.m && echo "spm_pairwise.m exists"'
     expected_output_contains: "spm_pairwise.m exists"
 
   - name: spm_series_align function exists
     description: Verify longitudinal series alignment function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal/spm_series_align.m && echo "spm_series_align.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal/spm_series_align.m && echo "spm_series_align.m exists"'
     expected_output_contains: "spm_series_align.m exists"
 
   - name: spm_noise_estimate function exists
     description: Verify noise estimation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal/spm_noise_estimate.m && echo "spm_noise_estimate.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/toolbox/Longitudinal/spm_noise_estimate.m && echo "spm_noise_estimate.m exists"'
     expected_output_contains: "spm_noise_estimate.m exists"
 
   # ==========================================================================
@@ -729,16 +729,7 @@ tests:
 
   - name: Nipype SPM path configuration
     description: Verify nipype can be configured for SPM standalone
-    command: |
-      python3 -c "
-      try:
-          import nipype.interfaces.spm as spm
-          matlab_cmd = '/opt/spm12/run_spm12.sh /opt/mcr/v97/ script'
-          spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)
-          print('Nipype SPM path configured successfully')
-      except Exception as e:
-          print('Configuration test:', str(e))
-      " 2>&1 || echo "Nipype config test complete"
+    command: "bash -lc 'python3 -c \"\ntry:\n    import nipype.interfaces.spm as spm\n    matlab_cmd = '\"'\"'/opt/spm12/run_spm12.sh /opt/mcr/v97/ script'\"'\"'\n    spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)\n    print('\"'\"'Nipype SPM path configured successfully'\"'\"')\nexcept Exception as e:\n    print('\"'\"'Configuration test:'\"'\"', str(e))\n\" 2>&1 || echo \"Nipype config test complete\"'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -746,27 +737,27 @@ tests:
   # ==========================================================================
   - name: spm_dicom_convert function exists
     description: Verify DICOM conversion function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_dicom_convert.m && echo "spm_dicom_convert.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_dicom_convert.m && echo "spm_dicom_convert.m exists"'
     expected_output_contains: "spm_dicom_convert.m exists"
 
   - name: spm_file_merge function exists
     description: Verify 4D file merging function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_file_merge.m && echo "spm_file_merge.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_file_merge.m && echo "spm_file_merge.m exists"'
     expected_output_contains: "spm_file_merge.m exists"
 
   - name: spm_file_split function exists
     description: Verify 4D file splitting function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_file_split.m && echo "spm_file_split.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_file_split.m && echo "spm_file_split.m exists"'
     expected_output_contains: "spm_file_split.m exists"
 
   - name: GIfTI class exists
     description: Verify GIfTI surface file class
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/@gifti && echo "gifti class exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/@gifti && echo "gifti class exists"'
     expected_output_contains: "gifti class exists"
 
   - name: NIfTI class exists
     description: Verify NIfTI file class
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/@nifti && echo "nifti class exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/@nifti && echo "nifti class exists"'
     expected_output_contains: "nifti class exists"
 
   # ==========================================================================
@@ -774,32 +765,32 @@ tests:
   # ==========================================================================
   - name: Cortex surface template 5124 exists
     description: Verify cortex surface template (5124 vertices)
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/cortex_5124.surf.gii && echo "cortex_5124.surf.gii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/cortex_5124.surf.gii && echo "cortex_5124.surf.gii exists"'
     expected_output_contains: "cortex_5124.surf.gii exists"
 
   - name: Cortex surface template 8196 exists
     description: Verify cortex surface template (8196 vertices)
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/cortex_8196.surf.gii && echo "cortex_8196.surf.gii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/cortex_8196.surf.gii && echo "cortex_8196.surf.gii exists"'
     expected_output_contains: "cortex_8196.surf.gii exists"
 
   - name: Cortex surface template 20484 exists
     description: Verify cortex surface template (20484 vertices)
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/cortex_20484.surf.gii && echo "cortex_20484.surf.gii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/cortex_20484.surf.gii && echo "cortex_20484.surf.gii exists"'
     expected_output_contains: "cortex_20484.surf.gii exists"
 
   - name: Skull inner surface template exists
     description: Verify inner skull surface template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/iskull_2562.surf.gii && echo "iskull_2562.surf.gii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/iskull_2562.surf.gii && echo "iskull_2562.surf.gii exists"'
     expected_output_contains: "iskull_2562.surf.gii exists"
 
   - name: Skull outer surface template exists
     description: Verify outer skull surface template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/oskull_2562.surf.gii && echo "oskull_2562.surf.gii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/oskull_2562.surf.gii && echo "oskull_2562.surf.gii exists"'
     expected_output_contains: "oskull_2562.surf.gii exists"
 
   - name: Scalp surface template exists
     description: Verify scalp surface template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/scalp_2562.surf.gii && echo "scalp_2562.surf.gii exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/canonical/scalp_2562.surf.gii && echo "scalp_2562.surf.gii exists"'
     expected_output_contains: "scalp_2562.surf.gii exists"
 
   # ==========================================================================
@@ -807,22 +798,22 @@ tests:
   # ==========================================================================
   - name: spm_dcm_estimate function exists
     description: Verify DCM estimation function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_dcm_estimate.m && echo "spm_dcm_estimate.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_dcm_estimate.m && echo "spm_dcm_estimate.m exists"'
     expected_output_contains: "spm_dcm_estimate.m exists"
 
   - name: DCM fMRI config module exists
     description: Verify DCM for fMRI batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dcm_fmri.m && echo "spm_cfg_dcm_fmri.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dcm_fmri.m && echo "spm_cfg_dcm_fmri.m exists"'
     expected_output_contains: "spm_cfg_dcm_fmri.m exists"
 
   - name: DCM BMS config module exists
     description: Verify DCM Bayesian Model Selection batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dcm_bms.m && echo "spm_cfg_dcm_bms.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dcm_bms.m && echo "spm_cfg_dcm_bms.m exists"'
     expected_output_contains: "spm_cfg_dcm_bms.m exists"
 
   - name: DCM PEB config module exists
     description: Verify DCM Parametric Empirical Bayes batch configuration
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dcm_peb.m && echo "spm_cfg_dcm_peb.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg_dcm_peb.m && echo "spm_cfg_dcm_peb.m exists"'
     expected_output_contains: "spm_cfg_dcm_peb.m exists"
 
   # ==========================================================================
@@ -830,17 +821,17 @@ tests:
   # ==========================================================================
   - name: spm_jobman function exists
     description: Verify batch job manager function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_jobman.m && echo "spm_jobman.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_jobman.m && echo "spm_jobman.m exists"'
     expected_output_contains: "spm_jobman.m exists"
 
   - name: matlabbatch directory exists
     description: Verify matlabbatch system directory
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/matlabbatch && echo "matlabbatch dir exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/matlabbatch && echo "matlabbatch dir exists"'
     expected_output_contains: "matlabbatch dir exists"
 
   - name: SPM12 batch applications config exists
     description: Verify batch applications config
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg.m && echo "spm_cfg.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/config/spm_cfg.m && echo "spm_cfg.m exists"'
     expected_output_contains: "spm_cfg.m exists"
 
   # ==========================================================================
@@ -849,50 +840,50 @@ tests:
   - name: Create segment verification batch
     description: Create batch file to verify segmentation setup (dry run)
     command: |
-      cat > test_output/spm_batch/segment_dryrun.m << 'MATLABEOF'
+      bash -lc 'cat > test_output/spm_batch/segment_dryrun.m << '\''MATLABEOF'\''
       % Segmentation batch structure verification
-      matlabbatch{1}.spm.spatial.preproc.channel.vols = {'INPUTFILE'};
+      matlabbatch{1}.spm.spatial.preproc.channel.vols = {'\''INPUTFILE'\''};
       matlabbatch{1}.spm.spatial.preproc.channel.biasreg = 0.001;
       matlabbatch{1}.spm.spatial.preproc.channel.biasfwhm = 60;
       matlabbatch{1}.spm.spatial.preproc.channel.write = [0 0];
-      matlabbatch{1}.spm.spatial.preproc.tissue(1).tpm = {'TPMFILE,1'};
+      matlabbatch{1}.spm.spatial.preproc.tissue(1).tpm = {'\''TPMFILE,1'\''};
       matlabbatch{1}.spm.spatial.preproc.tissue(1).ngaus = 1;
       matlabbatch{1}.spm.spatial.preproc.tissue(1).native = [1 0];
       matlabbatch{1}.spm.spatial.preproc.tissue(1).warped = [0 0];
-      matlabbatch{1}.spm.spatial.preproc.tissue(2).tpm = {'TPMFILE,2'};
+      matlabbatch{1}.spm.spatial.preproc.tissue(2).tpm = {'\''TPMFILE,2'\''};
       matlabbatch{1}.spm.spatial.preproc.tissue(2).ngaus = 1;
       matlabbatch{1}.spm.spatial.preproc.tissue(2).native = [1 0];
       matlabbatch{1}.spm.spatial.preproc.tissue(2).warped = [0 0];
-      matlabbatch{1}.spm.spatial.preproc.tissue(3).tpm = {'TPMFILE,3'};
+      matlabbatch{1}.spm.spatial.preproc.tissue(3).tpm = {'\''TPMFILE,3'\''};
       matlabbatch{1}.spm.spatial.preproc.tissue(3).ngaus = 2;
       matlabbatch{1}.spm.spatial.preproc.tissue(3).native = [1 0];
       matlabbatch{1}.spm.spatial.preproc.tissue(3).warped = [0 0];
-      matlabbatch{1}.spm.spatial.preproc.tissue(4).tpm = {'TPMFILE,4'};
+      matlabbatch{1}.spm.spatial.preproc.tissue(4).tpm = {'\''TPMFILE,4'\''};
       matlabbatch{1}.spm.spatial.preproc.tissue(4).ngaus = 3;
       matlabbatch{1}.spm.spatial.preproc.tissue(4).native = [0 0];
       matlabbatch{1}.spm.spatial.preproc.tissue(4).warped = [0 0];
-      matlabbatch{1}.spm.spatial.preproc.tissue(5).tpm = {'TPMFILE,5'};
+      matlabbatch{1}.spm.spatial.preproc.tissue(5).tpm = {'\''TPMFILE,5'\''};
       matlabbatch{1}.spm.spatial.preproc.tissue(5).ngaus = 4;
       matlabbatch{1}.spm.spatial.preproc.tissue(5).native = [0 0];
       matlabbatch{1}.spm.spatial.preproc.tissue(5).warped = [0 0];
-      matlabbatch{1}.spm.spatial.preproc.tissue(6).tpm = {'TPMFILE,6'};
+      matlabbatch{1}.spm.spatial.preproc.tissue(6).tpm = {'\''TPMFILE,6'\''};
       matlabbatch{1}.spm.spatial.preproc.tissue(6).ngaus = 2;
       matlabbatch{1}.spm.spatial.preproc.tissue(6).native = [0 0];
       matlabbatch{1}.spm.spatial.preproc.tissue(6).warped = [0 0];
       matlabbatch{1}.spm.spatial.preproc.warp.mrf = 1;
       matlabbatch{1}.spm.spatial.preproc.warp.cleanup = 1;
       matlabbatch{1}.spm.spatial.preproc.warp.reg = [0 0.001 0.5 0.05 0.2];
-      matlabbatch{1}.spm.spatial.preproc.warp.affreg = 'mni';
+      matlabbatch{1}.spm.spatial.preproc.warp.affreg = '\''mni'\'';
       matlabbatch{1}.spm.spatial.preproc.warp.fwhm = 0;
       matlabbatch{1}.spm.spatial.preproc.warp.samp = 3;
       matlabbatch{1}.spm.spatial.preproc.warp.write = [0 0];
-      disp('Segmentation batch structure created successfully');
+      disp('\''Segmentation batch structure created successfully'\'');
       MATLABEOF
       T1_PATH=$(pwd)/test_output/sub-01_T1w.nii
       TPM_PATH=$(find /opt/spm12 -name "TPM.nii" -type f 2>/dev/null | head -1)
       sed -i "s|INPUTFILE|${T1_PATH}|g" test_output/spm_batch/segment_dryrun.m && \
       sed -i "s|TPMFILE|${TPM_PATH}|g" test_output/spm_batch/segment_dryrun.m && \
-      echo "Batch file created"
+      echo "Batch file created"'
     depends_on: Prepare uncompressed T1w for SPM12
     expected_exit_code: 0
     expected_output_contains: "Batch file created"
@@ -912,17 +903,17 @@ tests:
   # ==========================================================================
   - name: spm_render function exists
     description: Verify surface rendering function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_render.m && echo "spm_render.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_render.m && echo "spm_render.m exists"'
     expected_output_contains: "spm_render.m exists"
 
   - name: MIP matrix template exists
     description: Verify Maximum Intensity Projection template
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/MIP.mat && echo "MIP.mat exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/MIP.mat && echo "MIP.mat exists"'
     expected_output_contains: "MIP.mat exists"
 
   - name: Render directory exists
     description: Verify rendering templates directory
-    command: test -d /opt/spm12/spm12_mcr/spm12/spm12/rend && echo "rend dir exists"
+    command: bash -lc 'test -d /opt/spm12/spm12_mcr/spm12/spm12/rend && echo "rend dir exists"'
     expected_output_contains: "rend dir exists"
 
   # ==========================================================================
@@ -930,12 +921,12 @@ tests:
   # ==========================================================================
   - name: spm_jsonread function exists
     description: Verify JSON read function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_jsonread.m && echo "spm_jsonread.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_jsonread.m && echo "spm_jsonread.m exists"'
     expected_output_contains: "spm_jsonread.m exists"
 
   - name: spm_jsonwrite function exists
     description: Verify JSON write function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_jsonwrite.m && echo "spm_jsonwrite.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_jsonwrite.m && echo "spm_jsonwrite.m exists"'
     expected_output_contains: "spm_jsonwrite.m exists"
 
   # ==========================================================================
@@ -943,7 +934,7 @@ tests:
   # ==========================================================================
   - name: spm_BIDS function exists
     description: Verify BIDS dataset handling function
-    command: test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_BIDS.m && echo "spm_BIDS.m exists"
+    command: bash -lc 'test -f /opt/spm12/spm12_mcr/spm12/spm12/spm_BIDS.m && echo "spm_BIDS.m exists"'
     expected_output_contains: "spm_BIDS.m exists"
 
   # ==========================================================================

--- a/recipes/spm25/fulltest.yaml
+++ b/recipes/spm25/fulltest.yaml
@@ -58,27 +58,27 @@ tests:
   # ==========================================================================
   - name: SPM25 help
     description: Verify SPM25 binary runs and displays help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b help 2>&1'
     expected_output_contains: "Usage: spm"
 
   - name: SPM25 verbose help
     description: List all available batch nodes
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b help --verbose 2>&1 | head -20
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b help --verbose 2>&1 | head -20'
     expected_output_contains: "spm.spatial"
 
   - name: MATLAB Runtime check
     description: Verify MATLAB Runtime is available
-    command: ls -la /usr/local/MATLAB/MATLAB_Runtime/R2024b/
+    command: "bash -lc 'ls -la /usr/local/MATLAB/MATLAB_Runtime/R2024b/'"
     expected_output_contains: "runtime"
 
   - name: SPM25 binary exists
     description: Verify SPM25 compiled binary exists
-    command: ls -la /opt/spm/spm25
+    command: "bash -lc 'ls -la /opt/spm/spm25'"
     expected_output_contains: "spm25"
 
   - name: SPM25 CTF archive exists
     description: Verify SPM25 compiled archive exists
-    command: ls -la /opt/spm/spm25.ctf
+    command: "bash -lc 'ls -la /opt/spm/spm25.ctf'"
     expected_output_contains: "spm25.ctf"
 
   # ==========================================================================
@@ -86,114 +86,114 @@ tests:
   # ==========================================================================
   - name: ImCalc help
     description: Display image calculator help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc help 2>&1'
     expected_output_contains: "--expression"
 
   - name: ImCalc identity operation
     description: Copy image using image calculator (i1)
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_copy.nii --expression "i1" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_copy.nii --expression "i1" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_copy.nii
 
   - name: ImCalc scalar multiplication
     description: Multiply image by scalar value
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_mul2.nii --expression "i1*2" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_mul2.nii --expression "i1*2" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_mul2.nii
 
   - name: ImCalc scalar addition
     description: Add scalar to image
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_add100.nii --expression "i1+100" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_add100.nii --expression "i1+100" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_add100.nii
 
   - name: ImCalc division
     description: Divide image by scalar
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_div2.nii --expression "i1/2" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_div2.nii --expression "i1/2" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_div2.nii
 
   - name: ImCalc square root
     description: Calculate square root of image
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_sqrt.nii --expression "sqrt(i1)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_sqrt.nii --expression "sqrt(i1)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_sqrt.nii
 
   - name: ImCalc log transform
     description: Calculate natural log (with threshold)
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_log.nii --expression "log(i1+1)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_log.nii --expression "log(i1+1)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_log.nii
 
   - name: ImCalc exponential
     description: Calculate exponential (scaled)
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_exp.nii --expression "exp(i1/1000)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_exp.nii --expression "exp(i1/1000)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_exp.nii
 
   - name: ImCalc absolute value
     description: Calculate absolute value
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_abs.nii --expression "abs(i1)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_abs.nii --expression "abs(i1)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_abs.nii
 
   - name: ImCalc thresholding
     description: Apply threshold to image
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_thr.nii --expression "i1.*(i1>100)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_thr.nii --expression "i1.*(i1>100)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_thr.nii
 
   - name: ImCalc binarize
     description: Binarize image at threshold
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_bin.nii --expression "i1>100" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_bin.nii --expression "i1>100" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_bin.nii
 
   - name: ImCalc power function
     description: Raise image to power
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_pow2.nii --expression "i1.^2" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_pow2.nii --expression "i1.^2" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_pow2.nii
 
   - name: ImCalc trigonometric sin
     description: Calculate sine of image
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_sin.nii --expression "sin(i1)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_sin.nii --expression "sin(i1)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_sin.nii
 
   - name: ImCalc trigonometric cos
     description: Calculate cosine of image
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_cos.nii --expression "cos(i1)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_cos.nii --expression "cos(i1)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_cos.nii
 
   - name: ImCalc min clamp
     description: Clamp minimum values
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_minclamp.nii --expression "max(i1,50)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_minclamp.nii --expression "max(i1,50)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_minclamp.nii
 
   - name: ImCalc max clamp
     description: Clamp maximum values
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_maxclamp.nii --expression "min(i1,500)" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output test_output/imcalc/t1w_maxclamp.nii --expression "min(i1,500)" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_maxclamp.nii
 
   - name: ImCalc NaN replacement
     description: Replace NaN values with zero
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output ${output_dir}/imcalc/t1w_nantozero.nii --expression "i1" --options --mask "NaNs should be zeroed" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output ${output_dir}/imcalc/t1w_nantozero.nii --expression "i1" --options --mask "NaNs should be zeroed" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_nantozero.nii
 
   - name: ImCalc output dtype float
     description: Output as single precision float
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output ${output_dir}/imcalc/t1w_float.nii --expression "i1" --dtype "FLOAT32 - single prec. float" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output ${output_dir}/imcalc/t1w_float.nii --expression "i1" --dtype "FLOAT32 - single prec. float" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_float.nii
 
   - name: ImCalc output dtype float64
     description: Output as double precision float (INT16 broken - MATLAB collapses whitespace in option strings)
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output ${output_dir}/imcalc/t1w_float64.nii --expression "i1" --dtype "FLOAT64 - double prec. float" 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.imcalc --input ${output_dir}/sub-02_T1w.nii --output ${output_dir}/imcalc/t1w_float64.nii --expression "i1" --dtype "FLOAT64 - double prec. float" 2>&1'
     validate:
       - output_exists: ${output_dir}/imcalc/t1w_float64.nii
 
@@ -202,44 +202,44 @@ tests:
   # ==========================================================================
   - name: Bounding box help
     description: Display bbox utility help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.bbox help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.bbox help 2>&1'
     expected_output_contains: "--image"
 
   - name: Bounding box calculation
     description: Calculate image bounding box
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.bbox --image ${output_dir}/sub-02_T1w.nii 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.bbox --image ${output_dir}/sub-02_T1w.nii 2>&1'
     expected_exit_code: 0
 
   - name: Reorient help
     description: Display reorient utility help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.reorient help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.reorient help 2>&1'
     expected_output_contains: "--transform"
 
   - name: Cat (concatenate) help
     description: Display 3D to 4D concatenation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.cat help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.cat help 2>&1'
     expected_output_contains: "--vols"
 
   - name: Split help
     description: Display 4D to 3D split help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.split help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.split help 2>&1'
     expected_output_contains: "--vol"
 
   - name: Split 4D to 3D volumes
     description: Split 4D BOLD into 3D volumes
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.split --vol ${output_dir}/bold_run01.nii --outdir test_output/util 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.split --vol ${output_dir}/bold_run01.nii --outdir test_output/util 2>&1'
     expected_exit_code: 0
     validate:
       - output_dir_not_empty: test_output/util
 
   - name: Deface help
     description: Display deface utility help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.deface help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.deface help 2>&1'
     expected_output_contains: "--images"
 
   - name: Tissue volume help
     description: Display tissue volume calculation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.tvol help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.tvol help 2>&1'
     expected_output_contains: "--matfiles"
 
   # ==========================================================================
@@ -247,42 +247,42 @@ tests:
   # ==========================================================================
   - name: Smooth help
     description: Display smoothing help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth help 2>&1'
     expected_output_contains: "--fwhm"
 
   - name: Smooth 4mm FWHM
     description: Apply 4mm isotropic Gaussian smoothing
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[4 4 4]" --prefix s4_ 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[4 4 4]" --prefix s4_ 2>&1'
     validate:
       - output_exists: ${output_dir}/s4_sub-02_T1w.nii
 
   - name: Smooth 6mm FWHM
     description: Apply 6mm isotropic Gaussian smoothing
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[6 6 6]" --prefix s6_ 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[6 6 6]" --prefix s6_ 2>&1'
     validate:
       - output_exists: ${output_dir}/s6_sub-02_T1w.nii
 
   - name: Smooth 8mm FWHM
     description: Apply 8mm isotropic Gaussian smoothing (common for fMRI)
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[8 8 8]" --prefix s8_ 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[8 8 8]" --prefix s8_ 2>&1'
     validate:
       - output_exists: ${output_dir}/s8_sub-02_T1w.nii
 
   - name: Smooth 12mm FWHM
     description: Apply 12mm isotropic Gaussian smoothing
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[12 12 12]" --prefix s12_ 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[12 12 12]" --prefix s12_ 2>&1'
     validate:
       - output_exists: ${output_dir}/s12_sub-02_T1w.nii
 
   - name: Smooth anisotropic
     description: Apply anisotropic Gaussian smoothing
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[4 6 8]" --prefix saniso_ 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[4 6 8]" --prefix saniso_ 2>&1'
     validate:
       - output_exists: ${output_dir}/saniso_sub-02_T1w.nii
 
   - name: Smooth with implicit mask
     description: Apply smoothing with implicit masking
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[6 6 6]" --im Yes --prefix sim_ 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.smooth --data ${output_dir}/sub-02_T1w.nii --fwhm "[6 6 6]" --im Yes --prefix sim_ 2>&1'
     validate:
       - output_exists: ${output_dir}/sim_sub-02_T1w.nii
 
@@ -291,17 +291,17 @@ tests:
   # ==========================================================================
   - name: Realign estimate help
     description: Display realignment estimation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realign.estimate help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realign.estimate help 2>&1'
     expected_output_contains: "--quality"
 
   - name: Realign write help
     description: Display realignment reslice help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realign.write help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realign.write help 2>&1'
     expected_output_contains: "--interp"
 
   - name: Realign estwrite help
     description: Display combined realignment help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realign.estwrite help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realign.estwrite help 2>&1'
     expected_output_contains: "--quality"
 
   # ==========================================================================
@@ -309,17 +309,17 @@ tests:
   # ==========================================================================
   - name: Coreg estimate help
     description: Display coregistration estimation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.coreg.estimate help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.coreg.estimate help 2>&1'
     expected_output_contains: "--cost_fun"
 
   - name: Coreg write help
     description: Display coregistration reslice help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.coreg.write help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.coreg.write help 2>&1'
     expected_output_contains: "--interp"
 
   - name: Coreg estwrite help
     description: Display combined coregistration help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.coreg.estwrite help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.coreg.estwrite help 2>&1'
     expected_output_contains: "--cost_fun"
 
   # ==========================================================================
@@ -327,7 +327,7 @@ tests:
   # ==========================================================================
   - name: Preproc (Segment) help
     description: Display unified segmentation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.preproc help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.preproc help 2>&1'
     expected_output_contains: "--biasreg"
 
   # ==========================================================================
@@ -335,17 +335,17 @@ tests:
   # ==========================================================================
   - name: Normalize estimate help
     description: Display normalization estimation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.normalise.est help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.normalise.est help 2>&1'
     expected_output_contains: "--tpm"
 
   - name: Normalize write help
     description: Display normalization write help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.normalise.write help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.normalise.write help 2>&1'
     expected_output_contains: "--interp"
 
   - name: Normalize estwrite help
     description: Display combined normalization help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.normalise.estwrite help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.normalise.estwrite help 2>&1'
     expected_output_contains: "--biasreg"
 
   # ==========================================================================
@@ -353,7 +353,7 @@ tests:
   # ==========================================================================
   - name: Slice timing help
     description: Display slice timing correction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.temporal.st help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.temporal.st help 2>&1'
     expected_output_contains: "--nslices"
 
   # ==========================================================================
@@ -361,42 +361,42 @@ tests:
   # ==========================================================================
   - name: fMRI specification help
     description: Display fMRI model specification help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.fmri_spec help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.fmri_spec help 2>&1'
     expected_output_contains: "--timing"
 
   - name: fMRI design help
     description: Display fMRI design matrix help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.fmri_design help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.fmri_design help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: fMRI estimation help
     description: Display fMRI model estimation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.fmri_est help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.fmri_est help 2>&1'
     expected_output_contains: "--spmmat"
 
   - name: Contrast help
     description: Display contrast specification help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.con help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.con help 2>&1'
     expected_output_contains: "--spmmat"
 
   - name: Results help
     description: Display results reporting help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.results help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.results help 2>&1'
     expected_output_contains: "--spmmat"
 
   - name: Factorial design help
     description: Display factorial design help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.factorial_design help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.factorial_design help 2>&1'
     expected_output_contains: "--dir"
 
   - name: PPI help
     description: Display PPI extraction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.ppi help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.ppi help 2>&1'
     expected_output_contains: "--spmmat"
 
   - name: VOI extraction help
     description: Display VOI time series extraction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.voi help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.voi help 2>&1'
     expected_output_contains: "--spmmat"
 
   # ==========================================================================
@@ -404,17 +404,17 @@ tests:
   # ==========================================================================
   - name: DCM estimate help
     description: Display DCM estimation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.dcm.estimate help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.dcm.estimate help 2>&1'
     expected_output_contains: "--dcms"
 
   - name: DCM BMS inference help
     description: Display DCM Bayesian model selection help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.dcm.bms.inference help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.dcm.bms.inference help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: DCM PEB specify help
     description: Display PEB specification help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.dcm.peb.specify help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.dcm.peb.specify help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -422,27 +422,27 @@ tests:
   # ==========================================================================
   - name: DARTEL warp help
     description: Display DARTEL warping help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.warp help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.warp help 2>&1'
     expected_output_contains: "--images"
 
   - name: DARTEL warp1 help
     description: Display DARTEL single subject warp help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.warp1 help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.warp1 help 2>&1'
     expected_output_contains: "--images"
 
   - name: DARTEL MNI norm help
     description: Display DARTEL to MNI normalization help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.mni_norm help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.mni_norm help 2>&1'
     expected_output_contains: "--template"
 
   - name: DARTEL create warped help
     description: Display DARTEL create warped images help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.crt_warped help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.crt_warped help 2>&1'
     expected_output_contains: "--flowfields"
 
   - name: DARTEL Jacobian help
     description: Display DARTEL Jacobian determinant help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.jacdet help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.dartel.jacdet help 2>&1'
     expected_output_contains: "--flowfields"
 
   # ==========================================================================
@@ -450,17 +450,17 @@ tests:
   # ==========================================================================
   - name: Shoot warp help
     description: Display Shoot warping help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.shoot.warp help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.shoot.warp help 2>&1'
     expected_output_contains: "--images"
 
   - name: Shoot warp1 help
     description: Display Shoot single subject warp help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.shoot.warp1 help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.shoot.warp1 help 2>&1'
     expected_output_contains: "--images"
 
   - name: Shoot MNI norm help
     description: Display Shoot to MNI normalization help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.shoot.norm help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.shoot.norm help 2>&1'
     expected_output_contains: "--template"
 
   # ==========================================================================
@@ -468,12 +468,12 @@ tests:
   # ==========================================================================
   - name: Longitudinal pairwise help
     description: Display pairwise longitudinal registration help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.longit.pairwise help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.longit.pairwise help 2>&1'
     expected_output_contains: "--vols1"
 
   - name: Longitudinal series help
     description: Display series longitudinal registration help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.longit.series help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.longit.series help 2>&1'
     expected_output_contains: "--vols"
 
   # ==========================================================================
@@ -481,17 +481,17 @@ tests:
   # ==========================================================================
   - name: SCOPE help
     description: Display SCOPE susceptibility correction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.spatial.scope help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.spatial.scope help 2>&1'
     expected_output_contains: "--vol1"
 
   - name: Denoise help
     description: Display TV denoising help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.spatial.denoise help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.spatial.denoise help 2>&1'
     expected_output_contains: "--lambda"
 
   - name: Slice2Vol help
     description: Display slice-to-volume alignment help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.spatial.slice2vol help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.spatial.slice2vol help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -499,12 +499,12 @@ tests:
   # ==========================================================================
   - name: Fieldmap calculate VDM help
     description: Display fieldmap VDM calculation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.fieldmap.calculatevdm help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.fieldmap.calculatevdm help 2>&1'
     expected_output_contains: "--subj"
 
   - name: Fieldmap apply VDM help
     description: Display fieldmap VDM application help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.fieldmap.applyvdm help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.fieldmap.applyvdm help 2>&1'
     expected_output_contains: "--data"
 
   # ==========================================================================
@@ -512,17 +512,17 @@ tests:
   # ==========================================================================
   - name: Old segment help
     description: Display old segmentation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.oldseg help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.oldseg help 2>&1'
     expected_output_contains: "--data"
 
   - name: Old normalize estimate help
     description: Display old normalization estimation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.oldnorm.est help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.oldnorm.est help 2>&1'
     expected_output_contains: "--source"
 
   - name: Old normalize write help
     description: Display old normalization write help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.oldnorm.write help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.oldnorm.write help 2>&1'
     expected_output_contains: "--subj"
 
   # ==========================================================================
@@ -530,57 +530,57 @@ tests:
   # ==========================================================================
   - name: MEEG convert help
     description: Display MEEG conversion help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.convert help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.convert help 2>&1'
     expected_output_contains: "--dataset"
 
   - name: MEEG epoch help
     description: Display MEEG epoching help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.epoch help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.epoch help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG filter help
     description: Display MEEG filtering help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.filter help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.filter help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG downsample help
     description: Display MEEG downsampling help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.downsample help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.downsample help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG artefact help
     description: Display MEEG artefact detection help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.artefact help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.artefact help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG baseline correction help
     description: Display MEEG baseline correction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.bc help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.bc help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG montage help
     description: Display MEEG montage help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.montage help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.preproc.montage help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG average help
     description: Display MEEG averaging help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.averaging.average help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.averaging.average help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG time-frequency help
     description: Display MEEG TF analysis help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.tf.tf help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.tf.tf help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG source invert help
     description: Display MEEG source reconstruction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.source.invert help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.source.invert help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MEEG headmodel help
     description: Display MEEG head model help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.source.headmodel help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.source.headmodel help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -588,17 +588,17 @@ tests:
   # ==========================================================================
   - name: OPM create help
     description: Display OPM creation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.OPM.create help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.OPM.create help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: OPM denoise help
     description: Display OPM denoising help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.OPM.denoise help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.OPM.denoise help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: OPM epoch help
     description: Display OPM epoching help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.OPM.epoch help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.meeg.OPM.epoch help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -606,22 +606,22 @@ tests:
   # ==========================================================================
   - name: Beamforming data help
     description: Display beamforming data preparation help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.data help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.data help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: Beamforming sources help
     description: Display beamforming source definition help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.sources help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.sources help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: Beamforming inverse help
     description: Display beamforming inverse help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.inverse help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.inverse help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: Beamforming output help
     description: Display beamforming output help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.output help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.beamforming.output help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -629,12 +629,12 @@ tests:
   # ==========================================================================
   - name: Surface extract help
     description: Display surface extraction help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.render.extract help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.render.extract help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: Surface render help
     description: Display surface rendering help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.render.display help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.render.display help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -642,17 +642,17 @@ tests:
   # ==========================================================================
   - name: MINC import help
     description: Display MINC import help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.import.minc help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.import.minc help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: ECAT import help
     description: Display ECAT import help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.import.ecat help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.import.ecat help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: PAR/REC import help
     description: Display Philips PAR/REC import help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.import.parrec help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.import.parrec help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -660,12 +660,12 @@ tests:
   # ==========================================================================
   - name: TSSS help
     description: Display TSSS cleanup help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.tsss.tsss help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.tsss.tsss help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: TSSS momentspace help
     description: Display TSSS moment space help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.tsss.momentspace help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.tools.tsss.momentspace help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -673,7 +673,7 @@ tests:
   # ==========================================================================
   - name: Realign unwarp help
     description: Display realignment with unwarping help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realignunwarp help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.spatial.realignunwarp help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -681,7 +681,7 @@ tests:
   # ==========================================================================
   - name: Print help
     description: Display print utility help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.print help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.util.print help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -689,17 +689,17 @@ tests:
   # ==========================================================================
   - name: Model review help
     description: Display model review help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.review help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.review help 2>&1'
     expected_output_contains: "--spmmat"
 
   - name: Set level test help
     description: Display set level test help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.setlevel help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.setlevel help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: BMS map inference help
     description: Display BMS map inference help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.bms_map.inference help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.bms_map.inference help 2>&1'
     expected_output_contains: "Usage:"
 
   # ==========================================================================
@@ -707,12 +707,12 @@ tests:
   # ==========================================================================
   - name: MFX FFX help
     description: Display mixed effects FFX help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.mfx.ffx help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.mfx.ffx help 2>&1'
     expected_output_contains: "Usage:"
 
   - name: MFX spec help
     description: Display mixed effects specification help
-    command: /opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.mfx.spec help 2>&1
+    command: bash -lc '/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b spm.stats.mfx.spec help 2>&1'
     expected_output_contains: "Usage:"
 
 cleanup:

--- a/recipes/surfice/fulltest.yaml
+++ b/recipes/surfice/fulltest.yaml
@@ -63,33 +63,32 @@ tests:
   # ==========================================================================
   - name: Container README check
     description: Verify container has documentation
-    command: cat /README.md
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen cat /README.md'"
     expected_output_contains: "surfice"
 
   - name: Binary exists
     description: Verify surfice binary is present
-    command: test -x /opt/Surf_Ice/surfice && echo "surfice binary found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -x /opt/Surf_Ice/surfice && echo \"surfice binary found\"'\"'\"''"
     expected_output_contains: "surfice binary found"
 
   - name: Version check via binary
     description: Verify Surfice binary is executable and has help flag (GUI can't run headlessly)
-    command: |
-      test -x /opt/Surf_Ice/surfice && echo "Surfice binary is executable" && ls -la /opt/Surf_Ice/surfice
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -x /opt/Surf_Ice/surfice && echo \"Surfice binary is executable\" && ls -la /opt/Surf_Ice/surfice'\"'\"''"
     expected_output_contains: "Surfice binary is executable"
 
   - name: Sample files exist - MNI152 mesh
     description: Verify sample MNI152 brain mesh exists
-    command: test -f /opt/Surf_Ice/sample/mni152_2009.mz3 && echo "MNI152 mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/sample/mni152_2009.mz3 && echo \"MNI152 mesh found\"'\"'\"''"
     expected_output_contains: "MNI152 mesh found"
 
   - name: Sample files exist - stroke mesh
     description: Verify stroke sample mesh exists
-    command: test -f /opt/Surf_Ice/sample/stroke.mz3 && echo "Stroke mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/sample/stroke.mz3 && echo \"Stroke mesh found\"'\"'\"''"
     expected_output_contains: "Stroke mesh found"
 
   - name: Sample files exist - tractography
     description: Verify tractography sample file exists
-    command: test -f /opt/Surf_Ice/sample/stroke.trk.gz && echo "Tractography found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/sample/stroke.trk.gz && echo \"Tractography found\"'\"'\"''"
     expected_output_contains: "Tractography found"
 
   # ==========================================================================
@@ -97,27 +96,27 @@ tests:
   # ==========================================================================
   - name: Shaders directory exists
     description: Verify shader resources are present
-    command: ls /opt/Surf_Ice/Resources/shaders/*.txt | wc -l
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/Surf_Ice/Resources/shaders/*.txt | wc -l'\"'\"''"
     expected_output_contains: "2"
 
   - name: Default shader exists
     description: Verify default shader file exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Default.txt && echo "Default shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Default.txt && echo \"Default shader found\"'\"'\"''"
     expected_output_contains: "Default shader found"
 
   - name: MatCap resources exist
     description: Verify matcap textures are present
-    command: ls /opt/Surf_Ice/Resources/matcap/*.jpg 2>/dev/null | wc -l
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/Surf_Ice/Resources/matcap/*.jpg 2>/dev/null | wc -l'\"'\"''"
     expected_output_contains: ""
 
   - name: Color lookup tables exist
     description: Verify color LUT files are present
-    command: ls /opt/Surf_Ice/Resources/lut/*.clut | wc -l
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'ls /opt/Surf_Ice/Resources/lut/*.clut | wc -l'\"'\"''"
     expected_output_contains: ""
 
   - name: Python scripting resources exist
     description: Verify Python 3.7 resources are present
-    command: test -d /opt/Surf_Ice/Resources/python37 && echo "Python resources found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -d /opt/Surf_Ice/Resources/python37 && echo \"Python resources found\"'\"'\"''"
     expected_output_contains: "Python resources found"
 
   # ==========================================================================
@@ -125,37 +124,37 @@ tests:
   # ==========================================================================
   - name: BrainNet mesh - left hemisphere
     description: Verify BrainNet left hemisphere mesh exists
-    command: test -f /opt/Surf_Ice/BrainNet/BrainMesh_ICBM152.lh.mz3 && echo "LH mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/BrainMesh_ICBM152.lh.mz3 && echo \"LH mesh found\"'\"'\"''"
     expected_output_contains: "LH mesh found"
 
   - name: BrainNet mesh - right hemisphere
     description: Verify BrainNet right hemisphere mesh exists
-    command: test -f /opt/Surf_Ice/BrainNet/BrainMesh_ICBM152.rh.mz3 && echo "RH mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/BrainMesh_ICBM152.rh.mz3 && echo \"RH mesh found\"'\"'\"''"
     expected_output_contains: "RH mesh found"
 
   - name: BrainNet mesh - full brain
     description: Verify BrainNet full brain mesh exists
-    command: test -f /opt/Surf_Ice/BrainNet/BrainMesh_ICBM152.mz3 && echo "Full brain mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/BrainMesh_ICBM152.mz3 && echo \"Full brain mesh found\"'\"'\"''"
     expected_output_contains: "Full brain mesh found"
 
   - name: BrainNet node file
     description: Verify LPBA40 node file exists for connectome visualization
-    command: test -f /opt/Surf_Ice/BrainNet/LPBA40.node && echo "Node file found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/LPBA40.node && echo \"Node file found\"'\"'\"''"
     expected_output_contains: "Node file found"
 
   - name: BrainNet edge file
     description: Verify LPBA40 edge file exists for connectome visualization
-    command: test -f /opt/Surf_Ice/BrainNet/LPBA40.edge && echo "Edge file found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/LPBA40.edge && echo \"Edge file found\"'\"'\"''"
     expected_output_contains: "Edge file found"
 
   - name: BrainNet Ch2 mesh
     description: Verify Colin27 (Ch2) template mesh exists
-    command: test -f /opt/Surf_Ice/BrainNet/BrainMesh_Ch2.mz3 && echo "Ch2 mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/BrainMesh_Ch2.mz3 && echo \"Ch2 mesh found\"'\"'\"''"
     expected_output_contains: "Ch2 mesh found"
 
   - name: BrainNet cerebellum mesh
     description: Verify cerebellum mesh exists
-    command: test -f /opt/Surf_Ice/BrainNet/BrainMesh_Cerebellum_by_SLF.mz3 && echo "Cerebellum mesh found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/BrainNet/BrainMesh_Cerebellum_by_SLF.mz3 && echo \"Cerebellum mesh found\"'\"'\"''"
     expected_output_contains: "Cerebellum mesh found"
 
   # ==========================================================================
@@ -163,37 +162,37 @@ tests:
   # ==========================================================================
   - name: AAL atlas mesh
     description: Verify AAL atlas mesh exists
-    command: test -f /opt/Surf_Ice/atlas/aal.mz3 && echo "AAL atlas found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/aal.mz3 && echo \"AAL atlas found\"'\"'\"''"
     expected_output_contains: "AAL atlas found"
 
   - name: AAL atlas labels
     description: Verify AAL atlas label file exists
-    command: test -f /opt/Surf_Ice/atlas/aal.txt && echo "AAL labels found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/aal.txt && echo \"AAL labels found\"'\"'\"''"
     expected_output_contains: "AAL labels found"
 
   - name: AICHA atlas mesh
     description: Verify AICHA atlas mesh exists
-    command: test -f /opt/Surf_Ice/atlas/AICHAhr.mz3 && echo "AICHA atlas found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/AICHAhr.mz3 && echo \"AICHA atlas found\"'\"'\"''"
     expected_output_contains: "AICHA atlas found"
 
   - name: AICHA atlas left hemisphere
     description: Verify AICHA atlas left hemisphere exists
-    command: test -f /opt/Surf_Ice/atlas/AICHAhr.lh.mz3 && echo "AICHA LH found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/AICHAhr.lh.mz3 && echo \"AICHA LH found\"'\"'\"''"
     expected_output_contains: "AICHA LH found"
 
   - name: JHU atlas mesh
     description: Verify JHU white matter atlas mesh exists
-    command: test -f /opt/Surf_Ice/atlas/jhu.mz3 && echo "JHU atlas found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/jhu.mz3 && echo \"JHU atlas found\"'\"'\"''"
     expected_output_contains: "JHU atlas found"
 
   - name: CIT168 subcortical atlas
     description: Verify CIT168 reinforcement learning atlas exists
-    command: test -f /opt/Surf_Ice/atlas/CIT168.mz3 && echo "CIT168 atlas found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/CIT168.mz3 && echo \"CIT168 atlas found\"'\"'\"''"
     expected_output_contains: "CIT168 atlas found"
 
   - name: Shen268 parcellation atlas
     description: Verify Shen 268-region parcellation atlas exists
-    command: test -f /opt/Surf_Ice/atlas/shen268.mz3 && echo "Shen268 atlas found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/atlas/shen268.mz3 && echo \"Shen268 atlas found\"'\"'\"''"
     expected_output_contains: "Shen268 atlas found"
 
   # ==========================================================================
@@ -201,27 +200,27 @@ tests:
   # ==========================================================================
   - name: FreeSurfer pial surface - left
     description: Verify FreeSurfer left pial surface exists
-    command: test -f /opt/Surf_Ice/fs/lh.pial && echo "LH pial found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/fs/lh.pial && echo \"LH pial found\"'\"'\"''"
     expected_output_contains: "LH pial found"
 
   - name: FreeSurfer pial surface - right
     description: Verify FreeSurfer right pial surface exists
-    command: test -f /opt/Surf_Ice/fs/rh.pial && echo "RH pial found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/fs/rh.pial && echo \"RH pial found\"'\"'\"''"
     expected_output_contains: "RH pial found"
 
   - name: FreeSurfer inflated surface - left
     description: Verify FreeSurfer left inflated surface exists
-    command: test -f /opt/Surf_Ice/fs/lh.inflated && echo "LH inflated found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/fs/lh.inflated && echo \"LH inflated found\"'\"'\"''"
     expected_output_contains: "LH inflated found"
 
   - name: FreeSurfer curvature file
     description: Verify FreeSurfer curvature file exists
-    command: test -f /opt/Surf_Ice/fs/lh.curv && echo "LH curv found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/fs/lh.curv && echo \"LH curv found\"'\"'\"''"
     expected_output_contains: "LH curv found"
 
   - name: FreeSurfer annotation file
     description: Verify FreeSurfer annotation file exists
-    command: test -f /opt/Surf_Ice/fs/boggle.lh.annot && echo "Annotation found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/fs/boggle.lh.annot && echo \"Annotation found\"'\"'\"''"
     expected_output_contains: "Annotation found"
 
   # ==========================================================================
@@ -229,27 +228,27 @@ tests:
   # ==========================================================================
   - name: Caret GIfTI fiducial surface
     description: Verify Caret GIfTI fiducial surface exists
-    command: test -f "/opt/Surf_Ice/caret/Human.colin.Cerebral.R.FIDUCIAL.TLRC.711-2B.71723.surf.gii" && echo "GIfTI fiducial found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f \"/opt/Surf_Ice/caret/Human.colin.Cerebral.R.FIDUCIAL.TLRC.711-2B.71723.surf.gii\" && echo \"GIfTI fiducial found\"'\"'\"''"
     expected_output_contains: "GIfTI fiducial found"
 
   - name: Caret GIfTI flat surface
     description: Verify Caret GIfTI flat map surface exists
-    command: test -f "/opt/Surf_Ice/caret/Human.colin.Cerebral.R.FLAT.CartSTD.71723.surf.gii" && echo "GIfTI flat found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f \"/opt/Surf_Ice/caret/Human.colin.Cerebral.R.FLAT.CartSTD.71723.surf.gii\" && echo \"GIfTI flat found\"'\"'\"''"
     expected_output_contains: "GIfTI flat found"
 
   - name: Caret GIfTI inflated surface
     description: Verify Caret GIfTI inflated surface exists
-    command: test -f "/opt/Surf_Ice/caret/Human.colin.Cerebral.R.VERY_INFLATED.71723.surf.gii" && echo "GIfTI inflated found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f \"/opt/Surf_Ice/caret/Human.colin.Cerebral.R.VERY_INFLATED.71723.surf.gii\" && echo \"GIfTI inflated found\"'\"'\"''"
     expected_output_contains: "GIfTI inflated found"
 
   - name: Caret functional data
     description: Verify Caret functional GIfTI file exists
-    command: test -f "/opt/Surf_Ice/caret/Human.colin.R.FUNCTIONAL.71723.func.gii" && echo "Functional GIfTI found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f \"/opt/Surf_Ice/caret/Human.colin.R.FUNCTIONAL.71723.func.gii\" && echo \"Functional GIfTI found\"'\"'\"''"
     expected_output_contains: "Functional GIfTI found"
 
   - name: Caret shape data
     description: Verify Caret shape GIfTI file exists
-    command: test -f "/opt/Surf_Ice/caret/Human.colin.R.shape.71723.shape.gii" && echo "Shape GIfTI found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f \"/opt/Surf_Ice/caret/Human.colin.R.shape.71723.shape.gii\" && echo \"Shape GIfTI found\"'\"'\"''"
     expected_output_contains: "Shape GIfTI found"
 
   # ==========================================================================
@@ -257,37 +256,37 @@ tests:
   # ==========================================================================
   - name: GLS script - mesh loading
     description: Verify mesh.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/mesh.gls && echo "mesh.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/mesh.gls && echo \"mesh.gls found\"'\"'\"''"
     expected_output_contains: "mesh.gls found"
 
   - name: GLS script - track visualization
     description: Verify track.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/track.gls && echo "track.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/track.gls && echo \"track.gls found\"'\"'\"''"
     expected_output_contains: "track.gls found"
 
   - name: GLS script - scalp rendering
     description: Verify scalp.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/scalp.gls && echo "scalp.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/scalp.gls && echo \"scalp.gls found\"'\"'\"''"
     expected_output_contains: "scalp.gls found"
 
   - name: GLS script - node visualization
     description: Verify node.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/node.gls && echo "node.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/node.gls && echo \"node.gls found\"'\"'\"''"
     expected_output_contains: "node.gls found"
 
   - name: GLS script - shader demo
     description: Verify shaders.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/shaders.gls && echo "shaders.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/shaders.gls && echo \"shaders.gls found\"'\"'\"''"
     expected_output_contains: "shaders.gls found"
 
   - name: GLS script - fMRI mesh
     description: Verify fmri_mesh.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/fmri_mesh.gls && echo "fmri_mesh.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/fmri_mesh.gls && echo \"fmri_mesh.gls found\"'\"'\"''"
     expected_output_contains: "fmri_mesh.gls found"
 
   - name: GLS script - atlas creation
     description: Verify create_atlas.gls sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/create_atlas.gls && echo "create_atlas.gls found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/create_atlas.gls && echo \"create_atlas.gls found\"'\"'\"''"
     expected_output_contains: "create_atlas.gls found"
 
   # ==========================================================================
@@ -295,67 +294,67 @@ tests:
   # ==========================================================================
   - name: Python script - help
     description: Verify help.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/help.py && echo "help.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/help.py && echo \"help.py found\"'\"'\"''"
     expected_output_contains: "help.py found"
 
   - name: Python script - mesh loading
     description: Verify mesh.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/mesh.py && echo "mesh.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/mesh.py && echo \"mesh.py found\"'\"'\"''"
     expected_output_contains: "mesh.py found"
 
   - name: Python script - track visualization
     description: Verify track.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/track.py && echo "track.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/track.py && echo \"track.py found\"'\"'\"''"
     expected_output_contains: "track.py found"
 
   - name: Python script - scalp rendering
     description: Verify scalp.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/scalp.py && echo "scalp.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/scalp.py && echo \"scalp.py found\"'\"'\"''"
     expected_output_contains: "scalp.py found"
 
   - name: Python script - node visualization
     description: Verify node.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/node.py && echo "node.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/node.py && echo \"node.py found\"'\"'\"''"
     expected_output_contains: "node.py found"
 
   - name: Python script - shader demo
     description: Verify shaders.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/shaders.py && echo "shaders.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/shaders.py && echo \"shaders.py found\"'\"'\"''"
     expected_output_contains: "shaders.py found"
 
   - name: Python script - fMRI mesh
     description: Verify fmri_mesh.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/fmri_mesh.py && echo "fmri_mesh.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/fmri_mesh.py && echo \"fmri_mesh.py found\"'\"'\"''"
     expected_output_contains: "fmri_mesh.py found"
 
   - name: Python script - atlas creation
     description: Verify create_atlas.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/create_atlas.py && echo "create_atlas.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/create_atlas.py && echo \"create_atlas.py found\"'\"'\"''"
     expected_output_contains: "create_atlas.py found"
 
   - name: Python script - contour
     description: Verify contour.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/contour.py && echo "contour.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/contour.py && echo \"contour.py found\"'\"'\"''"
     expected_output_contains: "contour.py found"
 
   - name: Python script - subcortical
     description: Verify subcortical.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/subcortical.py && echo "subcortical.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/subcortical.py && echo \"subcortical.py found\"'\"'\"''"
     expected_output_contains: "subcortical.py found"
 
   - name: Python script - walnut brain
     description: Verify walnut.py sample script (WalnutBrain emulation) exists
-    command: test -f /opt/Surf_Ice/Resources/script/walnut.py && echo "walnut.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/walnut.py && echo \"walnut.py found\"'\"'\"''"
     expected_output_contains: "walnut.py found"
 
   - name: Python script - matcap mesh
     description: Verify matcapMesh.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/matcapMesh.py && echo "matcapMesh.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/matcapMesh.py && echo \"matcapMesh.py found\"'\"'\"''"
     expected_output_contains: "matcapMesh.py found"
 
   - name: Python script - basic paint surface
     description: Verify basic_paint_surface.py sample script exists
-    command: test -f /opt/Surf_Ice/Resources/script/basic_paint_surface.py && echo "basic_paint_surface.py found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/script/basic_paint_surface.py && echo \"basic_paint_surface.py found\"'\"'\"''"
     expected_output_contains: "basic_paint_surface.py found"
 
   # ==========================================================================
@@ -363,57 +362,57 @@ tests:
   # ==========================================================================
   - name: Shader - Default
     description: Verify Default shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Default.txt && echo "Default shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Default.txt && echo \"Default shader found\"'\"'\"''"
     expected_output_contains: "Default shader found"
 
   - name: Shader - Metal
     description: Verify Metal shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Metal.txt && echo "Metal shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Metal.txt && echo \"Metal shader found\"'\"'\"''"
     expected_output_contains: "Metal shader found"
 
   - name: Shader - Toon
     description: Verify Toon shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Toon.txt && echo "Toon shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Toon.txt && echo \"Toon shader found\"'\"'\"''"
     expected_output_contains: "Toon shader found"
 
   - name: Shader - Wire
     description: Verify Wire shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Wire.txt && echo "Wire shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Wire.txt && echo \"Wire shader found\"'\"'\"''"
     expected_output_contains: "Wire shader found"
 
   - name: Shader - Wireframe
     description: Verify Wireframe shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Wireframe.txt && echo "Wireframe shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Wireframe.txt && echo \"Wireframe shader found\"'\"'\"''"
     expected_output_contains: "Wireframe shader found"
 
   - name: Shader - Phong
     description: Verify Phong shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Phong.txt && echo "Phong shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Phong.txt && echo \"Phong shader found\"'\"'\"''"
     expected_output_contains: "Phong shader found"
 
   - name: Shader - MatCap
     description: Verify MatCap shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/MatCap.txt && echo "MatCap shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/MatCap.txt && echo \"MatCap shader found\"'\"'\"''"
     expected_output_contains: "MatCap shader found"
 
   - name: Shader - Gooch
     description: Verify Gooch shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Gooch.txt && echo "Gooch shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Gooch.txt && echo \"Gooch shader found\"'\"'\"''"
     expected_output_contains: "Gooch shader found"
 
   - name: Shader - Flat
     description: Verify Flat shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Flat.txt && echo "Flat shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Flat.txt && echo \"Flat shader found\"'\"'\"''"
     expected_output_contains: "Flat shader found"
 
   - name: Shader - Outline
     description: Verify Outline shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/Outline.txt && echo "Outline shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/Outline.txt && echo \"Outline shader found\"'\"'\"''"
     expected_output_contains: "Outline shader found"
 
   - name: Shader - HideCurves
     description: Verify HideCurves shader exists
-    command: test -f /opt/Surf_Ice/Resources/shaders/HideCurves.txt && echo "HideCurves shader found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/shaders/HideCurves.txt && echo \"HideCurves shader found\"'\"'\"''"
     expected_output_contains: "HideCurves shader found"
 
   # ==========================================================================
@@ -421,32 +420,32 @@ tests:
   # ==========================================================================
   - name: LUT - Viridis
     description: Verify Viridis color lookup table exists
-    command: test -f /opt/Surf_Ice/Resources/lut/Viridis.clut && echo "Viridis LUT found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Viridis.clut && echo \"Viridis LUT found\"'\"'\"''"
     expected_output_contains: "Viridis LUT found"
 
   - name: LUT - Plasma
     description: Verify Plasma color lookup table exists
-    command: test -f /opt/Surf_Ice/Resources/lut/Plasma.clut && echo "Plasma LUT found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Plasma.clut && echo \"Plasma LUT found\"'\"'\"''"
     expected_output_contains: "Plasma LUT found"
 
   - name: LUT - Inferno
     description: Verify Inferno color lookup table exists
-    command: test -f /opt/Surf_Ice/Resources/lut/Inferno.clut && echo "Inferno LUT found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Inferno.clut && echo \"Inferno LUT found\"'\"'\"''"
     expected_output_contains: "Inferno LUT found"
 
   - name: LUT - Kelvin
     description: Verify Kelvin color lookup table exists
-    command: test -f /opt/Surf_Ice/Resources/lut/Kelvin.clut && echo "Kelvin LUT found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Kelvin.clut && echo \"Kelvin LUT found\"'\"'\"''"
     expected_output_contains: "Kelvin LUT found"
 
   - name: LUT - Gold
     description: Verify Gold color lookup table exists
-    command: test -f /opt/Surf_Ice/Resources/lut/Gold.clut && echo "Gold LUT found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Gold.clut && echo \"Gold LUT found\"'\"'\"''"
     expected_output_contains: "Gold LUT found"
 
   - name: LUT - Surface
     description: Verify Surface color lookup table exists
-    command: test -f /opt/Surf_Ice/Resources/lut/Surface.clut && echo "Surface LUT found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Surface.clut && echo \"Surface LUT found\"'\"'\"''"
     expected_output_contains: "Surface LUT found"
 
   # ==========================================================================
@@ -454,17 +453,17 @@ tests:
   # ==========================================================================
   - name: MatCap - Cortex
     description: Verify Cortex MatCap texture exists
-    command: test -f /opt/Surf_Ice/Resources/matcap/Cortex.jpg && echo "Cortex MatCap found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/matcap/Cortex.jpg && echo \"Cortex MatCap found\"'\"'\"''"
     expected_output_contains: "Cortex MatCap found"
 
   - name: MatCap - ShinyWhite
     description: Verify ShinyWhite MatCap texture exists
-    command: test -f /opt/Surf_Ice/Resources/matcap/00ShinyWhite.jpg && echo "ShinyWhite MatCap found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/matcap/00ShinyWhite.jpg && echo \"ShinyWhite MatCap found\"'\"'\"''"
     expected_output_contains: "ShinyWhite MatCap found"
 
   - name: MatCap - Metal
     description: Verify Metal MatCap textures exist
-    command: test -f /opt/Surf_Ice/Resources/matcap/MetalShiny.jpg && echo "Metal MatCap found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/matcap/MetalShiny.jpg && echo \"Metal MatCap found\"'\"'\"''"
     expected_output_contains: "Metal MatCap found"
 
   # ==========================================================================
@@ -472,32 +471,32 @@ tests:
   # ==========================================================================
   - name: GLS script syntax - mesh.gls contains meshload
     description: Verify mesh.gls contains proper meshload command
-    command: grep -q "meshload" /opt/Surf_Ice/Resources/script/mesh.gls && echo "meshload command found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"meshload\" /opt/Surf_Ice/Resources/script/mesh.gls && echo \"meshload command found\"'\"'\"''"
     expected_output_contains: "meshload command found"
 
   - name: GLS script syntax - track.gls contains trackload
     description: Verify track.gls contains proper trackload command
-    command: grep -q "trackload" /opt/Surf_Ice/Resources/script/track.gls && echo "trackload command found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"trackload\" /opt/Surf_Ice/Resources/script/track.gls && echo \"trackload command found\"'\"'\"''"
     expected_output_contains: "trackload command found"
 
   - name: Python script syntax - mesh.py imports gl
     description: Verify mesh.py imports the gl module
-    command: grep -q "import gl" /opt/Surf_Ice/Resources/script/mesh.py && echo "gl import found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"import gl\" /opt/Surf_Ice/Resources/script/mesh.py && echo \"gl import found\"'\"'\"''"
     expected_output_contains: "gl import found"
 
   - name: Python script syntax - mesh.py uses gl.meshload
     description: Verify mesh.py uses gl.meshload function
-    command: grep -q "gl.meshload" /opt/Surf_Ice/Resources/script/mesh.py && echo "gl.meshload found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"gl.meshload\" /opt/Surf_Ice/Resources/script/mesh.py && echo \"gl.meshload found\"'\"'\"''"
     expected_output_contains: "gl.meshload found"
 
   - name: Python script syntax - track.py uses gl.trackload
     description: Verify track.py uses gl.trackload function
-    command: grep -q "gl.trackload" /opt/Surf_Ice/Resources/script/track.py && echo "gl.trackload found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"gl.trackload\" /opt/Surf_Ice/Resources/script/track.py && echo \"gl.trackload found\"'\"'\"''"
     expected_output_contains: "gl.trackload found"
 
   - name: Python script syntax - shaders.py uses gl.shadername
     description: Verify shaders.py uses gl.shadername function
-    command: grep -q "gl.shadername" /opt/Surf_Ice/Resources/script/shaders.py && echo "gl.shadername found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"gl.shadername\" /opt/Surf_Ice/Resources/script/shaders.py && echo \"gl.shadername found\"'\"'\"''"
     expected_output_contains: "gl.shadername found"
 
   # ==========================================================================
@@ -505,17 +504,17 @@ tests:
   # ==========================================================================
   - name: Alternative binary - surfice_qt5
     description: Verify Qt5 version of surfice exists
-    command: test -x /opt/Surf_Ice/surfice_qt5 && echo "surfice_qt5 found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -x /opt/Surf_Ice/surfice_qt5 && echo \"surfice_qt5 found\"'\"'\"''"
     expected_output_contains: "surfice_qt5 found"
 
   - name: Alternative binary - surficeOld
     description: Verify OpenGL 2.1 compatible version exists
-    command: test -x /opt/Surf_Ice/surficeOld && echo "surficeOld found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -x /opt/Surf_Ice/surficeOld && echo \"surficeOld found\"'\"'\"''"
     expected_output_contains: "surficeOld found"
 
   - name: Alternative binary - surficeOld_qt5
     description: Verify OpenGL 2.1 + Qt5 version exists
-    command: test -x /opt/Surf_Ice/surficeOld_qt5 && echo "surficeOld_qt5 found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -x /opt/Surf_Ice/surficeOld_qt5 && echo \"surficeOld_qt5 found\"'\"'\"''"
     expected_output_contains: "surficeOld_qt5 found"
 
   # ==========================================================================
@@ -523,32 +522,32 @@ tests:
   # ==========================================================================
   - name: MZ3 format support - sample mesh
     description: Verify MZ3 mesh file is valid (non-empty)
-    command: test -s /opt/Surf_Ice/sample/mni152_2009.mz3 && echo "MZ3 file valid"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -s /opt/Surf_Ice/sample/mni152_2009.mz3 && echo \"MZ3 file valid\"'\"'\"''"
     expected_output_contains: "MZ3 file valid"
 
   - name: MZ3 format support - mini mesh
     description: Verify mini MZ3 mesh file is valid
-    command: test -s /opt/Surf_Ice/sample/mni152_2009mini.mz3 && echo "Mini MZ3 file valid"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -s /opt/Surf_Ice/sample/mni152_2009mini.mz3 && echo \"Mini MZ3 file valid\"'\"'\"''"
     expected_output_contains: "Mini MZ3 file valid"
 
   - name: MZ3 format support - AO mesh
     description: Verify ambient occlusion MZ3 mesh file is valid
-    command: test -s /opt/Surf_Ice/sample/mni152_2009AO.mz3 && echo "AO MZ3 file valid"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -s /opt/Surf_Ice/sample/mni152_2009AO.mz3 && echo \"AO MZ3 file valid\"'\"'\"''"
     expected_output_contains: "AO MZ3 file valid"
 
   - name: NIfTI format support - motor volume
     description: Verify NIfTI volume file is valid
-    command: test -s /opt/Surf_Ice/sample/motor_4t95vol.nii.gz && echo "NIfTI file valid"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -s /opt/Surf_Ice/sample/motor_4t95vol.nii.gz && echo \"NIfTI file valid\"'\"'\"''"
     expected_output_contains: "NIfTI file valid"
 
   - name: TRK format support - tractography
     description: Verify TRK tractography file is valid
-    command: test -s /opt/Surf_Ice/sample/stroke.trk.gz && echo "TRK file valid"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -s /opt/Surf_Ice/sample/stroke.trk.gz && echo \"TRK file valid\"'\"'\"''"
     expected_output_contains: "TRK file valid"
 
   - name: Curvature format support
     description: Verify curvature file is valid
-    command: test -s /opt/Surf_Ice/sample/mni152_2009.curv && echo "CURV file valid"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -s /opt/Surf_Ice/sample/mni152_2009.curv && echo \"CURV file valid\"'\"'\"''"
     expected_output_contains: "CURV file valid"
 
   # ==========================================================================
@@ -556,17 +555,17 @@ tests:
   # ==========================================================================
   - name: Font - OpenSans
     description: Verify OpenSans font resources exist
-    command: test -f /opt/Surf_Ice/Resources/lut/OpenSans.png && echo "OpenSans font found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/OpenSans.png && echo \"OpenSans font found\"'\"'\"''"
     expected_output_contains: "OpenSans font found"
 
   - name: Font - Roboto
     description: Verify Roboto font resources exist
-    command: test -f /opt/Surf_Ice/Resources/lut/Roboto.png && echo "Roboto font found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Roboto.png && echo \"Roboto font found\"'\"'\"''"
     expected_output_contains: "Roboto font found"
 
   - name: Font - Ubuntu
     description: Verify Ubuntu font resources exist
-    command: test -f /opt/Surf_Ice/Resources/lut/Ubuntu.png && echo "Ubuntu font found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/Resources/lut/Ubuntu.png && echo \"Ubuntu font found\"'\"'\"''"
     expected_output_contains: "Ubuntu font found"
 
   # ==========================================================================
@@ -574,7 +573,7 @@ tests:
   # ==========================================================================
   - name: MNI2FS directory exists
     description: Verify mni2fs directory for MNI to FreeSurfer conversion exists
-    command: test -d /opt/Surf_Ice/mni2fs && echo "mni2fs directory found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -d /opt/Surf_Ice/mni2fs && echo \"mni2fs directory found\"'\"'\"''"
     expected_output_contains: "mni2fs directory found"
 
   # ==========================================================================
@@ -582,17 +581,17 @@ tests:
   # ==========================================================================
   - name: Installation documentation
     description: Verify installation documentation exists
-    command: test -f /opt/Surf_Ice/surfice_Linux_Installation.txt && echo "Installation docs found"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'test -f /opt/Surf_Ice/surfice_Linux_Installation.txt && echo \"Installation docs found\"'\"'\"''"
     expected_output_contains: "Installation docs found"
 
   - name: Installation docs mention Qt5
     description: Verify installation docs mention Qt5 widget set
-    command: grep -q "qt5" /opt/Surf_Ice/surfice_Linux_Installation.txt && echo "Qt5 mentioned"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -q \"qt5\" /opt/Surf_Ice/surfice_Linux_Installation.txt && echo \"Qt5 mentioned\"'\"'\"''"
     expected_output_contains: "Qt5 mentioned"
 
   - name: Installation docs mention OpenGL
     description: Verify installation docs mention OpenGL requirements
-    command: grep -qi "opengl" /opt/Surf_Ice/surfice_Linux_Installation.txt && echo "OpenGL mentioned"
+    command: "bash -lc 'env QT_QPA_PLATFORM=offscreen bash -lc '\"'\"'grep -qi \"opengl\" /opt/Surf_Ice/surfice_Linux_Installation.txt && echo \"OpenGL mentioned\"'\"'\"''"
     expected_output_contains: "OpenGL mentioned"
 
 cleanup:

--- a/recipes/syncro/fulltest.yaml
+++ b/recipes/syncro/fulltest.yaml
@@ -327,20 +327,12 @@ tests:
   # ==========================================================================
   - name: MNI template exists in container
     description: Verify MNI152 template is bundled in container
-    command: ls -la /opt/MNI152_T1_1mm_brain.nii.gz
+    command: "bash -lc 'ls -la /opt/MNI152_T1_1mm_brain.nii.gz'"
     expected_output_contains: "MNI152_T1_1mm_brain.nii.gz"
 
   - name: MNI template dimensions
     description: Verify MNI template has expected dimensions
-    command: |
-      python3 -c "
-      import nibabel as nib
-      img = nib.load('/opt/MNI152_T1_1mm_brain.nii.gz')
-      print(f'MNI template shape: {img.shape}')
-      print(f'MNI template voxel size: {img.header.get_zooms()}')
-      assert img.shape == (182, 218, 182), f'Unexpected shape {img.shape}'
-      print('MNI template verified')
-      "
+    command: "bash -lc 'python3 -c \"\nimport nibabel as nib\nimg = nib.load('\"'\"'/opt/MNI152_T1_1mm_brain.nii.gz'\"'\"')\nprint(f'\"'\"'MNI template shape: {img.shape}'\"'\"')\nprint(f'\"'\"'MNI template voxel size: {img.header.get_zooms()}'\"'\"')\nassert img.shape == (182, 218, 182), f'\"'\"'Unexpected shape {img.shape}'\"'\"'\nprint('\"'\"'MNI template verified'\"'\"')\n\"'"
     expected_output_contains: "MNI template verified"
 
   # ==========================================================================
@@ -375,106 +367,17 @@ tests:
   # ==========================================================================
   - name: Test distance transform smoothing
     description: Verify binary mask dilation and smoothing works
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt')
-      from SYNcro import dilate_smooth_nifti
-      import nibabel as nib
-      import numpy as np
-      import tempfile
-      import os
-
-      # Create a simple binary test image
-      data = np.zeros((50, 50, 50), dtype=np.float32)
-      data[20:30, 20:30, 20:30] = 1
-      affine = np.eye(4)
-      img = nib.Nifti1Image(data, affine)
-
-      with tempfile.NamedTemporaryFile(suffix='.nii.gz', delete=False) as f:
-          nib.save(img, f.name)
-          dilate_smooth_nifti(f.name, dilate_vox=2, fwhm_mm=2)
-          result = nib.load(f.name).get_fdata()
-          os.unlink(f.name)
-
-      # Check that dilation expanded the mask
-      assert result.sum() > data.sum(), 'Dilation should expand mask'
-      # Check that smoothing created non-binary values
-      unique_count = len(np.unique(result))
-      assert unique_count > 2, f'Smoothing should create gradient, got {unique_count} unique values'
-      print('Distance transform and smoothing work correctly')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt'\"'\"')\nfrom SYNcro import dilate_smooth_nifti\nimport nibabel as nib\nimport numpy as np\nimport tempfile\nimport os\n\n# Create a simple binary test image\ndata = np.zeros((50, 50, 50), dtype=np.float32)\ndata[20:30, 20:30, 20:30] = 1\naffine = np.eye(4)\nimg = nib.Nifti1Image(data, affine)\n\nwith tempfile.NamedTemporaryFile(suffix='\"'\"'.nii.gz'\"'\"', delete=False) as f:\n    nib.save(img, f.name)\n    dilate_smooth_nifti(f.name, dilate_vox=2, fwhm_mm=2)\n    result = nib.load(f.name).get_fdata()\n    os.unlink(f.name)\n\n# Check that dilation expanded the mask\nassert result.sum() > data.sum(), '\"'\"'Dilation should expand mask'\"'\"'\n# Check that smoothing created non-binary values\nunique_count = len(np.unique(result))\nassert unique_count > 2, f'\"'\"'Smoothing should create gradient, got {unique_count} unique values'\"'\"'\nprint('\"'\"'Distance transform and smoothing work correctly'\"'\"')\n\"'"
     expected_output_contains: "work correctly"
 
   - name: Test nifti_min_max_binary function
     description: Verify binary detection function works
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt')
-      from SYNcro import nifti_min_max_binary
-      import nibabel as nib
-      import numpy as np
-      import tempfile
-      import os
-
-      # Test with binary image
-      data = np.zeros((10, 10, 10), dtype=np.float32)
-      data[3:7, 3:7, 3:7] = 1
-      affine = np.eye(4)
-      img = nib.Nifti1Image(data, affine)
-
-      with tempfile.NamedTemporaryFile(suffix='.nii.gz', delete=False) as f:
-          nib.save(img, f.name)
-          min_val, max_val, is_binary = nifti_min_max_binary(f.name)
-          os.unlink(f.name)
-
-      assert min_val == 0, f'Expected min 0, got {min_val}'
-      assert max_val == 1, f'Expected max 1, got {max_val}'
-      assert is_binary == True, f'Expected binary=True, got {is_binary}'
-
-      # Test with non-binary image
-      data = np.random.rand(10, 10, 10).astype(np.float32)
-      img = nib.Nifti1Image(data, affine)
-
-      with tempfile.NamedTemporaryFile(suffix='.nii.gz', delete=False) as f:
-          nib.save(img, f.name)
-          min_val, max_val, is_binary = nifti_min_max_binary(f.name)
-          os.unlink(f.name)
-
-      assert is_binary == False, f'Expected binary=False for random data, got {is_binary}'
-      print('nifti_min_max_binary function works correctly')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt'\"'\"')\nfrom SYNcro import nifti_min_max_binary\nimport nibabel as nib\nimport numpy as np\nimport tempfile\nimport os\n\n# Test with binary image\ndata = np.zeros((10, 10, 10), dtype=np.float32)\ndata[3:7, 3:7, 3:7] = 1\naffine = np.eye(4)\nimg = nib.Nifti1Image(data, affine)\n\nwith tempfile.NamedTemporaryFile(suffix='\"'\"'.nii.gz'\"'\"', delete=False) as f:\n    nib.save(img, f.name)\n    min_val, max_val, is_binary = nifti_min_max_binary(f.name)\n    os.unlink(f.name)\n\nassert min_val == 0, f'\"'\"'Expected min 0, got {min_val}'\"'\"'\nassert max_val == 1, f'\"'\"'Expected max 1, got {max_val}'\"'\"'\nassert is_binary == True, f'\"'\"'Expected binary=True, got {is_binary}'\"'\"'\n\n# Test with non-binary image\ndata = np.random.rand(10, 10, 10).astype(np.float32)\nimg = nib.Nifti1Image(data, affine)\n\nwith tempfile.NamedTemporaryFile(suffix='\"'\"'.nii.gz'\"'\"', delete=False) as f:\n    nib.save(img, f.name)\n    min_val, max_val, is_binary = nifti_min_max_binary(f.name)\n    os.unlink(f.name)\n\nassert is_binary == False, f'\"'\"'Expected binary=False for random data, got {is_binary}'\"'\"'\nprint('\"'\"'nifti_min_max_binary function works correctly'\"'\"')\n\"'"
     expected_output_contains: "works correctly"
 
   - name: Test binarize_nifti function
     description: Verify binarization function works
-    command: |
-      python3 -c "
-      import sys
-      sys.path.insert(0, '/opt')
-      from SYNcro import binarize_nifti
-      import nibabel as nib
-      import numpy as np
-      import tempfile
-      import os
-
-      # Create non-binary image (simulating post-interpolation)
-      data = np.array([[[0.0, 0.2, 0.5], [0.8, 1.0, 0.3], [0.1, 0.9, 0.4]]], dtype=np.float32)
-      affine = np.eye(4)
-      img = nib.Nifti1Image(data, affine)
-
-      with tempfile.NamedTemporaryFile(suffix='.nii.gz', delete=False) as f:
-          nib.save(img, f.name)
-          binarize_nifti(f.name)
-          result = nib.load(f.name).get_fdata()
-          os.unlink(f.name)
-
-      unique_vals = np.unique(result)
-      assert len(unique_vals) == 2, f'Expected 2 unique values, got {len(unique_vals)}'
-      assert 0 in unique_vals and 1 in unique_vals, 'Expected values 0 and 1'
-      print('binarize_nifti function works correctly')
-      "
+    command: "bash -lc 'python3 -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt'\"'\"')\nfrom SYNcro import binarize_nifti\nimport nibabel as nib\nimport numpy as np\nimport tempfile\nimport os\n\n# Create non-binary image (simulating post-interpolation)\ndata = np.array([[[0.0, 0.2, 0.5], [0.8, 1.0, 0.3], [0.1, 0.9, 0.4]]], dtype=np.float32)\naffine = np.eye(4)\nimg = nib.Nifti1Image(data, affine)\n\nwith tempfile.NamedTemporaryFile(suffix='\"'\"'.nii.gz'\"'\"', delete=False) as f:\n    nib.save(img, f.name)\n    binarize_nifti(f.name)\n    result = nib.load(f.name).get_fdata()\n    os.unlink(f.name)\n\nunique_vals = np.unique(result)\nassert len(unique_vals) == 2, f'\"'\"'Expected 2 unique values, got {len(unique_vals)}'\"'\"'\nassert 0 in unique_vals and 1 in unique_vals, '\"'\"'Expected values 0 and 1'\"'\"'\nprint('\"'\"'binarize_nifti function works correctly'\"'\"')\n\"'"
     expected_output_contains: "works correctly"
 
   # ==========================================================================
@@ -482,35 +385,7 @@ tests:
   # ==========================================================================
   - name: Output registration quality check
     description: Verify registered output is reasonably aligned to MNI space
-    command: |
-      python3 -c "
-      import nibabel as nib
-      import numpy as np
-
-      # Load normalized output and template
-      output = nib.load('test_output/syncro_basic/wbt1sub-01_T1w.nii.gz')
-      template = nib.load('/opt/MNI152_T1_1mm_brain.nii.gz')
-
-      out_data = output.get_fdata()
-      tpl_data = template.get_fdata()
-
-      # Basic sanity checks
-      assert out_data.shape == tpl_data.shape, 'Shapes must match'
-
-      # Check that output has reasonable intensity range
-      out_nonzero = out_data[out_data > 0]
-      assert len(out_nonzero) > 0, 'Output should have nonzero voxels'
-
-      # Calculate overlap with template brain region
-      tpl_mask = tpl_data > 0
-      out_mask = out_data > 0
-      overlap = np.sum(tpl_mask & out_mask) / np.sum(tpl_mask | out_mask)
-      print(f'Dice-like overlap with template: {overlap:.3f}')
-
-      # Overlap should be reasonable (> 0.5 for brain region)
-      assert overlap > 0.4, f'Overlap too low: {overlap}'
-      print('Registration quality check passed')
-      "
+    command: "bash -lc 'python3 -c \"\nimport nibabel as nib\nimport numpy as np\n\n# Load normalized output and template\noutput = nib.load('\"'\"'test_output/syncro_basic/wbt1sub-01_T1w.nii.gz'\"'\"')\ntemplate = nib.load('\"'\"'/opt/MNI152_T1_1mm_brain.nii.gz'\"'\"')\n\nout_data = output.get_fdata()\ntpl_data = template.get_fdata()\n\n# Basic sanity checks\nassert out_data.shape == tpl_data.shape, '\"'\"'Shapes must match'\"'\"'\n\n# Check that output has reasonable intensity range\nout_nonzero = out_data[out_data > 0]\nassert len(out_nonzero) > 0, '\"'\"'Output should have nonzero voxels'\"'\"'\n\n# Calculate overlap with template brain region\ntpl_mask = tpl_data > 0\nout_mask = out_data > 0\noverlap = np.sum(tpl_mask & out_mask) / np.sum(tpl_mask | out_mask)\nprint(f'\"'\"'Dice-like overlap with template: {overlap:.3f}'\"'\"')\n\n# Overlap should be reasonable (> 0.5 for brain region)\nassert overlap > 0.4, f'\"'\"'Overlap too low: {overlap}'\"'\"'\nprint('\"'\"'Registration quality check passed'\"'\"')\n\"'"
     depends_on: Basic T1w normalization
     expected_output_contains: "quality check passed"
 

--- a/recipes/tgvqsm/fulltest.yaml
+++ b/recipes/tgvqsm/fulltest.yaml
@@ -108,43 +108,43 @@ tests:
   # ==========================================================================
   - name: bet2 help
     description: Verify bet2 binary runs and displays help
-    command: /bet2/bin/bet2 2>&1
+    command: bash -lc '/bet2/bin/bet2 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Brain Extraction Tool"
 
   - name: bet2 version
     description: Check bet2 version information
-    command: /bet2/bin/bet2 2>&1
+    command: bash -lc '/bet2/bin/bet2 2>&1'
     ignore_exit_code: true
     expected_output_contains: "Part of FSL"
 
   - name: bet2 usage info
     description: Verify bet2 shows usage syntax
-    command: /bet2/bin/bet2 2>&1
+    command: bash -lc '/bet2/bin/bet2 2>&1'
     ignore_exit_code: true
     expected_output_contains: "bet2 <input_fileroot> <output_fileroot>"
 
   - name: bet2 fractional threshold option
     description: Verify bet2 shows -f option
-    command: /bet2/bin/bet2 2>&1
+    command: bash -lc '/bet2/bin/bet2 2>&1'
     ignore_exit_code: true
     expected_output_contains: "fractional intensity threshold"
 
   - name: bet2 mask option
     description: Verify bet2 shows mask generation option
-    command: /bet2/bin/bet2 2>&1
+    command: bash -lc '/bet2/bin/bet2 2>&1'
     ignore_exit_code: true
     expected_output_contains: "--mask"
 
   - name: bet2 skull option
     description: Verify bet2 shows skull estimation option
-    command: /bet2/bin/bet2 2>&1
+    command: bash -lc '/bet2/bin/bet2 2>&1'
     ignore_exit_code: true
     expected_output_contains: "--skull"
 
   - name: bet2 basic brain extraction
     description: Run bet2 on T1w image with default settings
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain'
     validate:
       - output_exists: ${output_dir}/t1w_brain.nii.gz
 
@@ -170,26 +170,26 @@ tests:
 
   - name: bet2 with fractional threshold 0.3
     description: Run bet2 with lower threshold for larger brain estimate
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_f03 -f 0.3
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_f03 -f 0.3'
     validate:
       - output_exists: ${output_dir}/t1w_brain_f03.nii.gz
 
   - name: bet2 with fractional threshold 0.7
     description: Run bet2 with higher threshold for smaller brain estimate
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_f07 -f 0.7
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_f07 -f 0.7'
     validate:
       - output_exists: ${output_dir}/t1w_brain_f07.nii.gz
 
   - name: bet2 with outline
     description: Run bet2 with brain surface outline output
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_outline -o
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_outline -o'
     validate:
       - output_exists: ${output_dir}/t1w_brain_outline.nii.gz
       - output_exists: ${output_dir}/t1w_brain_outline_overlay.nii.gz
 
   - name: bet2 with skull estimation
     description: Run bet2 (skull flag -s not supported, verify brain extraction only)
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_skull
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_skull'
     validate:
       - output_exists: ${output_dir}/t1w_brain_skull.nii.gz
 
@@ -212,32 +212,32 @@ tests:
 
   - name: bet2 with mesh output
     description: Run bet2 with VTK mesh output
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_mesh -e
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_mesh -e'
     validate:
       - output_exists: ${output_dir}/t1w_brain_mesh.nii.gz
       - output_exists: ${output_dir}/t1w_brain_mesh_mesh.vtk
 
   - name: bet2 with gradient
     description: Run bet2 with vertical gradient adjustment
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_grad -g 0.1
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_grad -g 0.1'
     validate:
       - output_exists: ${output_dir}/t1w_brain_grad.nii.gz
 
   - name: bet2 with smoothness factor
     description: Run bet2 with adjusted smoothness
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_smooth -w 0.5
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_smooth -w 0.5'
     validate:
       - output_exists: ${output_dir}/t1w_brain_smooth.nii.gz
 
   - name: bet2 with thresholding
     description: Run bet2 with thresholding applied
-    command: /bet2/bin/bet2 ${t1w} test_output/t1w_brain_thr -t
+    command: bash -lc '/bet2/bin/bet2 ${t1w} test_output/t1w_brain_thr -t'
     validate:
       - output_exists: ${output_dir}/t1w_brain_thr.nii.gz
 
   - name: bet2 on inplane T2
     description: Run bet2 on T2-weighted image
-    command: /bet2/bin/bet2 ${t2} test_output/t2_brain
+    command: bash -lc '/bet2/bin/bet2 ${t2} test_output/t2_brain'
     validate:
       - output_exists: ${output_dir}/t2_brain.nii.gz
 
@@ -266,53 +266,53 @@ tests:
   # ==========================================================================
   - name: dcm2niix help
     description: Verify dcm2niix binary runs and displays help
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "dcm2niiX"
 
   - name: dcm2niix version
     description: Check dcm2niix version information
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "Chris Rorden"
 
   - name: dcm2niix usage info
     description: Verify dcm2niix shows usage syntax
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "dcm2niix [options] <in_folder>"
 
   - name: dcm2niix output options
     description: Verify dcm2niix shows output directory option
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "-o : output directory"
 
   - name: dcm2niix filename format
     description: Verify dcm2niix shows filename format option
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "-f : filename"
 
   - name: dcm2niix compression option
     description: Verify dcm2niix shows compression option
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "-z : gz compress"
 
   - name: dcm2niix BIDS option
     description: Verify dcm2niix shows BIDS sidecar option
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "-b : BIDS sidecar"
 
   - name: dcm2niix verbose option
     description: Verify dcm2niix shows verbose option
-    command: /opt/dcm2niix-latest/bin/dcm2niix -h 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
     expected_output_contains: "-v : verbose"
 
   - name: dcm2niix version check
     description: Get dcm2niix version number
-    command: /opt/dcm2niix-latest/bin/dcm2niix --version 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix --version 2>&1'
     ignore_exit_code: true
     expected_output_contains: "v1.0.20210317"
 
   - name: dcm2niix xml features
     description: Check dcm2niix XML output mode
-    command: /opt/dcm2niix-latest/bin/dcm2niix --xml 2>&1
+    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix --xml 2>&1'
     expected_output_contains: "dcm2niix"
 
   # ==========================================================================
@@ -621,16 +621,16 @@ tests:
   - name: Full QSM pipeline - brain extraction
     description: First step of QSM pipeline - extract brain and create mask
     command: |
-      /bet2/bin/bet2 ${t1w} test_output/pipeline_magnitude_bet -f 0.4 && \
+      bash -lc '/bet2/bin/bet2 ${t1w} test_output/pipeline_magnitude_bet -f 0.4 && \
       python2 -c "
       import nibabel as nib
       import numpy as np
-      img = nib.load('test_output/pipeline_magnitude_bet.nii.gz')
+      img = nib.load('\''test_output/pipeline_magnitude_bet.nii.gz'\'')
       data = img.get_data()
       mask = nib.Nifti1Image((data > 0).astype(np.uint8), img.affine, img.header)
-      mask.to_filename('test_output/pipeline_magnitude_bet_mask.nii.gz')
-      print('Pipeline mask created')
-      "
+      mask.to_filename('\''test_output/pipeline_magnitude_bet_mask.nii.gz'\'')
+      print('\''Pipeline mask created'\'')
+      "'
     expected_output_contains: "Pipeline mask created"
     validate:
       - output_exists: ${output_dir}/pipeline_magnitude_bet.nii.gz
@@ -697,12 +697,12 @@ tests:
 
   - name: bet2 missing input
     description: Test bet2 error when input file is missing
-    command: /bet2/bin/bet2 nonexistent.nii.gz test_output/bet_error 2>&1
+    command: bash -lc '/bet2/bin/bet2 nonexistent.nii.gz test_output/bet_error 2>&1'
     ignore_exit_code: true
 
   - name: dcm2niix empty directory
     description: Test dcm2niix on directory with no DICOMs
-    command: mkdir -p test_output/empty_dir && /opt/dcm2niix-latest/bin/dcm2niix -o test_output test_output/empty_dir 2>&1 || true
+    command: bash -lc 'mkdir -p test_output/empty_dir && /opt/dcm2niix-latest/bin/dcm2niix -o test_output test_output/empty_dir 2>&1 || true'
     expected_output_contains: "Unable to find"
 
   # ==========================================================================

--- a/recipes/trackvis/fulltest.yaml
+++ b/recipes/trackvis/fulltest.yaml
@@ -149,22 +149,22 @@ tests:
   # ==========================================================================
   - name: Version check
     description: Verify track_vis binary runs and reports version
-    command: /opt/trackvis-0.6.1/track_vis --version
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis --version'
     expected_output_contains: "track_vis"
 
   - name: Help display
     description: Display full help/usage information
-    command: /opt/trackvis-0.6.1/track_vis --help 2>&1 | head -50
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis --help 2>&1 | head -50'
     expected_output_contains: "Usage:"
 
   - name: Help filtering options
     description: Check filtering options are documented
-    command: /opt/trackvis-0.6.1/track_vis --help 2>&1 | grep -A2 "length_threshold"
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis --help 2>&1 | grep -A2 "length_threshold"'
     expected_output_contains: "length"
 
   - name: Help output options
     description: Check output options are documented
-    command: /opt/trackvis-0.6.1/track_vis --help 2>&1 | grep -A2 "\-\-output"
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis --help 2>&1 | grep -A2 "\-\-output"'
     expected_output_contains: "output"
 
   # ==========================================================================
@@ -172,12 +172,12 @@ tests:
   # ==========================================================================
   - name: Load track file (no render)
     description: Load synthetic track file without rendering
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nr 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nr 2>&1'
     expected_exit_code: 0
 
   - name: Display track count
     description: Load tracks and report statistics (disabled log)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -185,17 +185,17 @@ tests:
   # ==========================================================================
   - name: Length threshold (minimum only)
     description: Filter tracks by minimum length
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 10 1000 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 10 1000 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Length threshold (range)
     description: Filter tracks within length range 20-100mm
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 20 100 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 20 100 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Length threshold output
     description: Filter by length and save filtered tracks
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 10 500 -o test_output/tracks_length_filtered.trk -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 10 500 -o test_output/tracks_length_filtered.trk -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/tracks_length_filtered.trk
 
@@ -204,32 +204,32 @@ tests:
   # ==========================================================================
   - name: Sagittal slice filter
     description: Filter tracks crossing sagittal slice 80
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nx 80 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nx 80 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Coronal slice filter
     description: Filter tracks crossing coronal slice 96
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ny 96 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ny 96 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Axial slice filter
     description: Filter tracks crossing axial slice 96
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nz 96 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nz 96 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Slab filter (multiple slices)
     description: Filter tracks crossing sagittal slab 70-90
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nx 70 90 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -nx 70 90 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Sagittal slice exclusion
     description: Exclude tracks crossing sagittal slice 100
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -mx 100 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -mx 100 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: End point sagittal filter
     description: Filter tracks ending in sagittal slice range
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ex 80 120 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ex 80 120 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -237,17 +237,17 @@ tests:
   # ==========================================================================
   - name: U-factor threshold
     description: Filter by U-factor (U-shapeness measure)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -u -0.5 0.5 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -u -0.5 0.5 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Curvature threshold
     description: Filter tracks by curvature range
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -curvature 0 0.5 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -curvature 0 0.5 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Torsion threshold
     description: Filter tracks by torsion range
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -torsion -1 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -torsion -1 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -255,12 +255,12 @@ tests:
   # ==========================================================================
   - name: Skip tracks
     description: Display every 2nd track only
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -skip 2 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -skip 2 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Proportional skip
     description: Skip tracks proportionally based on length
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -skipp 2 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -skipp 2 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -268,7 +268,7 @@ tests:
   # ==========================================================================
   - name: Extend tracks
     description: Extend track endpoints by 5mm before filtering
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ext 5 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ext 5 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -276,17 +276,17 @@ tests:
   # ==========================================================================
   - name: ROI pointer (single voxel)
     description: Filter tracks passing through voxel ROI at (80,96,96) radius 5
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 5 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 5 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Dual ROI pointers
     description: Filter tracks passing through two ROI points
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 5 1 -roi_pt2 100 96 110 5 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 5 1 -roi_pt2 100 96 110 5 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: ROI disk filter
     description: Filter tracks passing through a disk ROI
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_disk 80 96 96 10 1 0 0 0 90 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_disk 80 96 96 10 1 0 0 0 90 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -294,19 +294,19 @@ tests:
   # ==========================================================================
   - name: Output filtered tracks
     description: Save filtered tracks to new file
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 5 1000 -o test_output/tracks_filtered.trk -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 5 1000 -o test_output/tracks_filtered.trk -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/tracks_filtered.trk
 
   - name: Output track volume
     description: Convert tracks to volume image (NIfTI)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ov test_output/tracks_volume.nii.gz -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ov test_output/tracks_volume.nii.gz -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/tracks_volume.nii.gz
 
   - name: Output endpoint volume
     description: Convert track endpoints only to volume
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ov test_output/tracks_endpoints.nii.gz 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ov test_output/tracks_endpoints.nii.gz 1 -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/tracks_endpoints.nii.gz
 
@@ -315,27 +315,27 @@ tests:
   # ==========================================================================
   - name: Save camera position
     description: Test save_cam option is accepted (file not created with -nr since no camera initialized)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -save_cam test_output/camera.cam -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -save_cam test_output/camera.cam -nr -disable_log 2>&1'
     expected_output_contains: "Number of tracks"
 
   - name: Camera azimuth rotation
     description: Apply camera rotation (no display)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -camera azimuth 45 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -camera azimuth 45 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Camera elevation rotation
     description: Apply camera elevation (no display)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -camera elevation 30 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -camera elevation 30 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Camera dolly (zoom)
     description: Apply camera dolly/zoom
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -camera dolly 1.5 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -camera dolly 1.5 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Camera offset
     description: Set focal point offset
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -offset 10 10 10 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -offset 10 10 10 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -343,92 +343,92 @@ tests:
   # ==========================================================================
   - name: Solid color option
     description: Set solid color for tracks (red)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -c 1 0 0 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -c 1 0 0 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Directional color coding
     description: Enable direction-coded coloring
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -dc -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -dc -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Transparent display
     description: Enable transparent track display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -t -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -t -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Shading option
     description: Enable shaded tube display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -s -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -s -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Wireframe option
     description: Enable wireframe tube display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -wf -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -wf -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Tube radius
     description: Set tube radius for shaded display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -s -r 0.1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -s -r 0.1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Number of sides
     description: Set number of sides for tubes
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -s -ns 8 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -s -ns 8 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Frame box display
     description: Enable frame box with axes
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -box -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -box -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Background color
     description: Set background color (white)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -bc 1 1 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -bc 1 1 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Window size
     description: Set display window size
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ws 800 600 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ws 800 600 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Anti-aliasing
     description: Enable anti-aliasing render
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -aa -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -aa -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Title overlay
     description: Set title text overlay
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -title "Test Title" -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -title "Test Title" -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: No annotation
     description: Disable annotation display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -na -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -na -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Ball marker
     description: Display ball marker at position
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ball 80 96 96 5 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -ball 80 96 96 5 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Circle display
     description: Display circle with each track
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -circle -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -circle -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Alternative color coding
     description: Use mid segment for color coding
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -cc -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -cc -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Helix color coding
     description: Use helix angle for color coding
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -helix 0 0 1 80 96 96 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -helix 0 0 1 80 96 96 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Axis thickness
     description: Set helix axis thickness
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -helix 0 0 1 80 96 96 -at 2 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -helix 0 0 1 80 96 96 -at 2 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -436,27 +436,27 @@ tests:
   # ==========================================================================
   - name: Brain image overlay
     description: Load brain image as background
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Axial brain slice
     description: Display specific axial brain slice
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -bz 96 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -bz 96 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Sagittal brain slice
     description: Display specific sagittal brain slice
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -bx 80 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -bx 80 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Coronal brain slice
     description: Display specific coronal brain slice
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -by 96 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -by 96 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Window level adjustment
     description: Set window level for brain display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -bz 96 -w 0 500 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -b ${t1w} -bz 96 -w 0 500 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -464,23 +464,23 @@ tests:
   # ==========================================================================
   - name: ROI from NIfTI file
     description: Filter tracks using NIfTI ROI mask
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi ${t1w} 100 10000 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi ${t1w} 100 10000 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Dual ROI files
     description: Filter tracks passing through two ROI regions
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi ${t1w} 100 10000 -roi2 ${t1w} 50 5000 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi ${t1w} 100 10000 -roi2 ${t1w} 50 5000 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Output ROI volume
     description: Output ROI region to volume
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 10 0 -o_roi test_output/roi_output.nii.gz -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 10 0 -o_roi test_output/roi_output.nii.gz -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/roi_output.nii.gz
 
   - name: ROI display with tracks
     description: Display ROI overlays
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -rois ${t1w} 200 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -rois ${t1w} 200 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -488,7 +488,7 @@ tests:
   # ==========================================================================
   - name: Background tracks
     description: Display second track file as background
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -bg test_output/synthetic_tracks2.trk -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -bg test_output/synthetic_tracks2.trk -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -496,17 +496,17 @@ tests:
   # ==========================================================================
   - name: End ROI filter
     description: Filter tracks ending in ROI
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_end ${t1w} 100 10000 0 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_end ${t1w} 100 10000 0 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Both ends ROI filter
     description: Filter tracks with both ends in ROI
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_end ${t1w} 100 10000 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_end ${t1w} 100 10000 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: End point iteration
     description: Use end points as ROI for filtering
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 10 1 -end_pt 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 10 1 -end_pt 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -514,7 +514,7 @@ tests:
   # ==========================================================================
   - name: ROI tube filter
     description: Use track to construct tube ROI
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_tube 2 45 5 1 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_tube 2 45 5 1 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -522,13 +522,13 @@ tests:
   # ==========================================================================
   - name: Screen capture single
     description: Capture single screen to image
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -sc test_output/capture.png -disable_log 2>&1 || true
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -sc test_output/capture.png -disable_log 2>&1 || true'
     # Note: May fail without display, testing command parsing
     expected_exit_code: 0
 
   - name: Screen capture magnification
     description: Test magnification option parsing
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -mag 2 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -mag 2 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -536,12 +536,12 @@ tests:
   # ==========================================================================
   - name: Custom log ID
     description: Set custom log ID string
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -log test_run -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -log test_run -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Disable log
     description: Disable command-line logging
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -disable_log -nr 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -disable_log -nr 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -549,7 +549,7 @@ tests:
   # ==========================================================================
   - name: Duplicate arguments
     description: Apply same arguments to multiple track files
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -bg test_output/synthetic_tracks2.trk -dup -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -bg test_output/synthetic_tracks2.trk -dup -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -557,24 +557,24 @@ tests:
   # ==========================================================================
   - name: Complex filter pipeline
     description: Combine multiple filtering options
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 10 500 -nx 70 100 -u -0.8 0.8 -o test_output/tracks_complex.trk -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 10 500 -nx 70 100 -u -0.8 0.8 -o test_output/tracks_complex.trk -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/tracks_complex.trk
 
   - name: Filter with brain overlay
     description: Filter tracks with brain image display
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 5 1000 -b ${t1w} -bz 96 -w 0 500 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -l 5 1000 -b ${t1w} -bz 96 -w 0 500 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Filter with ROI and output
     description: Filter by ROI pointer and save volume
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 15 1 -ov test_output/roi_filtered_vol.nii.gz -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi_pt 80 96 96 15 1 -ov test_output/roi_filtered_vol.nii.gz -nr -disable_log 2>&1'
     validate:
       - output_exists: ${output_dir}/roi_filtered_vol.nii.gz
 
   - name: Full display pipeline
     description: Combine display options (no render)
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -dc -s -r 0.08 -ns 6 -bc 0.2 0.2 0.2 -box -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -dc -s -r 0.08 -ns 6 -bc 0.2 0.2 0.2 -box -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -582,12 +582,12 @@ tests:
   # ==========================================================================
   - name: Surface file generation
     description: Generate surface from volume
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -sf ${t1w} 0.5 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -sf ${t1w} 0.5 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   - name: Surface threshold
     description: Set threshold for surface generation
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -sf ${t1w} 0.5 -sf_th 100 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -sf ${t1w} 0.5 -sf_th 100 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -595,7 +595,7 @@ tests:
   # ==========================================================================
   - name: Lattice ROI filter
     description: Apply lattice-shaped ROI filtering
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi ${t1w} 100 10000 -lattice 2 2 2 5 5 5 0 0 0 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -roi ${t1w} 100 10000 -lattice 2 2 2 5 5 5 0 0 0 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -603,7 +603,7 @@ tests:
   # ==========================================================================
   - name: KT threshold
     description: Filter by curvature times torsion
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -kt -1 1 -nr -disable_log 2>&1
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk -kt -1 1 -nr -disable_log 2>&1'
     expected_exit_code: 0
 
   # ==========================================================================
@@ -611,12 +611,12 @@ tests:
   # ==========================================================================
   - name: Missing track file error
     description: Test error handling for missing file
-    command: /opt/trackvis-0.6.1/track_vis nonexistent.trk -nr 2>&1 || echo "Expected error for missing file"
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis nonexistent.trk -nr 2>&1 || echo "Expected error for missing file"'
     expected_output_contains: "error"
 
   - name: Invalid option handling
     description: Test handling of invalid options
-    command: /opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk --invalid-option 2>&1 || echo "Invalid option handled"
+    command: bash -lc '/opt/trackvis-0.6.1/track_vis test_output/synthetic_tracks.trk --invalid-option 2>&1 || echo "Invalid option handled"'
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/tractseg/fulltest.yaml
+++ b/recipes/tractseg/fulltest.yaml
@@ -724,22 +724,22 @@ tests:
   # ==========================================================================
   - name: TractSeg weights directory
     description: Verify pretrained weights are installed
-    command: ls -la /opt/miniconda/share/TractSeg/weights/ | head -10
+    command: "bash -lc 'ls -la /opt/miniconda/share/TractSeg/weights/ | head -10'"
     expected_exit_code: 0
 
   - name: TractSeg bundle segmentation weights
     description: Check bundle segmentation model exists
-    command: ls /opt/miniconda/share/TractSeg/weights/ | grep tract_segmentation
+    command: "bash -lc 'ls /opt/miniconda/share/TractSeg/weights/ | grep tract_segmentation'"
     expected_exit_code: 0
 
   - name: TractSeg endings weights
     description: Check endings segmentation model exists
-    command: ls /opt/miniconda/share/TractSeg/weights/ | grep -i ending
+    command: "bash -lc 'ls /opt/miniconda/share/TractSeg/weights/ | grep -i ending'"
     expected_exit_code: 0
 
   - name: TractSeg TOM weights
     description: Check TOM model exists
-    command: ls /opt/miniconda/share/TractSeg/weights/ | grep peak_regression
+    command: "bash -lc 'ls /opt/miniconda/share/TractSeg/weights/ | grep peak_regression'"
     expected_exit_code: 0
 
   # ==========================================================================

--- a/recipes/vesselapp/fulltest.yaml
+++ b/recipes/vesselapp/fulltest.yaml
@@ -195,12 +195,7 @@ tests:
   # ==========================================================================
   - name: nibabel NIfTI reading
     description: Test nibabel can read demo NIfTI file
-    command: |
-      python3 << 'PYEOF'
-      import nibabel as nib
-      img = nib.load("/opt/vessel-app/demo_data/img_patch.nii.gz")
-      print("Image shape:", img.shape)
-      PYEOF
+    command: "bash -lc 'python3 << '\"'\"'PYEOF'\"'\"'\nimport nibabel as nib\nimg = nib.load(\"/opt/vessel-app/demo_data/img_patch.nii.gz\")\nprint(\"Image shape:\", img.shape)\nPYEOF'"
     expected_output_contains: "Image shape:"
 
   - name: nibabel get_fdata
@@ -218,13 +213,7 @@ tests:
 
   - name: nibabel affine extraction
     description: Test nibabel affine matrix extraction
-    command: |
-      python3 << 'PYEOF'
-      import nibabel as nib
-      img = nib.load("/opt/vessel-app/demo_data/img_patch.nii.gz")
-      affine = img.affine
-      print("Affine shape:", affine.shape)
-      PYEOF
+    command: "bash -lc 'python3 << '\"'\"'PYEOF'\"'\"'\nimport nibabel as nib\nimg = nib.load(\"/opt/vessel-app/demo_data/img_patch.nii.gz\")\naffine = img.affine\nprint(\"Affine shape:\", affine.shape)\nPYEOF'"
     expected_output_contains: "Affine shape: (4, 4)"
 
   - name: nibabel NIfTI creation and save
@@ -235,13 +224,7 @@ tests:
 
   - name: nibabel header inspection
     description: Test nibabel header reading
-    command: |
-      python3 << 'PYEOF'
-      import nibabel as nib
-      img = nib.load("/opt/vessel-app/demo_data/img_patch.nii.gz")
-      hdr = img.header
-      print("Data type:", hdr.get_data_dtype())
-      PYEOF
+    command: "bash -lc 'python3 << '\"'\"'PYEOF'\"'\"'\nimport nibabel as nib\nimg = nib.load(\"/opt/vessel-app/demo_data/img_patch.nii.gz\")\nhdr = img.header\nprint(\"Data type:\", hdr.get_data_dtype())\nPYEOF'"
     expected_output_contains: "Data type:"
 
   # ==========================================================================
@@ -277,72 +260,72 @@ tests:
   # ==========================================================================
   - name: VesselApp directory exists
     description: Verify vessel-app directory is present
-    command: ls -la /opt/vessel-app/backend/
+    command: "bash -lc 'ls -la /opt/vessel-app/backend/'"
     expected_output_contains: "serve.py"
 
   - name: VesselApp demo data exists
     description: Verify demo data files exist
-    command: ls -la /opt/vessel-app/demo_data/
+    command: "bash -lc 'ls -la /opt/vessel-app/demo_data/'"
     expected_output_contains: "img_patch.nii.gz"
 
   - name: VesselApp UNet model import
     description: Test importing 3D UNet model
-    command: "cd /opt/vessel-app/backend && python3 -c \"from implementations.dl_models.unet import UNet3D; model = UNet3D(filters=[16, 32, 64, 128], c_in=1, c_out=2); print('UNet3D created with', sum(p.numel() for p in model.parameters()), 'parameters')\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"from implementations.dl_models.unet import UNet3D; model = UNet3D(filters=[16, 32, 64, 128], c_in=1, c_out=2); print('\"'\"'UNet3D created with'\"'\"', sum(p.numel() for p in model.parameters()), '\"'\"'parameters'\"'\"')\"'"
     expected_output_contains: "UNet3D created with"
 
   - name: VesselApp ASPP CNN model import
     description: Test importing ASPP CNN model
-    command: "cd /opt/vessel-app/backend && python3 -c \"from implementations.dl_models.aspp_cnn import AsppCnn3D; model = AsppCnn3D(c=16, c_in=1, c_out=2, dilation_rates=[1, 2, 3, 5, 7]); print('AsppCnn3D created with', sum(p.numel() for p in model.parameters()), 'parameters')\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"from implementations.dl_models.aspp_cnn import AsppCnn3D; model = AsppCnn3D(c=16, c_in=1, c_out=2, dilation_rates=[1, 2, 3, 5, 7]); print('\"'\"'AsppCnn3D created with'\"'\"', sum(p.numel() for p in model.parameters()), '\"'\"'parameters'\"'\"')\"'"
     expected_output_contains: "AsppCnn3D created with"
 
   - name: VesselApp UNet forward pass
     description: Test UNet forward pass with random input
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_models.unet import UNet3D; model = UNet3D(filters=[16, 32, 64, 128], c_in=1, c_out=2); model.eval(); x = torch.randn(1, 1, 32, 32, 32); y = model(x); print('Output shape:', y.shape)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_models.unet import UNet3D; model = UNet3D(filters=[16, 32, 64, 128], c_in=1, c_out=2); model.eval(); x = torch.randn(1, 1, 32, 32, 32); y = model(x); print('\"'\"'Output shape:'\"'\"', y.shape)\"'"
     expected_output_contains: "Output shape: torch.Size([1, 2, 32, 32, 32])"
 
   - name: VesselApp ASPP CNN forward pass
     description: Test ASPP CNN forward pass with random input
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_models.aspp_cnn import AsppCnn3D; model = AsppCnn3D(c=16, c_in=1, c_out=2, dilation_rates=[1, 2, 3, 5, 7]); model.eval(); x = torch.randn(1, 1, 32, 32, 32); y = model(x); print('Output shape:', y.shape)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_models.aspp_cnn import AsppCnn3D; model = AsppCnn3D(c=16, c_in=1, c_out=2, dilation_rates=[1, 2, 3, 5, 7]); model.eval(); x = torch.randn(1, 1, 32, 32, 32); y = model(x); print('\"'\"'Output shape:'\"'\"', y.shape)\"'"
     expected_output_contains: "Output shape: torch.Size([1, 2, 32, 32, 32])"
 
   - name: VesselApp intensity standardization
     description: Test intensity standardization function
-    command: "cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.intensity import IntensityStandardisation; arr = np.random.rand(32, 32, 32) * 100 + 50; std = IntensityStandardisation(); result = std(arr); print('Mean:', round(result.mean(), 4), 'Std:', round(result.std(), 4))\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.intensity import IntensityStandardisation; arr = np.random.rand(32, 32, 32) * 100 + 50; std = IntensityStandardisation(); result = std(arr); print('\"'\"'Mean:'\"'\"', round(result.mean(), 4), '\"'\"'Std:'\"'\"', round(result.std(), 4))\"'"
     expected_output_contains: "Std: 1.0"
 
   - name: VesselApp simple thresholding
     description: Test simple thresholding segmentation
-    command: "cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.segmentation import SimpleThresholding; arr = np.random.rand(32, 32, 32) * 1000; thresh = SimpleThresholding(lower=500, upper=800); result = thresh(arr); print('Mask unique values:', np.unique(result))\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.segmentation import SimpleThresholding; arr = np.random.rand(32, 32, 32) * 1000; thresh = SimpleThresholding(lower=500, upper=800); result = thresh(arr); print('\"'\"'Mask unique values:'\"'\"', np.unique(result))\"'"
     expected_output_contains: "Mask unique values:"
 
   - name: VesselApp remove small objects
     description: Test small object removal function
-    command: "cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.cleanup import RemoveSmallObjectsFromBinaryArray; mask = np.zeros((32, 32, 32), dtype=np.uint8); mask[5:8, 5:8, 5:8] = 1; mask[15:25, 15:25, 15:25] = 1; cleanup = RemoveSmallObjectsFromBinaryArray(min_size=50); result = cleanup(mask); print('Cleaned mask sum:', result.sum())\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.cleanup import RemoveSmallObjectsFromBinaryArray; mask = np.zeros((32, 32, 32), dtype=np.uint8); mask[5:8, 5:8, 5:8] = 1; mask[15:25, 15:25, 15:25] = 1; cleanup = RemoveSmallObjectsFromBinaryArray(min_size=50); result = cleanup(mask); print('\"'\"'Cleaned mask sum:'\"'\"', result.sum())\"'"
     expected_output_contains: "Cleaned mask sum:"
 
   - name: VesselApp operation pipeline
     description: Test operation pipeline chaining
-    command: "cd /opt/vessel-app/backend && python3 -c \"from implementations.functions.operation import Operation; from implementations.functions.intensity import IntensityStandardisation; import numpy as np; op = Operation(IntensityStandardisation()); arr = np.random.rand(16, 16, 16) * 100; result = op(arr); print('Pipeline executed, result shape:', result.shape)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"from implementations.functions.operation import Operation; from implementations.functions.intensity import IntensityStandardisation; import numpy as np; op = Operation(IntensityStandardisation()); arr = np.random.rand(16, 16, 16) * 100; result = op(arr); print('\"'\"'Pipeline executed, result shape:'\"'\"', result.shape)\"'"
     expected_output_contains: "Pipeline executed, result shape: (16, 16, 16)"
 
   - name: VesselApp torch tensor conversion
     description: Test numpy to torch tensor conversion
-    command: "cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.torch_ops import NumpyArray2TorchTensor; arr = np.random.rand(16, 16, 16).astype(np.float32); converter = NumpyArray2TorchTensor(); result = converter(arr); print('Tensor type:', type(result).__name__, 'dtype:', result.dtype)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from implementations.functions.torch_ops import NumpyArray2TorchTensor; arr = np.random.rand(16, 16, 16).astype(np.float32); converter = NumpyArray2TorchTensor(); result = converter(arr); print('\"'\"'Tensor type:'\"'\"', type(result).__name__, '\"'\"'dtype:'\"'\"', result.dtype)\"'"
     expected_output_contains: "Tensor type: Tensor"
 
   - name: VesselApp WHD to NCWHD conversion
     description: Test tensor dimension expansion
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.functions.torch_ops import WHDTensor2NCWHD; tensor = torch.randn(16, 16, 16); converter = WHDTensor2NCWHD(); result = converter(tensor); print('Expanded shape:', result.shape)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.functions.torch_ops import WHDTensor2NCWHD; tensor = torch.randn(16, 16, 16); converter = WHDTensor2NCWHD(); result = converter(tensor); print('\"'\"'Expanded shape:'\"'\"', result.shape)\"'"
     expected_output_contains: "Expanded shape: torch.Size([1, 1, 16, 16, 16])"
 
   - name: VesselApp tensor interpolation
     description: Test 3D tensor interpolation
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.functions.torch_ops import NCWHDTensorInterpolation; tensor = torch.randn(1, 1, 16, 16, 16); interp = NCWHDTensorInterpolation(target_size=[32, 32, 32], modes=['trilinear']); result = interp(tensor); print('Interpolated shape:', result.shape)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.functions.torch_ops import NCWHDTensorInterpolation; tensor = torch.randn(1, 1, 16, 16, 16); interp = NCWHDTensorInterpolation(target_size=[32, 32, 32], modes=['\"'\"'trilinear'\"'\"']); result = interp(tensor); print('\"'\"'Interpolated shape:'\"'\"', result.shape)\"'"
     expected_output_contains: "Interpolated shape: torch.Size([1, 1, 32, 32, 32])"
 
   - name: VesselApp one-hot encoding
     description: Test one-hot encoding for segmentation labels
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.functions.torch_ops import N1WHDTensor2NCWHDOnehot; tensor = torch.randint(0, 2, (1, 1, 8, 8, 8)); onehot = N1WHDTensor2NCWHDOnehot(num_classes=2); result = onehot(tensor); print('One-hot shape:', result.shape)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.functions.torch_ops import N1WHDTensor2NCWHDOnehot; tensor = torch.randint(0, 2, (1, 1, 8, 8, 8)); onehot = N1WHDTensor2NCWHDOnehot(num_classes=2); result = onehot(tensor); print('\"'\"'One-hot shape:'\"'\"', result.shape)\"'"
     expected_output_contains: "One-hot shape: torch.Size([1, 2, 8, 8, 8])"
 
   # ==========================================================================
@@ -350,12 +333,12 @@ tests:
   # ==========================================================================
   - name: VesselApp Dice coefficient computation
     description: Test per-channel Dice score computation
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_training_pipelins.losses import compute_per_channel_dice; pred = torch.rand(2, 2, 8, 8, 8); target = torch.randint(0, 2, (2, 2, 8, 8, 8)).float(); dice = compute_per_channel_dice(pred, target); print('Dice score:', round(dice.item(), 4))\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_training_pipelins.losses import compute_per_channel_dice; pred = torch.rand(2, 2, 8, 8, 8); target = torch.randint(0, 2, (2, 2, 8, 8, 8)).float(); dice = compute_per_channel_dice(pred, target); print('\"'\"'Dice score:'\"'\"', round(dice.item(), 4))\"'"
     expected_output_contains: "Dice score:"
 
   - name: VesselApp accuracy computation
     description: Test accuracy metric computation
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_training_pipelins.losses import compute_acc; pred = torch.tensor([1, 0, 1, 1]); target = torch.tensor([1, 0, 0, 1]); acc = compute_acc(pred, target); print('Accuracy:', round(acc.item(), 4))\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from implementations.dl_training_pipelins.losses import compute_acc; pred = torch.tensor([1, 0, 1, 1]); target = torch.tensor([1, 0, 0, 1]); acc = compute_acc(pred, target); print('\"'\"'Accuracy:'\"'\"', round(acc.item(), 4))\"'"
     expected_output_contains: "Accuracy: 0.75"
 
   # ==========================================================================
@@ -363,17 +346,17 @@ tests:
   # ==========================================================================
   - name: VesselApp save as nifti
     description: Test saving numpy array as NIfTI
-    command: "cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from utilities.img_utils import save_as_nifti; data = np.random.rand(16, 16, 16).astype(np.float32); save_as_nifti('/tmp/test_vessel_output.nii.gz', data); print('NIfTI saved successfully')\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from utilities.img_utils import save_as_nifti; data = np.random.rand(16, 16, 16).astype(np.float32); save_as_nifti('\"'\"'/tmp/test_vessel_output.nii.gz'\"'\"', data); print('\"'\"'NIfTI saved successfully'\"'\"')\"'"
     expected_output_contains: "NIfTI saved successfully"
 
   - name: VesselApp save with middle slice
     description: Test saving NIfTI with middle slice visualization
-    command: "cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from utilities.img_utils import save_as_nifti; data = np.random.rand(16, 16, 16).astype(np.float32); mid_dir, mip_dir, nii_path = save_as_nifti('/tmp/test_vessel_mid.nii.gz', data, middle_slice_index=2); print('Middle slice saved:', mid_dir is not None)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import numpy as np; from utilities.img_utils import save_as_nifti; data = np.random.rand(16, 16, 16).astype(np.float32); mid_dir, mip_dir, nii_path = save_as_nifti('\"'\"'/tmp/test_vessel_mid.nii.gz'\"'\"', data, middle_slice_index=2); print('\"'\"'Middle slice saved:'\"'\"', mid_dir is not None)\"'"
     expected_output_contains: "Middle slice saved: True"
 
   - name: VesselApp torch tensor to nifti
     description: Test saving PyTorch tensor as NIfTI
-    command: "cd /opt/vessel-app/backend && python3 -c \"import torch; from utilities.img_utils import save_as_nifti; data = torch.rand(16, 16, 16); save_as_nifti('/tmp/test_vessel_torch.nii.gz', data); print('Torch tensor saved as NIfTI successfully')\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"import torch; from utilities.img_utils import save_as_nifti; data = torch.rand(16, 16, 16); save_as_nifti('\"'\"'/tmp/test_vessel_torch.nii.gz'\"'\"', data); print('\"'\"'Torch tensor saved as NIfTI successfully'\"'\"')\"'"
     expected_output_contains: "Torch tensor saved as NIfTI successfully"
 
   # ==========================================================================
@@ -381,12 +364,12 @@ tests:
   # ==========================================================================
   - name: VesselApp data pipeline import
     description: Test data pipeline module import
-    command: cd /opt/vessel-app/backend && python3 -c "from implementations.dl_data_pipelines.single_sample_patch_based import SingleSamplePatchBased; print('SingleSamplePatchBased imported successfully')"
+    command: bash -lc 'cd /opt/vessel-app/backend && python3 -c "from implementations.dl_data_pipelines.single_sample_patch_based import SingleSamplePatchBased; print('\''SingleSamplePatchBased imported successfully'\'')"'
     expected_output_contains: "SingleSamplePatchBased imported successfully"
 
   - name: VesselApp training pipeline import
     description: Test training pipeline module import
-    command: cd /opt/vessel-app/backend && python3 -c "from implementations.dl_training_pipelins.standard_segmentation import StandardSegmentation; print('StandardSegmentation imported successfully')"
+    command: bash -lc 'cd /opt/vessel-app/backend && python3 -c "from implementations.dl_training_pipelins.standard_segmentation import StandardSegmentation; print('\''StandardSegmentation imported successfully'\'')"'
     expected_output_contains: "StandardSegmentation imported successfully"
 
   # ==========================================================================
@@ -394,17 +377,17 @@ tests:
   # ==========================================================================
   - name: VesselApp API endpoints
     description: Test API endpoint constants
-    command: "cd /opt/vessel-app/backend && python3 -c \"from apis.register import ENDPOINTS; print('Models endpoint:', ENDPOINTS.get_models)\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"from apis.register import ENDPOINTS; print('\"'\"'Models endpoint:'\"'\"', ENDPOINTS.get_models)\"'"
     expected_output_contains: "Models endpoint: /get_models"
 
   - name: VesselApp exposed objects
     description: Test exposed objects registry
-    command: "cd /opt/vessel-app/backend && python3 -c \"from apis.export import get_exposed_objects, exposed_objects; from implementations import *; funcs = get_exposed_objects('/get_functions'); print('Number of exposed functions:', len(funcs))\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"from apis.export import get_exposed_objects, exposed_objects; from implementations import *; funcs = get_exposed_objects('\"'\"'/get_functions'\"'\"'); print('\"'\"'Number of exposed functions:'\"'\"', len(funcs))\"'"
     expected_output_contains: "Number of exposed functions:"
 
   - name: VesselApp get models
     description: Test getting exposed models
-    command: "cd /opt/vessel-app/backend && python3 -c \"from apis.export import get_exposed_objects; from implementations import *; models = get_exposed_objects('/get_models'); print('Number of exposed models:', len(models))\""
+    command: "bash -lc 'cd /opt/vessel-app/backend && python3 -c \"from apis.export import get_exposed_objects; from implementations import *; models = get_exposed_objects('\"'\"'/get_models'\"'\"'); print('\"'\"'Number of exposed models:'\"'\"', len(models))\"'"
     expected_output_contains: "Number of exposed models:"
 
   # ==========================================================================
@@ -458,7 +441,7 @@ tests:
   - name: End-to-end intensity preprocessing
     description: Test complete intensity preprocessing pipeline (uses synthetic data - demo data has CRC corruption)
     command: |
-      cd /opt/vessel-app/backend && python3 << 'PYEOF'
+      bash -lc 'cd /opt/vessel-app/backend && python3 << '\''PYEOF'\''
       import numpy as np
       from implementations.functions.intensity import IntensityStandardisation
 
@@ -471,13 +454,13 @@ tests:
 
       print("Original mean:", round(data.mean(), 2), "std:", round(data.std(), 2))
       print("Normalized mean:", round(normalized.mean(), 4), "std:", round(normalized.std(), 4))
-      PYEOF
+      PYEOF'
     expected_output_contains: "Normalized mean:"
 
   - name: End-to-end thresholding pipeline
     description: Test complete thresholding segmentation (uses synthetic data - demo data has CRC corruption)
     command: |
-      cd /opt/vessel-app/backend && python3 << 'PYEOF'
+      bash -lc 'cd /opt/vessel-app/backend && python3 << '\''PYEOF'\''
       import numpy as np
       from implementations.functions.segmentation import SimpleThresholding
 
@@ -494,13 +477,13 @@ tests:
 
       print("Mask shape:", mask.shape)
       print("Vessel voxels:", int(mask.sum()))
-      PYEOF
+      PYEOF'
     expected_output_contains: "Mask shape:"
 
   - name: End-to-end model inference
     description: Test complete model inference on demo data
     command: |
-      cd /opt/vessel-app/backend && python3 << 'PYEOF'
+      bash -lc 'cd /opt/vessel-app/backend && python3 << '\''PYEOF'\''
       import torch
       import nibabel as nib
       import numpy as np
@@ -521,7 +504,7 @@ tests:
       print("Input shape:", tuple(x.shape))
       print("Output shape:", tuple(output.shape))
       print("Prediction shape:", tuple(pred.shape))
-      PYEOF
+      PYEOF'
     expected_output_contains: "Prediction shape: (1, 32, 32, 32)"
 
 cleanup:

--- a/recipes/vesselboost/fulltest.yaml
+++ b/recipes/vesselboost/fulltest.yaml
@@ -63,22 +63,22 @@ tests:
 
   - name: prediction.py help
     description: Verify prediction.py script runs and shows help
-    command: python /opt/VesselBoost/prediction.py --help
+    command: "bash -lc 'python /opt/VesselBoost/prediction.py --help'"
     expected_output_contains: "VesselBoost prediction arguments"
 
   - name: test_time_adaptation.py help
     description: Verify test_time_adaptation.py script runs and shows help
-    command: python /opt/VesselBoost/test_time_adaptation.py --help
+    command: "bash -lc 'python /opt/VesselBoost/test_time_adaptation.py --help'"
     expected_output_contains: "VesselBoost test time adaptation arguments"
 
   - name: boost.py help
     description: Verify boost.py script runs and shows help
-    command: python /opt/VesselBoost/boost.py --help
+    command: "bash -lc 'python /opt/VesselBoost/boost.py --help'"
     expected_output_contains: "VesselBoost training arguments"
 
   - name: train.py help
     description: Verify train.py script runs and shows help
-    command: python /opt/VesselBoost/train.py --help
+    command: "bash -lc 'python /opt/VesselBoost/train.py --help'"
     expected_output_contains: "VesselBoost training arguments"
 
   # ==========================================================================
@@ -86,17 +86,17 @@ tests:
   # ==========================================================================
   - name: Verify manual_0429 model exists
     description: Check that the manual_0429 pre-trained model is available
-    command: ls -la /opt/VesselBoost/saved_models/manual_0429
+    command: "bash -lc 'ls -la /opt/VesselBoost/saved_models/manual_0429'"
     expected_exit_code: 0
 
   - name: Verify omelette1_0429 model exists
     description: Check that the omelette1_0429 pre-trained model is available
-    command: ls -la /opt/VesselBoost/saved_models/omelette1_0429
+    command: "bash -lc 'ls -la /opt/VesselBoost/saved_models/omelette1_0429'"
     expected_exit_code: 0
 
   - name: Verify omelette2_0429 model exists
     description: Check that the omelette2_0429 pre-trained model is available
-    command: ls -la /opt/VesselBoost/saved_models/omelette2_0429
+    command: "bash -lc 'ls -la /opt/VesselBoost/saved_models/omelette2_0429'"
     expected_exit_code: 0
 
   # ==========================================================================
@@ -129,19 +129,19 @@ tests:
   - name: Import VesselBoost utils
     description: Verify VesselBoost utility modules can be imported
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       from utils import preprocess_procedure, make_prediction
-      print('VesselBoost utils imported successfully')
-      "
+      print('\''VesselBoost utils imported successfully'\'')
+      "'
     expected_output_contains: "VesselBoost utils imported successfully"
 
   - name: Import VesselBoost UNet
     description: Verify VesselBoost UNet model can be imported
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       from models.unet_3d import Unet
-      print('Unet model imported successfully')
-      "
+      print('\''Unet model imported successfully'\'')
+      "'
     expected_output_contains: "Unet model imported successfully"
 
   # ==========================================================================
@@ -149,44 +149,19 @@ tests:
   # ==========================================================================
   - name: Prediction with manual_0429 model (no preprocessing)
     description: Run vessel segmentation prediction using manual_0429 pretrained model with prep_mode=4 (no preprocessing)
-    command: |
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'python /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred
 
   - name: Prediction with omelette1_0429 model (no preprocessing)
     description: Run vessel segmentation prediction using omelette1_0429 pretrained model
-    command: |
-      rm -rf test_output/vesselboost/output_pred_omelette1 && \
-      mkdir -p test_output/vesselboost/output_pred_omelette1 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_omelette1 \
-        --pretrained /opt/VesselBoost/saved_models/omelette1_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_omelette1 && \\\nmkdir -p test_output/vesselboost/output_pred_omelette1 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_omelette1 \\\n  --pretrained /opt/VesselBoost/saved_models/omelette1_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_omelette1
 
   - name: Prediction with omelette2_0429 model (no preprocessing)
     description: Run vessel segmentation prediction using omelette2_0429 pretrained model
-    command: |
-      rm -rf test_output/vesselboost/output_pred_omelette2 && \
-      mkdir -p test_output/vesselboost/output_pred_omelette2 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_omelette2 \
-        --pretrained /opt/VesselBoost/saved_models/omelette2_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_omelette2 && \\\nmkdir -p test_output/vesselboost/output_pred_omelette2 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_omelette2 \\\n  --pretrained /opt/VesselBoost/saved_models/omelette2_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_omelette2
 
@@ -195,46 +170,19 @@ tests:
   # ==========================================================================
   - name: Prediction with lower threshold (thresh=0.05)
     description: Run prediction with lower binary threshold for more sensitive detection
-    command: |
-      rm -rf test_output/vesselboost/output_pred_thresh05 && \
-      mkdir -p test_output/vesselboost/output_pred_thresh05 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_thresh05 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.05 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_thresh05 && \\\nmkdir -p test_output/vesselboost/output_pred_thresh05 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_thresh05 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.05 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_thresh05
 
   - name: Prediction with higher threshold (thresh=0.3)
     description: Run prediction with higher binary threshold for more specific detection
-    command: |
-      rm -rf test_output/vesselboost/output_pred_thresh30 && \
-      mkdir -p test_output/vesselboost/output_pred_thresh30 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_thresh30 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.3 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_thresh30 && \\\nmkdir -p test_output/vesselboost/output_pred_thresh30 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_thresh30 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.3 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_thresh30
 
   - name: Prediction with very high threshold (thresh=0.5)
     description: Run prediction with very high binary threshold
-    command: |
-      rm -rf test_output/vesselboost/output_pred_thresh50 && \
-      mkdir -p test_output/vesselboost/output_pred_thresh50 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_thresh50 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.5 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_thresh50 && \\\nmkdir -p test_output/vesselboost/output_pred_thresh50 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_thresh50 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.5 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_thresh50
 
@@ -243,46 +191,19 @@ tests:
   # ==========================================================================
   - name: Prediction with no connected component filtering (cc=0)
     description: Run prediction without connected component denoising
-    command: |
-      rm -rf test_output/vesselboost/output_pred_cc0 && \
-      mkdir -p test_output/vesselboost/output_pred_cc0 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_cc0 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 0
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_cc0 && \\\nmkdir -p test_output/vesselboost/output_pred_cc0 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_cc0 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 0'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_cc0
 
   - name: Prediction with higher cc threshold (cc=50)
     description: Run prediction with higher connected component threshold for more aggressive denoising
-    command: |
-      rm -rf test_output/vesselboost/output_pred_cc50 && \
-      mkdir -p test_output/vesselboost/output_pred_cc50 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_cc50 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 50
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_cc50 && \\\nmkdir -p test_output/vesselboost/output_pred_cc50 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_cc50 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 50'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_cc50
 
   - name: Prediction with very high cc threshold (cc=100)
     description: Run prediction with very high connected component threshold
-    command: |
-      rm -rf test_output/vesselboost/output_pred_cc100 && \
-      mkdir -p test_output/vesselboost/output_pred_cc100 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_cc100 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 100
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_cc100 && \\\nmkdir -p test_output/vesselboost/output_pred_cc100 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_cc100 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 100'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_cc100
 
@@ -291,54 +212,21 @@ tests:
   # ==========================================================================
   - name: Prediction with bias field correction only (prep_mode=1)
     description: Run prediction with N4 bias field correction preprocessing
-    command: |
-      rm -rf test_output/vesselboost/output_pred_prep1 test_output/vesselboost/preprocessed_prep1 && \
-      mkdir -p test_output/vesselboost/output_pred_prep1 && \
-      mkdir -p test_output/vesselboost/preprocessed_prep1 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --ps_path test_output/vesselboost/preprocessed_prep1 \
-        --out_path test_output/vesselboost/output_pred_prep1 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 1 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_prep1 test_output/vesselboost/preprocessed_prep1 && \\\nmkdir -p test_output/vesselboost/output_pred_prep1 && \\\nmkdir -p test_output/vesselboost/preprocessed_prep1 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --ps_path test_output/vesselboost/preprocessed_prep1 \\\n  --out_path test_output/vesselboost/output_pred_prep1 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 1 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_prep1
 
   - name: Prediction with denoising only (prep_mode=2)
     description: Run prediction with denoising preprocessing
     timeout: 300
-    command: |
-      rm -rf test_output/vesselboost/output_pred_prep2 test_output/vesselboost/preprocessed_prep2 && \
-      mkdir -p test_output/vesselboost/output_pred_prep2 && \
-      mkdir -p test_output/vesselboost/preprocessed_prep2 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --ps_path test_output/vesselboost/preprocessed_prep2 \
-        --out_path test_output/vesselboost/output_pred_prep2 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 2 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_prep2 test_output/vesselboost/preprocessed_prep2 && \\\nmkdir -p test_output/vesselboost/output_pred_prep2 && \\\nmkdir -p test_output/vesselboost/preprocessed_prep2 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --ps_path test_output/vesselboost/preprocessed_prep2 \\\n  --out_path test_output/vesselboost/output_pred_prep2 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 2 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_prep2
 
   - name: Prediction with bias field correction and denoising (prep_mode=3)
     description: Run prediction with both N4 bias field correction and denoising
     timeout: 300
-    command: |
-      rm -rf test_output/vesselboost/output_pred_prep3 test_output/vesselboost/preprocessed_prep3 && \
-      mkdir -p test_output/vesselboost/output_pred_prep3 && \
-      mkdir -p test_output/vesselboost/preprocessed_prep3 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --ps_path test_output/vesselboost/preprocessed_prep3 \
-        --out_path test_output/vesselboost/output_pred_prep3 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 3 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_prep3 test_output/vesselboost/preprocessed_prep3 && \\\nmkdir -p test_output/vesselboost/output_pred_prep3 && \\\nmkdir -p test_output/vesselboost/preprocessed_prep3 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --ps_path test_output/vesselboost/preprocessed_prep3 \\\n  --out_path test_output/vesselboost/output_pred_prep3 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 3 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_prep3
 
@@ -347,16 +235,7 @@ tests:
   # ==========================================================================
   - name: Prediction on T2-weighted image
     description: Run vessel segmentation on T2-weighted image
-    command: |
-      rm -rf test_output/vesselboost/output_pred_t2 && \
-      mkdir -p test_output/vesselboost/output_pred_t2 && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t2 \
-        --out_path test_output/vesselboost/output_pred_t2 \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_t2 && \\\nmkdir -p test_output/vesselboost/output_pred_t2 && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t2 \\\n  --out_path test_output/vesselboost/output_pred_t2 \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_t2
 
@@ -383,38 +262,14 @@ tests:
 
   - name: Boost module training (minimal epochs)
     description: Test boost module with minimal epochs for quick verification
-    command: |
-      rm -rf test_output/vesselboost/output_boost_test test_output/vesselboost/models/boost_test && \
-      mkdir -p test_output/vesselboost/output_boost_test && \
-      python /opt/VesselBoost/boost.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --lb_path test_output/vesselboost/labels \
-        --out_path test_output/vesselboost/output_boost_test \
-        --outmo test_output/vesselboost/models/boost_test \
-        --prep_mode 4 \
-        --ep 2 \
-        --lr 1e-3 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_boost_test test_output/vesselboost/models/boost_test && \\\nmkdir -p test_output/vesselboost/output_boost_test && \\\npython /opt/VesselBoost/boost.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --lb_path test_output/vesselboost/labels \\\n  --out_path test_output/vesselboost/output_boost_test \\\n  --outmo test_output/vesselboost/models/boost_test \\\n  --prep_mode 4 \\\n  --ep 2 \\\n  --lr 1e-3 \\\n  --thresh 0.1 \\\n  --cc 10'"
     depends_on: Create dummy label for boost testing
     validate:
       - output_exists: ${output_dir}/vesselboost/output_boost_test
 
   - name: Boost module with different learning rate
     description: Test boost module with lower learning rate
-    command: |
-      rm -rf test_output/vesselboost/output_boost_lr test_output/vesselboost/models/boost_lr && \
-      mkdir -p test_output/vesselboost/output_boost_lr && \
-      python /opt/VesselBoost/boost.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --lb_path test_output/vesselboost/labels \
-        --out_path test_output/vesselboost/output_boost_lr \
-        --outmo test_output/vesselboost/models/boost_lr \
-        --prep_mode 4 \
-        --ep 2 \
-        --lr 1e-4 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_boost_lr test_output/vesselboost/models/boost_lr && \\\nmkdir -p test_output/vesselboost/output_boost_lr && \\\npython /opt/VesselBoost/boost.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --lb_path test_output/vesselboost/labels \\\n  --out_path test_output/vesselboost/output_boost_lr \\\n  --outmo test_output/vesselboost/models/boost_lr \\\n  --prep_mode 4 \\\n  --ep 2 \\\n  --lr 1e-4 \\\n  --thresh 0.1 \\\n  --cc 10'"
     depends_on: Create dummy label for boost testing
     validate:
       - output_exists: ${output_dir}/vesselboost/output_boost_lr
@@ -424,15 +279,7 @@ tests:
   # ==========================================================================
   - name: Train module basic functionality
     description: Test train.py module with minimal epochs
-    command: |
-      rm -rf test_output/vesselboost/models/train_test && \
-      python /opt/VesselBoost/train.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --lb_path test_output/vesselboost/labels \
-        --outmo test_output/vesselboost/models/train_test \
-        --prep_mode 4 \
-        --ep 2 \
-        --lr 1e-3
+    command: "bash -lc 'rm -rf test_output/vesselboost/models/train_test && \\\npython /opt/VesselBoost/train.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --lb_path test_output/vesselboost/labels \\\n  --outmo test_output/vesselboost/models/train_test \\\n  --prep_mode 4 \\\n  --ep 2 \\\n  --lr 1e-3'"
     depends_on: Create dummy label for boost testing
     expected_exit_code: 0
 
@@ -441,73 +288,26 @@ tests:
   # ==========================================================================
   - name: Test-time adaptation without proxy (minimal epochs)
     description: Test TTA module without providing proxy segmentation
-    command: |
-      rm -rf test_output/vesselboost/output_tta_noproxy && \
-      mkdir -p test_output/vesselboost/output_tta_noproxy && \
-      python /opt/VesselBoost/test_time_adaptation.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_tta_noproxy \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --ep 2 \
-        --lr 1e-3 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_tta_noproxy && \\\nmkdir -p test_output/vesselboost/output_tta_noproxy && \\\npython /opt/VesselBoost/test_time_adaptation.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_tta_noproxy \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --ep 2 \\\n  --lr 1e-3 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_tta_noproxy
 
   - name: Test-time adaptation with proxy segmentation
     description: Test TTA module with provided proxy segmentation
-    command: |
-      rm -rf test_output/vesselboost/output_tta_proxy && \
-      mkdir -p test_output/vesselboost/output_tta_proxy && \
-      python /opt/VesselBoost/test_time_adaptation.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --px_path test_output/vesselboost/labels \
-        --out_path test_output/vesselboost/output_tta_proxy \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --ep 2 \
-        --lr 1e-3 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_tta_proxy && \\\nmkdir -p test_output/vesselboost/output_tta_proxy && \\\npython /opt/VesselBoost/test_time_adaptation.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --px_path test_output/vesselboost/labels \\\n  --out_path test_output/vesselboost/output_tta_proxy \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --ep 2 \\\n  --lr 1e-3 \\\n  --thresh 0.1 \\\n  --cc 10'"
     depends_on: Create dummy label for boost testing
     validate:
       - output_exists: ${output_dir}/vesselboost/output_tta_proxy
 
   - name: Test-time adaptation with preprocessing
     description: Test TTA module with bias field correction
-    command: |
-      rm -rf test_output/vesselboost/output_tta_preproc test_output/vesselboost/preprocessed_tta && \
-      mkdir -p test_output/vesselboost/output_tta_preproc && \
-      mkdir -p test_output/vesselboost/preprocessed_tta && \
-      python /opt/VesselBoost/test_time_adaptation.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --ps_path test_output/vesselboost/preprocessed_tta \
-        --out_path test_output/vesselboost/output_tta_preproc \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 1 \
-        --ep 2 \
-        --lr 1e-3 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_tta_preproc test_output/vesselboost/preprocessed_tta && \\\nmkdir -p test_output/vesselboost/output_tta_preproc && \\\nmkdir -p test_output/vesselboost/preprocessed_tta && \\\npython /opt/VesselBoost/test_time_adaptation.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --ps_path test_output/vesselboost/preprocessed_tta \\\n  --out_path test_output/vesselboost/output_tta_preproc \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 1 \\\n  --ep 2 \\\n  --lr 1e-3 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_tta_preproc
 
   - name: Test-time adaptation with different model
     description: Test TTA module with omelette1 model
-    command: |
-      rm -rf test_output/vesselboost/output_tta_omelette && \
-      mkdir -p test_output/vesselboost/output_tta_omelette && \
-      python /opt/VesselBoost/test_time_adaptation.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_tta_omelette \
-        --pretrained /opt/VesselBoost/saved_models/omelette1_0429 \
-        --prep_mode 4 \
-        --ep 2 \
-        --lr 1e-3 \
-        --thresh 0.1 \
-        --cc 10
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_tta_omelette && \\\nmkdir -p test_output/vesselboost/output_tta_omelette && \\\npython /opt/VesselBoost/test_time_adaptation.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_tta_omelette \\\n  --pretrained /opt/VesselBoost/saved_models/omelette1_0429 \\\n  --prep_mode 4 \\\n  --ep 2 \\\n  --lr 1e-3 \\\n  --thresh 0.1 \\\n  --cc 10'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_tta_omelette
 
@@ -517,20 +317,20 @@ tests:
   - name: UNet3D model architecture verification
     description: Verify Unet model can be instantiated with default parameters
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       import torch
       from models.unet_3d import Unet
       model = Unet(1, 1, 16)
-      print(f'Model created successfully')
-      print(f'Total parameters: {sum(p.numel() for p in model.parameters())}')
-      print(f'Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}')
-      "
+      print(f'\''Model created successfully'\'')
+      print(f'\''Total parameters: {sum(p.numel() for p in model.parameters())}'\'')
+      print(f'\''Trainable parameters: {sum(p.numel() for p in model.parameters() if p.requires_grad)}'\'')
+      "'
     expected_output_contains: "Model created successfully"
 
   - name: UNet3D forward pass test
     description: Verify Unet model can perform forward pass
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       import torch
       from models.unet_3d import Unet
       model = Unet(1, 1, 16)
@@ -538,24 +338,24 @@ tests:
       dummy_input = torch.randn(1, 1, 64, 64, 64)
       with torch.no_grad():
           output = model(dummy_input)
-      print(f'Input shape: {dummy_input.shape}')
-      print(f'Output shape: {output.shape}')
-      print('Forward pass successful')
-      "
+      print(f'\''Input shape: {dummy_input.shape}'\'')
+      print(f'\''Output shape: {output.shape}'\'')
+      print('\''Forward pass successful'\'')
+      "'
     expected_output_contains: "Forward pass successful"
 
   - name: Load pretrained model weights
     description: Verify pretrained model weights can be loaded
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       import torch
       from models.unet_3d import Unet
       model = Unet(1, 1, 16)
-      state_dict = torch.load('/opt/VesselBoost/saved_models/manual_0429', map_location='cpu')
+      state_dict = torch.load('\''/opt/VesselBoost/saved_models/manual_0429'\'', map_location='\''cpu'\'')
       model.load_state_dict(state_dict)
-      print('Pretrained model loaded successfully')
-      print(f'Model device: cpu')
-      "
+      print('\''Pretrained model loaded successfully'\'')
+      print(f'\''Model device: cpu'\'')
+      "'
     expected_output_contains: "Pretrained model loaded successfully"
 
   # ==========================================================================
@@ -581,10 +381,10 @@ tests:
   - name: Verify preprocessing utilities
     description: Test preprocessing function availability
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       from utils.module_utils import preprocess_procedure
-      print('Preprocessing utilities available')
-      "
+      print('\''Preprocessing utilities available'\'')
+      "'
     expected_output_contains: "Preprocessing utilities available"
 
   # ==========================================================================
@@ -639,7 +439,7 @@ tests:
   - name: Memory usage estimation
     description: Estimate memory requirements for model inference
     command: |
-      cd /opt/VesselBoost && python -c "
+      bash -lc 'cd /opt/VesselBoost && python -c "
       import torch
       from models.unet_3d import Unet
 
@@ -649,10 +449,10 @@ tests:
       buffer_size = sum(b.nelement() * b.element_size() for b in model.buffers())
       total_size_mb = (param_size + buffer_size) / (1024 * 1024)
 
-      print(f'Model size: {total_size_mb:.2f} MB')
-      print(f'Recommended minimum RAM: {total_size_mb * 4:.0f} MB')
-      print('Memory estimation complete')
-      "
+      print(f'\''Model size: {total_size_mb:.2f} MB'\'')
+      print(f'\''Recommended minimum RAM: {total_size_mb * 4:.0f} MB'\'')
+      print('\''Memory estimation complete'\'')
+      "'
     expected_output_contains: "Memory estimation complete"
 
   # ==========================================================================
@@ -660,16 +460,7 @@ tests:
   # ==========================================================================
   - name: Prediction with combined parameters
     description: Test prediction with various combined parameters
-    command: |
-      rm -rf test_output/vesselboost/output_pred_combined && \
-      mkdir -p test_output/vesselboost/output_pred_combined && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_combined \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 \
-        --thresh 0.15 \
-        --cc 25
+    command: "bash -lc 'rm -rf test_output/vesselboost/output_pred_combined && \\\nmkdir -p test_output/vesselboost/output_pred_combined && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_combined \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 \\\n  --thresh 0.15 \\\n  --cc 25'"
     validate:
       - output_exists: ${output_dir}/vesselboost/output_pred_combined
 
@@ -678,23 +469,12 @@ tests:
   # ==========================================================================
   - name: Invalid model path handling
     description: Test error handling for invalid pretrained model path
-    command: |
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/input_t1w \
-        --out_path test_output/vesselboost/output_pred_invalid \
-        --pretrained /nonexistent/model/path \
-        --prep_mode 4 2>&1 || echo "Expected error occurred"
+    command: "bash -lc 'python /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/input_t1w \\\n  --out_path test_output/vesselboost/output_pred_invalid \\\n  --pretrained /nonexistent/model/path \\\n  --prep_mode 4 2>&1 || echo \"Expected error occurred\"'"
     expected_output_contains: "error"
 
   - name: Empty input directory handling
     description: Test error handling for empty input directory
-    command: |
-      mkdir -p test_output/vesselboost/empty_input && \
-      python /opt/VesselBoost/prediction.py \
-        --ds_path test_output/vesselboost/empty_input \
-        --out_path test_output/vesselboost/output_pred_empty \
-        --pretrained /opt/VesselBoost/saved_models/manual_0429 \
-        --prep_mode 4 2>&1 || echo "Expected error or empty run occurred"
+    command: "bash -lc 'mkdir -p test_output/vesselboost/empty_input && \\\npython /opt/VesselBoost/prediction.py \\\n  --ds_path test_output/vesselboost/empty_input \\\n  --out_path test_output/vesselboost/output_pred_empty \\\n  --pretrained /opt/VesselBoost/saved_models/manual_0429 \\\n  --prep_mode 4 2>&1 || echo \"Expected error or empty run occurred\"'"
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/vesselvio/fulltest.yaml
+++ b/recipes/vesselvio/fulltest.yaml
@@ -301,62 +301,62 @@ tests:
   # ==========================================================================
   - name: VesselVio image_processing module
     description: Test VesselVio image processing module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import image_processing as ImProc; print('image_processing imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import image_processing as ImProc; print('\"'\"'image_processing imported successfully'\"'\"')\"'"
     expected_output_contains: "image_processing imported successfully"
 
   - name: VesselVio volume_processing module
     description: Test VesselVio volume processing module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import volume_processing as VolProc; print('volume_processing imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import volume_processing as VolProc; print('\"'\"'volume_processing imported successfully'\"'\"')\"'"
     expected_output_contains: "volume_processing imported successfully"
 
   - name: VesselVio graph_processing module
     description: Test VesselVio graph processing module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import graph_processing as GProc; print('graph_processing imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import graph_processing as GProc; print('\"'\"'graph_processing imported successfully'\"'\"')\"'"
     expected_output_contains: "graph_processing imported successfully"
 
   - name: VesselVio feature_extraction module
     description: Test VesselVio feature extraction module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import feature_extraction as FeatExt; print('feature_extraction imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import feature_extraction as FeatExt; print('\"'\"'feature_extraction imported successfully'\"'\"')\"'"
     expected_output_contains: "feature_extraction imported successfully"
 
   - name: VesselVio graph_io module
     description: Test VesselVio graph I/O module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import graph_io as GIO; print('graph_io imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import graph_io as GIO; print('\"'\"'graph_io imported successfully'\"'\"')\"'"
     expected_output_contains: "graph_io imported successfully"
 
   - name: VesselVio helpers module
     description: Test VesselVio helpers utility module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import helpers; print('helpers imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import helpers; print('\"'\"'helpers imported successfully'\"'\"')\"'"
     expected_output_contains: "helpers imported successfully"
 
   - name: VesselVio input_classes module
     description: Test VesselVio input classes module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import input_classes as IC; print('input_classes imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import input_classes as IC; print('\"'\"'input_classes imported successfully'\"'\"')\"'"
     expected_output_contains: "input_classes imported successfully"
 
   - name: VesselVio results_export module
     description: Test VesselVio results export module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import results_export as ResExp; print('results_export imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import results_export as ResExp; print('\"'\"'results_export imported successfully'\"'\"')\"'"
     expected_output_contains: "results_export imported successfully"
 
   - name: VesselVio volume_visualization module
     description: Test VesselVio volume visualization module import
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import volume_visualization as VolVis; print('volume_visualization imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import volume_visualization as VolVis; print('\"'\"'volume_visualization imported successfully'\"'\"')\"'"
     expected_output_contains: "volume_visualization imported successfully"
 
   - name: VesselVio lee94 skeletonization module
     description: Test VesselVio Lee94 skeletonization algorithm module
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import lee94; print('lee94 imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import lee94; print('\"'\"'lee94 imported successfully'\"'\"')\"'"
     expected_output_contains: "lee94 imported successfully"
 
   - name: VesselVio pk12 module
     description: Test VesselVio PK12 algorithm module
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import pk12; print('pk12 imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import pk12; print('\"'\"'pk12 imported successfully'\"'\"')\"'"
     expected_output_contains: "pk12 imported successfully"
 
   - name: VesselVio radii_corrections module
     description: Test VesselVio radii corrections module
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import radii_corrections as RadCor; print('radii_corrections imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import radii_corrections as RadCor; print('\"'\"'radii_corrections imported successfully'\"'\"')\"'"
     expected_output_contains: "radii_corrections imported successfully"
 
   # ==========================================================================
@@ -364,17 +364,17 @@ tests:
   # ==========================================================================
   - name: VesselVio annotation labeling module
     description: Test VesselVio annotation labeling module
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library.annotation import labeling; print('annotation labeling imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library.annotation import labeling; print('\"'\"'annotation labeling imported successfully'\"'\"')\"'"
     expected_output_contains: "annotation labeling imported successfully"
 
   - name: VesselVio annotation segmentation module
     description: Test VesselVio annotation segmentation module
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library.annotation import segmentation; print('annotation segmentation imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library.annotation import segmentation; print('\"'\"'annotation segmentation imported successfully'\"'\"')\"'"
     expected_output_contains: "annotation segmentation imported successfully"
 
   - name: VesselVio annotation tree_processing module
     description: Test VesselVio annotation tree processing module
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library.annotation import tree_processing; print('annotation tree_processing imported successfully')"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library.annotation import tree_processing; print('\"'\"'annotation tree_processing imported successfully'\"'\"')\"'"
     expected_output_contains: "annotation tree_processing imported successfully"
 
   # ==========================================================================
@@ -382,22 +382,22 @@ tests:
   # ==========================================================================
   - name: Sample vertices CSV exists
     description: Verify sample vertices CSV file exists
-    command: ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv
+    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv'"
     expected_output_contains: "vertices.csv"
 
   - name: Sample edges CSV exists
     description: Verify sample edges CSV file exists
-    command: ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv
+    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv'"
     expected_output_contains: "edges.csv"
 
   - name: Load sample vertices with Pandas
     description: Test loading sample vertices CSV data
-    command: python -c "import pandas as pd; df = pd.read_csv('/opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv', delimiter=';'); print('Vertices shape:', df.shape); print('Columns:', list(df.columns))"
+    command: "bash -lc 'python -c \"import pandas as pd; df = pd.read_csv('\"'\"'/opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv'\"'\"', delimiter='\"'\"';'\"'\"'); print('\"'\"'Vertices shape:'\"'\"', df.shape); print('\"'\"'Columns:'\"'\"', list(df.columns))\"'"
     expected_output_contains: "Vertices shape:"
 
   - name: Load sample edges with Pandas
     description: Test loading sample edges CSV data
-    command: python -c "import pandas as pd; df = pd.read_csv('/opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv', delimiter=';'); print('Edges shape:', df.shape)"
+    command: "bash -lc 'python -c \"import pandas as pd; df = pd.read_csv('\"'\"'/opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv'\"'\"', delimiter='\"'\"';'\"'\"'); print('\"'\"'Edges shape:'\"'\"', df.shape)\"'"
     expected_output_contains: "Edges shape:"
 
   # ==========================================================================
@@ -582,26 +582,17 @@ tests:
   # ==========================================================================
   - name: VesselVio resolution preparation
     description: Test VesselVio resolution format preparation
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import image_processing as ImProc; res = ImProc.prep_resolution(1.0); print('Resolution:', res); res2 = ImProc.prep_resolution([1.0, 1.0, 1.0]); print('Resolution array:', res2)"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import image_processing as ImProc; res = ImProc.prep_resolution(1.0); print('\"'\"'Resolution:'\"'\"', res); res2 = ImProc.prep_resolution([1.0, 1.0, 1.0]); print('\"'\"'Resolution array:'\"'\"', res2)\"'"
     expected_output_contains: "Resolution:"
 
   - name: VesselVio binary check
     description: Test VesselVio binary volume validation
-    command: |
-      python -c "
-      import sys
-      sys.path.insert(0, '/opt/vesselvio-1.1.2')
-      import numpy as np
-      from library import image_processing as ImProc
-      binary_vol = np.array([[[0,1],[1,0]],[[1,0],[0,1]]], dtype=np.uint8)
-      result = ImProc.binary_check(binary_vol)
-      print('Binary check result:', result)
-      "
+    command: "bash -lc 'python -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"')\nimport numpy as np\nfrom library import image_processing as ImProc\nbinary_vol = np.array([[[0,1],[1,0]],[[1,0],[0,1]]], dtype=np.uint8)\nresult = ImProc.binary_check(binary_vol)\nprint('\"'\"'Binary check result:'\"'\"', result)\n\"'"
     expected_output_contains: "Binary check result: True"
 
   - name: VesselVio filename extraction
     description: Test VesselVio filename extraction utility
-    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import image_processing as ImProc; name = ImProc.get_filename('/path/to/vessel_data.nii.gz'); print('Extracted filename:', name)"
+    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import image_processing as ImProc; name = ImProc.get_filename('\"'\"'/path/to/vessel_data.nii.gz'\"'\"'); print('\"'\"'Extracted filename:'\"'\"', name)\"'"
     expected_output_contains: "Extracted filename:"
 
   # ==========================================================================
@@ -609,17 +600,17 @@ tests:
   # ==========================================================================
   - name: VesselVio installation directory
     description: Verify VesselVio installation directory structure
-    command: ls -la /opt/vesselvio-1.1.2/
+    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/'"
     expected_output_contains: "VVTerminal.py"
 
   - name: VesselVio library directory
     description: Verify VesselVio library modules
-    command: ls -la /opt/vesselvio-1.1.2/library/
+    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/library/'"
     expected_output_contains: "feature_extraction.py"
 
   - name: VesselVio annotation directory
     description: Verify VesselVio annotation modules
-    command: ls -la /opt/vesselvio-1.1.2/library/annotation/
+    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/library/annotation/'"
     expected_output_contains: "labeling.py"
 
   - name: VesselVio executable script
@@ -629,7 +620,7 @@ tests:
 
   - name: VesselVio README exists
     description: Verify VesselVio documentation
-    command: head -5 /opt/vesselvio-1.1.2/README.md
+    command: "bash -lc 'head -5 /opt/vesselvio-1.1.2/README.md'"
     expected_output_contains: "VesselVio"
 
   - name: Container README

--- a/recipes/xnat/fulltest.yaml
+++ b/recipes/xnat/fulltest.yaml
@@ -66,7 +66,7 @@ tests:
   # ==========================================================================
   - name: PostgreSQL initdb version
     description: Verify PostgreSQL initdb is available
-    command: /usr/lib/postgresql/12/bin/initdb --version
+    command: bash -lc '/usr/lib/postgresql/12/bin/initdb --version'
     expected_output_contains: "initdb (PostgreSQL) 12"
 
   - name: PostgreSQL psql version
@@ -86,22 +86,22 @@ tests:
 
   - name: PostgreSQL pg_dump version
     description: Verify pg_dump backup utility is available
-    command: /usr/lib/postgresql/12/bin/pg_dump --version
+    command: bash -lc '/usr/lib/postgresql/12/bin/pg_dump --version'
     expected_output_contains: "pg_dump (PostgreSQL) 12"
 
   - name: PostgreSQL pg_restore version
     description: Verify pg_restore utility is available
-    command: /usr/lib/postgresql/12/bin/pg_restore --version
+    command: bash -lc '/usr/lib/postgresql/12/bin/pg_restore --version'
     expected_output_contains: "pg_restore (PostgreSQL) 12"
 
   - name: PostgreSQL pg_ctl help
     description: Verify pg_ctl control utility is available
-    command: /usr/lib/postgresql/12/bin/pg_ctl --help 2>&1 | head -10
+    command: bash -lc '/usr/lib/postgresql/12/bin/pg_ctl --help 2>&1 | head -10'
     expected_output_contains: "pg_ctl"
 
   - name: PostgreSQL configuration
     description: Verify PostgreSQL config utility
-    command: /usr/lib/postgresql/12/bin/pg_config --version
+    command: bash -lc '/usr/lib/postgresql/12/bin/pg_config --version'
     expected_output_contains: "PostgreSQL 12"
 
   # ==========================================================================
@@ -109,37 +109,37 @@ tests:
   # ==========================================================================
   - name: Tomcat version check
     description: Verify Apache Tomcat 9 is installed
-    command: /usr/share/tomcat9/bin/version.sh 2>&1
+    command: bash -lc '/usr/share/tomcat9/bin/version.sh 2>&1'
     expected_output_contains: "Apache Tomcat/9"
 
   - name: Tomcat server number
     description: Verify Tomcat server version number
-    command: /usr/share/tomcat9/bin/version.sh 2>&1
+    command: bash -lc '/usr/share/tomcat9/bin/version.sh 2>&1'
     expected_output_contains: "9.0.31"
 
   - name: Tomcat catalina script
     description: Verify Tomcat catalina.sh exists and is executable
-    command: test -x /usr/share/tomcat9/bin/catalina.sh && echo "catalina.sh is executable"
+    command: bash -lc 'test -x /usr/share/tomcat9/bin/catalina.sh && echo "catalina.sh is executable"'
     expected_output_contains: "catalina.sh is executable"
 
   - name: Tomcat startup script
     description: Verify Tomcat startup.sh exists
-    command: test -f /usr/share/tomcat9/bin/startup.sh && echo "startup.sh exists"
+    command: bash -lc 'test -f /usr/share/tomcat9/bin/startup.sh && echo "startup.sh exists"'
     expected_output_contains: "startup.sh exists"
 
   - name: Tomcat shutdown script
     description: Verify Tomcat shutdown.sh exists
-    command: test -f /usr/share/tomcat9/bin/shutdown.sh && echo "shutdown.sh exists"
+    command: bash -lc 'test -f /usr/share/tomcat9/bin/shutdown.sh && echo "shutdown.sh exists"'
     expected_output_contains: "shutdown.sh exists"
 
   - name: Tomcat bootstrap jar
     description: Verify Tomcat bootstrap.jar exists
-    command: test -f /usr/share/tomcat9/bin/bootstrap.jar && echo "bootstrap.jar exists"
+    command: bash -lc 'test -f /usr/share/tomcat9/bin/bootstrap.jar && echo "bootstrap.jar exists"'
     expected_output_contains: "bootstrap.jar exists"
 
   - name: Tomcat configuration directory
     description: Verify Tomcat conf directory exists
-    command: test -d /usr/share/tomcat9/conf && echo "conf directory exists"
+    command: bash -lc 'test -d /usr/share/tomcat9/conf && echo "conf directory exists"'
     expected_output_contains: "conf directory exists"
 
   # ==========================================================================
@@ -147,42 +147,42 @@ tests:
   # ==========================================================================
   - name: XNAT webapp directory
     description: Verify XNAT webapp directory exists
-    command: test -d /opt/xnat-webapp && echo "xnat-webapp exists"
+    command: bash -lc 'test -d /opt/xnat-webapp && echo "xnat-webapp exists"'
     expected_output_contains: "xnat-webapp exists"
 
   - name: XNAT WEB-INF directory
     description: Verify XNAT WEB-INF directory structure
-    command: test -d /opt/xnat-webapp/WEB-INF && echo "WEB-INF exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/WEB-INF && echo "WEB-INF exists"'
     expected_output_contains: "WEB-INF exists"
 
   - name: XNAT web.xml
     description: Verify XNAT web.xml deployment descriptor exists
-    command: test -f /opt/xnat-webapp/WEB-INF/web.xml && echo "web.xml exists"
+    command: bash -lc 'test -f /opt/xnat-webapp/WEB-INF/web.xml && echo "web.xml exists"'
     expected_output_contains: "web.xml exists"
 
   - name: XNAT lib directory
     description: Verify XNAT lib directory with JAR files exists
-    command: test -d /opt/xnat-webapp/WEB-INF/lib && echo "lib directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/WEB-INF/lib && echo "lib directory exists"'
     expected_output_contains: "lib directory exists"
 
   - name: XNAT classes directory
     description: Verify XNAT classes directory exists
-    command: test -d /opt/xnat-webapp/WEB-INF/classes && echo "classes directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/WEB-INF/classes && echo "classes directory exists"'
     expected_output_contains: "classes directory exists"
 
   - name: XNAT scripts directory
     description: Verify XNAT scripts directory exists
-    command: test -d /opt/xnat-webapp/scripts && ls /opt/xnat-webapp/scripts | wc -l
+    command: bash -lc 'test -d /opt/xnat-webapp/scripts && ls /opt/xnat-webapp/scripts | wc -l'
     expected_exit_code: 0
 
   - name: XNAT templates directory
     description: Verify XNAT templates directory exists
-    command: test -d /opt/xnat-webapp/templates && echo "templates directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/templates && echo "templates directory exists"'
     expected_output_contains: "templates directory exists"
 
   - name: XNAT favicon
     description: Verify XNAT favicon.ico exists
-    command: test -f /opt/xnat-webapp/favicon.ico && echo "favicon.ico exists"
+    command: bash -lc 'test -f /opt/xnat-webapp/favicon.ico && echo "favicon.ico exists"'
     expected_output_contains: "favicon.ico exists"
 
   # ==========================================================================
@@ -190,32 +190,32 @@ tests:
   # ==========================================================================
   - name: XNAT config directory
     description: Verify XNAT configuration directory exists
-    command: test -d /opt/xnat-config && echo "xnat-config exists"
+    command: bash -lc 'test -d /opt/xnat-config && echo "xnat-config exists"'
     expected_output_contains: "xnat-config exists"
 
   - name: XNAT properties template
     description: Verify XNAT configuration properties template exists
-    command: test -f /opt/xnat-config/xnat-conf.properties.template && echo "properties template exists"
+    command: bash -lc 'test -f /opt/xnat-config/xnat-conf.properties.template && echo "properties template exists"'
     expected_output_contains: "properties template exists"
 
   - name: XNAT datasource driver config
     description: Verify PostgreSQL driver is configured
-    command: grep -q "org.postgresql.Driver" /opt/xnat-config/xnat-conf.properties.template && echo "PostgreSQL driver configured"
+    command: "bash -lc 'grep -q \"org.postgresql.Driver\" /opt/xnat-config/xnat-conf.properties.template && echo \"PostgreSQL driver configured\"'"
     expected_output_contains: "PostgreSQL driver configured"
 
   - name: XNAT database URL config
     description: Verify database URL is configured
-    command: grep "datasource.url" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"datasource.url\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "jdbc:postgresql://localhost/xnat"
 
   - name: XNAT Hibernate dialect config
     description: Verify Hibernate PostgreSQL dialect is configured
-    command: grep "hibernate.dialect" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"hibernate.dialect\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "PostgreSQL9Dialect"
 
   - name: XNAT web-default.xml
     description: Verify custom web.xml with servlet mappings exists
-    command: test -f /opt/xnat-config/web-default.xml && echo "web-default.xml exists"
+    command: bash -lc 'test -f /opt/xnat-config/web-default.xml && echo "web-default.xml exists"'
     expected_output_contains: "web-default.xml exists"
 
   # ==========================================================================
@@ -223,7 +223,7 @@ tests:
   # ==========================================================================
   - name: Custom server.xml
     description: Verify custom Tomcat server.xml exists
-    command: test -f /usr/share/tomcat9/conf/server.xml && echo "server.xml exists"
+    command: bash -lc 'test -f /usr/share/tomcat9/conf/server.xml && echo "server.xml exists"'
     expected_output_contains: "server.xml exists"
 
   - name: Server HTTP connector port
@@ -246,22 +246,22 @@ tests:
   # ==========================================================================
   - name: XNAT entrypoint script exists
     description: Verify XNAT entrypoint script exists
-    command: test -f /usr/bin/xnat && echo "xnat script exists"
+    command: bash -lc 'test -f /usr/bin/xnat && echo "xnat script exists"'
     expected_output_contains: "xnat script exists"
 
   - name: XNAT entrypoint script executable
     description: Verify XNAT entrypoint script is executable
-    command: test -x /usr/bin/xnat && echo "xnat script is executable"
+    command: bash -lc 'test -x /usr/bin/xnat && echo "xnat script is executable"'
     expected_output_contains: "xnat script is executable"
 
   - name: Init-postgres script exists
     description: Verify PostgreSQL initialization script exists
-    command: test -f /usr/bin/init-postgres && echo "init-postgres exists"
+    command: bash -lc 'test -f /usr/bin/init-postgres && echo "init-postgres exists"'
     expected_output_contains: "init-postgres exists"
 
   - name: Init-postgres script executable
     description: Verify init-postgres script is executable
-    command: test -x /usr/bin/init-postgres && echo "init-postgres is executable"
+    command: bash -lc 'test -x /usr/bin/init-postgres && echo "init-postgres is executable"'
     expected_output_contains: "init-postgres is executable"
 
   - name: XNAT version in entrypoint
@@ -297,7 +297,7 @@ tests:
   # ==========================================================================
   - name: Build YAML exists
     description: Verify build.yaml exists in container
-    command: test -f /build.yaml && echo "build.yaml exists"
+    command: bash -lc 'test -f /build.yaml && echo "build.yaml exists"'
     expected_output_contains: "build.yaml exists"
 
   - name: Build YAML version
@@ -312,7 +312,7 @@ tests:
 
   - name: README exists
     description: Verify README.md exists
-    command: test -f /README.md && cat /README.md
+    command: bash -lc 'test -f /README.md && cat /README.md'
     expected_output_contains: "xnat"
 
   # ==========================================================================
@@ -320,42 +320,42 @@ tests:
   # ==========================================================================
   - name: XNAT images directory
     description: Verify XNAT images directory exists
-    command: test -d /opt/xnat-webapp/images && echo "images directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/images && echo "images directory exists"'
     expected_output_contains: "images directory exists"
 
   - name: XNAT style directory
     description: Verify XNAT style directory exists
-    command: test -d /opt/xnat-webapp/style && echo "style directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/style && echo "style directory exists"'
     expected_output_contains: "style directory exists"
 
   - name: XNAT resources directory
     description: Verify XNAT resources directory exists
-    command: test -d /opt/xnat-webapp/resources && echo "resources directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/resources && echo "resources directory exists"'
     expected_output_contains: "resources directory exists"
 
   - name: XNAT themes directory
     description: Verify XNAT themes directory exists
-    command: test -d /opt/xnat-webapp/themes && echo "themes directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/themes && echo "themes directory exists"'
     expected_output_contains: "themes directory exists"
 
   - name: XNAT base-templates directory
     description: Verify XNAT base-templates directory exists
-    command: test -d /opt/xnat-webapp/base-templates && echo "base-templates directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/base-templates && echo "base-templates directory exists"'
     expected_output_contains: "base-templates directory exists"
 
   - name: XNAT xnat-templates directory
     description: Verify XNAT xnat-templates directory exists
-    command: test -d /opt/xnat-webapp/xnat-templates && echo "xnat-templates directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/xnat-templates && echo "xnat-templates directory exists"'
     expected_output_contains: "xnat-templates directory exists"
 
   - name: XNAT xdat-templates directory
     description: Verify XNAT xdat-templates directory exists
-    command: test -d /opt/xnat-webapp/xdat-templates && echo "xdat-templates directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/xdat-templates && echo "xdat-templates directory exists"'
     expected_output_contains: "xdat-templates directory exists"
 
   - name: XNAT setup directory
     description: Verify XNAT setup directory exists
-    command: test -d /opt/xnat-webapp/setup && echo "setup directory exists"
+    command: bash -lc 'test -d /opt/xnat-webapp/setup && echo "setup directory exists"'
     expected_output_contains: "setup directory exists"
 
   # ==========================================================================
@@ -363,47 +363,47 @@ tests:
   # ==========================================================================
   - name: PostgreSQL clusterdb
     description: Verify clusterdb utility exists
-    command: test -x /usr/lib/postgresql/12/bin/clusterdb && echo "clusterdb exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/clusterdb && echo "clusterdb exists"'
     expected_output_contains: "clusterdb exists"
 
   - name: PostgreSQL createuser
     description: Verify createuser utility exists
-    command: test -x /usr/lib/postgresql/12/bin/createuser && echo "createuser exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/createuser && echo "createuser exists"'
     expected_output_contains: "createuser exists"
 
   - name: PostgreSQL dropdb
     description: Verify dropdb utility exists
-    command: test -x /usr/lib/postgresql/12/bin/dropdb && echo "dropdb exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/dropdb && echo "dropdb exists"'
     expected_output_contains: "dropdb exists"
 
   - name: PostgreSQL dropuser
     description: Verify dropuser utility exists
-    command: test -x /usr/lib/postgresql/12/bin/dropuser && echo "dropuser exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/dropuser && echo "dropuser exists"'
     expected_output_contains: "dropuser exists"
 
   - name: PostgreSQL pg_basebackup
     description: Verify pg_basebackup utility exists
-    command: test -x /usr/lib/postgresql/12/bin/pg_basebackup && echo "pg_basebackup exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/pg_basebackup && echo "pg_basebackup exists"'
     expected_output_contains: "pg_basebackup exists"
 
   - name: PostgreSQL pgbench
     description: Verify pgbench benchmarking tool exists
-    command: test -x /usr/lib/postgresql/12/bin/pgbench && echo "pgbench exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/pgbench && echo "pgbench exists"'
     expected_output_contains: "pgbench exists"
 
   - name: PostgreSQL pg_dumpall
     description: Verify pg_dumpall utility exists
-    command: /usr/lib/postgresql/12/bin/pg_dumpall --version
+    command: bash -lc '/usr/lib/postgresql/12/bin/pg_dumpall --version'
     expected_output_contains: "pg_dumpall (PostgreSQL) 12"
 
   - name: PostgreSQL vacuumdb
     description: Verify vacuumdb utility exists
-    command: test -x /usr/lib/postgresql/12/bin/vacuumdb && echo "vacuumdb exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/vacuumdb && echo "vacuumdb exists"'
     expected_output_contains: "vacuumdb exists"
 
   - name: PostgreSQL reindexdb
     description: Verify reindexdb utility exists
-    command: test -x /usr/lib/postgresql/12/bin/reindexdb && echo "reindexdb exists"
+    command: bash -lc 'test -x /usr/lib/postgresql/12/bin/reindexdb && echo "reindexdb exists"'
     expected_output_contains: "reindexdb exists"
 
   # ==========================================================================
@@ -424,27 +424,27 @@ tests:
   # ==========================================================================
   - name: MIME types CSS configured
     description: Verify CSS MIME type is configured
-    command: grep -q "text/css" /opt/xnat-config/web-default.xml && echo "CSS MIME type configured"
+    command: "bash -lc 'grep -q \"text/css\" /opt/xnat-config/web-default.xml && echo \"CSS MIME type configured\"'"
     expected_output_contains: "CSS MIME type configured"
 
   - name: MIME types JavaScript configured
     description: Verify JavaScript MIME type is configured
-    command: grep -q "application/javascript" /opt/xnat-config/web-default.xml && echo "JS MIME type configured"
+    command: "bash -lc 'grep -q \"application/javascript\" /opt/xnat-config/web-default.xml && echo \"JS MIME type configured\"'"
     expected_output_contains: "JS MIME type configured"
 
   - name: MIME types JSON configured
     description: Verify JSON MIME type is configured
-    command: grep -q "application/json" /opt/xnat-config/web-default.xml && echo "JSON MIME type configured"
+    command: "bash -lc 'grep -q \"application/json\" /opt/xnat-config/web-default.xml && echo \"JSON MIME type configured\"'"
     expected_output_contains: "JSON MIME type configured"
 
   - name: MIME types PNG configured
     description: Verify PNG MIME type is configured
-    command: grep -q "image/png" /opt/xnat-config/web-default.xml && echo "PNG MIME type configured"
+    command: "bash -lc 'grep -q \"image/png\" /opt/xnat-config/web-default.xml && echo \"PNG MIME type configured\"'"
     expected_output_contains: "PNG MIME type configured"
 
   - name: MIME types SVG configured
     description: Verify SVG MIME type is configured
-    command: grep -q "image/svg+xml" /opt/xnat-config/web-default.xml && echo "SVG MIME type configured"
+    command: "bash -lc 'grep -q \"image/svg+xml\" /opt/xnat-config/web-default.xml && echo \"SVG MIME type configured\"'"
     expected_output_contains: "SVG MIME type configured"
 
   # ==========================================================================
@@ -452,17 +452,17 @@ tests:
   # ==========================================================================
   - name: Default servlet configured
     description: Verify default servlet is configured
-    command: grep -q "DefaultServlet" /opt/xnat-config/web-default.xml && echo "DefaultServlet configured"
+    command: "bash -lc 'grep -q \"DefaultServlet\" /opt/xnat-config/web-default.xml && echo \"DefaultServlet configured\"'"
     expected_output_contains: "DefaultServlet configured"
 
   - name: JSP servlet configured
     description: Verify JSP servlet is configured
-    command: grep -q "JspServlet" /opt/xnat-config/web-default.xml && echo "JspServlet configured"
+    command: "bash -lc 'grep -q \"JspServlet\" /opt/xnat-config/web-default.xml && echo \"JspServlet configured\"'"
     expected_output_contains: "JspServlet configured"
 
   - name: Session timeout configured
     description: Verify session timeout is configured
-    command: grep -q "session-timeout" /opt/xnat-config/web-default.xml && echo "session-timeout configured"
+    command: "bash -lc 'grep -q \"session-timeout\" /opt/xnat-config/web-default.xml && echo \"session-timeout configured\"'"
     expected_output_contains: "session-timeout configured"
 
   # ==========================================================================
@@ -470,12 +470,12 @@ tests:
   # ==========================================================================
   - name: XNAT lib JAR files count
     description: Count JAR files in XNAT lib directory
-    command: ls /opt/xnat-webapp/WEB-INF/lib/*.jar 2>/dev/null | wc -l
+    command: bash -lc 'ls /opt/xnat-webapp/WEB-INF/lib/*.jar 2>/dev/null | wc -l'
     expected_exit_code: 0
 
   - name: Tomcat bootstrap JAR
     description: Verify Tomcat bootstrap JAR file exists
-    command: test -f /usr/share/tomcat9/bin/bootstrap.jar && echo "bootstrap.jar verified"
+    command: bash -lc 'test -f /usr/share/tomcat9/bin/bootstrap.jar && echo "bootstrap.jar verified"'
     expected_output_contains: "bootstrap.jar verified"
 
   # ==========================================================================
@@ -524,22 +524,22 @@ tests:
   # ==========================================================================
   - name: Hibernate cache configuration
     description: Verify Hibernate second-level cache is configured
-    command: grep "use_second_level_cache" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"use_second_level_cache\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "true"
 
   - name: Hibernate query cache configuration
     description: Verify Hibernate query cache is configured
-    command: grep "use_query_cache" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"use_query_cache\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "true"
 
   - name: Max file size configuration
     description: Verify max file upload size is configured (1GB)
-    command: grep "max-file-size" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"max-file-size\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "1073741824"
 
   - name: Max request size configuration
     description: Verify max request size is configured (1GB)
-    command: grep "max-request-size" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"max-request-size\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "1073741824"
 
   # ==========================================================================
@@ -547,12 +547,12 @@ tests:
   # ==========================================================================
   - name: Database username configuration
     description: Verify database username is configured
-    command: grep "datasource.username" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"datasource.username\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "xnat"
 
   - name: Database name in URL
     description: Verify database name in JDBC URL
-    command: grep "datasource.url" /opt/xnat-config/xnat-conf.properties.template
+    command: "bash -lc 'grep \"datasource.url\" /opt/xnat-config/xnat-conf.properties.template'"
     expected_output_contains: "/xnat"
 
   # ==========================================================================
@@ -560,12 +560,12 @@ tests:
   # ==========================================================================
   - name: Tomcat webapps directory
     description: Verify Tomcat webapps directory exists
-    command: test -d /var/lib/tomcat9/webapps && echo "webapps directory exists" || echo "using CATALINA_BASE"
+    command: bash -lc 'test -d /var/lib/tomcat9/webapps && echo "webapps directory exists" || echo "using CATALINA_BASE"'
     expected_exit_code: 0
 
   - name: Tomcat lib directory
     description: Verify Tomcat lib directory exists
-    command: test -d /usr/share/tomcat9/lib && echo "lib directory exists"
+    command: bash -lc 'test -d /usr/share/tomcat9/lib && echo "lib directory exists"'
     expected_output_contains: "lib directory exists"
 
   - name: Tomcat conf directory contents


### PR DESCRIPTION
## Summary

This updates affected `recipes/*/fulltest.yaml` files so the fulltest suites work when pyneurodesk runs them through the host-side shell wrapper interface.

The root cause is that several fulltests assumed they were already executing inside the container. That made host-shell commands try to resolve container-only absolute paths such as `/opt/...`, `/freesurfer/...`, and `/.singularity.d/...` on the host. Recipe-level `env:` values also were not applied by the pyneurodesk fulltest runner, so suites such as DSI Studio needed their required environment passed explicitly through the wrapped command.

## Changes

- Wrap commands that need container-only paths with `bash -lc '...'` so the shell execution happens inside the loaded container wrapper.
- Move required recipe environment values into the wrapped command path, for example `QT_QPA_PLATFORM=offscreen` for DSI Studio.
- Replace quickshear's invalid `/freesurfer/mri_synthstrip` invocations with the `mri_synthstrip` wrapper entrypoint.
- Make the quickshear `mri_synthstrip --help` check tolerate the tool's exit code while still checking the expected help text.
- Keep the AFNI version check's longer timeout for the large `afni -ver` startup path.

## Validation

- Parsed every `recipes/*/fulltest.yaml` with PyYAML.
- Scanned commands to verify there are no remaining `env` or absolute-path first commands.
- Scanned commands to verify known container-only absolute paths are not left to the host shell.
- Ran `git diff --check`.
- Ran local pyneurodesk smoke tests:
  - `quickshear`: `mri_synthstrip help`
  - `dsistudio`: `DSI Studio atlas directory exists`

## Notes

This intentionally keeps the tests in wrapper mode. Commands that need guest filesystem semantics now request a wrapped shell explicitly instead of bypassing the shell-wrapper interface.
