### PR TITLE
Document AppArmor limits for nested Neurodesktop containers

### DIFF
--- a/recipes/neurodesktop/config/README.md
+++ b/recipes/neurodesktop/config/README.md
@@ -1,1 +1,16 @@
-# Config
+# Neurodesktop runtime configuration
+
+## Nested Apptainer/Singularity app containers
+
+Neurodesktop is expected to run in environments where nested container execution is allowed, such as HPC systems, Docker deployments with host-level setup, or a VM/container host configured for this workflow.
+
+On Ubuntu hosts, AppArmor can block rootless nested Apptainer/Singularity even when unprivileged user namespaces are otherwise enabled. A typical failure is:
+
+```text
+Could not write info to setgroups: Permission denied
+Error while waiting event for user namespace mappings: no event received
+```
+
+This is a host security-policy limitation rather than a broken Neurodesk app container. Supported workarounds are to run on a host profile that permits the nested runtime, disable Ubuntu's AppArmor user-namespace restriction for the deployment, or bind a host setuid Singularity runtime and set `NEURODESKTOP_NESTED_CONTAINER_RUNTIME=host`.
+
+The default `neurodesk_singularity_opts` uses `/tmp/apptainer_overlay` for app containers. Some setuid Singularity installations reject directory overlays for non-root users; in those environments use a rootless/user-namespace launch mode, a writable overlay image, or the host-runtime path above.

--- a/recipes/neurodesktop/config/jupyter/environment_variables.sh
+++ b/recipes/neurodesktop/config/jupyter/environment_variables.sh
@@ -291,8 +291,13 @@ case "${NEURODESKTOP_SLURM_MODE}" in
                 ;;
 esac
 
-# This is needed to make containers writable as a workaround for macos with Apple Silicon. We need to do it here for the desktop
-# and in the dockerfile for the jupyter notebook
+# This is needed to make app containers writable as a workaround for macos with Apple Silicon.
+# We need to do it here for the desktop and in the dockerfile for the jupyter notebook.
+#
+# Host note: some setuid Singularity installations reject directory overlays for
+# non-root users. If /tmp/apptainer_overlay fails on a host, use a rootless
+# launch mode, a writable overlay image, or the host-runtime nested container
+# path documented in /opt/neurodesktop/nested_container_runtime.sh.
 export neurodesk_singularity_opts=" --overlay /tmp/apptainer_overlay "
 # export neurodesk_singularity_opts=" -w " THIS DOES NOT WORK FOR SIMG FILES IN OFFLINE MODE
 # There is a small delay in using --overlay in comparison to -w - maybe it would be faster to use a fixed size overlay file instead?

--- a/recipes/neurodesktop/config/jupyter/nested_container_runtime.sh
+++ b/recipes/neurodesktop/config/jupyter/nested_container_runtime.sh
@@ -2,6 +2,15 @@
 
 # Configure the runtime used by Neurodesk app wrappers when Neurodesktop is
 # itself running inside Apptainer/Singularity.
+#
+# Host note: Ubuntu AppArmor can restrict unprivileged user namespaces. When
+# that policy is active, the bundled rootless Apptainer runtime may fail before
+# an app container starts with errors such as:
+#   Could not write info to setgroups: Permission denied
+# This is a host security-policy limitation, not an app-container failure. Use
+# an environment that permits nested rootless containers, disable the relevant
+# AppArmor userns restriction for the deployment, or bind a host setuid
+# Singularity runtime and set NEURODESKTOP_NESTED_CONTAINER_RUNTIME=host.
 
 neurodesktop_path_prepend_once() {
         local dir="$1"


### PR DESCRIPTION
## Summary
- document Ubuntu AppArmor/userns limits for nested Neurodesktop app containers
- note host-runtime workaround and directory overlay caveat
- add inline comments near nested runtime and overlay configuration

## Validation
- Tested neurodesktop_20260428_20260509.simg after disabling AppArmor on astra-yolo: nested niimath app container downloads, module loads, and niimath executable prints usage successfully.
- Verified exact directory overlay still requires rootless/userns mode on this host; plain setuid Singularity rejects non-root directory overlays.
- Ran bash syntax checks for updated shell files and a small docs smoke assertion.
