### PR TITLE
Fix miniconda pip bootstrap quoting

### DIFF
--- a/builder/templates/miniconda.yaml
+++ b/builder/templates/miniconda.yaml
@@ -84,8 +84,8 @@ binaries:
             {% endfor %}
             {% endif -%}
             {% if self.pip_install -%}
-            if ! conda run --name {{ self.env_name }} python -m pip --version >/dev/null 2>&1; then conda install -y {{ self.conda_opts|default("-q") }} --name {{ self.env_name }} python pip; fi
             bash -c "source activate {{ self.env_name }}
+              if ! python -m pip --version >/dev/null 2>&1; then conda install -y {{ self.conda_opts|default("-q") }} --name {{ self.env_name }} python pip; fi
               python -m pip install --no-cache-dir {{ self.pip_opts }} \
               {%- for pkg in self.pip_install.split() %}
                   {% if not loop.last -%}

--- a/builder/tests/test_template_rendering.py
+++ b/builder/tests/test_template_rendering.py
@@ -95,6 +95,7 @@ def test_miniconda_template_bootstraps_python_and_pip_for_pip_install() -> None:
         directives.append,
     )
     command = "\n".join(item.command for item in directives if isinstance(item, Run))
-    assert "conda run --name testenv python -m pip --version" in command
+    assert 'bash -c "source activate testenv' in command
+    assert "if ! python -m pip --version >/dev/null 2>&1; then" in command
     assert "conda install -y" in command
     assert "--name testenv python pip" in command


### PR DESCRIPTION
## Summary
- keep the miniconda pip bootstrap inside the quoted activation shell
- avoid shell flattening issues in generated Dockerfiles for fresh conda envs

## Testing
- python3 -m builder generate bidscoin --recreate --architecture aarch64 --ignore-architectures
- . .codex-venv/bin/activate && python -m pytest builder/tests/test_template_rendering.py -q

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->