### PR TITLE
Install Apptainer from PPA on arm64

### DIFF
--- a/.github/actions/setup-apptainer/action.yml
+++ b/.github/actions/setup-apptainer/action.yml
@@ -39,10 +39,19 @@ runs:
         deb_path="${cache_dir}/apptainer.deb"
         mkdir -p "$cache_dir"
 
-        if [[ ! -s "$deb_path" ]]; then
-          url="https://github.com/apptainer/apptainer/releases/download/v${version}/apptainer_${version}_${arch}.deb"
-          curl -fsSL "$url" -o "$deb_path"
+        if [[ "$arch" == "arm64" ]]; then
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends software-properties-common
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends apptainer
+        else
+          if [[ ! -s "$deb_path" ]]; then
+            url="https://github.com/apptainer/apptainer/releases/download/v${version}/apptainer_${version}_${arch}.deb"
+            curl -fsSL "$url" -o "$deb_path"
+          fi
+
+          sudo apt-get install -y "$deb_path"
         fi
 
-        sudo apt-get install -y "$deb_path"
         echo "apptainer-version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -110,10 +110,17 @@ jobs:
           esac
           APPTAINER_VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
-          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
-            -o /tmp/apptainer.deb
-          sudo apt-get install -y /tmp/apptainer.deb
-          rm /tmp/apptainer.deb
+          if [ "$APPTAINER_ARCH" = "arm64" ]; then
+            sudo apt-get install -y --no-install-recommends software-properties-common
+            sudo add-apt-repository -y ppa:apptainer/ppa
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends apptainer
+          else
+            curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
+              -o /tmp/apptainer.deb
+            sudo apt-get install -y /tmp/apptainer.deb
+            rm /tmp/apptainer.deb
+          fi
           python3 -m venv "$RUNNER_TEMP/openstack-client-venv"
           "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install --upgrade pip
           "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install \
@@ -303,10 +310,17 @@ jobs:
           esac
           APPTAINER_VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
-          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
-            -o /tmp/apptainer.deb
-          sudo apt-get install -y /tmp/apptainer.deb
-          rm /tmp/apptainer.deb
+          if [ "$APPTAINER_ARCH" = "arm64" ]; then
+            sudo apt-get install -y --no-install-recommends software-properties-common
+            sudo add-apt-repository -y ppa:apptainer/ppa
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends apptainer
+          else
+            curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
+              -o /tmp/apptainer.deb
+            sudo apt-get install -y /tmp/apptainer.deb
+            rm /tmp/apptainer.deb
+          fi
           python3 -m venv "$RUNNER_TEMP/openstack-client-venv"
           "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install --upgrade pip
           "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install \
@@ -876,10 +890,17 @@ jobs:
           esac
           APPTAINER_VER=$(curl -fsSL https://api.github.com/repos/apptainer/apptainer/releases/latest \
             | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
-          curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
-            -o /tmp/apptainer.deb
-          sudo apt-get install -y /tmp/apptainer.deb
-          rm /tmp/apptainer.deb
+          if [ "$APPTAINER_ARCH" = "arm64" ]; then
+            sudo apt-get install -y --no-install-recommends software-properties-common
+            sudo add-apt-repository -y ppa:apptainer/ppa
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends apptainer
+          else
+            curl -fsSL "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VER}/apptainer_${APPTAINER_VER}_${APPTAINER_ARCH}.deb" \
+              -o /tmp/apptainer.deb
+            sudo apt-get install -y /tmp/apptainer.deb
+            rm /tmp/apptainer.deb
+          fi
           python3 -m venv "$RUNNER_TEMP/openstack-client-venv"
           "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install --upgrade pip
           "$RUNNER_TEMP/openstack-client-venv/bin/python" -m pip install \


### PR DESCRIPTION
## Summary

- use Apptainer GitHub release .deb packages on amd64 as before
- install Apptainer from the official Apptainer Ubuntu PPA on arm64 runners
- apply the same arm64 install path to workflow bootstrap and the setup-apptainer composite action

## Failure

The arm64 Blacksmith config job failed because the workflow tried to download a GitHub release asset that does not exist:

`https://github.com/apptainer/apptainer/releases/download/v1.5.0/apptainer_1.5.0_arm64.deb`

Apptainer's GitHub release assets are amd64-only for Debian packages, while their Ubuntu PPA provides arm64 packages.

## Validation

- git diff --check
- parsed .github/workflows/build-app.yml as YAML
- parsed .github/actions/setup-apptainer/action.yml as YAML
- verified edited YAML files use LF line endings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->