### PR TITLE
Fix ARM64 release PR generation

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1012,11 +1012,11 @@ jobs:
     - name: Install Builder Dependencies
       run: |
         pip install -r requirements.txt
-    - name: Generate Dockerfile and Release File
+    - name: Generate Release File
       id: generate
       run: |
         echo "APPLICATION: $APPLICATION"
-        python3 -m builder build "$APPLICATION" --recreate --generate-release --architecture "$ARCHITECTURE"
+        python3 -m builder release "$APPLICATION" --write --architecture "$ARCHITECTURE"
 
     - name: Create Release File Pull Request
       if: steps.generate.outputs.container_name

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -9,3 +9,13 @@ def test_build_app_workflow_uses_staged_cache_context() -> None:
     assert '--build-context "neurocontainer-cache=./cache"' in workflow
     assert "neurocontainer-cache=$HOME/.cache/neurocontainers/build-context" not in workflow
 
+
+def test_create_pr_job_generates_release_without_rebuilding() -> None:
+    workflow = Path(".github/workflows/build-app.yml").read_text()
+    create_pr_job = workflow.split("  create-pr:", 1)[1]
+
+    assert 'python3 -m builder release "$APPLICATION" --write --architecture "$ARCHITECTURE"' in create_pr_job
+    assert (
+        'python3 -m builder build "$APPLICATION" --recreate --generate-release --architecture "$ARCHITECTURE"'
+        not in create_pr_job
+    )


### PR DESCRIPTION
## Summary
- use builder release instead of builder build in the create-pr job
- add workflow contract coverage so ARM64 release metadata generation does not rebuild on an x86 runner

## Validation
- python3 -m builder release afib1 --architecture aarch64
- GITHUB_OUTPUT=/tmp/neurocontainers-release-output.txt python3 -m builder release afib1 --write --architecture aarch64
- inline workflow contract assertions
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->