### PR TITLE
Fix staged file cache context in build workflow

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -428,12 +428,12 @@ jobs:
               echo "Auto-upload is disabled. Skipping registry cache export."
             fi
           fi
-          mkdir -p "$HOME/.cache/neurocontainers/build-context"
+          mkdir -p cache
           docker buildx build . \
             --load \
             --file "${DOCKERFILE}" \
             --tag "ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE}" \
-            --build-context "neurocontainer-cache=$HOME/.cache/neurocontainers/build-context" \
+            --build-context "neurocontainer-cache=./cache" \
             "${CACHE_FROM_ARGS[@]}" \
             "${CACHE_TO_ARGS[@]}" \
             --label "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_build_app_workflow_uses_staged_cache_context() -> None:
+    workflow = Path(".github/workflows/build-app.yml").read_text()
+
+    assert '--build-context "neurocontainer-cache=./cache"' in workflow
+    assert "neurocontainer-cache=$HOME/.cache/neurocontainers/build-context" not in workflow
+


### PR DESCRIPTION
## Summary
- point the workflow's second docker build at the builder-staged ./cache directory
- add a regression check for the workflow cache-context contract

## Why
The new builder stages declared files under build/<recipe>/cache and emits Dockerfile mounts from the reserved neurocontainer-cache context. The manual build workflow generated and staged files correctly during python -m builder build, but its later direct docker buildx invocation pointed neurocontainer-cache at an empty global cache directory. Recipes using get_file() then fail in the second build phase.

## Validation
- python -m builder stage afib1 --recreate --architecture aarch64 --ignore-architectures
- python -m builder stage dcm2niix --recreate --architecture aarch64 --ignore-architectures
- python -m builder build afib1 --recreate --architecture aarch64 --ignore-architectures --dry-run
- python -m builder build dcm2niix --recreate --architecture aarch64 --ignore-architectures --dry-run
- python builder/validation.py recipes/afib1/build.yaml
- python builder/validation.py recipes/dcm2niix/build.yaml
- python inline workflow contract assertion

Note: pytest is not installed in the current local environment, so the new regression test was validated with an equivalent inline Python assertion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->