### PR TITLE
Fix declared copy source staging

### DIFF
--- a/builder/recipe.py
+++ b/builder/recipe.py
@@ -12,7 +12,7 @@ from typing import Any
 import yaml
 
 from .ir import Copy, Definition, Entrypoint, Env, From, Install, Run, RunWithMounts, User, Workdir
-from .staging import StagingPlan, declared_file_from_mapping
+from .staging import CopySource, StagingPlan, declared_file_from_mapping
 from .template import RenderContext, TemplateRenderer
 from .template_backend import apply_builtin_template
 from .validation import validate_recipe_dict
@@ -402,10 +402,16 @@ def compile_recipe(
                 parts = _copy_parts(renderer.render_value(directive["copy"], context))
                 if len(parts) < 2:
                     raise ValueError("copy directive requires source and destination")
+                resolved_sources: list[str] = []
                 for source in parts[:-1]:
                     if source not in context.file_paths:
-                        plan.copy_sources.append(source)
-                definition.add(Copy(tuple(parts[:-1]), parts[-1]))
+                        plan.copy_sources.append(CopySource(source=source))
+                        resolved_sources.append(source)
+                        continue
+                    resolved = context.file_paths[source]
+                    plan.copy_sources.append(CopySource(source=resolved, declared_name=source))
+                    resolved_sources.append(resolved)
+                definition.add(Copy(tuple(resolved_sources), parts[-1]))
             elif "variables" in directive:
                 values = directive["variables"]
                 if not isinstance(values, dict):

--- a/builder/staging.py
+++ b/builder/staging.py
@@ -18,9 +18,15 @@ class DeclaredFile:
 
 
 @dataclass
+class CopySource:
+    source: str
+    declared_name: str | None = None
+
+
+@dataclass
 class StagingPlan:
     files: dict[str, DeclaredFile] = field(default_factory=dict)
-    copy_sources: list[str] = field(default_factory=list)
+    copy_sources: list[CopySource] = field(default_factory=list)
     cache_mounts: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def add_file(self, file: DeclaredFile) -> None:
@@ -119,8 +125,15 @@ def materialize_plan(
             link_or_copy(source, target)
 
     for source in plan.copy_sources:
-        source_path = recipe_dir / source
-        target = build_dir / source
+        target = build_dir / source.source
+        if source.declared_name is not None:
+            source_path = materialized.get(source.declared_name)
+            if source_path is None:
+                raise FileNotFoundError(f"declared copy source not materialized: {source.declared_name}")
+            link_or_copy(source_path, target)
+            continue
+
+        source_path = recipe_dir / source.source
         if source_path.is_dir():
             if target.exists():
                 shutil.rmtree(target)

--- a/builder/tests/fixtures/copy_declared_files/build.yaml
+++ b/builder/tests/fixtures/copy_declared_files/build.yaml
@@ -1,0 +1,22 @@
+name: copy_declared_files
+version: "1.0"
+architectures:
+  - x86_64
+categories:
+  - workflows
+build:
+  kind: neurodocker
+  base-image: ubuntu:24.04
+  pkg-manager: apt
+  directives:
+    - copy: inline.txt /tmp/inline.txt
+    - copy: copied.txt /tmp/copied.txt
+deploy:
+  bins:
+    - cat
+readme: copy declared files
+files:
+  - name: inline.txt
+    contents: hello inline
+  - name: copied.txt
+    filename: copied.txt

--- a/builder/tests/fixtures/copy_declared_files/copied.txt
+++ b/builder/tests/fixtures/copy_declared_files/copied.txt
@@ -1,0 +1,1 @@
+hello copied

--- a/builder/tests/test_staging.py
+++ b/builder/tests/test_staging.py
@@ -61,3 +61,18 @@ def test_fixture_stages_filename_and_contents(tmp_path: Path) -> None:
     )
     assert (cache_dir / "inline.txt").read_text() == "hello inline"
     assert (cache_dir / "copied.txt").read_text() == "hello copied\n"
+
+
+def test_declared_copy_sources_are_staged_into_build_context(tmp_path: Path) -> None:
+    fixture = Path(__file__).resolve().parent / "fixtures" / "copy_declared_files"
+    compiled = compile_recipe(fixture, architecture="x86_64")
+    build_dir = tmp_path / "build"
+    materialize_plan(
+        compiled.staging_plan,
+        fixture,
+        build_dir,
+        http_cache_dir=tmp_path / "httpcache",
+        download=False,
+    )
+    assert (build_dir / "inline.txt").read_text() == "hello inline"
+    assert (build_dir / "copied.txt").read_text() == "hello copied\n"


### PR DESCRIPTION
## Summary
- stage declared files into the top-level Docker build context when they are referenced by `copy:` directives
- resolve `copy:` sources through declared-file aliases before emitting the Dockerfile
- add a regression test fixture for declared file copies

## Validation
- `python3 -m builder stage arfiproc --recreate --architecture aarch64 --ignore-architectures`
- `find build/arfiproc -maxdepth 3 -type f | sort`
- `python3 -m pytest builder/tests/test_staging.py -q` via a temporary local venv with `requirements.txt` and `pytest` installed

## Why
The manual ARM64 `arfiproc` main-branch run failed in `build-app / config` because the generated Dockerfile emitted:
- `COPY ["arfiproc.py", "/opt/code/python-ismrmrd-server/arfiproc.py"]`

but the builder only staged declared files under `build/<recipe>/cache` for `get_file(...)` mounts, so the top-level Docker build context did not contain `arfiproc.py`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->