### PR TITLE
Fix hdbet ARM64 install command

### DIFF
--- a/recipes/hdbet/build.yaml
+++ b/recipes/hdbet/build.yaml
@@ -38,10 +38,7 @@ build:
         - cp {{ get_file("2_model") }} /opt/HD-BET/hd-bet_params/2.model
         - cp {{ get_file("3_model") }} /opt/HD-BET/hd-bet_params/3.model
         - cp {{ get_file("4_model") }} /opt/HD-BET/hd-bet_params/4.model
-        - |
-          bash -lc "source activate hdbet
-          python -m pip install -e .
-          "
+        - /opt/miniconda-latest/envs/hdbet/bin/python -m pip install -e .
 
 deploy:
   bins:


### PR DESCRIPTION
## Summary
- replace the multiline `bash -lc` hdbet install snippet with a direct conda-env Python invocation
- preserve the ARM64 hdbet recipe introduced in #2251 while fixing Dockerfile generation

## Validation
- `python3 builder/validation.py recipes/hdbet/build.yaml`
- `python3 -m builder generate hdbet --recreate`
- `python3 -m builder generate hdbet --recreate --architecture aarch64 --ignore-architectures`
- inspected the generated install line in `build/hdbet/hdbet_1.0.0.Dockerfile`

## Failure fixed
- manual ARM64 run `25746851870` failed in `build-app (hdbet) / config`
- the generated Dockerfile had an unterminated `bash -lc` string during `pip install -e .`
- this change removes that fragile quoting path entirely
