### PR TITLE
Add pip to hdbet ARM64 conda env

### DIFF
--- a/recipes/hdbet/build.yaml
+++ b/recipes/hdbet/build.yaml
@@ -18,7 +18,7 @@ build:
     - template:
         name: miniconda
         version: latest
-        conda_install: python=3.10
+        conda_install: python=3.10 pip
         env_name: hdbet
         env_exists: "false"
 


### PR DESCRIPTION
## Summary
- add `pip` to the fresh `hdbet` miniconda environment
- keep the direct env-Python editable install from #2252

## Validation
- `python3 builder/validation.py recipes/hdbet/build.yaml`
- `python3 -m builder generate hdbet --recreate`
- `python3 -m builder generate hdbet --recreate --architecture aarch64 --ignore-architectures`

## Failure fixed
- manual ARM64 run `25747707831` failed in `build-app (hdbet) / config`
- the generated Dockerfile reached the editable install step, then failed with `/opt/miniconda-latest/envs/hdbet/bin/python: No module named pip`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->