### PR TITLE
Add ARM64 support for julia

### DIFF
--- a/recipes/julia/build.yaml
+++ b/recipes/julia/build.yaml
@@ -7,6 +7,27 @@ copyright:
 
 architectures:
   - x86_64
+  - aarch64
+
+variables:
+  vscode_deb:
+    try:
+      - value: vscode_linux_deb_x64
+        condition: arch == "x86_64"
+      - value: vscode_linux_deb_arm64
+        condition: arch == "aarch64"
+  julia_archive:
+    try:
+      - value: julia_1_9_4_linux_x86_64_tar_gz
+        condition: arch == "x86_64"
+      - value: julia_1_9_4_linux_aarch64_tar_gz
+        condition: arch == "aarch64"
+  julia_tarball:
+    try:
+      - value: julia-1.9.4-linux-x86_64.tar.gz
+        condition: arch == "x86_64"
+      - value: julia-1.9.4-linux-aarch64.tar.gz
+        condition: arch == "aarch64"
 
 build:
   kind: neurodocker
@@ -56,16 +77,16 @@ build:
         - pkg-config
 
     - run:
-        - cp {{ get_file("download") }} vscode.deb
+        - cp {{ get_file(context.vscode_deb) }} vscode.deb
         - apt install ./vscode.deb
         - rm -rf ./vscode.deb
 
     - workdir: /opt
 
     - run:
-        - cp {{ get_file("julia_1_9_4_linux_x86_64_tar_gz") }} julia-1.9.4-linux-x86_64.tar.gz
-        - tar zxvf julia-1.9.4-linux-x86_64.tar.gz
-        - rm -rf julia-1.9.4-linux-x86_64.tar.gz
+        - cp {{ get_file(context.julia_archive) }} {{ context.julia_tarball }}
+        - tar zxvf {{ context.julia_tarball }}
+        - rm -rf {{ context.julia_tarball }}
         - ln -s /opt/julia-1.9.4 /opt/julia-latest
 
     - run:
@@ -122,11 +143,15 @@ readme: |-
   ----------------------------------
 
 files:
-  - name: download
+  - name: vscode_linux_deb_x64
     url: https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64
+  - name: vscode_linux_deb_arm64
+    url: https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-arm64
 
   - name: julia_1_9_4_linux_x86_64_tar_gz
     url: https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.4-linux-x86_64.tar.gz
+  - name: julia_1_9_4_linux_aarch64_tar_gz
+    url: https://julialang-s3.julialang.org/bin/linux/aarch64/1.9/julia-1.9.4-linux-aarch64.tar.gz
   - name: install_packages.jl
     contents: |-
       using Pkg

--- a/recipes/julia/fulltest.yaml
+++ b/recipes/julia/fulltest.yaml
@@ -924,7 +924,9 @@ tests:
   - name: Least squares
     description: Test overdetermined system
     command: julia -e 'A = [1.0 1.0; 1.0 2.0; 1.0 3.0]; b = [1.0, 2.0, 3.0]; x = A \ b; println(round.(x, digits=1))'
-    expected_output_contains: "[0.0, 1.0]"
+    expected_output_contains:
+      - "[-0.0, 1.0]"
+      - "[0.0, 1.0]"
     expected_exit_code: 0
 
 cleanup:


### PR DESCRIPTION
## Summary
- add aarch64 support to the julia recipe
- select architecture-specific VS Code and Julia payloads through declared files and template variables
- relax the least-squares fulltest expectation to allow the ARM64 rounding variant

## Validation
- python3 builder/validation.py recipes/julia/build.yaml
- python3 -m builder generate julia --recreate
- python3 -m builder generate julia --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->