### PR TITLE
Add ARM64 support for cosmomvpa

### DIFF
--- a/recipes/cosmomvpa/build.yaml
+++ b/recipes/cosmomvpa/build.yaml
@@ -3,6 +3,7 @@ version: 1.1.0
 
 architectures:
   - x86_64
+  - aarch64
 
 build:
   kind: neurodocker
@@ -23,6 +24,7 @@ build:
         - liboctave-dev
         - patch
         - make
+        - pkg-config
         - fonts-freefont-otf
         - units
 

--- a/recipes/cosmomvpa/fulltest.yaml
+++ b/recipes/cosmomvpa/fulltest.yaml
@@ -1,0 +1,46 @@
+# cosmomvpa container test suite
+# Tests for cosmomvpa v1.1.0 - CoSMoMVPA toolbox for GNU Octave
+#
+# Tests focus on the packaged Octave runtime and the installed CoSMoMVPA
+# toolbox entrypoints that the image actually exposes.
+
+name: cosmomvpa
+version: 1.1.0
+container: cosmomvpa_1.1.0.simg
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p test_output/cosmomvpa
+
+tests:
+  - name: octave on PATH
+    description: Verify Octave is available in the image
+    command: command -v octave
+    expected_output_contains: "/usr/bin/octave"
+
+  - name: octave version
+    description: Verify Octave starts successfully
+    command: octave --version | head -1
+    expected_output_contains: "GNU Octave"
+
+  - name: CoSMoMVPA tree exists
+    description: Verify the CoSMoMVPA source tree was installed
+    command: ls -d /opt/cosmomvpa-1.1.0/CoSMoMVPA
+    expected_output_contains: "/opt/cosmomvpa-1.1.0/CoSMoMVPA"
+
+  - name: cosmo_wtf resolves
+    description: Verify Octave can resolve the main CoSMoMVPA diagnostic function
+    command: octave --no-gui --eval "addpath(genpath('/opt/cosmomvpa-1.1.0/CoSMoMVPA')); which cosmo_wtf"
+    expected_output_contains: "cosmo_wtf.m"
+
+  - name: cosmo_wtf runs
+    description: Verify the CoSMoMVPA diagnostic function executes
+    command: octave --no-gui --eval "addpath(genpath('/opt/cosmomvpa-1.1.0/CoSMoMVPA')); cosmo_wtf();"
+    expected_output_contains: "warning: Using cosmo_config"
+
+cleanup:
+  script: |
+    #!/usr/bin/env bash
+    echo "Test outputs preserved in test_output/cosmomvpa/"


### PR DESCRIPTION
## Summary
- add aarch64 support to the cosmomvpa recipe
- install pkg-config for the ARM64 build path
- add a focused full test for the installed Octave and CoSMoMVPA entrypoints

## Testing
- python3 builder/validation.py recipes/cosmomvpa/build.yaml
- python3 -m builder generate cosmomvpa --recreate
- python3 -m builder generate cosmomvpa --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->