### PR TITLE
Add ARM64 support for lqt

### DIFF
--- a/recipes/lqt/build.yaml
+++ b/recipes/lqt/build.yaml
@@ -5,6 +5,7 @@ copyright:
     url: https://github.com/jdwor/LQT
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: |-
     LQT is an R implementation of the lesion quantification toolkit, based on the paper “Lesion Quantification Toolkit: A MATLAB software tool for estimating grey matter damage and white matter disconnections in patients with focal brain lesions” by Griffis et al. The LQT is “a publicly available software package for quantifying the structural impacts of focal brain lesions. It uses atlas-based approaches to estimate parcel-level grey matter lesion loads and multiple measures of white matter disconnection severity that include tract-level disconnection measures, voxel-wise disconnection maps, and parcel-wise disconnection matrices. The toolkit also estimates lesion-induced increases in the lengths of the shortest structural paths between parcel pairs, which provide information about changes in higher-order structural network topology.”
@@ -86,8 +87,9 @@ build:
     - install:
         - r-base
         - r-base-dev
+        - libgsl-dev
     - run:
-        - R --slave -e "if (!require('devtools', quietly = TRUE)) install.packages('devtools', repos='https://cloud.r-project.org/'); devtools::install_github('jdwor/LQT', dependencies=TRUE, upgrade='never'); cat('Installed LQT from GitHub\n')"
+        - R --slave -e "options(repos = c(CRAN = 'https://cloud.r-project.org')); install.packages('remotes'); remotes::install_version('gsl', version = '2.1-8', repos = 'https://cloud.r-project.org'); install.packages('aws', dependencies = TRUE); remotes::install_github('jdwor/LQT', dependencies = NA, upgrade = 'never', build_vignettes = FALSE); cat('Installed LQT from GitHub\n')"
     - test:
         name: verify_r_installation
         script: |-

--- a/recipes/lqt/fulltest.yaml
+++ b/recipes/lqt/fulltest.yaml
@@ -1,0 +1,46 @@
+# lqt container test suite
+# Tests for lqt v0.1.0 on ARM64.
+#
+# This suite validates the installed R runtime and the packaged LQT library
+# without expanding into data-heavy analyses.
+
+name: lqt
+version: 0.1.0
+container: lqt_0.1.0.simg
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p test_output/lqt
+
+tests:
+  - name: R version
+    description: Verify the packaged R runtime starts
+    command: R --version
+    expected_output_contains: "R version 4.3"
+
+  - name: LQT library loads
+    description: Verify the LQT package loads successfully in R
+    command: R --slave -e "library(LQT); cat('LQT loaded\\n')"
+    expected_output_contains: "LQT loaded"
+
+  - name: LQT package version
+    description: Verify the installed LQT package reports the expected version
+    command: R --slave -e "library(LQT); cat(as.character(packageVersion('LQT')), '\\n')"
+    expected_output_contains: "0.1.0"
+
+  - name: LQT package path
+    description: Verify the installed package path resolves inside site-library
+    command: R --slave -e "cat(system.file(package='LQT'), '\\n')"
+    expected_output_contains: "/usr/local/lib/R/site-library/LQT"
+
+  - name: LQT namespace exports
+    description: Verify the installed namespace exports at least one symbol
+    command: R --slave -e "library(LQT); cat(length(getNamespaceExports('LQT')) > 0, '\\n')"
+    expected_output_contains: "TRUE"
+
+cleanup:
+  script: |
+    #!/usr/bin/env bash
+    echo "Test outputs preserved in test_output/lqt/"


### PR DESCRIPTION
## Summary
- add aarch64 support to the lqt recipe
- install the ARM64-specific R package prerequisites needed for LQT
- add a focused ARM64 fulltest covering R startup and LQT package availability

## Validation
- python3 builder/validation.py recipes/lqt/build.yaml
- python3 -m builder generate lqt --recreate
- python3 -m builder generate lqt --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->