### PR TITLE
Fix contribution issue base64 fence parsing

### DIFF
--- a/.github/workflows/process-issues.yml
+++ b/.github/workflows/process-issues.yml
@@ -43,7 +43,7 @@ jobs:
             const issueBody = context.payload.issue.body;
 
             // Extract base64 encoded content from issue body
-            const base64Regex = /```base64\n([\s\S]*?)\n```/;
+            const base64Regex = /```base64\r?\n([\s\S]*?)(?:\r?\n)?```/;
             const match = issueBody.match(base64Regex);
 
             if (!match) {


### PR DESCRIPTION
## Summary
- Allow contribution issue base64 fences to close immediately after the encoded payload, without requiring a newline before the closing ``` fence.
- Keep CRLF tolerance for issue bodies copied from different platforms.

## Evidence
- Reproduced the failing #2178 issue body parser locally against GitHub issue #2178.
- Verified the updated regex extracts and inflates the submitted linda recipe with Node, `js-yaml`, and `pako`:
  - parsed `name: linda`
  - parsed `version: 0.5.1`
  - decompressed YAML length: 19890 bytes

## Context
The failing `Process Contribution Issues` workflow run stopped in "Parse base64 encoded deflate compressed YAML from issue body" because issue #2178's generated body has the closing code fence directly after the base64 payload (`...==````), not on a separate line.