### PR TITLE
Install OpenStack clients in bootstrap venv

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -114,12 +114,12 @@ jobs:
             -o /tmp/apptainer.deb
           sudo apt-get install -y /tmp/apptainer.deb
           rm /tmp/apptainer.deb
-          PIP_BREAK_SYSTEM_PACKAGES=""
-          if python3 -m pip install --help | grep -q -- '--break-system-packages'; then
-            PIP_BREAK_SYSTEM_PACKAGES="--break-system-packages"
-          fi
-          sudo python3 -m pip install ${PIP_BREAK_SYSTEM_PACKAGES} \
+          python3 -m venv "$RUNNER_TEMP/openstack-client-venv"
+          "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install \
             python-swiftclient python-keystoneclient
+          echo "$RUNNER_TEMP/openstack-client-venv/bin" >> "$GITHUB_PATH"
+          export PATH="$RUNNER_TEMP/openstack-client-venv/bin:$PATH"
           # AWS CLI v2 — guarded so a pre-existing install isn't clobbered.
           if ! command -v aws >/dev/null 2>&1; then
             curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" \
@@ -307,12 +307,12 @@ jobs:
             -o /tmp/apptainer.deb
           sudo apt-get install -y /tmp/apptainer.deb
           rm /tmp/apptainer.deb
-          PIP_BREAK_SYSTEM_PACKAGES=""
-          if python3 -m pip install --help | grep -q -- '--break-system-packages'; then
-            PIP_BREAK_SYSTEM_PACKAGES="--break-system-packages"
-          fi
-          sudo python3 -m pip install ${PIP_BREAK_SYSTEM_PACKAGES} \
+          python3 -m venv "$RUNNER_TEMP/openstack-client-venv"
+          "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install \
             python-swiftclient python-keystoneclient
+          echo "$RUNNER_TEMP/openstack-client-venv/bin" >> "$GITHUB_PATH"
+          export PATH="$RUNNER_TEMP/openstack-client-venv/bin:$PATH"
           # AWS CLI v2 — guarded so a pre-existing install isn't clobbered.
           if ! command -v aws >/dev/null 2>&1; then
             curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" \
@@ -880,12 +880,12 @@ jobs:
             -o /tmp/apptainer.deb
           sudo apt-get install -y /tmp/apptainer.deb
           rm /tmp/apptainer.deb
-          PIP_BREAK_SYSTEM_PACKAGES=""
-          if python3 -m pip install --help | grep -q -- '--break-system-packages'; then
-            PIP_BREAK_SYSTEM_PACKAGES="--break-system-packages"
-          fi
-          sudo python3 -m pip install ${PIP_BREAK_SYSTEM_PACKAGES} \
+          python3 -m venv "$RUNNER_TEMP/openstack-client-venv"
+          "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install --upgrade pip
+          "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install \
             python-swiftclient python-keystoneclient
+          echo "$RUNNER_TEMP/openstack-client-venv/bin" >> "$GITHUB_PATH"
+          export PATH="$RUNNER_TEMP/openstack-client-venv/bin:$PATH"
           # AWS CLI v2 — guarded so a pre-existing install isn't clobbered.
           if ! command -v aws >/dev/null 2>&1; then
             curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" \


### PR DESCRIPTION
## Summary

- install python-swiftclient and python-keystoneclient into an isolated venv during workflow bootstrap
- add that venv to PATH so swift is available to the current and later steps
- avoid modifying Debian-managed system Python packages on Blacksmith/Ubuntu 24.04 runners

## Failure

The Blacksmith config job failed during bootstrap when pip attempted to uninstall Debian's typing_extensions package while installing OpenStack clients globally:

`ERROR: Cannot uninstall typing_extensions 4.10.0, RECORD file not found. Hint: The package was installed by debian.`

## Validation

- git diff --check
- parsed .github/workflows/build-app.yml as YAML
- verified .github/workflows/build-app.yml uses LF line endings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->