### PR TITLE
Add ARM64 support for b0map

### DIFF
--- a/recipes/b0map/build.yaml
+++ b/recipes/b0map/build.yaml
@@ -2,6 +2,7 @@ name: b0map
 version: 1.0.0
 architectures:
     - x86_64
+    - aarch64
 
 files:
     - name: b0map.py
@@ -61,7 +62,7 @@ readme: |-
     you can build this recipe with:
     ```bash
     source env/bin/activate
-    sf-login b0map --architecture x86_64
+    ./builder/build.py generate b0map --recreate --build --login --architecture x86_64
     ```
 
     or shorter: open the build.yaml file in the local terminal and run:

--- a/recipes/b0map/fulltest.yaml
+++ b/recipes/b0map/fulltest.yaml
@@ -1,0 +1,46 @@
+# b0map container test suite
+# Focused ARM64 verification for the shipped BET2 binary and OpenRecon runtime.
+
+name: b0map
+version: 1.0.0
+container: b0map_1.0.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: Native ARM64 runtime
+    description: Verify the local Docker image runs natively on ARM64
+    script: |
+      uname -m | grep -x 'aarch64'
+
+  - name: BET2 binary in PATH
+    description: Verify the compiled BET2 executable is installed on PATH
+    script: |
+      command -v bet2 | grep -x '/opt/code/FSL-BET2/bin/bet2'
+
+  - name: BET2 help output
+    description: Verify the bundled BET2 CLI renders its usage text
+    script: |
+      bet2 2>&1 | sed -n '1,12p' | grep 'BET (Brain Extraction Tool) v2.1'
+
+  - name: OpenRecon server help
+    description: Verify the shipped python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: DICOM to MRD converter help
+    description: Verify the dicom2mrd helper script is available
+    script: |
+      python /opt/code/python-ismrmrd-server/dicom2mrd.py -h 2>&1 | sed -n '1,12p' | grep 'Convert DICOMs to MRD file'
+
+  - name: b0map module imports
+    description: Verify the shipped reconstruction module imports with its server-side helpers
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import b0map, ismrmrd, nibabel, scipy, skimage; print(b0map.__file__)" | grep -x '/opt/code/python-ismrmrd-server/b0map.py'


### PR DESCRIPTION
## Summary
- add `aarch64` support to the `b0map` recipe
- add a focused fulltest for the shipped BET2 binary and OpenRecon runtime
- update the readme example command to match the current builder entrypoint

## Validation
- `python3 builder/validation.py recipes/b0map/build.yaml`
- `python3 -m builder generate b0map --recreate`
- `python3 -m builder generate b0map --recreate --architecture aarch64 --ignore-architectures`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->