### PR TITLE
Add ARM64 support for eharmonize

### DIFF
--- a/recipes/eharmonize/build.yaml
+++ b/recipes/eharmonize/build.yaml
@@ -2,6 +2,7 @@ name: eharmonize
 version: 1.0.0
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: ENIGMA Harmonization (eharmonize) is a python-based package that harmonizes provided data to included lifespan reference curves. The package is currently set up for outputs of the ENIGMA-DTI pipeline.
   example: eharmonize --help
@@ -20,6 +21,8 @@ build:
         name: miniconda
         version: latest
         install_path: /opt/miniconda
+        env_name: eharmonize
+        env_exists: "false"
     - run:
         - cd /opt
         - git clone https://github.com/ahzhu/eharmonize.git

--- a/recipes/eharmonize/fulltest.yaml
+++ b/recipes/eharmonize/fulltest.yaml
@@ -1,0 +1,41 @@
+# eharmonize container test suite
+# Minimal no-rebuild verification for the shipped eharmonize CLI and Python package.
+
+name: eharmonize
+version: 1.0.0
+container: eharmonize_1.0.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: eharmonize binary in PATH
+    description: Verify the shipped CLI is installed on PATH
+    command: command -v eharmonize
+    expected_output_contains: "/opt/miniconda/bin/eharmonize"
+
+  - name: eharmonize help output
+    description: Verify the main CLI help text renders
+    command: eharmonize --help 2>&1 | sed -n '1,20p'
+    expected_output_contains: "eharmonize (ENIGMA harmonization)"
+
+  - name: harmonize-fa help output
+    description: Verify the harmonize-fa subcommand is exposed
+    command: eharmonize harmonize-fa --help 2>&1 | sed -n '1,20p'
+    expected_output_contains: "Usage: eharmonize harmonize-fa"
+
+  - name: Python runtime available
+    description: Verify Python resolves from the Miniconda installation
+    command: python --version
+    expected_output_contains: "Python 3.13."
+
+  - name: eharmonize package metadata
+    description: Verify the installed Python package metadata matches the shipped runtime
+    command: python -m pip show eharmonize 2>&1 | sed -n '1,20p'
+    expected_output_contains: "Version: 0.0.0"


### PR DESCRIPTION
## Summary
- add `aarch64` to the eharmonize recipe
- create a dedicated miniconda env for the package install
- add an ARM64-oriented fulltest for the shipped CLI and package metadata

## Validation
- `python3 builder/validation.py recipes/eharmonize/build.yaml`
- `python3 -m builder generate eharmonize --recreate`
- `python3 -m builder generate eharmonize --recreate --architecture aarch64 --ignore-architectures`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->