### PR TITLE
Fix brittle fulltest YAML checks

### DIFF
--- a/recipes/dicompare/fulltest.yaml
+++ b/recipes/dicompare/fulltest.yaml
@@ -137,7 +137,7 @@ tests:
   - name: start.sh contains serve command
     description: Verify startup script runs serve
     command: "bash -lc 'cat /opt/dicompare/start.sh'"
-    expected_output_contains: "serve -s dist -l 3001"
+    expected_output_contains: "serve -s dist -l ${NEURODESK_WEBAPP_PORT:-3001}"
 
   # ==========================================================================
   # INDEX.HTML VERIFICATION
@@ -483,43 +483,43 @@ tests:
   # ==========================================================================
   - name: Web server can start
     description: Test that serve can start serving files
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3002 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3002/ || echo \"failed\"\npkill -f \"serve.*3002\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3002 >/tmp/dicompare-3002.log 2>&1 &\npid=$!\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3002/ || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server serves index.html
     description: Test that serve returns HTML content
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3003 &\nsleep 2\ncurl -s http://localhost:3003/ | head -1 || echo \"failed\"\npkill -f \"serve.*3003\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3003 >/tmp/dicompare-3003.log 2>&1 &\npid=$!\nsleep 2\ncurl -s http://localhost:3003/ | head -1 || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "<!DOCTYPE html>"
     timeout: 10
 
   - name: Web server serves favicon
     description: Test that serve returns favicon
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3004 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3004/favicon.ico || echo \"failed\"\npkill -f \"serve.*3004\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3004 >/tmp/dicompare-3004.log 2>&1 &\npid=$!\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3004/favicon.ico || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server serves manifest.json
     description: Test that serve returns manifest.json
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3005 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3005/manifest.json || echo \"failed\"\npkill -f \"serve.*3005\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3005 >/tmp/dicompare-3005.log 2>&1 &\npid=$!\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3005/manifest.json || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server serves schema files
     description: Test that serve returns schema index
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3006 &\nsleep 2\ncurl -s http://localhost:3006/schemas/index.json | head -1 || echo \"failed\"\npkill -f \"serve.*3006\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3006 >/tmp/dicompare-3006.log 2>&1 &\npid=$!\nsleep 2\ncurl -s http://localhost:3006/schemas/index.json | head -1 || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "["
     timeout: 10
 
   - name: Web server serves validation functions
     description: Test that serve returns validation function
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3007 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3007/validation-functions/validate_echo_count.json || echo \"failed\"\npkill -f \"serve.*3007\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3007 >/tmp/dicompare-3007.log 2>&1 &\npid=$!\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3007/validation-functions/validate_echo_count.json || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 
   - name: Web server single page mode works
     description: Test that SPA routing redirects to index.html
-    command: "bash -lc 'timeout 5s serve -s /opt/dicompare/dist -l 3008 &\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3008/nonexistent/path || echo \"failed\"\npkill -f \"serve.*3008\" 2>/dev/null || true'"
+    command: "bash -lc 'serve -s /opt/dicompare/dist -l 3008 >/tmp/dicompare-3008.log 2>&1 &\npid=$!\nsleep 2\ncurl -s -o /dev/null -w \"%{http_code}\" http://localhost:3008/nonexistent/path || echo \"failed\"\nkill \"$pid\" 2>/dev/null || true\nwait \"$pid\" 2>/dev/null || true'"
     expected_output_contains: "200"
     timeout: 10
 

--- a/recipes/eeglab/fulltest.yaml
+++ b/recipes/eeglab/fulltest.yaml
@@ -310,8 +310,8 @@ tests:
 
   - name: Environment scripts exist
     description: Verify environment setup scripts are present
-    command: bash -lc 'test -d /.singularity.d/env && ls /.singularity.d/env/*.sh | wc -l'
-    expected_output_contains: "6"
+    command: bash -lc 'test -d /.singularity.d/env && count=$(ls /.singularity.d/env/*.sh | wc -l); test "$count" -ge 6 && echo "env scripts ok ($count)"'
+    expected_output_contains: "env scripts ok"
 
   # ==========================================================================
   # SYSTEM LIBRARY COMPATIBILITY

--- a/recipes/mfcsc/fulltest.yaml
+++ b/recipes/mfcsc/fulltest.yaml
@@ -47,41 +47,51 @@ setup:
 
     # Create a Python script to generate test connectivity matrices
     cat > test_output/mfcsc/generate_test_data.py << 'PYTHON_SCRIPT'
-    import numpy as np
-    import os
+    import random
 
-    np.random.seed(42)  # For reproducibility
+    random.seed(42)  # For reproducibility
 
     n_regions = 10  # 5 regions per hemisphere
     n_subjects = 3
 
+    def symmetric_matrix(value_fn, diagonal):
+        matrix = [[0.0 for _ in range(n_regions)] for _ in range(n_regions)]
+        for i in range(n_regions):
+            matrix[i][i] = diagonal
+            for j in range(i + 1, n_regions):
+                value = value_fn(i, j)
+                matrix[i][j] = value
+                matrix[j][i] = value
+        return matrix
+
+    def write_csv(path, matrix):
+        with open(path, 'w') as f:
+            for row in matrix:
+                f.write(','.join(f'{value:.6f}' for value in row) + '\n')
+
     # Generate FC and SC matrices for multiple subjects
     for subj in range(1, n_subjects + 1):
-        # Generate random symmetric FC matrix (correlation-like values between -1 and 1)
-        fc_raw = np.random.uniform(-0.5, 0.8, (n_regions, n_regions))
-        fc = (fc_raw + fc_raw.T) / 2  # Make symmetric
-        np.fill_diagonal(fc, 1.0)  # Diagonal is 1 for correlations
+        # Generate symmetric FC matrix (correlation-like values between -1 and 1)
+        fc = symmetric_matrix(lambda _i, _j: random.uniform(-0.5, 0.8), 1.0)
 
-        # Generate random symmetric SC matrix (streamline counts, positive values)
-        sc_raw = np.random.exponential(scale=50, size=(n_regions, n_regions))
-        sc = (sc_raw + sc_raw.T) / 2  # Make symmetric
-        np.fill_diagonal(sc, 0)  # No self-connections in SC
+        # Generate symmetric SC matrix (streamline counts, positive values)
+        def sc_value(i, j):
+            value = random.expovariate(1 / 50)
+            # Add some structure - stronger ipsilateral than contralateral connections
+            # Left hemisphere: regions 0-4, Right hemisphere: regions 5-9
+            if (i < 5 and j < 5) or (i >= 5 and j >= 5):
+                value *= 1.5
+            return value
 
-        # Add some structure - stronger ipsilateral than contralateral connections
-        # Left hemisphere: regions 0-4, Right hemisphere: regions 5-9
-        for i in range(5):
-            for j in range(5):
-                if i != j:
-                    sc[i, j] *= 1.5  # Boost left-left connections
-                    sc[i+5, j+5] *= 1.5  # Boost right-right connections
+        sc = symmetric_matrix(sc_value, 0.0)
 
         # Save FC matrix
         fc_file = f'test_output/mfcsc/FC/subject{subj:02d}_fc.csv'
-        np.savetxt(fc_file, fc, delimiter=',', fmt='%.6f')
+        write_csv(fc_file, fc)
 
         # Save SC matrix
         sc_file = f'test_output/mfcsc/SC/subject{subj:02d}_sc.csv'
-        np.savetxt(sc_file, sc, delimiter=',', fmt='%.6f')
+        write_csv(sc_file, sc)
 
     print(f"Generated {n_subjects} FC and SC matrices with {n_regions} regions each")
     PYTHON_SCRIPT
@@ -91,9 +101,9 @@ setup:
 
     # Create the FC_SC_LIST file (tab-separated matching file)
     # List FC files in first column, matching SC files in second column
-    paste <(ls test_output/mfcsc/FC/*.csv | xargs -n1 basename | sort) \
-          <(ls test_output/mfcsc/SC/*.csv | xargs -n1 basename | sort) \
-          > test_output/mfcsc/fc_sc_list.txt
+    ls test_output/mfcsc/FC/*.csv | xargs -n1 basename | sort > test_output/mfcsc/fc_files.txt
+    ls test_output/mfcsc/SC/*.csv | xargs -n1 basename | sort > test_output/mfcsc/sc_files.txt
+    paste test_output/mfcsc/fc_files.txt test_output/mfcsc/sc_files.txt > test_output/mfcsc/fc_sc_list.txt
 
     echo "Test data setup complete"
     echo "FC_SC_LIST contents:"


### PR DESCRIPTION
## Summary

Fixes three brittle fulltest YAML checks from the current backlog-selected fulltest failures:

- `mfcsc`: make host setup `/bin/sh`-compatible by removing process substitution, and generate synthetic CSV matrices with Python stdlib instead of requiring NumPy on the host runner.
- `dicompare`: align the start script expectation with the current `${NEURODESK_WEBAPP_PORT:-3001}` startup command, and make web-server smoke tests stop their background `serve` process without returning SIGTERM/143.
- `eeglab`: avoid an exact Singularity env script count; require at least six env scripts and print a stable success marker.

## Evidence

- Parsed changed fulltest YAML with Python `yaml.safe_load`:
  - `recipes/dicompare/fulltest.yaml`
  - `recipes/eeglab/fulltest.yaml`
  - `recipes/mfcsc/fulltest.yaml`
- Executed the updated `mfcsc` `setup.host_script` locally under `/bin/sh`; it exits 0 and generates the expected `fc_sc_list.txt` with 3 FC/SC pairs.
- `git diff --check` passed before commit.

## Notes

I did not run full Docker/Apptainer container rebuilds for these containers in-window because the changes are fulltest harness fixes and rebuilding all three containers would be disproportionately expensive. The local evidence targets the exact observed failure modes.