### PR TITLE
[codex] Add docker-to-simg option to run-fulltest

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -2,6 +2,7 @@ name: run-fulltest
 
 permissions:
   contents: read
+  packages: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -23,6 +24,16 @@ on:
         description: "Directory for downloaded .simg files"
         required: false
         default: "/tmp/containers"
+        type: string
+      docker_to_simg:
+        description: "Pull Docker images and convert them to SIMG before testing"
+        required: false
+        default: false
+        type: boolean
+      docker_registry:
+        description: "GHCR namespace for Docker images"
+        required: false
+        default: "neurodesk"
         type: string
 
 jobs:
@@ -106,6 +117,20 @@ jobs:
         with:
           apptainer-version: 1.4.3
 
+      - name: Set up Go
+        if: ${{ github.event.inputs.docker_to_simg == 'true' }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.5"
+
+      - name: Login to GHCR
+        if: ${{ github.event.inputs.docker_to_simg == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
       - name: Install test dependencies
         run: |
           uv pip install --system datalad datalad-installer
@@ -123,6 +148,9 @@ jobs:
           SUITE: ${{ matrix.suite }}
           VERSION: ${{ github.event.inputs.version }}
           CONTAINERS_DIR: ${{ github.event.inputs.containers_dir }}
+          DOCKER_TO_SIMG: ${{ github.event.inputs.docker_to_simg || 'false' }}
+          DOCKER_REGISTRY: ${{ github.event.inputs.docker_registry || 'neurodesk' }}
+          DOCKER_SAVE_TO_SIMG: builder/docker-save-to-simg.go
           PYTHONUNBUFFERED: "1"
         run: |
           mkdir -p "$CONTAINERS_DIR"
@@ -133,12 +161,19 @@ jobs:
           import sys
           from pathlib import Path
 
-          from workflows.container_tester import ReleaseContainerDownloader
+          from workflows.container_tester import (
+              DockerToSimgConverter,
+              ReleaseContainerDownloader,
+              build_release_docker_image_ref,
+          )
           from workflows.test_utils import find_latest_release_file
 
           suite = os.environ["SUITE"].strip()
           requested_version = os.environ.get("VERSION", "").strip()
           containers_dir = Path(os.environ["CONTAINERS_DIR"]).resolve()
+          docker_to_simg = os.environ.get("DOCKER_TO_SIMG", "false").lower() == "true"
+          docker_registry = os.environ.get("DOCKER_REGISTRY", "neurodesk") or "neurodesk"
+          converter_source = os.environ.get("DOCKER_SAVE_TO_SIMG", "builder/docker-save-to-simg.go")
 
           suite_path = Path("recipes") / suite / "fulltest.yaml"
           if not suite_path.is_file():
@@ -178,15 +213,38 @@ jobs:
               print(f"Build date missing in release file: {release_file}", file=sys.stderr)
               sys.exit(1)
 
-          downloader = ReleaseContainerDownloader(cache_dir=str(containers_dir))
-          container_file = downloader.download_from_release(suite, release_version, build_date)
-          if not container_file:
-              print(
-                  f"Failed to download container {suite}:{release_version} "
-                  f"with build date {build_date}",
-                  file=sys.stderr,
+          if docker_to_simg:
+              image_ref = build_release_docker_image_ref(
+                  suite,
+                  release_version,
+                  build_date,
+                  docker_registry=docker_registry,
               )
-              sys.exit(1)
+              converter = DockerToSimgConverter(
+                  cache_dir=str(containers_dir),
+                  converter_source=converter_source,
+              )
+              try:
+                  container_file = converter.convert(
+                      image_ref,
+                      f"{suite}_{release_version}_{build_date}.docker.simg",
+                      verbose=True,
+                  )
+              except Exception as exc:
+                  print(f"Failed to convert Docker image {image_ref}: {exc}", file=sys.stderr)
+                  sys.exit(1)
+          else:
+              downloader = ReleaseContainerDownloader(cache_dir=str(containers_dir))
+              container_file = downloader.download_from_release(suite, release_version, build_date)
+              if not container_file:
+                  print(
+                      f"Failed to download container {suite}:{release_version} "
+                      f"with build date {build_date}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+
+          print(f"Using container file: {container_file}")
 
           workdir = Path("results")
           workdir.mkdir(exist_ok=True)

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -601,6 +601,31 @@ class DockerToSimgConverter:
         return output_path
 
 
+def build_release_docker_image_ref(
+    name: str,
+    version: str,
+    build_date: str,
+    docker_registry: str = "neurodesk",
+) -> str:
+    """Return the release Docker image ref for a NeuroContainers build."""
+
+    image_name = f"{name}_{version}".lower()
+    registry_namespace = docker_registry.strip().strip("/") or "neurodesk"
+    if "://" in registry_namespace:
+        parsed = urllib.parse.urlsplit(registry_namespace)
+        if parsed.scheme != "https":
+            raise RuntimeError("Docker registry URLs must use https")
+        registry_namespace = f"{parsed.netloc}{parsed.path}".strip("/")
+
+    registry_parts = registry_namespace.split("/")
+    if registry_parts[0].lower() in {"ghcr.io", "docker.io"}:
+        registry_path = registry_namespace
+    else:
+        registry_path = f"ghcr.io/{registry_namespace}"
+
+    return f"{registry_path}/{image_name}:{build_date}"
+
+
 class ContainerTester:
     """Main container testing orchestrator"""
 
@@ -705,21 +730,12 @@ class ContainerTester:
                 "Docker-to-SIMG conversion requires release metadata with a build date"
             )
 
-        image_name = f"{name}_{version}".lower()
-        registry_namespace = docker_registry.strip().strip("/") or "neurodesk"
-        if "://" in registry_namespace:
-            parsed = urllib.parse.urlsplit(registry_namespace)
-            if parsed.scheme != "https":
-                raise RuntimeError("Docker registry URLs must use https")
-            registry_namespace = f"{parsed.netloc}{parsed.path}".strip("/")
-
-        registry_parts = registry_namespace.split("/")
-        if registry_parts[0].lower() in {"ghcr.io", "docker.io"}:
-            registry_path = registry_namespace
-        else:
-            registry_path = f"ghcr.io/{registry_namespace}"
-
-        image_ref = f"{registry_path}/{image_name}:{build_date}"
+        image_ref = build_release_docker_image_ref(
+            name,
+            version,
+            build_date,
+            docker_registry=docker_registry,
+        )
 
         if converter_source:
             self.docker_to_simg.converter_source = converter_source


### PR DESCRIPTION
## Summary

Adds the Docker-to-SIMG conversion option to the `run-fulltest.yml` workflow, which is the fulltest workflow that downloads a container into `containers_dir` and runs `builder/run_tests.py` against `recipes/<suite>/fulltest.yaml`.

## Changes

- Adds `docker_to_simg` and `docker_registry` dispatch inputs to `run-fulltest.yml`.
- Adds conditional Go setup and GHCR login for conversion runs.
- Uses `DockerToSimgConverter` to write converted `.docker.simg` files into the requested `containers_dir`.
- Extracts Docker release image-ref construction into `build_release_docker_image_ref` so both fulltest workflows share the same registry parsing.

## Validation

- `python -m py_compile workflows/container_tester.py`
- Parsed `.github/workflows/run-fulltest.yml` with PyYAML
- Verified image refs for `neurodesk`, `ghcr.io/neurodesk`, and `https://ghcr.io/neurodesk`
