### PR TITLE
Add ARM64 support for amico

### DIFF
--- a/recipes/amico/build.yaml
+++ b/recipes/amico/build.yaml
@@ -2,6 +2,7 @@ name: amico
 version: 2.1.0
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: >-
     Accelerated Microstructure Imaging via Convex Optimization (AMICO) from
@@ -57,7 +58,11 @@ build:
         name: miniconda
         version: latest
         install_path: /opt/miniconda
+        env_name: amico
+        env_exists: "false"
         pip_install: dmri-amico
+    - environment:
+        PATH: /opt/miniconda/envs/amico/bin:/opt/miniconda/bin:$PATH
     - deploy:
         path: []
         bins:
@@ -139,4 +144,3 @@ readme: >-
 copyright:
   - name: AMICO software license agreement
     url: https://github.com/daducci/AMICO/blob/master/LICENSE
-

--- a/recipes/amico/fulltest.yaml
+++ b/recipes/amico/fulltest.yaml
@@ -29,7 +29,7 @@
 
 name: amico
 version: 2.1.0
-container: amico_2.1.0_20250628.simg
+container: amico_2.1.0.simg
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
## Summary
- declare  support for amico
- install  in a dedicated miniconda env and expose that env on 
- align the fulltest container filename with the current builder output name

## Validation
- python3 builder/validation.py recipes/amico/build.yaml
- python3 -m builder generate amico --recreate
- python3 -m builder generate amico --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->