### PR TITLE
Fix bids-validator template on Python 3.12

### DIFF
--- a/builder/templates/bids_validator.yaml
+++ b/builder/templates/bids_validator.yaml
@@ -15,6 +15,7 @@ binaries:
     - curl
     - apt-utils
     - gnupg
+    - python3-setuptools
     yum:
     - curl
   directives:

--- a/builder/tests/test_template_rendering.py
+++ b/builder/tests/test_template_rendering.py
@@ -69,3 +69,10 @@ def test_builtin_templates_are_native_directive_format() -> None:
             assert "env" not in method_data, f"{path.name}:{method} still uses legacy env"
             assert "instructions" not in method_data, f"{path.name}:{method} still uses legacy instructions"
             assert isinstance(method_data.get("directives"), list), f"{path.name}:{method} has no directives"
+
+
+def test_bids_validator_template_installs_setuptools_on_apt() -> None:
+    path = Path(__file__).resolve().parents[1] / "templates" / "bids_validator.yaml"
+    data = yaml.safe_load(path.read_text())
+    apt_dependencies = data["binaries"]["dependencies"]["apt"]
+    assert "python3-setuptools" in apt_dependencies


### PR DESCRIPTION
## Summary
- install `python3-setuptools` in the shared `bids_validator` apt dependency set
- add a regression check that the template keeps that dependency

## Validation
- rendered the `bidscoin` ARM64 Dockerfile and verified `python3-setuptools` is present in the `bids_validator` install step
- `python -m pytest builder/tests/test_template_rendering.py -q` in a temporary local venv with `requirements.txt` and `pytest`

## Why
The ARM64 `bidscoin` manual main-branch build failed while installing `bids-validator@1.13.0` because `node-gyp` on Ubuntu 24.04 / Python 3.12 could not import `distutils` during the native `@parcel/watcher` build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->