### PR TITLE
Fix Blacksmith bootstrap Docker install

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -89,8 +89,11 @@ jobs:
           fi
           set -x
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends --no-upgrade \
-            ca-certificates curl docker.io git gh jq python3 python3-pip python3-venv unzip
+          APT_PACKAGES=(ca-certificates curl git gh jq python3 python3-pip python3-venv unzip)
+          if ! command -v docker >/dev/null 2>&1; then
+            APT_PACKAGES+=(docker.io)
+          fi
+          sudo apt-get install -y --no-install-recommends --no-upgrade "${APT_PACKAGES[@]}"
           case "$(uname -m)" in
             x86_64)
               APPTAINER_ARCH=amd64
@@ -279,8 +282,11 @@ jobs:
           fi
           set -x
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends --no-upgrade \
-            ca-certificates curl docker.io git gh jq python3 python3-pip python3-venv unzip
+          APT_PACKAGES=(ca-certificates curl git gh jq python3 python3-pip python3-venv unzip)
+          if ! command -v docker >/dev/null 2>&1; then
+            APT_PACKAGES+=(docker.io)
+          fi
+          sudo apt-get install -y --no-install-recommends --no-upgrade "${APT_PACKAGES[@]}"
           case "$(uname -m)" in
             x86_64)
               APPTAINER_ARCH=amd64
@@ -849,8 +855,11 @@ jobs:
           fi
           set -x
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends --no-upgrade \
-            ca-certificates curl docker.io git gh jq python3 python3-pip python3-venv unzip
+          APT_PACKAGES=(ca-certificates curl git gh jq python3 python3-pip python3-venv unzip)
+          if ! command -v docker >/dev/null 2>&1; then
+            APT_PACKAGES+=(docker.io)
+          fi
+          sudo apt-get install -y --no-install-recommends --no-upgrade "${APT_PACKAGES[@]}"
           case "$(uname -m)" in
             x86_64)
               APPTAINER_ARCH=amd64


### PR DESCRIPTION
## Summary

- avoid installing Ubuntu's docker.io package when Docker is already present on Blacksmith runners
- keep docker.io installation for runners that actually lack Docker
- apply the same bootstrap package selection to config, build-image, and upload-nectar jobs

## Failure

Manual Blacksmith build failed in the config job bootstrap step because apt tried to install docker.io on a runner that already had containerd.io, causing:

`containerd.io : Conflicts: containerd`

## Validation

- git diff --check
- parsed .github/workflows/build-app.yml as YAML
- verified .github/workflows/build-app.yml uses LF line endings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->