### PR TITLE
Fix neurodesktop launcher build permissions

### DIFF
--- a/recipes/neurodesktop/build.yaml
+++ b/recipes/neurodesktop/build.yaml
@@ -339,6 +339,7 @@ build:
         - install -m 0644 -o ${NB_UID} -g ${NB_GID} /tmp/config/guacamole/user-mapping-vnc-rdp.xml /etc/guacamole/user-mapping-vnc-rdp.xml
         - ln -sf /etc/guacamole/user-mapping-vnc.xml /etc/guacamole/user-mapping.xml
         - chown -R ${NB_UID}:${NB_GID} /etc/guacamole /usr/local/tomcat
+        - chown -R ${NB_UID}:${NB_GID} /tmp/neurodesk-launcher
         - chmod -R a+rX /usr/local/tomcat /etc/guacamole
 
     - user: ${NB_USER}


### PR DESCRIPTION
## Summary
- chown the copied neurodesktop launcher extension directory to the notebook user before installing it as NB_USER
- fixes the jlpm install failure where Yarn could not create /tmp/neurodesk-launcher/.yarn

## Validation
- .venv/bin/python builder/validation.py recipes/neurodesktop/build.yaml
- .venv/bin/python builder/build.py generate neurodesktop --recreate --check-only