### PR TITLE
[codex] Fix docker-to-simg fulltest failures

### DIFF
--- a/.github/workflows/run-fulltest.yml
+++ b/.github/workflows/run-fulltest.yml
@@ -164,7 +164,7 @@ jobs:
           from workflows.container_tester import (
               DockerToSimgConverter,
               ReleaseContainerDownloader,
-              build_release_docker_image_ref,
+              build_release_docker_image_ref_candidates,
           )
           from workflows.test_utils import find_latest_release_file
 
@@ -214,7 +214,7 @@ jobs:
               sys.exit(1)
 
           if docker_to_simg:
-              image_ref = build_release_docker_image_ref(
+              image_refs = build_release_docker_image_ref_candidates(
                   suite,
                   release_version,
                   build_date,
@@ -224,14 +224,21 @@ jobs:
                   cache_dir=str(containers_dir),
                   converter_source=converter_source,
               )
-              try:
-                  container_file = converter.convert(
-                      image_ref,
-                      f"{suite}_{release_version}_{build_date}.docker.simg",
-                      verbose=True,
-                  )
-              except Exception as exc:
-                  print(f"Failed to convert Docker image {image_ref}: {exc}", file=sys.stderr)
+              errors = []
+              for image_ref in image_refs:
+                  try:
+                      container_file = converter.convert(
+                          image_ref,
+                          f"{suite}_{release_version}_{build_date}.docker.simg",
+                          verbose=True,
+                      )
+                      break
+                  except Exception as exc:
+                      errors.append(f"{image_ref}: {exc}")
+              else:
+                  print("Failed to convert any Docker image candidate:", file=sys.stderr)
+                  for error in errors:
+                      print(f"  - {error}", file=sys.stderr)
                   sys.exit(1)
           else:
               downloader = ReleaseContainerDownloader(cache_dir=str(containers_dir))

--- a/builder/docker-save-to-simg.go
+++ b/builder/docker-save-to-simg.go
@@ -717,7 +717,7 @@ func assignInodeTypesAndSizes(inodes []*node) {
 			n.inodeType = squashInodeBasicDir
 			n.inodeSize = 32
 		case nodeRegular:
-			if n.size > 0xffffffff {
+			if n.size > 0xffffffff || n.fileStartRel > 0xffffffff {
 				n.inodeType = squashInodeLongFile
 				n.inodeSize = 56 + len(n.fileBlocks)*4
 			} else {

--- a/builder/docker-save-to-simg_test.go
+++ b/builder/docker-save-to-simg_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+func TestRegularFileUsesLongInodeWhenDataStartExceeds32Bit(t *testing.T) {
+	n := &node{
+		kind:         nodeRegular,
+		size:         12,
+		fileStartRel: 0x1_0000_0000,
+	}
+
+	assignInodeTypesAndSizes([]*node{n})
+
+	if n.inodeType != squashInodeLongFile {
+		t.Fatalf("inodeType = %d, want %d", n.inodeType, squashInodeLongFile)
+	}
+}

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -561,10 +561,18 @@ class DockerToSimgConverter:
 
         binary = self._ensure_binary(verbose=verbose)
         output_path = os.path.join(self.cache_dir, output_name)
-        if os.path.exists(output_path):
+        if (
+            os.path.exists(output_path)
+            and os.path.getsize(output_path) > 0
+            and os.path.getmtime(output_path) >= os.path.getmtime(binary)
+        ):
             if verbose:
                 print(f"Using cached docker-converted container: {output_path}")
             return output_path
+        if os.path.exists(output_path):
+            if verbose:
+                print(f"Rebuilding stale docker-converted container: {output_path}")
+            os.remove(output_path)
 
         print(f"Pulling Docker image: {image_ref}")
         subprocess.run(["docker", "pull", image_ref], check=True)
@@ -604,7 +612,7 @@ class DockerToSimgConverter:
 def build_release_docker_image_ref(
     name: str,
     version: str,
-    build_date: str,
+    image_tag: str,
     docker_registry: str = "neurodesk",
 ) -> str:
     """Return the release Docker image ref for a NeuroContainers build."""
@@ -623,7 +631,32 @@ def build_release_docker_image_ref(
     else:
         registry_path = f"ghcr.io/{registry_namespace}"
 
-    return f"{registry_path}/{image_name}:{build_date}"
+    return f"{registry_path}/{image_name}:{image_tag}"
+
+
+def build_release_docker_image_ref_candidates(
+    name: str,
+    version: str,
+    build_date: str,
+    docker_registry: str = "neurodesk",
+) -> List[str]:
+    """Return candidate release Docker refs, most-specific first."""
+
+    tags = [build_date]
+    if build_date != "latest":
+        tags.append("latest")
+
+    candidates: List[str] = []
+    for tag in tags:
+        ref = build_release_docker_image_ref(
+            name,
+            version,
+            tag,
+            docker_registry=docker_registry,
+        )
+        if ref not in candidates:
+            candidates.append(ref)
+    return candidates
 
 
 class ContainerTester:
@@ -730,7 +763,7 @@ class ContainerTester:
                 "Docker-to-SIMG conversion requires release metadata with a build date"
             )
 
-        image_ref = build_release_docker_image_ref(
+        image_refs = build_release_docker_image_ref_candidates(
             name,
             version,
             build_date,
@@ -741,11 +774,20 @@ class ContainerTester:
             self.docker_to_simg.converter_source = converter_source
 
         output_name = f"{name}_{version}_{build_date}.docker.simg"
-        converted_path = self.docker_to_simg.convert(
-            image_ref,
-            output_name,
-            verbose=verbose,
-        )
+        errors: List[str] = []
+        for image_ref in image_refs:
+            try:
+                converted_path = self.docker_to_simg.convert(
+                    image_ref,
+                    output_name,
+                    verbose=verbose,
+                )
+                break
+            except Exception as exc:
+                errors.append(f"{image_ref}: {exc}")
+        else:
+            raise RuntimeError("; ".join(errors))
+
         self.downloaded_container_path = converted_path
         return converted_path
 


### PR DESCRIPTION
## Summary

Fixes bugs found by the `run-fulltest` Docker-to-SIMG all-suite run.

## Bugs fixed

- Converted large images could be corrupt because small files with data offsets beyond 4 GiB were still encoded as SquashFS basic file inodes. Basic file inodes only have a 32-bit start offset, so Apptainer read the wrong bytes for files such as `/.singularity.d/env/*` and `/bin/sh`, causing invalid UTF-8 and input/output errors.
- Docker-to-SIMG converted files were cached forever. After fixing the converter, an old corrupt `.docker.simg` could still be reused. The cache now rebuilds converted images when the converter binary is newer than the output.
- Some release SIFs were built from Docker `:latest` rather than a build-date tag, so Docker-to-SIMG failed with `manifest unknown` for the build-date tag. The workflow now tries the build-date tag first, then falls back to `latest`.

## Validation

- `python -m py_compile workflows/container_tester.py workflows/test_runner.py workflows/full_container_test.py builder/build.py`
- `GO111MODULE=off go test ./builder`
- Parsed `.github/workflows/run-fulltest.yml` and `.github/workflows/full-container-test.yml` with PyYAML
- Verified Docker image ref candidate generation for build-date and `latest` fallback
