### PR TITLE
Use fulltest data variables in Nipype interface checks

### DIFF
--- a/recipes/nipype/fulltest.yaml
+++ b/recipes/nipype/fulltest.yaml
@@ -262,13 +262,15 @@ tests:
     description: Test SelectFiles for template-based file selection
     command: |
       python -c "
+      from pathlib import Path
       from nipype.interfaces.io import SelectFiles
       templates = {'anat': 'sub-{subject}/anat/*_T1w.nii.gz',
                    'func': 'sub-{subject}/func/*_bold.nii.gz'}
       sf = SelectFiles(templates)
-      sf.inputs.base_directory = 'ds000001'
+      sf.inputs.base_directory = str(Path('${t1w}').parents[2])
       sf.inputs.subject = '01'
       print('SelectFiles configured with templates')
+      print('Base directory:', sf.inputs.base_directory)
       print('Anat template:', templates['anat'])
       "
     expected_output_contains: "T1w.nii.gz"
@@ -323,7 +325,7 @@ tests:
       python -c "
       from nipype.interfaces.fsl import BET
       bet = BET()
-      bet.inputs.in_file = 'ds000001/sub-01/anat/sub-01_T1w.nii.gz'
+      bet.inputs.in_file = '${t1w}'
       bet.inputs.frac = 0.5
       bet.inputs.mask = True
       bet.inputs.out_file = 'test_output/brain.nii.gz'
@@ -357,7 +359,7 @@ tests:
       python -c "
       from nipype.interfaces.fsl import MCFLIRT
       mc = MCFLIRT()
-      mc.inputs.in_file = 'ds000001/sub-01/func/sub-01_task-balloonanalogrisktask_run-01_bold.nii.gz'
+      mc.inputs.in_file = '${bold}'
       mc.inputs.ref_vol = 0
       mc.inputs.save_plots = True
       mc.inputs.save_mats = True


### PR DESCRIPTION
## Summary

Use the fulltest runner-substituted dataset paths in the Nipype interface setup checks.

The failing tests were hard-coding `ds000001/...` relative paths. The runner can place copied required files under the suite work directory, and the fulltest already defines `${t1w}` and `${bold}` for the resolved test data. This patch uses those variables for FSL BET/MCFLIRT input validation and derives the `SelectFiles` base directory from `${t1w}`.

## Evidence

- Current `data/snapshot.json` reports three Nipype failures: `SelectFiles interface`, `FSL BET interface setup`, and `FSL MCFLIRT interface setup`, all `Expected exit code 0, got 1`.
- Nipype FSL interfaces validate `in_file` existence at assignment, so stale hard-coded paths fail before running FSL binaries.
- Parsed `recipes/nipype/fulltest.yaml` with Python/YAML.
- Ran targeted commands in local SIF from `docker://ghcr.io/neurodesk/nipype_1.8.3:20220825` with required files mounted at `/work/nipype/ds000001/...`:
  - `SelectFiles` configured with base `/work/nipype/ds000001`
  - BET interface configured from `${t1w}`
  - MCFLIRT interface configured from `${bold}`
- `git diff --check` passed.

## Not run

- Full Nipype fulltest suite. This is a targeted path-resolution fix for the three selected failures.