### PR TITLE
Add ARM64 support for cbsb0stats

### DIFF
--- a/recipes/cbsb0stats/build.yaml
+++ b/recipes/cbsb0stats/build.yaml
@@ -3,6 +3,7 @@ version: 1.2.0
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAADsUlEQVRIS7WVbUjTWxzHv2erucc2VwaVvfCSuOl6cDW7BVsQinjBAs0SSzMiwZDswWp3XXsA71WsXgWhpZCvBMkwiN5UEA1rg0atpVOiKGfTclulW2mudXfO2j/nJAj1wJ/B2f///fwevud3yOZzge/hBbro7/Rntvtk01k/U58L8R9CMVoMMF/iVJf8eWYsDvC7Gc0UOQs6LEQ2nh6NAUwV/zb5BcHPH0AEUvAFkhnL+Cvx8AcgWbWfOAAVD4VC8Lss8D5rh9z/ECqVCjabDcEV+ZD9kYPX13cxQ0xdiZkHIFqug3ilAWSBkEVOxVmJdP985FwUCn3DsOUSMsWP0dHRAbFYzOnY7XZs1m/F5zEfC4IQwv0XDAZhNpuxveI8lmz5F3xhIpct2XDqA+eiMZcVsFajr68PPT09yMvLg8fjQVlZGZqamtDd3Q29Xs8Azc3NqK+vh1QqRW1tLYqLi1FZWYkbL1ZBllYQC4i66NWNcnRePgyDwQC5XA4kasJlycY783+oq6uDTqdDbm4uAzQ0NMBkMrEsNBoNHA4HjEYjmu+MQrmx5idgvcnHSkQbar+QjIGBAUxMTCA1NRXqgz3gi5Tw2K5i+P5priQU4HQ6YbFYIJPJkJ2dDYlEgqSkJAi0JshUOyIA6iLt314GmAyM4PklNbxeL1wuF3T6v5BWYWMvjr68A9fNvTEAGoTf7wePx4NCoWBZ5efn4/EXA6SqIq7RJNPoiWQQnIDjYjJ6e3uRkpICkUiE9Oo3AG8BvE+vYYP4IUpLS1mtp5dIKBSyoOij1Wqxcr8DPH5CxEXrTo5wLnpz6yCunN2JoqIiZGRkwLesFMIkDQZvVcD55AGoW9RqdRyApma1WllZlUolVuw2gy9eGgGsPfGec9Hoq3sIPKiG2+2Gz+dDYWEh+vv70djYiPLycpSUlKC9vZ0BOjs70dLSAoFAgKqqKuTk5KCrqwsFBQVI3mcHiWZAAVEXhYJf4bpdhW1Zi9Da2so+jq62tjYGiR7G6eeAHkbabEGmEZK0H02mGaw5/i5mVIz7XmLo7kmMuy2snrSB9BDRpio3nYDvUWPcSY5uKLJqIEnfw0XPXLS6Zjh22NFx8TWAwKAFk/4hhMLN54sWQ7BYBX6CHOMjzrBDwp9G747w+7yFEpAEBfjSZMaKWpTNIs2xoZ+AKTMkZoTPYp9kHHVHALMQ+VUwJP3I28iFOcN1ORf7EcA8ibNzoD48GA+Yw4yIqtoV56K5LBdJOzQwry76H0tMj7XJU3hkAAAAAElFTkSuQmCC
 architectures:
   - x86_64
+  - aarch64
 
 files:
   - name: cbsb0stats.py
@@ -64,7 +65,7 @@ readme: |-
   you can build this recipe with:
   ```bash
   source env/bin/activate
-  sf-login testing --architecture x86_64
+  ./builder/build.py generate testing --recreate --build --login --architecture x86_64
   ```
 
   or shorter: open the build.yaml file in the local terminal and run:

--- a/recipes/cbsb0stats/fulltest.yaml
+++ b/recipes/cbsb0stats/fulltest.yaml
@@ -1,0 +1,47 @@
+# cbsb0stats container test suite
+# Tests for cbsb0stats v1.2.0 on ARM64.
+#
+# This suite validates the concrete runtime surface in the built image:
+# the installed BET2 binary, the bundled reconstruction script, and the
+# OpenRecon Python server/client entrypoints.
+
+name: cbsb0stats
+version: 1.2.0
+container: cbsb0stats_1.2.0.simg
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p test_output/cbsb0stats
+
+tests:
+  - name: bet2 binary exists
+    description: Verify the packaged BET2 binary is present at its installed path
+    command: ls /opt/code/FSL-BET2/bin/bet2
+    expected_output_contains: "/opt/code/FSL-BET2/bin/bet2"
+
+  - name: cbsb0stats script exists
+    description: Verify the recipe-specific reconstruction script is present
+    command: ls /opt/code/python-ismrmrd-server/cbsb0stats.py
+    expected_output_contains: "cbsb0stats.py"
+
+  - name: cbsb0stats script compiles
+    description: Verify the bundled reconstruction script compiles successfully
+    command: python3 -m py_compile /opt/code/python-ismrmrd-server/cbsb0stats.py
+    expected_exit_code: 0
+
+  - name: main server help
+    description: Verify the OpenRecon server entrypoint starts and prints help output
+    command: python3 /opt/code/python-ismrmrd-server/main.py --help
+    expected_output_contains: "Example server for MRD streaming format"
+
+  - name: client help
+    description: Verify the OpenRecon client entrypoint starts and prints help output
+    command: python3 /opt/code/python-ismrmrd-server/client.py --help
+    expected_output_contains: "Example client for MRD streaming format"
+
+cleanup:
+  script: |
+    #!/usr/bin/env bash
+    echo "Test outputs preserved in test_output/cbsb0stats/"


### PR DESCRIPTION
## Summary
- add aarch64 support to the cbsb0stats recipe
- add a focused ARM64 fulltest for BET2 and the OpenRecon entrypoints
- update the documented local build/test commands to the current builder surface

## Validation
- python3 builder/validation.py recipes/cbsb0stats/build.yaml
- python3 -m builder generate cbsb0stats --recreate
- python3 -m builder generate cbsb0stats --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->