### PR TITLE
fix(neurodesktop): use fuse3 with sshfs

### DIFF
--- a/recipes/neurodesktop/build.yaml
+++ b/recipes/neurodesktop/build.yaml
@@ -66,7 +66,7 @@ build:
         - dirmngr
         - dnsutils
         - freerdp2-dev
-        - fuse
+        - fuse3
         - g++
         - gcc
         - gedit
@@ -308,7 +308,7 @@ build:
         - install -D -m 0644 /tmp/config/lxde/rc.xml /etc/xdg/openbox/rc.xml
         - sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         - rm -f /usr/bin/lxpolkit
-        - chmod +x /usr/bin/fusermount
+        - if [ -e /usr/bin/fusermount3 ]; then chmod +x /usr/bin/fusermount3; elif [ -e /usr/bin/fusermount ]; then chmod +x /usr/bin/fusermount; fi
         - mkdir -p /usr/local/bin/start-notebook.d /usr/local/bin/before-notebook.d /opt/neurodesktop/scripts /opt/neurodesktop/webapp_wrapper
         - install -m 0755 /tmp/config/jupyter/start_notebook.sh /usr/local/bin/start-notebook.d/start_notebook.sh
         - install -m 0755 /tmp/config/jupyter/before_notebook.sh /usr/local/bin/before-notebook.d/before_notebook.sh


### PR DESCRIPTION
## Summary

- Replace legacy `fuse` with `fuse3` in the neurodesktop package list
- Make the fusermount chmod step handle `fusermount3` while still tolerating older `fusermount`

## Root cause

The neurodesktop Docker build failed during apt package resolution because Ubuntu's `sshfs` depends on FUSE 3 behavior and conflicts with the legacy `fuse` package:

```text
fuse3 : Breaks: fuse
sshfs : Breaks: fuse (< 3)
```

## Validation

- `.venv/bin/python builder/validation.py recipes/neurodesktop/build.yaml`
- `.venv/bin/python builder/build.py generate neurodesktop --recreate --check-only`
- Confirmed generated Dockerfile contains `fuse3` and `fusermount3` handling
