### PR TITLE
Isolate XNAT Tomcat version checks from host Java env

### DIFF
--- a/recipes/xnat/fulltest.yaml
+++ b/recipes/xnat/fulltest.yaml
@@ -109,12 +109,12 @@ tests:
   # ==========================================================================
   - name: Tomcat version check
     description: Verify Apache Tomcat 9 is installed
-    command: bash -lc '/usr/share/tomcat9/bin/version.sh 2>&1'
+    command: bash -lc 'unset JAVA_HOME JRE_HOME; /usr/share/tomcat9/bin/version.sh 2>&1'
     expected_output_contains: "Apache Tomcat/9"
 
   - name: Tomcat server number
     description: Verify Tomcat server version number
-    command: bash -lc '/usr/share/tomcat9/bin/version.sh 2>&1'
+    command: bash -lc 'unset JAVA_HOME JRE_HOME; /usr/share/tomcat9/bin/version.sh 2>&1'
     expected_output_contains: "9.0.31"
 
   - name: Tomcat catalina script


### PR DESCRIPTION
## Summary

Make the XNAT Tomcat fulltest version checks ignore leaked host Java environment variables.

The XNAT image has Java/Tomcat installed, but Tomcat's `version.sh` delegates through `catalina.sh`, which honors `JAVA_HOME`/`JRE_HOME` from the environment. Under Apptainer/Singularity these host variables can leak into the container; when they point to a host-only path, `version.sh` exits 127 before it can report the Tomcat version. The fulltest matrix failure matched that mode (`Tomcat version check` and `Tomcat server number` exit 127).

## Evidence

- Parsed `recipes/xnat/fulltest.yaml` and `recipes/xnat/build.yaml` with Python/YAML.
- Downloaded the Ubuntu focal `tomcat9-common_9.0.31-1ubuntu0.9_all.deb` package and verified it ships `/usr/share/tomcat9/bin/version.sh` and `catalina.sh`; `setclasspath.sh` uses `JRE_HOME/bin/java` when `JRE_HOME` is set.
- Built a local SIF from `docker://ghcr.io/neurodesk/xnat_1.9.2.1:20250805` and reproduced/fixed the issue:
  - with bogus `JAVA_HOME`/`JRE_HOME`, old command exited 127: `/definitely/missing/bin/java: not found`
  - with `unset JAVA_HOME JRE_HOME`, `version.sh` exited 0 and printed `Apache Tomcat/9.0.31 (Ubuntu)` / `Server number: 9.0.31.0`
- `git diff --check` passed.

## Not run

- Full XNAT fulltest suite. This targeted change was validated against the released container and the failing commands.