### PR TITLE
Fix ARM64 env setup for bidscoin

### DIFF
--- a/recipes/bidscoin/build.yaml
+++ b/recipes/bidscoin/build.yaml
@@ -25,6 +25,7 @@ build:
     - install:
         - python3-pyqt6     # Avoid GUI issues
         - build-essential   # Needed for pip (needs gcc)
+        - dcm2niix
         - libgl1
         - libxcb-cursor0
         - tk
@@ -32,18 +33,19 @@ build:
         - qt6-wayland       # Make sure wayland is supported
 
     - template:
-        name: dcm2niix
-        version: latest
-
-    - template:
         name: bids_validator
         version: 1.13.0
 
     - template:
         name: miniconda
+        env_name: bidscoin
+        env_exists: "false"
         conda_install: -c conda-forge -c https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/ fsl-libvis fsl-avwutils fsl-flirt
-        pip_install: bidscoin[spec2nii2bids,deface]=={{ context.version }}
+        pip_install: setuptools==78.1.1 bidscoin[spec2nii2bids,deface]=={{ context.version }}
         version: latest
+
+    - environment:
+        PATH: /opt/miniconda-latest/envs/bidscoin/bin:$PATH
 
     - deploy:
         bins:


### PR DESCRIPTION
## Summary
- replace the `dcm2niix` template dependency with distro `dcm2niix`
- configure the Miniconda template to create an explicit `bidscoin` env on ARM64
- export the conda env `PATH` so the packaged tools resolve correctly

## Validation
- `python3 builder/validation.py recipes/bidscoin/build.yaml`
- `python3 -m builder generate bidscoin --recreate`
- `python3 -m builder generate bidscoin --recreate --architecture aarch64 --ignore-architectures`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->