### PR TITLE
Add ARM64 support for afib1

### DIFF
--- a/recipes/afib1/build.yaml
+++ b/recipes/afib1/build.yaml
@@ -2,6 +2,7 @@ name: afib1
 version: 1.6.0
 architectures:
     - x86_64
+    - aarch64
 
 files:
     - name: afib1.py
@@ -37,7 +38,8 @@ build:
               PATH: ${PATH}:/opt/code/FSL-BET2/bin
 
         #openrecon application
-        - copy: afib1.py /opt/code/python-ismrmrd-server/afib1.py
+        - run:
+              - cp {{ get_file("afib1.py") }} /opt/code/python-ismrmrd-server/afib1.py
 
 deploy:
     path:

--- a/recipes/afib1/fulltest.yaml
+++ b/recipes/afib1/fulltest.yaml
@@ -1,0 +1,33 @@
+name: afib1
+version: 1.6.0
+container: afib1_1.6.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: bet2 help available
+    description: Verify the rebuilt BET2 binary starts and prints its usage banner
+    command: bet2 -h 2>&1
+    expected_output_contains: "BET (Brain Extraction Tool) v2.1"
+
+  - name: bet2 usage includes mask option
+    description: Verify the command help exposes a representative runtime option
+    command: bet2 -h 2>&1
+    expected_output_contains: "-m,--mask"
+
+  - name: afib1 openrecon script present
+    description: Verify the shipped OpenRecon server script is deployed in the image
+    command: bash -lc "test -f /opt/code/python-ismrmrd-server/afib1.py && printf 'True\n'"
+    expected_output_contains: "True"
+
+  - name: afib1 openrecon script parses
+    description: Verify the shipped OpenRecon server script is valid Python
+    command: python -m py_compile /opt/code/python-ismrmrd-server/afib1.py
+    expected_exit_code: 0


### PR DESCRIPTION
## Summary
- add aarch64 to afib1 supported architectures
- add focused full-container smoke tests for BET2 and the OpenRecon script

## Local validation
- python -m builder generate afib1 --recreate
- python -m builder generate afib1 --recreate --architecture aarch64 --ignore-architectures
- python builder/validation.py recipes/afib1/build.yaml

## Build plan
- trigger manual ARM64 build on blacksmith-8vcpu-ubuntu-2404-arm and monitor logs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->