### PR TITLE
Add Blacksmith arm64 manual build support

### DIFF
--- a/.github/actions/setup-apptainer/action.yml
+++ b/.github/actions/setup-apptainer/action.yml
@@ -27,10 +27,13 @@ runs:
         fi
 
         arch="$(dpkg --print-architecture)"
-        if [[ "$arch" != "amd64" ]]; then
-          echo "Apptainer ${version} release packages are only available for amd64 runners; found ${arch}." >&2
-          exit 1
-        fi
+        case "$arch" in
+          amd64|arm64) ;;
+          *)
+            echo "Apptainer ${version} release packages are not configured for ${arch} runners." >&2
+            exit 1
+            ;;
+        esac
 
         cache_dir="${RUNNER_TEMP:-/tmp}/apptainer/${version}/${arch}"
         deb_path="${cache_dir}/apptainer.deb"

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -60,6 +60,9 @@ jobs:
       SHORT_SHA: ${{ steps.envars.outputs.SHORT_SHA }}
       IMAGETAG: ${{ steps.envars.outputs.IMAGETAG }}
       VERSION: ${{ steps.envars.outputs.VERSION }}
+      ARCHITECTURE: ${{ steps.envars.outputs.ARCHITECTURE }}
+      IMAGE_SUFFIX: ${{ steps.envars.outputs.IMAGE_SUFFIX }}
+      RELEASE_VERSION: ${{ steps.envars.outputs.RELEASE_VERSION }}
       ROOTFS_CACHE: ${{ steps.getrootfs.outputs.ROOTFS_CACHE }}
     steps:
       - name: Checkout repository
@@ -88,9 +91,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends --no-upgrade \
             ca-certificates curl docker.io git gh jq python3 python3-pip python3-venv unzip
+          case "$(uname -m)" in
+            x86_64)
+              APPTAINER_ARCH=amd64
+              AWSCLI_ARCH=x86_64
+              ;;
+            aarch64|arm64)
+              APPTAINER_ARCH=arm64
+              AWSCLI_ARCH=aarch64
+              ;;
+            *)
+              echo "Unsupported machine architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
           APPTAINER_VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
-          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_amd64.deb" \
+          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
             -o /tmp/apptainer.deb
           sudo apt-get install -y /tmp/apptainer.deb
           rm /tmp/apptainer.deb
@@ -102,7 +119,7 @@ jobs:
             python-swiftclient python-keystoneclient
           # AWS CLI v2 — guarded so a pre-existing install isn't clobbered.
           if ! command -v aws >/dev/null 2>&1; then
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" \
               -o /tmp/awscliv2.zip
             unzip -q /tmp/awscliv2.zip -d /tmp
             sudo /tmp/aws/install
@@ -121,6 +138,14 @@ jobs:
             echo "Recipe version not found for $APPLICATION"
             exit 1
           fi
+          ARCHITECTURE="x86_64"
+          IMAGE_SUFFIX=""
+          RELEASE_VERSION="$VERSION"
+          if [[ "${{ inputs.runner }}" == *"arm"* ]]; then
+            ARCHITECTURE="aarch64"
+            IMAGE_SUFFIX="_arm64"
+            RELEASE_VERSION="${VERSION}-arm64"
+          fi
           # Get the commit date of the recipe's build.yaml file
           # This ensures consistent build dates based on when the recipe was last modified
           BUILDDATE=$(git log -1 --format=%ad --date=format:%Y%m%d -- recipes/${APPLICATION}/build.yaml)
@@ -133,6 +158,12 @@ jobs:
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "ARCHITECTURE=$ARCHITECTURE" >> $GITHUB_ENV
+          echo "ARCHITECTURE=$ARCHITECTURE" >> $GITHUB_OUTPUT
+          echo "IMAGE_SUFFIX=$IMAGE_SUFFIX" >> $GITHUB_ENV
+          echo "IMAGE_SUFFIX=$IMAGE_SUFFIX" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "BUILDDATE=$BUILDDATE" >> $GITHUB_ENV
           echo "BUILDDATE=$BUILDDATE" >> $GITHUB_OUTPUT
           if [ "${{ inputs.skip_docker_build }}" = "true" ]; then
@@ -167,7 +198,8 @@ jobs:
             exit 1
           fi
           DOCKERFILE=$(basename "$DOCKERFILE_PATH")
-          IMAGENAME=$(echo "${DOCKERFILE%.*}" | tr '[:upper:]' '[:lower:]')
+          BASE_IMAGENAME=$(echo "${DOCKERFILE%.*}" | tr '[:upper:]' '[:lower:]')
+          IMAGENAME="${BASE_IMAGENAME}${IMAGE_SUFFIX}"
           echo "DOCKERFILE: $DOCKERFILE"
           echo "IMAGENAME: $IMAGENAME"
           echo "DOCKERFILE=$DOCKERFILE" >> "$GITHUB_ENV"
@@ -206,6 +238,8 @@ jobs:
       IMAGETAG: ${{ needs.config.outputs.IMAGETAG }}
       ROOTFS_CACHE: ${{ needs.config.outputs.ROOTFS_CACHE }}
       SHORT_SHA: ${{ needs.config.outputs.SHORT_SHA }}
+      ARCHITECTURE: ${{ needs.config.outputs.ARCHITECTURE }}
+      IMAGE_SUFFIX: ${{ needs.config.outputs.IMAGE_SUFFIX }}
     steps:
       - name: Set runner base path
         run: |
@@ -247,9 +281,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends --no-upgrade \
             ca-certificates curl docker.io git gh jq python3 python3-pip python3-venv unzip
+          case "$(uname -m)" in
+            x86_64)
+              APPTAINER_ARCH=amd64
+              AWSCLI_ARCH=x86_64
+              ;;
+            aarch64|arm64)
+              APPTAINER_ARCH=arm64
+              AWSCLI_ARCH=aarch64
+              ;;
+            *)
+              echo "Unsupported machine architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
           APPTAINER_VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
-          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_amd64.deb" \
+          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
             -o /tmp/apptainer.deb
           sudo apt-get install -y /tmp/apptainer.deb
           rm /tmp/apptainer.deb
@@ -261,7 +309,7 @@ jobs:
             python-swiftclient python-keystoneclient
           # AWS CLI v2 — guarded so a pre-existing install isn't clobbered.
           if ! command -v aws >/dev/null 2>&1; then
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" \
               -o /tmp/awscliv2.zip
             unzip -q /tmp/awscliv2.zip -d /tmp
             sudo /tmp/aws/install
@@ -287,7 +335,7 @@ jobs:
         id: generate
         run: |
           echo "APPLICATION: $APPLICATION"
-          ./builder/build.py generate $APPLICATION --recreate --auto-build --generate-release
+          ./builder/build.py generate $APPLICATION --recreate --auto-build --generate-release --architecture "$ARCHITECTURE"
 
       - name: Set image variables
         id: imgvars
@@ -301,7 +349,8 @@ jobs:
             exit 1
           fi
           DOCKERFILE=$(basename "$DOCKERFILE_PATH")
-          IMAGENAME=$(echo "${DOCKERFILE%.*}" | tr '[:upper:]' '[:lower:]')
+          BASE_IMAGENAME=$(echo "${DOCKERFILE%.*}" | tr '[:upper:]' '[:lower:]')
+          IMAGENAME="${BASE_IMAGENAME}${IMAGE_SUFFIX}"
           echo "DOCKERFILE: $DOCKERFILE"
           echo "IMAGENAME: $IMAGENAME"
           echo "DOCKERFILE=$DOCKERFILE" >> $GITHUB_ENV
@@ -317,8 +366,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: inputs.skip_docker_build != 'true'
+        if: ${{ inputs.skip_docker_build != 'true' && !contains(inputs.runner, 'blacksmith') }}
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Set up Blacksmith Docker builder
+        if: ${{ inputs.skip_docker_build != 'true' && contains(inputs.runner, 'blacksmith') }}
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Debug Dockerfile
         run: cat ./build/${APPLICATION}/${DOCKERFILE}
@@ -333,21 +386,27 @@ jobs:
         env:
           DISABLE_AUTO_UPLOAD: ${{ inputs.disable_auto_upload }}
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
+          IS_BLACKSMITH_RUNNER: ${{ contains(inputs.runner, 'blacksmith') }}
         run: |
           cd "./build/${APPLICATION}"
           CACHE_REF=ghcr.io/${GH_REGISTRY}/${IMAGENAME}:buildcache
           CACHE_FROM_ARGS=()
-          CACHE_TO_ARGS=(--cache-to type=inline)
-          if docker buildx imagetools inspect "${CACHE_REF}" >/dev/null 2>&1; then
-            echo "Using cache image ${CACHE_REF}"
-            CACHE_FROM_ARGS=(--cache-from "type=registry,ref=${CACHE_REF}")
+          CACHE_TO_ARGS=()
+          if [ "${IS_BLACKSMITH_RUNNER}" = "true" ]; then
+            echo "Using Blacksmith Docker layer cache"
           else
-            echo "Cache image ${CACHE_REF} is unavailable; building without --cache-from"
-          fi
-          if [ "${DISABLE_AUTO_UPLOAD}" != "true" ]; then
-            CACHE_TO_ARGS+=(--cache-to "type=registry,ref=${CACHE_REF},mode=max")
-          else
-            echo "Auto-upload is disabled. Skipping registry cache export."
+            CACHE_TO_ARGS=(--cache-to type=inline)
+            if docker buildx imagetools inspect "${CACHE_REF}" >/dev/null 2>&1; then
+              echo "Using cache image ${CACHE_REF}"
+              CACHE_FROM_ARGS=(--cache-from "type=registry,ref=${CACHE_REF}")
+            else
+              echo "Cache image ${CACHE_REF} is unavailable; building without --cache-from"
+            fi
+            if [ "${DISABLE_AUTO_UPLOAD}" != "true" ]; then
+              CACHE_TO_ARGS+=(--cache-to "type=registry,ref=${CACHE_REF},mode=max")
+            else
+              echo "Auto-upload is disabled. Skipping registry cache export."
+            fi
           fi
           mkdir -p "$HOME/.cache/neurocontainers/build-context"
           docker buildx build . \
@@ -359,25 +418,25 @@ jobs:
             "${CACHE_TO_ARGS[@]}" \
             --label "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
             --label "GITHUB_SHA=${SHORT_SHA}"
-          
+
       - name: Debug storage
         run: |
           sudo df -ha
           sudo du -sh --exclude="$BASE_PATH/docker" "$BASE_PATH"
-          
+
       # - name: Save new image to file
       #   if: inputs.skip_docker_build != 'true'
       #   env:
       #     GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
       #   run: docker save ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE} -o /tmp/${{ env.IMAGENAME }}-${{ env.BUILDDATE }}.tar
-          
+
       # - name: Debug storage
       #   run: |
       #     sudo df -ha
       #     sudo du -sh /mnt
       #     sudo du -sh /mnt/*
 
-      # - name: Build and save new image 
+      # - name: Build and save new image
       #   uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       #   with:
       #     context: ./build/${{ env.APPLICATION }}
@@ -400,7 +459,7 @@ jobs:
           if docker inspect ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE} >/dev/null 2>&1; then
             ROOTFS_NEW=$(docker inspect --format='{{.RootFS}}' ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE})
             echo "ROOTFS_NEW=$ROOTFS_NEW" >> $GITHUB_ENV
-            
+
             if [ "$DISABLE_AUTO_UPLOAD" = "true" ]; then
               echo "Auto-upload is disabled. Skipping push to registry."
             elif [ "$ROOTFS_NEW" = "$ROOTFS_CACHE" ]; then
@@ -529,7 +588,7 @@ jobs:
       #     name: ${{ env.IMAGENAME }}-${{ env.BUILDDATE }}
       #     path: /tmp/${{ env.IMAGENAME }}-${{ env.BUILDDATE }}.tar
       #     retention-days: 7
-        
+
       - name: Push to GHCR
         if: steps.imgcompare.outputs.IMGDIFFERS == 'true'
         env:
@@ -589,7 +648,7 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
+      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
 
     steps:
       - name: Configure GitHub-hosted runner
@@ -644,14 +703,14 @@ jobs:
   build-simg:
     needs: [config, build-image]
     if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_nectar == 'true' || inputs.force_upload_s3 == 'true' || inputs.skip_simg_build == 'false' }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ contains(inputs.runner, 'arm') && 'blacksmith-8vcpu-ubuntu-2404-arm' || 'ubuntu-22.04' }}
     permissions:
       packages: write
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
       IMAGETAG: ${{ needs.config.outputs.IMAGETAG }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
+      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
 
     steps:
       - name: Set runner base path
@@ -700,11 +759,9 @@ jobs:
           # echo "/mnt/apptainer/bin" >> $GITHUB_PATH
 
       - name: Checkout repository
-        if: ${{ runner.environment == 'github-hosted' }}
         uses: actions/checkout@v5
 
       - name: Install Apptainer
-        if: ${{ runner.environment == 'github-hosted' }}
         uses: ./.github/actions/setup-apptainer
         with:
           apptainer-version: 1.4.3
@@ -752,7 +809,7 @@ jobs:
         run: |
           sudo df -ha
           sudo du -sh --exclude="$BASE_PATH/docker" "$BASE_PATH"
-  
+
       - name: Upload simg artifact
         if: inputs.skip_simg_build != 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
@@ -772,7 +829,7 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
+      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
 
     steps:
       - name: Bootstrap build tooling
@@ -794,9 +851,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends --no-upgrade \
             ca-certificates curl docker.io git gh jq python3 python3-pip python3-venv unzip
+          case "$(uname -m)" in
+            x86_64)
+              APPTAINER_ARCH=amd64
+              AWSCLI_ARCH=x86_64
+              ;;
+            aarch64|arm64)
+              APPTAINER_ARCH=arm64
+              AWSCLI_ARCH=aarch64
+              ;;
+            *)
+              echo "Unsupported machine architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
           APPTAINER_VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
-          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_amd64.deb" \
+          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
             -o /tmp/apptainer.deb
           sudo apt-get install -y /tmp/apptainer.deb
           rm /tmp/apptainer.deb
@@ -808,7 +879,7 @@ jobs:
             python-swiftclient python-keystoneclient
           # AWS CLI v2 — guarded so a pre-existing install isn't clobbered.
           if ! command -v aws >/dev/null 2>&1; then
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" \
               -o /tmp/awscliv2.zip
             unzip -q /tmp/awscliv2.zip -d /tmp
             sudo /tmp/aws/install
@@ -839,7 +910,7 @@ jobs:
             --segment-size 1073741824 \
             --segment-threads 10
           echo "[DEBUG] Done with uploading to Nectar Object Storage!"
-  
+
   upload-s3:
     needs: [config, build-image, build-simg]
     if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_s3 == 'true' }}
@@ -850,7 +921,8 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
+      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      AWSCLI_ARCH: x86_64
     steps:
       - name: Configure runner
         run: |
@@ -874,7 +946,7 @@ jobs:
         run: |
           if ! command -v aws &>/dev/null; then
             echo "[DEBUG] Installing AWS CLI"
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install && rm -rf aws awscliv2.zip
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install && rm -rf aws awscliv2.zip
           fi
 
       - name: Upload to AWS S3
@@ -898,7 +970,8 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
+      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      ARCHITECTURE: ${{ needs.config.outputs.ARCHITECTURE }}
       SHORT_SHA: ${{ needs.config.outputs.SHORT_SHA }}
     steps:
     - uses: actions/checkout@v5
@@ -911,7 +984,7 @@ jobs:
       id: generate
       run: |
         echo "APPLICATION: $APPLICATION"
-        ./builder/build.py generate $APPLICATION --recreate --auto-build --generate-release
+        ./builder/build.py generate $APPLICATION --recreate --auto-build --generate-release --architecture "$ARCHITECTURE"
 
     - name: Create Release File Pull Request
       if: steps.generate.outputs.container_name
@@ -1026,7 +1099,7 @@ jobs:
         echo "✅ Pull request created for ${CONTAINER_NAME} ${CONTAINER_VERSION}"
     - name: Detect OpenReconLabel.json
       id: detect_openrecon
-      if: steps.generate.outputs.container_name
+      if: steps.generate.outputs.container_name && env.ARCHITECTURE == 'x86_64'
       env:
         CONTAINER_NAME: ${{ steps.generate.outputs.container_name }}
       run: |
@@ -1167,5 +1240,3 @@ jobs:
         echo "The container has been successfully build. To test the container, run this:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
         echo "bash /neurocommand/local/fetch_and_run.sh ${IMAGENAME//_/ } $BUILDDATE" >> $GITHUB_STEP_SUMMARY
-
-

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
-  
+
 on:
   workflow_dispatch:
     inputs:
@@ -20,6 +20,8 @@ on:
         type: choice
         options:
         - "neurodesk-arcrunner-neurocontainers"
+        - "blacksmith-8vcpu-ubuntu-2404"
+        - "blacksmith-8vcpu-ubuntu-2404-arm"
         - "ubuntu-22.04"
         - "self-hosted"
         default: "neurodesk-arcrunner-neurocontainers"
@@ -88,7 +90,7 @@ jobs:
           "neurodesk-arcrunner-neurocontainers")
             runner='"neurodesk-arcrunner-neurocontainers"'
             ;;
-          "ubuntu-22.04"|"self-hosted")
+          "blacksmith-8vcpu-ubuntu-2404"|"blacksmith-8vcpu-ubuntu-2404-arm"|"ubuntu-22.04"|"self-hosted")
             runner="\"$CHOICE\""
             ;;
           *)

--- a/builder/build.py
+++ b/builder/build.py
@@ -294,6 +294,7 @@ def generate_release_file(
     version: str,
     recipe: dict,
     recipe_path: str = None,
+    architecture: str | None = None,
 ) -> None:
     """
     Generate a release JSON file for the built container.
@@ -322,28 +323,53 @@ def generate_release_file(
         # Fallback: check environment variable first, then current date
         build_date = os.environ.get("BUILDDATE", datetime.datetime.now().strftime("%Y%m%d"))
     
-    cli_app_name = f"{name} {version}"
+    normalized_architecture = ARCHITECTURES.get(architecture or "x86_64", architecture or "x86_64")
+    is_arm64 = normalized_architecture == "aarch64"
+    release_version = f"{version}-arm64" if is_arm64 else version
+    app_version = f"{version} arm64" if is_arm64 else version
+    image_suffix = "_arm64" if is_arm64 else ""
+
+    cli_app_name = f"{name} {app_version}"
 
     # Create release data structure
+    cli_app_data = {
+        "version": build_date,
+        "exec": "",
+        "apptainer_args": apptainer_args,
+    }
+    if is_arm64:
+        cli_app_data.update(
+            {
+                "architecture": normalized_architecture,
+                "image": f"{name}_{version}{image_suffix}",
+            }
+        )
+
     release_data = {
         "apps": {
-            cli_app_name: {
-                "version": build_date,
-                "exec": "",
-                "apptainer_args": apptainer_args,
-            }
+            cli_app_name: cli_app_data
         },
         "categories": categories,
     }
+    if is_arm64:
+        release_data["architecture"] = normalized_architecture
 
     # Add GUI apps from build.yaml
     for gui_app in gui_apps:
-        gui_app_name = f"{gui_app['name']}-{name} {version}"
-        release_data["apps"][gui_app_name] = {
+        gui_app_name = f"{gui_app['name']}-{name} {app_version}"
+        gui_app_data = {
             "version": build_date,
             "exec": gui_app["exec"],
             "apptainer_args": apptainer_args,
         }
+        if is_arm64:
+            gui_app_data.update(
+                {
+                    "architecture": normalized_architecture,
+                    "image": f"{name}_{version}{image_suffix}",
+                }
+            )
+        release_data["apps"][gui_app_name] = gui_app_data
 
     # Convert to JSON string for potential GitHub Actions use
     release_json = json.dumps(release_data, indent=2)
@@ -355,10 +381,10 @@ def generate_release_file(
         if github_output:
             with open(github_output, "a") as f:
                 f.write(f"container_name={name}\n")
-                f.write(f"container_version={version}\n")
+                f.write(f"container_version={release_version}\n")
                 # For multiline output, use heredoc format
                 f.write(f"release_file_content<<EOF\n{release_json}\nEOF\n")
-        print(f"Generated release data for {name} {version} (GitHub Actions mode)")
+        print(f"Generated release data for {name} {release_version} (GitHub Actions mode)")
     else:
         # Local development mode - write file directly
         repo_path = get_repo_path()
@@ -366,7 +392,7 @@ def generate_release_file(
         os.makedirs(releases_dir, exist_ok=True)
 
         # Write release file
-        release_file = os.path.join(releases_dir, f"{version}.json")
+        release_file = os.path.join(releases_dir, f"{release_version}.json")
         with open(release_file, "w") as f:
             f.write(release_json)
 
@@ -2591,7 +2617,13 @@ def build_and_run_container(
 
     # Generate release file if in CI or auto-build mode
     if should_generate_release_file(generate_release):
-        generate_release_file(name, version, load_description_file(recipe_path), recipe_path)
+        generate_release_file(
+            name,
+            version,
+            load_description_file(recipe_path),
+            recipe_path,
+            architecture=architecture,
+        )
 
     if login:
         abs_path = os.path.abspath(recipe_path)
@@ -3852,6 +3884,7 @@ def main(args):
                 ctx.version,
                 recipe,
                 recipe_path,
+                architecture=args.architecture,
             )
 
         if args.build:

--- a/tools/generate_apps_json.py
+++ b/tools/generate_apps_json.py
@@ -55,6 +55,20 @@ def load_release_file(file_path: str) -> Dict[str, Any]:
         return {"apps": {}, "categories": []}
 
 
+def is_arm64_release(release_data: Dict[str, Any]) -> bool:
+    """Return whether a release targets arm64/aarch64."""
+    architecture = release_data.get('architecture')
+    if architecture in {'aarch64', 'arm64'}:
+        return True
+
+    apps = release_data.get('apps', {}) or {}
+    return any(
+        app_data.get('architecture') in {'aarch64', 'arm64'}
+        for app_data in apps.values()
+        if isinstance(app_data, dict)
+    )
+
+
 def merge_container_releases(container_name: str, release_files: list) -> Dict[str, Any]:
     """
     Merge all release files for a container into a single entry.
@@ -73,6 +87,9 @@ def merge_container_releases(container_name: str, release_files: list) -> Dict[s
         print(f"  Processing {container_name} {version}")
         
         release_data = load_release_file(file_path)
+        if is_arm64_release(release_data):
+            print(f"    Skipping {container_name} {version}: arm64 releases are not included in apps.json yet")
+            continue
         
         # Merge apps
         apps = release_data.get('apps', {})


### PR DESCRIPTION
## Summary

- add Blacksmith Ubuntu 24.04 x86_64 and arm64 runner choices to the manual build workflow
- use Blacksmith's Docker builder cache when builds run on Blacksmith runners
- preserve existing x86_64 image/release paths while suffixing arm64 images, SIMG artifacts, Nectar/S3 objects, and release files
- generate arm64 release metadata that remains visible when apps.json is regenerated
- allow Apptainer setup on arm64 runners and avoid OpenRecon metadata updates for arm64 release PRs

## Validation

- git diff --check
- python3 -m py_compile builder/build.py tools/generate_apps_json.py
- parsed edited workflow/action YAML and verified LF line endings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->