### PR TITLE
Pin neurodesktop launcher JupyterLab packages

### DIFF
--- a/recipes/neurodesktop/extensions/neurodesk-launcher/package-lock.json
+++ b/recipes/neurodesktop/extensions/neurodesk-launcher/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@jupyterlab/application": "^4.0.0",
-        "@jupyterlab/coreutils": "^6.0.0",
-        "@jupyterlab/launcher": "^4.0.0",
-        "@jupyterlab/services": "^7.0.0",
-        "@jupyterlab/ui-components": "^4.0.0"
+        "@jupyterlab/application": "4.5.4",
+        "@jupyterlab/coreutils": "6.5.4",
+        "@jupyterlab/launcher": "4.5.4",
+        "@jupyterlab/services": "7.5.4",
+        "@jupyterlab/ui-components": "4.5.4"
       },
       "devDependencies": {
-        "@jupyterlab/builder": "^4.0.0",
+        "@jupyterlab/builder": "4.5.4",
         "rimraf": "~5.0.0",
         "typescript": "~5.2.0"
       }

--- a/recipes/neurodesktop/extensions/neurodesk-launcher/package.json
+++ b/recipes/neurodesktop/extensions/neurodesk-launcher/package.json
@@ -16,14 +16,14 @@
     "clean": "rimraf lib tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@jupyterlab/application": "^4.0.0",
-    "@jupyterlab/launcher": "^4.0.0",
-    "@jupyterlab/services": "^7.0.0",
-    "@jupyterlab/ui-components": "^4.0.0",
-    "@jupyterlab/coreutils": "^6.0.0"
+    "@jupyterlab/application": "4.5.4",
+    "@jupyterlab/launcher": "4.5.4",
+    "@jupyterlab/services": "7.5.4",
+    "@jupyterlab/ui-components": "4.5.4",
+    "@jupyterlab/coreutils": "6.5.4"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.0.0",
+    "@jupyterlab/builder": "4.5.4",
     "rimraf": "~5.0.0",
     "typescript": "~5.2.0"
   },


### PR DESCRIPTION
## Summary
- pin the neurodesktop launcher JupyterLab JavaScript dependencies to the 4.5.4/7.5.4/6.5.4 versions already represented in package-lock.json
- prevents jlpm from drifting to @jupyterlab/builder 4.5.7, which fails under the current image with: required option --core-path <path> not specified

## Validation
- npm install --package-lock-only --ignore-scripts
- .venv/bin/python builder/validation.py recipes/neurodesktop/build.yaml
- .venv/bin/python builder/build.py generate neurodesktop --recreate --check-only