### PR TITLE
Add ARM64 support for heudiconv

### DIFF
--- a/recipes/heudiconv/build.yaml
+++ b/recipes/heudiconv/build.yaml
@@ -7,16 +7,25 @@ copyright:
 
 architectures:
   - x86_64
+  - aarch64
 
 build:
   kind: neurodocker
 
-  base-image: nipy/heudiconv:1.3.1
+  base-image: python:3.11-slim-bookworm
   pkg-manager: apt
 
   directives:
     - environment:
         DEBIAN_FRONTEND: noninteractive
+
+    - install:
+        - ca-certificates
+        - build-essential
+        - dcm2niix
+
+    - run:
+        - python -m pip install --no-cache-dir heudiconv=={{ context.version }}
 
     - copy: test.sh /test.sh
 


### PR DESCRIPTION
## Summary
- add `aarch64` support to the heudiconv recipe
- replace the x86-only upstream base image with a neutral Python base
- install `dcm2niix` and `heudiconv=={{ context.version }}` directly in the recipe

## Validation
- `python3 builder/validation.py recipes/heudiconv/build.yaml`
- `python3 -m builder generate heudiconv --recreate`
- `python3 -m builder generate heudiconv --recreate --architecture aarch64 --ignore-architectures`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->