### PR TITLE
Fix pip bootstrap in miniconda template

### DIFF
--- a/builder/templates/miniconda.yaml
+++ b/builder/templates/miniconda.yaml
@@ -84,6 +84,9 @@ binaries:
             {% endfor %}
             {% endif -%}
             {% if self.pip_install -%}
+            if ! conda run --name {{ self.env_name }} python -m pip --version >/dev/null 2>&1; then
+              conda install -y {{ self.conda_opts|default("-q") }} --name {{ self.env_name }} python pip
+            fi
             bash -c "source activate {{ self.env_name }}
               python -m pip install --no-cache-dir {{ self.pip_opts }} \
               {%- for pkg in self.pip_install.split() %}

--- a/builder/tests/test_template_rendering.py
+++ b/builder/tests/test_template_rendering.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import pytest
 import yaml
 
+from builder.ir import Run
 from builder.template import RenderContext, TemplateError, TemplateRenderer
 from builder.recipe import compile_recipe
+from builder.template_backend import apply_builtin_template
 
 
 def test_strict_context_rendering() -> None:
@@ -76,3 +78,23 @@ def test_bids_validator_template_installs_setuptools_on_apt() -> None:
     data = yaml.safe_load(path.read_text())
     apt_dependencies = data["binaries"]["dependencies"]["apt"]
     assert "python3-setuptools" in apt_dependencies
+
+
+def test_miniconda_template_bootstraps_python_and_pip_for_pip_install() -> None:
+    directives: list[Run] = []
+    apply_builtin_template(
+        "miniconda",
+        {
+            "version": "latest",
+            "env_name": "testenv",
+            "env_exists": "false",
+            "pip_install": "examplepkg",
+            "arch": "aarch64",
+        },
+        "apt",
+        directives.append,
+    )
+    command = "\n".join(item.command for item in directives if isinstance(item, Run))
+    assert "conda run --name testenv python -m pip --version" in command
+    assert "conda install -y" in command
+    assert "--name testenv python pip" in command


### PR DESCRIPTION
## Summary
- ensure the miniconda template installs python and pip before running pip_install in a named env
- cover the new bootstrap path with a template rendering test

## Testing
- python3 builder/validation.py recipes/bidscoin/build.yaml
- python3 -m builder generate bidscoin --recreate --architecture aarch64 --ignore-architectures
- . .codex-venv/bin/activate && python -m pytest builder/tests/test_template_rendering.py -q

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->