### PR TITLE
Set FREESURFER_HOME for SynthStrip fulltests

### DIFF
--- a/recipes/synthstrip/fulltest.yaml
+++ b/recipes/synthstrip/fulltest.yaml
@@ -34,6 +34,9 @@ test_data:
   t2: ds000001/sub-01/anat/sub-01_inplaneT2.nii.gz
   output_dir: test_output
 
+env:
+  FREESURFER_HOME: /freesurfer
+
 setup:
   script: |
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Set `FREESURFER_HOME=/freesurfer` for the SynthStrip fulltest suite.

The selected matrix failures all occur when real `mri_synthstrip` invocations exit before processing because `FREESURFER_HOME` is missing. The recipe build places SynthStrip weights under `/freesurfer/models` and the legacy build recipe intended `FREESURFER_HOME=/freesurfer`, so this exports that environment for fulltests only.

## Evidence

- Current selected fulltest snapshot reports 32 SynthStrip failures, all real `mri_synthstrip` runs exiting `1` while help-only tests pass.
- Fulltest artifact log for `Brain extraction T1w basic` reports: `Error: FREESURFER_HOME env variable must be set!`.
- `recipes/synthstrip/build.sh` sets `FREESURFER_HOME=/freesurfer`, and `recipes/synthstrip/synthstrip.star` installs `synthstrip.1.pt` / `synthstrip.nocsf.1.pt` under `freesurfer/models`.
- `builder/run_tests.py` supports top-level `env:` exports.
- Parsed `recipes/synthstrip/fulltest.yaml` with Python/YAML.
- Pulled local SIF from `docker://ghcr.io/neurodesk/synthstrip_7.4.1:20240913` and confirmed `/freesurfer/models` contains the SynthStrip weights and `FREESURFER_HOME=/freesurfer mri_synthstrip --help` runs.
- `git diff --check` passed.

## Not run

- Full SynthStrip extraction suite. This is a targeted environment fix for the common pre-processing failure.