### PR TITLE
Fix fmriprep fulltest version expectations

### DIFF
--- a/recipes/fmriprep/fulltest.yaml
+++ b/recipes/fmriprep/fulltest.yaml
@@ -1,5 +1,5 @@
 # fmriprep container test suite
-# Tests for fmriprep v25.2.3 - fMRI preprocessing pipeline
+# Tests for fmriprep v25.2.5 - fMRI preprocessing pipeline
 #
 # fMRIPrep is a functional magnetic resonance imaging (fMRI) data preprocessing
 # pipeline designed to provide an easily accessible, state-of-the-art interface
@@ -13,8 +13,8 @@
 # compute resources. This test suite focuses on component tools and quick checks.
 
 name: fmriprep
-version: 25.2.3
-container: fmriprep_25.2.3_20260107.simg
+version: 25.2.5
+container: fmriprep_25.2.5_20260413.simg
 
 required_files:
   - dataset: ds000001
@@ -46,7 +46,7 @@ tests:
   - name: fmriprep version check
     description: Verify fmriprep binary runs and reports version
     command: fmriprep --version 2>&1
-    expected_output_contains: "fMRIPrep v25.2.3"
+    expected_output_contains: "fMRIPrep v25.2.5"
 
   - name: fmriprep help
     description: Verify fmriprep help is accessible
@@ -56,7 +56,7 @@ tests:
   - name: fmriprep BIDS validation skip test
     description: Test fmriprep can parse BIDS dataset with validation skip
     command: fmriprep ${bids_dir} test_output/fmriprep_out participant --participant-label 01 --skip-bids-validation --version 2>&1
-    expected_output_contains: "fMRIPrep v25.2.3"
+    expected_output_contains: "fMRIPrep v25.2.5"
 
   # ==========================================================================
   # ANTs TOOLS - BIAS FIELD CORRECTION


### PR DESCRIPTION
## Summary

Update the fmriprep fulltest metadata and version assertions from 25.2.3 to the current 25.2.5 release.

The repository build recipe and latest release file are already on fmriprep 25.2.5 (`releases/fmriprep/25.2.5.json` build date `20260413`), so the fulltest runner downloads/runs the current container while the YAML still expected `fMRIPrep v25.2.3`. This caused the fmriprep version checks in the fulltest matrix to fail.

## Evidence

- Parsed `recipes/fmriprep/fulltest.yaml`, `recipes/fmriprep/build.yaml`, and `releases/fmriprep/25.2.5.json` with Python/YAML.
- Built a local SIF from `docker://nipreps/fmriprep:25.2.5` with Singularity and verified:
  - `singularity exec /tmp/neurocontainers-check/fmriprep_25.2.5.sif fmriprep --version`
  - output: `fMRIPrep v25.2.5`
- `git diff --check` passed.

## Not run

- Full fmriprep fulltest suite; it requires dataset preparation and substantial runtime. This change is limited to stale version metadata/assertions.