### PR TITLE
Fix Blacksmith simg temp directory setup

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -740,6 +740,8 @@ jobs:
           if [ -d /storage ]; then
             BASE_PATH=/storage
           fi
+          sudo mkdir -p "$BASE_PATH/tmp"
+          sudo chown "$USER" "$BASE_PATH/tmp"
           echo "BASE_PATH=$BASE_PATH" >> "$GITHUB_ENV"
           echo "base_path=$BASE_PATH" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- create the selected build-simg base tmp directory during the common base-path setup
- fixes Blacksmith arm64 simg builds writing to /mnt/tmp before that directory exists

## Confirmation
- Confirmed job 75477833179 failed in build-simg on a Blacksmith runner while opening /mnt/tmp/niimath_1.0.20250804_arm64_20251016.simg
- The GitHub-hosted setup creates /mnt/tmp, but the Blacksmith arm64 path skips that step

## Validation
- python YAML parse for .github/workflows/build-app.yml
- LF-only check for .github/workflows/build-app.yml
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->