### PR TITLE
Update dicompare to v0.5.4

### DIFF
--- a/recipes/dicompare/build.yaml
+++ b/recipes/dicompare/build.yaml
@@ -1,5 +1,5 @@
 name: dicompare
-version: 0.5.3
+version: 0.5.4
 
 categories:
   - "quality control"


### PR DESCRIPTION
## Summary

- Bump dicompare from v0.5.3 to v0.5.4
- Fixes schema library pages failing to load JSON in standalone container (`dicompare start`)

## Test plan

- [ ] Build container and verify `dicompare start` can load schema pages (e.g. `/schema/MS_CMSC_Guidelines_v1.0`)