### PR TITLE
fix(neurodesktop): install nextflow from cached script via stdin

### DIFF
--- a/recipes/neurodesktop/build.yaml
+++ b/recipes/neurodesktop/build.yaml
@@ -234,7 +234,7 @@ build:
     - run:
         - mkdir -p "${NF_TEST_HOME}"
         - cp {{ get_file("nextflow_install") }} /tmp/get-nextflow.sh
-        - cd /tmp && bash /tmp/get-nextflow.sh
+        - cd /tmp && bash < /tmp/get-nextflow.sh
         - mv /tmp/nextflow /usr/local/bin/nextflow
         - chmod 755 /usr/local/bin/nextflow
         - bash {{ get_file("nf_test_install") }} 0.9.5


### PR DESCRIPTION
## Summary

- Run the cached Nextflow installer through stdin so it takes the self-install path and creates `/tmp/nextflow`
- Preserve the existing builder cache usage via `{{ get_file("nextflow_install") }}`

## Root cause

The auto-build progressed past the FUSE package conflict but failed at the Nextflow install layer. The current `get.nextflow.io` script does not self-install when invoked as `bash /tmp/get-nextflow.sh`; it prints the Nextflow CLI help and exits without creating `/tmp/nextflow`. Running the same script via stdin matches the upstream pipe-to-bash install behavior and creates the executable in the current directory.

## Validation

- `.venv/bin/python builder/validation.py recipes/neurodesktop/build.yaml`
- `.venv/bin/python builder/build.py generate neurodesktop --recreate --check-only`
- Locally verified `bash < get-nextflow.sh` creates `./nextflow`, while `bash get-nextflow.sh` does not
