### PR TITLE
Add ARM64 support for arfiproc

### DIFF
--- a/recipes/arfiproc/build.yaml
+++ b/recipes/arfiproc/build.yaml
@@ -2,6 +2,7 @@ name: arfiproc
 version: 1.0.0
 architectures:
     - x86_64
+    - aarch64
 
 files:
     - name: arfiproc.py
@@ -51,7 +52,7 @@ readme: |-
 
     you can build this recipe with:
     ```bash
-    sf-login arfiproc --architecture x86_64
+    python builder/build.py generate arfiproc --recreate --build --login --architecture x86_64
     ```
 
     ----------------------------------

--- a/recipes/arfiproc/fulltest.yaml
+++ b/recipes/arfiproc/fulltest.yaml
@@ -1,0 +1,36 @@
+# arfiproc container test suite
+# Focused ARM64 verification for the shipped OpenRecon runtime and module import path.
+
+name: arfiproc
+version: 1.0.0
+container: arfiproc_1.0.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: Native ARM64 runtime
+    description: Verify the local Docker image runs natively on ARM64
+    script: |
+      uname -m | grep -x 'aarch64'
+
+  - name: OpenRecon server help
+    description: Verify the shipped python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: DICOM to MRD converter help
+    description: Verify the dicom2mrd helper script is available
+    script: |
+      python /opt/code/python-ismrmrd-server/dicom2mrd.py -h 2>&1 | sed -n '1,12p' | grep 'Convert DICOMs to MRD file'
+
+  - name: arfiproc module imports
+    description: Verify the shipped reconstruction module imports with its server-side helpers
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import arfiproc, ismrmrd, nibabel, scipy, skimage; print(arfiproc.__file__)" | grep -x '/opt/code/python-ismrmrd-server/arfiproc.py'


### PR DESCRIPTION
## Summary
- add `aarch64` support to the `arfiproc` recipe
- add a focused fulltest for the shipped OpenRecon runtime and module import path
- update the readme example command to match the current builder entrypoint

## Validation
- `python3 builder/validation.py recipes/arfiproc/build.yaml`
- `python3 -m builder generate arfiproc --recreate`
- `python3 -m builder generate arfiproc --recreate --architecture aarch64 --ignore-architectures`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->