### PR TITLE
Add ARM64 support for blastct

### DIFF
--- a/recipes/blastct/build.yaml
+++ b/recipes/blastct/build.yaml
@@ -5,6 +5,7 @@ copyright:
     url: https://www.apache.org/licenses/LICENSE-2.0
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: |-
     Brain Lesion Analysis and Segmentation Tool for Computed Tomography - Version 2.0.0
@@ -68,11 +69,13 @@ build:
     - template:
         name: miniconda
         version: py311_25.5.1-0
+        env_name: blastct
+        env_exists: "false"
         conda_install: ""
-        pip_install: scipy numpy pandas SimpleITK==1.2.4 "torch>=1.9"
+        pip_install: scipy numpy pandas SimpleITK==2.4.1 "torch>=1.9" tensorboard
         install_path: /opt/miniconda
     - run:
-        - pip install git+https://github.com/biomedia-mira/blast-ct.git
+        - conda run -n blastct pip install --no-deps git+https://github.com/biomedia-mira/blast-ct.git
     - deploy:
         bins:
           - python3

--- a/recipes/blastct/fulltest.yaml
+++ b/recipes/blastct/fulltest.yaml
@@ -1,0 +1,41 @@
+# blastct container test suite
+# Minimal no-rebuild verification for the installed BLAST-CT Python package.
+
+name: blastct
+version: 2.0.0
+container: blastct_2.0.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: Python runtime available
+    description: Verify the Python runtime matches the shipped image
+    command: python3 --version
+    expected_output_contains: "Python 3.11.13"
+
+  - name: BLAST-CT package import
+    description: Verify the main blast_ct module imports successfully
+    command: python3 -c "import blast_ct; print(blast_ct.__name__)"
+    expected_output_contains: "blast_ct"
+
+  - name: BLAST-CT package metadata
+    description: Verify pip metadata reports the installed blast_ct package
+    command: python3 -m pip show blast_ct 2>&1 | sed -n '1,12p'
+    expected_output_contains: "Home-page: https://github.com/biomedia-mira/blast_ct"
+
+  - name: SimpleITK version
+    description: Verify the expected SimpleITK runtime is installed
+    command: python3 -c "import SimpleITK as sitk; print(sitk.Version_VersionString())"
+    expected_output_contains: "2.4.1"
+
+  - name: BLAST-CT install location
+    description: Verify the module is installed under the Miniconda site-packages tree
+    command: python3 -c "import blast_ct; print(blast_ct.__file__)"
+    expected_output_contains: "/opt/miniconda/lib/python3.11/site-packages/blast_ct/"


### PR DESCRIPTION
## Summary
- add aarch64 support to the blastct recipe
- make the Miniconda environment explicit for the blastct install path
- add a focused ARM64 fulltest for the packaged Python runtime and modules

## Validation
- python3 builder/validation.py recipes/blastct/build.yaml
- python3 -m builder generate blastct --recreate
- python3 -m builder generate blastct --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->