### PR TITLE
[codex] Support fulltest suite matrix

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -9,9 +9,10 @@ env:
 on:
   workflow_dispatch:
     inputs:
-      container:
-        description: "Recipe container to test (e.g. fmriprep)"
+      suite:
+        description: "Fulltest suite to run: niimath, all, or a comma-separated list"
         required: true
+        default: "niimath"
         type: string
       version:
         description: "Optional release version (for example 25.2.3). Leave blank to use latest."
@@ -25,8 +26,69 @@ on:
         type: string
 
 jobs:
-  run-fulltest:
+  plan:
+    name: Select fulltest suites
     runs-on: ubuntu-22.04
+    outputs:
+      suites: ${{ steps.plan.outputs.suites }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build suite matrix
+        id: plan
+        env:
+          REQUESTED_SUITE: ${{ github.event.inputs.suite || 'niimath' }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          recipes = Path("recipes")
+          requested = os.environ["REQUESTED_SUITE"].strip() or "niimath"
+          available = sorted(path.parent.name for path in recipes.glob("*/fulltest.yaml"))
+
+          if not available:
+              print("No fulltest recipes found under recipes/", file=sys.stderr)
+              sys.exit(1)
+
+          if requested.lower() == "all":
+              selected = available
+          else:
+              selected = []
+              missing = []
+              for item in requested.replace("\n", ",").split(","):
+                  suite = item.strip()
+                  if not suite:
+                      continue
+                  if suite not in available:
+                      missing.append(suite)
+                  else:
+                      selected.append(suite)
+              if missing:
+                  print(f"Unknown fulltest suite(s): {', '.join(missing)}", file=sys.stderr)
+                  print(f"Available suites: {', '.join(available)}", file=sys.stderr)
+                  sys.exit(1)
+
+          selected = list(dict.fromkeys(selected))
+          if not selected:
+              print("No fulltest suites selected", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"suites={json.dumps(selected)}")
+          PY
+
+  run-fulltest:
+    name: ${{ matrix.suite }}
+    needs: plan
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJson(needs.plan.outputs.suites) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -58,7 +120,7 @@ jobs:
 
       - name: Pull container and run fulltest
         env:
-          CONTAINER: ${{ github.event.inputs.container }}
+          SUITE: ${{ matrix.suite }}
           VERSION: ${{ github.event.inputs.version }}
           CONTAINERS_DIR: ${{ github.event.inputs.containers_dir }}
           PYTHONUNBUFFERED: "1"
@@ -74,16 +136,16 @@ jobs:
           from workflows.container_tester import ReleaseContainerDownloader
           from workflows.test_utils import find_latest_release_file
 
-          container = os.environ["CONTAINER"].strip()
+          suite = os.environ["SUITE"].strip()
           requested_version = os.environ.get("VERSION", "").strip()
           containers_dir = Path(os.environ["CONTAINERS_DIR"]).resolve()
 
-          suite_path = Path("recipes") / container / "fulltest.yaml"
+          suite_path = Path("recipes") / suite / "fulltest.yaml"
           if not suite_path.is_file():
               print(f"Suite file not found: {suite_path}", file=sys.stderr)
               sys.exit(1)
 
-          releases_dir = Path("releases") / container
+          releases_dir = Path("releases") / suite
           if not releases_dir.is_dir():
               print(f"Release directory not found: {releases_dir}", file=sys.stderr)
               sys.exit(1)
@@ -97,7 +159,7 @@ jobs:
           else:
               release_file, release_version, _ = find_latest_release_file(releases_dir)
               if not release_file:
-                  print(f"No release file found for {container}", file=sys.stderr)
+                  print(f"No release file found for {suite}", file=sys.stderr)
                   sys.exit(1)
 
           try:
@@ -117,10 +179,10 @@ jobs:
               sys.exit(1)
 
           downloader = ReleaseContainerDownloader(cache_dir=str(containers_dir))
-          container_file = downloader.download_from_release(container, release_version, build_date)
+          container_file = downloader.download_from_release(suite, release_version, build_date)
           if not container_file:
               print(
-                  f"Failed to download container {container}:{release_version} "
+                  f"Failed to download container {suite}:{release_version} "
                   f"with build date {build_date}",
                   file=sys.stderr,
               )
@@ -128,8 +190,8 @@ jobs:
 
           workdir = Path("results")
           workdir.mkdir(exist_ok=True)
-          output_json = workdir / f"{container}-fulltest.json"
-          output_log = workdir / f"{container}-fulltest.log"
+          output_json = workdir / f"{suite}-fulltest.json"
+          output_log = workdir / f"{suite}-fulltest.log"
 
           cmd = [
               "uv",
@@ -154,5 +216,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fulltest-results-${{ github.event.inputs.container }}
+          name: fulltest-results-${{ matrix.suite }}
           path: results/


### PR DESCRIPTION
## Summary

- Update `run-fulltest` workflow input from a single `container` to a `suite` selector.
- Add a planning job that expands `niimath`, `all`, or comma-separated suite names into a matrix from `recipes/*/fulltest.yaml`.
- Keep execution on the GitHub Actions host with Apptainer and the existing `builder/run_tests.py` fulltest runner.

## Validation

- `uv run python` parsed `.github/workflows/run-fulltest.yml` as YAML successfully.
- Planner logic was checked locally for single-suite, comma-separated, deduped, and `all` selections.
- `git diff --check -- .github/workflows/run-fulltest.yml` passed.

## Notes

The workflow still downloads released `.simg` images before running tests; all currently discovered fulltest suites have release metadata.