### PR TITLE
Fix Neurodesktop nested app container runtime

### DIFF
--- a/recipes/neurodesktop/build.yaml
+++ b/recipes/neurodesktop/build.yaml
@@ -330,6 +330,7 @@ build:
         - install -m 0755 /tmp/config/jupyter/before_notebook.sh /usr/local/bin/before-notebook.d/before_notebook.sh
         - install -m 0755 /tmp/config/jupyter/jupyterlab_startup.sh /opt/neurodesktop/jupyterlab_startup.sh
         - install -m 0755 /tmp/config/jupyter/deferred_startup.sh /opt/neurodesktop/deferred_startup.sh
+        - install -m 0755 /tmp/config/jupyter/nested_container_runtime.sh /opt/neurodesktop/nested_container_runtime.sh
         - install -m 0755 /tmp/config/guacamole/guacamole.sh /opt/neurodesktop/guacamole.sh
         - install -m 0755 /tmp/config/guacamole/init_secrets.sh /opt/neurodesktop/init_secrets.sh
         - install -m 0755 /tmp/config/guacamole/ensure_rdp_backend.sh /opt/neurodesktop/ensure_rdp_backend.sh
@@ -464,6 +465,8 @@ readme: |-
   ```
 
   The JupyterLab launcher uses `${NEURODESK_WEBAPP_PORT:-8888}`. The Guacamole launcher delegates to Neurodesktop's Guacamole startup script.
+
+  When Neurodesktop is launched from Apptainer/Singularity and is expected to run Neurodesk app containers from inside the desktop, the outer runtime must allow nested container setup. If the outer container has `NoNewPrivs=1`, inner app launches can fail during user namespace setup. For setuid-capable deployments, bind a host Singularity runtime to `/opt/host-singularity-bin/singularity`; Neurodesktop will detect it automatically and put it first on `PATH` for app wrappers. Set `NEURODESKTOP_NESTED_CONTAINER_RUNTIME=host|image|auto` to force or disable this behavior.
 
   More documentation can be found here: https://www.neurodesk.org/
 

--- a/recipes/neurodesktop/config/jupyter/environment_variables.sh
+++ b/recipes/neurodesktop/config/jupyter/environment_variables.sh
@@ -67,9 +67,12 @@ if [ -z "$NEURODESKTOP_MSG_SHOWN" ] && [ -f '/usr/share/module.sh' ]; then
         fi
 fi
 
-# This also needs to be set in the Dockerfile, so it is available in a jupyter notebook
-export APPTAINER_BINDPATH=/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs
-# This also needs to be set in the Dockerfile, so it is available in a jupyter notebook
+if [ -r /opt/neurodesktop/nested_container_runtime.sh ]; then
+        source /opt/neurodesktop/nested_container_runtime.sh
+else
+        export APPTAINER_BINDPATH="${APPTAINER_BINDPATH:-/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs}"
+        export SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH:-${APPTAINER_BINDPATH}}"
+fi
 
 export APPTAINERENV_SUBJECTS_DIR=${HOME}/freesurfer-subjects-dir
 export MPLCONFIGDIR=${HOME}/.config/matplotlib-mpldir

--- a/recipes/neurodesktop/config/jupyter/nested_container_runtime.sh
+++ b/recipes/neurodesktop/config/jupyter/nested_container_runtime.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Configure the runtime used by Neurodesk app wrappers when Neurodesktop is
+# itself running inside Apptainer/Singularity.
+
+neurodesktop_path_prepend_once() {
+        local dir="$1"
+        if [ -z "${dir}" ] || [ ! -d "${dir}" ]; then
+                return 0
+        fi
+        case ":${PATH:-}:" in
+                *":${dir}:"*) ;;
+                *) export PATH="${dir}${PATH:+:${PATH}}" ;;
+        esac
+}
+
+neurodesktop_status_file="${NEURODESKTOP_PROC_STATUS:-/proc/self/status}"
+neurodesktop_no_new_privs=0
+if [ -r "${neurodesktop_status_file}" ] \
+        && awk '/^NoNewPrivs:[[:space:]]*1$/ { found=1 } END { exit found ? 0 : 1 }' "${neurodesktop_status_file}" 2>/dev/null; then
+        neurodesktop_no_new_privs=1
+fi
+
+neurodesktop_bindpath="${NEURODESKTOP_CONTAINER_BINDPATH:-/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs}"
+if [ -z "${APPTAINER_BINDPATH:-}" ] && [ -z "${SINGULARITY_BINDPATH:-}" ]; then
+        export APPTAINER_BINDPATH="${neurodesktop_bindpath}"
+        export SINGULARITY_BINDPATH="${neurodesktop_bindpath}"
+elif [ -z "${APPTAINER_BINDPATH:-}" ]; then
+        export APPTAINER_BINDPATH="${SINGULARITY_BINDPATH}"
+elif [ -z "${SINGULARITY_BINDPATH:-}" ]; then
+        export SINGULARITY_BINDPATH="${APPTAINER_BINDPATH}"
+fi
+
+neurodesktop_nested_runtime_mode="$(printf '%s' "${NEURODESKTOP_NESTED_CONTAINER_RUNTIME:-auto}" | tr '[:upper:]' '[:lower:]')"
+neurodesktop_host_singularity_bin="${NEURODESKTOP_HOST_SINGULARITY_BIN:-/opt/host-singularity-bin/singularity}"
+neurodesktop_host_singularity_dir="$(dirname "${neurodesktop_host_singularity_bin}")"
+
+export NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE=image
+case "${neurodesktop_nested_runtime_mode}" in
+        auto|host)
+                if [ -x "${neurodesktop_host_singularity_bin}" ]; then
+                        neurodesktop_path_prepend_once "${neurodesktop_host_singularity_dir}"
+                        export NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE=host
+                        export NEURODESKTOP_HOST_SINGULARITY_BIN="${neurodesktop_host_singularity_bin}"
+                elif [ "${neurodesktop_nested_runtime_mode}" = "host" ]; then
+                        export NEURODESKTOP_NESTED_CONTAINER_WARNING="NEURODESKTOP_NESTED_CONTAINER_RUNTIME=host was requested, but ${neurodesktop_host_singularity_bin} is not executable."
+                fi
+                ;;
+        image)
+                ;;
+        *)
+                export NEURODESKTOP_NESTED_CONTAINER_WARNING="Unknown NEURODESKTOP_NESTED_CONTAINER_RUNTIME='${NEURODESKTOP_NESTED_CONTAINER_RUNTIME}'. Expected auto, host, or image."
+                ;;
+esac
+
+if [ "${neurodesktop_no_new_privs}" = "1" ] \
+        && [ "${NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE}" != "host" ] \
+        && [ -z "${NEURODESKTOP_NESTED_CONTAINER_WARNING:-}" ]; then
+        export NEURODESKTOP_NESTED_CONTAINER_WARNING="Nested Neurodesk app containers may fail because the outer Apptainer/Singularity container has NoNewPrivs=1. Launch the outer container with setuid support and bind a host Singularity runtime to /opt/host-singularity-bin for nested app-container execution."
+fi
+
+if [ -n "${NEURODESKTOP_NESTED_CONTAINER_WARNING:-}" ] \
+        && [ -z "${NEURODESKTOP_NESTED_CONTAINER_WARNING_SHOWN:-}" ] \
+        && { [[ $- == *i* ]] || [ -t 1 ]; }; then
+        export NEURODESKTOP_NESTED_CONTAINER_WARNING_SHOWN=1
+        echo "[WARN] ${NEURODESKTOP_NESTED_CONTAINER_WARNING}" >&2
+fi
+
+unset neurodesktop_bindpath neurodesktop_host_singularity_bin neurodesktop_host_singularity_dir
+unset neurodesktop_nested_runtime_mode neurodesktop_no_new_privs neurodesktop_status_file

--- a/recipes/neurodesktop/fulltest.yaml
+++ b/recipes/neurodesktop/fulltest.yaml
@@ -76,6 +76,7 @@ tests:
           /opt/neurodesktop/guacamole.sh \
           /opt/neurodesktop/init_secrets.sh \
           /opt/neurodesktop/deferred_startup.sh \
+          /opt/neurodesktop/nested_container_runtime.sh \
           /opt/neurodesktop/environment_variables.sh
         do
           test -x "$path"
@@ -308,6 +309,31 @@ tests:
     description: Verify Apptainer is installed in the desktop image
     command: apptainer --version
     expected_output_contains: "apptainer version"
+
+  - name: Nested container runtime environment
+    description: Verify Neurodesk app-container runtime defaults and host runtime opt-in
+    command: |
+      bash -lc '
+        set -euo pipefail
+        NEURODESKTOP_HOST_SINGULARITY_BIN=/nonexistent \
+          source /opt/neurodesktop/environment_variables.sh >/dev/null 2>&1
+        test "${APPTAINER_BINDPATH:-}" = "/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs"
+        test "${SINGULARITY_BINDPATH:-}" = "/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs"
+        test "${NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE:-}" = "image"
+
+        tmpdir="$(mktemp -d)"
+        mkdir -p "$tmpdir/bin"
+        printf "%s\n" "#!/bin/sh" "exit 0" > "$tmpdir/bin/singularity"
+        chmod +x "$tmpdir/bin/singularity"
+        NEURODESKTOP_HOST_SINGULARITY_BIN="$tmpdir/bin/singularity" \
+          NEURODESKTOP_NESTED_CONTAINER_RUNTIME=auto \
+          APPTAINER_BINDPATH= \
+          SINGULARITY_BINDPATH= \
+          bash -lc "source /opt/neurodesktop/nested_container_runtime.sh; test \"\${NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE}\" = host; case \":\${PATH}:\" in *\":$tmpdir/bin:\"*) ;; *) exit 2 ;; esac"
+        rm -rf "$tmpdir"
+        echo "nested-runtime-env-ok"
+      '
+    expected_output_contains: "nested-runtime-env-ok"
 
   - name: Nextflow launcher is installed
     description: Verify the Nextflow launcher is installed without requiring network bootstrap

--- a/recipes/neurodesktop/tests/test_nested_container_runtime.py
+++ b/recipes/neurodesktop/tests/test_nested_container_runtime.py
@@ -1,0 +1,87 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+RUNTIME_SCRIPT = "/opt/neurodesktop/nested_container_runtime.sh"
+
+
+def run_bash(script, env=None):
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        ["/bin/bash", "-lc", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=merged_env,
+    )
+
+
+def test_nested_container_runtime_script_installed():
+    path = Path(RUNTIME_SCRIPT)
+    assert path.is_file(), f"{RUNTIME_SCRIPT} is missing"
+    assert os.access(path, os.X_OK), f"{RUNTIME_SCRIPT} is not executable"
+
+
+def test_nested_runtime_sets_matching_bindpaths_by_default():
+    result = run_bash(
+        f"""
+        unset APPTAINER_BINDPATH SINGULARITY_BINDPATH
+        source {RUNTIME_SCRIPT}
+        printf '%s\\n%s\\n%s\\n' \
+            "$APPTAINER_BINDPATH" \
+            "$SINGULARITY_BINDPATH" \
+            "$NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE"
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs",
+        "/data,/mnt,/neurodesktop-storage,/tmp,/cvmfs",
+        "image",
+    ]
+
+
+def test_nested_runtime_uses_bound_host_singularity(tmp_path):
+    host_bin_dir = tmp_path / "host-bin"
+    host_bin_dir.mkdir()
+    host_singularity = host_bin_dir / "singularity"
+    host_singularity.write_text("#!/bin/sh\nexit 0\n")
+    host_singularity.chmod(0o755)
+
+    result = run_bash(
+        f"""
+        source {RUNTIME_SCRIPT}
+        printf '%s\\n%s\\n' "$NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE" "$PATH"
+        """,
+        env={
+            "NEURODESKTOP_HOST_SINGULARITY_BIN": str(host_singularity),
+            "NEURODESKTOP_NESTED_CONTAINER_RUNTIME": "auto",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    active, path = result.stdout.splitlines()
+    assert active == "host"
+    assert str(host_bin_dir) in path.split(":")
+
+
+def test_nested_runtime_warns_when_no_new_privs_blocks_nested_userns(tmp_path):
+    status_file = tmp_path / "status"
+    status_file.write_text("Name:\tbash\nNoNewPrivs:\t1\n")
+
+    result = run_bash(
+        f"""
+        source {RUNTIME_SCRIPT}
+        printf '%s\\n%s\\n' "$NEURODESKTOP_NESTED_CONTAINER_RUNTIME_ACTIVE" "$NEURODESKTOP_NESTED_CONTAINER_WARNING"
+        """,
+        env={
+            "NEURODESKTOP_PROC_STATUS": str(status_file),
+            "NEURODESKTOP_NESTED_CONTAINER_RUNTIME": "image",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    active, warning = result.stdout.splitlines()
+    assert active == "image"
+    assert "NoNewPrivs=1" in warning


### PR DESCRIPTION
## Summary

- add a Neurodesktop runtime setup script for nested Neurodesk app-container execution
- keep image Apptainer as the default, but automatically prefer a bound host Singularity runtime at `/opt/host-singularity-bin/singularity`
- set matching `APPTAINER_BINDPATH`/`SINGULARITY_BINDPATH` defaults and warn when `NoNewPrivs=1` makes nested app containers likely to fail
- add fulltest and pytest coverage for default runtime setup, host-runtime detection, and NoNewPrivs diagnostics

## Background

Manual testing of `neurodesktop_20260428_20260505.simg` showed Jupyter, Guacamole, VNC, and GUI display were healthy, but Neurodesk app wrappers such as `niimath` and MRIcron failed when they attempted to run nested app containers from inside an unprivileged outer Apptainer container:

```text
ERROR  : Could not write info to setgroups: Permission denied
ERROR  : Error while waiting event for user namespace mappings: no event received
```

The root cause was the outer runtime setting `NoNewPrivs=1`, which prevents the inner Apptainer/Singularity runtime from completing user namespace or setuid setup. A local setuid-capable outer launch with a bound host Singularity runtime allowed the normal Neurodesk wrappers to run `niimath` and launch MRIcron through VNC.

## Notes

This cannot remove `NoNewPrivs` from inside the container. The container-side fix is to support the working host-runtime path cleanly and make the blocked mode explicit for users/operators.

For setuid-capable deployments, bind the host Singularity runtime to `/opt/host-singularity-bin/singularity`. The new setup script detects that path automatically. It can be controlled with `NEURODESKTOP_NESTED_CONTAINER_RUNTIME=auto|host|image`.

## Verification

- `bash -n recipes/neurodesktop/config/jupyter/nested_container_runtime.sh recipes/neurodesktop/config/jupyter/environment_variables.sh`
- `python3 builder/validation.py recipes/neurodesktop/build.yaml`
- `git diff --check`
- `python3 builder/build.py generate neurodesktop --recreate --check-only`
