### PR TITLE
Update qsmbly to v0.11.1

### DIFF
--- a/recipes/qsmbly/build.yaml
+++ b/recipes/qsmbly/build.yaml
@@ -1,5 +1,5 @@
 name: qsmbly
-version: 0.11.0
+version: 0.11.1
 
 categories:
   - "structural imaging"


### PR DESCRIPTION
## Summary

- Bump qsmbly from v0.11.0 to v0.11.1
- Ensures the tagged commit has the correct version in source files (CI fix)

## Test plan

- [ ] Build container and verify qsmbly shows v0.11.1