### PR TITLE
Fix miniconda template shell syntax

### DIFF
--- a/builder/templates/miniconda.yaml
+++ b/builder/templates/miniconda.yaml
@@ -84,9 +84,7 @@ binaries:
             {% endfor %}
             {% endif -%}
             {% if self.pip_install -%}
-            if ! conda run --name {{ self.env_name }} python -m pip --version >/dev/null 2>&1; then
-              conda install -y {{ self.conda_opts|default("-q") }} --name {{ self.env_name }} python pip
-            fi
+            if ! conda run --name {{ self.env_name }} python -m pip --version >/dev/null 2>&1; then conda install -y {{ self.conda_opts|default("-q") }} --name {{ self.env_name }} python pip; fi
             bash -c "source activate {{ self.env_name }}
               python -m pip install --no-cache-dir {{ self.pip_opts }} \
               {%- for pkg in self.pip_install.split() %}


### PR DESCRIPTION
## Summary
- render the miniconda pip bootstrap as a single valid shell clause
- keep the pip bootstrap added in #2233 intact while making the Dockerfile shell-safe

## Testing
- python3 -m builder generate bidscoin --recreate --architecture aarch64 --ignore-architectures
- . .codex-venv/bin/activate && python -m pytest builder/tests/test_template_rendering.py -q

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->