### PR TITLE
Add ARM64 support for niistat

### DIFF
--- a/recipes/niistat/build.yaml
+++ b/recipes/niistat/build.yaml
@@ -3,6 +3,7 @@ version: 1.0.20191216
 
 architectures:
   - x86_64
+  - aarch64
 
 build:
   kind: neurodocker
@@ -55,7 +56,7 @@ files:
       %% Download SPM12 r7771
       unzip ("https://github.com/spm/spm12/archive/r7771.zip", cwd);
       %% Patch SPM12
-      urlwrite ("https://raw.githubusercontent.com/spm/spm-docker/main/octave/spm12_r7771.patch", "spm12_r7771.patch");
+      urlwrite ("https://raw.githubusercontent.com/spm/spm-octave/main/spm12_r7771.patch", "spm12_r7771.patch");
       system ("patch -p3 -d spm12-r7771 < spm12_r7771.patch");
       %% Compile MEX files
       cd (fullfile (cwd, "spm12-r7771", "src"));

--- a/recipes/niistat/fulltest.yaml
+++ b/recipes/niistat/fulltest.yaml
@@ -18,7 +18,7 @@
 
 name: niistat
 version: 1.0.20191216
-container: niistat_1.0.20191216_20220111.simg
+container: niistat_1.0.20191216.simg
 
 required_files:
   - dataset: ds000001
@@ -45,7 +45,7 @@ tests:
   # ==========================================================================
   - name: Octave version check
     description: Verify Octave is installed and reports version
-    command: octave --version 2>&1 | grep -m1 "GNU Octave"
+    command: octave --version 2>/dev/null | head -1
     expected_output_contains: "GNU Octave"
     expected_exit_code: 0
 
@@ -72,29 +72,29 @@ tests:
   # ==========================================================================
   - name: SPM12 path exists
     description: Verify SPM12 installation directory exists
-    command: "bash -lc 'ls -la /opt/spm12-r7771/spm.m 2>&1'"
+    command: ls -la /opt/spm12-r7771/spm.m 2>&1
     expected_output_contains: "spm.m"
 
   - name: SPM12 version check
     description: Verify SPM12 loads and reports correct version
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); v = spm('\"'\"'Version'\"'\"'); disp(v); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); v = spm('Version'); disp(v); exit(0);" 2>&1
     expected_output_contains: "SPM12"
     expected_exit_code: 0
 
   - name: SPM12 nifti functions available
     description: Test SPM12 NIfTI file handling functions are accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); which spm_vol; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); which spm_vol; exit(0);" 2>&1
     expected_output_contains: "spm_vol"
     expected_exit_code: 0
 
   - name: SPM12 file_array class
     description: Verify SPM12 file_array class is functional
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); exist('\"'\"'file_array'\"'\"'); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); exist('file_array'); exit(0);" 2>&1
     expected_exit_code: 0
 
   - name: SPM12 matrix functions
     description: Test SPM matrix/transformation functions
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); M = spm_matrix([0 0 0]); disp(size(M)); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); M = spm_matrix([0 0 0]); disp(size(M)); exit(0);" 2>&1
     expected_output_contains: "4"
     expected_exit_code: 0
 
@@ -103,30 +103,30 @@ tests:
   # ==========================================================================
   - name: NiiStat path exists
     description: Verify NiiStat installation directory exists
-    command: "bash -lc 'ls -la /opt/niistat-1.0.20191216/NiiStat.m 2>&1'"
+    command: ls -la /opt/niistat-1.0.20191216/NiiStat.m 2>&1
     expected_output_contains: "NiiStat.m"
 
   - name: NiiStat main function accessible
     description: Test NiiStat main function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which NiiStat; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which NiiStat; exit(0);" 2>&1
     expected_output_contains: "NiiStat"
     expected_exit_code: 0
 
   - name: NiiStat core functions available
     description: Verify nii_stat_core function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_core; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_core; exit(0);" 2>&1
     expected_output_contains: "nii_stat_core"
     expected_exit_code: 0
 
   - name: NiiStat ROI functions available
     description: Verify nii_roi_list function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_roi_list; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_roi_list; exit(0);" 2>&1
     expected_output_contains: "nii_roi_list"
     expected_exit_code: 0
 
   - name: NiiStat modality list available
     description: Verify nii_modality_list function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_modality_list; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_modality_list; exit(0);" 2>&1
     expected_output_contains: "nii_modality_list"
     expected_exit_code: 0
 
@@ -135,47 +135,47 @@ tests:
   # ==========================================================================
   - name: ROI atlas directory exists
     description: Verify ROI atlas files are present
-    command: bash -lc 'ls /opt/niistat-1.0.20191216/roi/*.nii 2>&1 | wc -l'
+    command: ls /opt/niistat-1.0.20191216/roi/*.nii 2>&1 | wc -l
     expected_output_contains: "9"
 
   - name: AAL atlas present
     description: Verify AAL (Automated Anatomical Labeling) atlas is available
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/aal.nii 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/roi/aal.nii 2>&1
     expected_output_contains: "aal.nii"
 
   - name: JHU atlas present
     description: Verify JHU (Johns Hopkins University) white matter atlas is available
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/jhu.nii 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/roi/jhu.nii 2>&1
     expected_output_contains: "jhu.nii"
 
   - name: Brodmann atlas present
     description: Verify Brodmann areas atlas is available
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/bro.nii 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/roi/bro.nii 2>&1
     expected_output_contains: "bro.nii"
 
   - name: AICHA atlas present
     description: Verify AICHA (Atlas of Intrinsic Connectivity of Homotopic Areas) is available
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/AICHA.nii 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/roi/AICHA.nii 2>&1
     expected_output_contains: "AICHA.nii"
 
   - name: Fox atlas present
     description: Verify Fox atlas for resting state networks is available
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/fox.nii 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/roi/fox.nii 2>&1
     expected_output_contains: "fox.nii"
 
   - name: Catani atlas present
     description: Verify Catani white matter tract atlas is available
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/roi/cat.nii 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/roi/cat.nii 2>&1
     expected_output_contains: "cat.nii"
 
   - name: ROI label files present
     description: Verify ROI label text files are present
-    command: bash -lc 'ls /opt/niistat-1.0.20191216/roi/*.txt 2>&1 | wc -l'
+    command: ls /opt/niistat-1.0.20191216/roi/*.txt 2>&1 | wc -l
     expected_output_contains: "8"
 
   - name: ROI node files present
     description: Verify ROI node files for BrainNet Viewer are present
-    command: bash -lc 'ls /opt/niistat-1.0.20191216/roi/*.node 2>&1 | wc -l'
+    command: ls /opt/niistat-1.0.20191216/roi/*.node 2>&1 | wc -l
     expected_output_contains: "7"
 
   # ==========================================================================
@@ -183,25 +183,25 @@ tests:
   # ==========================================================================
   - name: ROI list function
     description: Test nii_roi_list returns available atlases
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [files, nums] = nii_roi_list(); disp(nums); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [files, nums] = nii_roi_list(); disp(nums); exit(0);" 2>&1
     expected_output_contains: "aal"
     expected_exit_code: 0
 
   - name: Modality list function
     description: Test nii_modality_list returns available modalities
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [files, nums] = nii_modality_list(); disp(nums); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [files, nums] = nii_modality_list(); disp(nums); exit(0);" 2>&1
     expected_output_contains: "lesion"
     expected_exit_code: 0
 
   - name: Binary check function
     description: Test nii_isBinary function with binary data
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [isBin, dat] = nii_isBinary([1 0 1 1]); disp(isBin); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [isBin, dat] = nii_isBinary([1 0 1 1]); disp(isBin); exit(0);" 2>&1
     expected_output_contains: "1"
     expected_exit_code: 0
 
   - name: Binary check function non-binary
     description: Test nii_isBinary function with non-binary data
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); [isBin, dat] = nii_isBinary([1 2 3 4]); disp(isBin); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); [isBin, dat] = nii_isBinary([1 2 3 4]); disp(isBin); exit(0);" 2>&1
     expected_output_contains: "0"
     expected_exit_code: 0
 
@@ -210,45 +210,50 @@ tests:
   # ==========================================================================
   - name: LibSVM directory exists
     description: Verify LibSVM installation directory exists
-    command: "bash -lc 'ls -la /opt/niistat-1.0.20191216/libsvm/ 2>&1'"
+    command: ls -la /opt/niistat-1.0.20191216/libsvm/ 2>&1
     expected_output_contains: "svmtrain"
 
-  - name: LibSVM MEX files present
-    description: Verify LibSVM compiled MEX files are present
-    command: bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/*.mexa64 2>&1 | wc -l'
-    expected_output_contains: "4"
+  - name: LibSVM svmtrain available
+    description: Verify svmtrain resolves after adding the LibSVM path
+    command: octave --no-gui --eval "addpath('/opt/niistat-1.0.20191216/libsvm'); which svmtrain; exit(0);" 2>&1
+    expected_output_contains: "svmtrain"
+    expected_exit_code: 0
 
-  - name: LibSVM svmtrain MEX available
-    description: Verify svmtrain MEX file exists
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/svmtrain.mexa64 2>&1'"
-    expected_output_contains: "svmtrain.mexa64"
+  - name: LibSVM svmpredict available
+    description: Verify svmpredict resolves after adding the LibSVM path
+    command: octave --no-gui --eval "addpath('/opt/niistat-1.0.20191216/libsvm'); which svmpredict; exit(0);" 2>&1
+    expected_output_contains: "svmpredict"
+    expected_exit_code: 0
 
-  - name: LibSVM svmpredict MEX available
-    description: Verify svmpredict MEX file exists
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/svmpredict.mexa64 2>&1'"
-    expected_output_contains: "svmpredict.mexa64"
-
-  - name: LibSVM read/write MEX available
-    description: Verify libsvmread and libsvmwrite MEX files exist
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/libsvm/libsvmread.mexa64 /opt/niistat-1.0.20191216/libsvm/libsvmwrite.mexa64 2>&1'"
-    expected_output_contains: "libsvmread.mexa64"
+  - name: LibSVM read/write functions available
+    description: Verify libsvmread and libsvmwrite resolve after adding the LibSVM path
+    command: |
+      octave --no-gui --eval "
+        addpath('/opt/niistat-1.0.20191216/libsvm');
+        which libsvmread;
+        which libsvmwrite;
+        exit(0);
+      " 2>&1
+    expected_output_contains: "libsvmread"
+    expected_exit_code: 0
 
   # ==========================================================================
   # TFCE (Threshold-Free Cluster Enhancement) TESTS
   # ==========================================================================
-  - name: TFCE MEX file present
-    description: Verify TFCE compiled MEX file exists
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/tfceMex.mexa64 2>&1'"
-    expected_output_contains: "tfceMex.mexa64"
+  - name: TFCE compiled function available
+    description: Verify TFCE resolves after adding the NiiStat path
+    command: octave --no-gui --eval "addpath('/opt/niistat-1.0.20191216'); which tfceMex; exit(0);" 2>&1
+    expected_output_contains: "tfceMex"
+    expected_exit_code: 0
 
   - name: TFCE function file present
     description: Verify TFCE MATLAB function file exists
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/tfceMex.m 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/tfceMex.m 2>&1
     expected_output_contains: "tfceMex.m"
 
   - name: TFCE C source present
     description: Verify TFCE C source code is included
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/tfceMex.c 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/tfceMex.c 2>&1
     expected_output_contains: "tfceMex.c"
 
   # ==========================================================================
@@ -256,18 +261,18 @@ tests:
   # ==========================================================================
   - name: GLM directory exists
     description: Verify GLM functions directory exists
-    command: "bash -lc 'ls -la /opt/niistat-1.0.20191216/glm/ 2>&1'"
+    command: ls -la /opt/niistat-1.0.20191216/glm/ 2>&1
     expected_output_contains: "xl_glm.m"
 
   - name: GLM function accessible
     description: Verify xl_glm function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"'); which xl_glm; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/glm'); which xl_glm; exit(0);" 2>&1
     expected_output_contains: "xl_glm"
     expected_exit_code: 0
 
   - name: SPM T-distribution function
     description: Test spm_Tcdf function for T-distribution
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"'); p = spm_Tcdf(2.0, 10); disp(p); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216/glm'); p = spm_Tcdf(2.0, 10); disp(p); exit(0);" 2>&1
     expected_output_contains: "0.9"
     expected_exit_code: 0
 
@@ -276,18 +281,18 @@ tests:
   # ==========================================================================
   - name: FDR function present
     description: Verify FDR correction function is present
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/fdr_bh.m 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/fdr_bh.m 2>&1
     expected_output_contains: "fdr_bh.m"
 
   - name: FDR function accessible
     description: Verify fdr_bh function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which fdr_bh; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which fdr_bh; exit(0);" 2>&1
     expected_output_contains: "fdr_bh"
     expected_exit_code: 0
 
   - name: FDR Benjamini-Hochberg correction
     description: Test FDR correction on p-values
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); pvals = [0.01 0.02 0.03 0.5 0.6]; [h, crit_p] = fdr_bh(pvals, 0.05); disp(sum(h)); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); pvals = [0.01 0.02 0.03 0.5 0.6]; [h, crit_p] = fdr_bh(pvals, 0.05); disp(sum(h)); exit(0);" 2>&1
     expected_output_contains: "3"
     expected_exit_code: 0
 
@@ -296,12 +301,12 @@ tests:
   # ==========================================================================
   - name: Fisher exact test function present
     description: Verify Fisher exact test function is present
-    command: "bash -lc 'ls /opt/niistat-1.0.20191216/fexact.m 2>&1'"
+    command: ls /opt/niistat-1.0.20191216/fexact.m 2>&1
     expected_output_contains: "fexact.m"
 
   - name: Fisher exact test accessible
     description: Verify fexact function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which fexact; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which fexact; exit(0);" 2>&1
     expected_output_contains: "fexact"
     expected_exit_code: 0
 
@@ -310,24 +315,32 @@ tests:
   # ==========================================================================
   - name: SPM volume read function
     description: Test SPM can read NIfTI header (copy to /tmp since SPM deletes .nii.gz after decompression)
-    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"'); disp(hdr.dim); exit(0);\" 2>&1'"
+    command: |
+      cp ${t1w} /tmp/t1w.nii.gz
+      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/t1w.nii.gz'); disp(hdr.dim); exit(0);" 2>&1
     expected_output_contains: "160"
     expected_exit_code: 0
 
   - name: SPM volume data read
     description: Test SPM can read NIfTI image data
-    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"'); img = spm_read_vols(hdr); disp(size(img)); exit(0);\" 2>&1'"
+    command: |
+      cp ${t1w} /tmp/t1w.nii.gz
+      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/t1w.nii.gz'); img = spm_read_vols(hdr); disp(size(img)); exit(0);" 2>&1
     expected_output_contains: "160"
     expected_exit_code: 0
 
   - name: NIfTI header information
     description: Extract NIfTI header information using SPM
-    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"'); disp(hdr.mat); exit(0);\" 2>&1'"
+    command: |
+      cp ${t1w} /tmp/t1w.nii.gz
+      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/t1w.nii.gz'); disp(hdr.mat); exit(0);" 2>&1
     expected_exit_code: 0
 
   - name: 4D NIfTI read
     description: Test reading 4D functional data (copy to /tmp since SPM deletes .nii.gz after decompression)
-    command: "bash -lc 'cp ${bold} /tmp/bold.nii.gz\noctave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); hdr = spm_vol('\"'\"'/tmp/bold.nii.gz'\"'\"'); disp(length(hdr)); exit(0);\" 2>&1'"
+    command: |
+      cp ${bold} /tmp/bold.nii.gz
+      octave --no-gui --eval "addpath('/opt/spm12-r7771'); hdr = spm_vol('/tmp/bold.nii.gz'); disp(length(hdr)); exit(0);" 2>&1
     expected_output_contains: "300"
     expected_exit_code: 0
 
@@ -336,31 +349,31 @@ tests:
   # ==========================================================================
   - name: Reslice function accessible
     description: Verify nii_reslice_target function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_reslice_target; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_reslice_target; exit(0);" 2>&1
     expected_output_contains: "nii_reslice_target"
     expected_exit_code: 0
 
   - name: NII to MAT conversion function
     description: Verify nii_nii2mat function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_nii2mat; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_nii2mat; exit(0);" 2>&1
     expected_output_contains: "nii_nii2mat"
     expected_exit_code: 0
 
   - name: MAT to NII conversion function
     description: Verify nii_mat2nii function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_mat2nii; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_mat2nii; exit(0);" 2>&1
     expected_output_contains: "nii_mat2nii"
     expected_exit_code: 0
 
   - name: ROI to stats function
     description: Verify nii_roi2stats function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_roi2stats; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_roi2stats; exit(0);" 2>&1
     expected_output_contains: "nii_roi2stats"
     expected_exit_code: 0
 
   - name: NII to ROI function
     description: Verify nii_nii2roi function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_nii2roi; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_nii2roi; exit(0);" 2>&1
     expected_output_contains: "nii_nii2roi"
     expected_exit_code: 0
 
@@ -369,31 +382,31 @@ tests:
   # ==========================================================================
   - name: SVM analysis function accessible
     description: Verify nii_stat_svm function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_svm; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_svm; exit(0);" 2>&1
     expected_output_contains: "nii_stat_svm"
     expected_exit_code: 0
 
   - name: SVM core function accessible
     description: Verify nii_stat_svm_core function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_svm_core; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_svm_core; exit(0);" 2>&1
     expected_output_contains: "nii_stat_svm_core"
     expected_exit_code: 0
 
   - name: SVR core function accessible
     description: Verify nii_stat_svr_core function for Support Vector Regression
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_stat_svr_core; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_stat_svr_core; exit(0);" 2>&1
     expected_output_contains: "nii_stat_svr_core"
     expected_exit_code: 0
 
   - name: PCA function accessible
     description: Verify nii_pca function for Principal Component Analysis
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_pca; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_pca; exit(0);" 2>&1
     expected_output_contains: "nii_pca"
     expected_exit_code: 0
 
   - name: Power analysis function accessible
     description: Verify nii_power function for statistical power analysis
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_power; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_power; exit(0);" 2>&1
     expected_output_contains: "nii_power"
     expected_exit_code: 0
 
@@ -402,25 +415,25 @@ tests:
   # ==========================================================================
   - name: Design file reader accessible
     description: Verify nii_read_design function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_read_design; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_read_design; exit(0);" 2>&1
     expected_output_contains: "nii_read_design"
     expected_exit_code: 0
 
   - name: Tab to MAT converter accessible
     description: Verify nii_tab2mat function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_tab2mat; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_tab2mat; exit(0);" 2>&1
     expected_output_contains: "nii_tab2mat"
     expected_exit_code: 0
 
   - name: XLS to MAT converter accessible
     description: Verify nii_xls2mat function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_xls2mat; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_xls2mat; exit(0);" 2>&1
     expected_output_contains: "nii_xls2mat"
     expected_exit_code: 0
 
   - name: VAL to MAT converter accessible
     description: Verify nii_val2mat function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_val2mat; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_val2mat; exit(0);" 2>&1
     expected_output_contains: "nii_val2mat"
     expected_exit_code: 0
 
@@ -429,25 +442,25 @@ tests:
   # ==========================================================================
   - name: Plot function accessible
     description: Verify nii_plot function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_plot; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_plot; exit(0);" 2>&1
     expected_output_contains: "nii_plot"
     expected_exit_code: 0
 
   - name: Power map function accessible
     description: Verify nii_powermap function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_powermap; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_powermap; exit(0);" 2>&1
     expected_output_contains: "nii_powermap"
     expected_exit_code: 0
 
   - name: Node file save function accessible
     description: Verify nii_save_nodz function for BrainNet Viewer output
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_save_nodz; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_save_nodz; exit(0);" 2>&1
     expected_output_contains: "nii_save_nodz"
     expected_exit_code: 0
 
   - name: Array to node conversion accessible
     description: Verify nii_array2node function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_array2node; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_array2node; exit(0);" 2>&1
     expected_output_contains: "nii_array2node"
     expected_exit_code: 0
 
@@ -456,31 +469,31 @@ tests:
   # ==========================================================================
   - name: Sphere creation function accessible
     description: Verify nii_sphere function for creating spherical ROIs
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_sphere; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_sphere; exit(0);" 2>&1
     expected_output_contains: "nii_sphere"
     expected_exit_code: 0
 
   - name: Custom ROI function accessible
     description: Verify nii_custom_roi function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_custom_roi; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_custom_roi; exit(0);" 2>&1
     expected_output_contains: "nii_custom_roi"
     expected_exit_code: 0
 
   - name: Make ROI function accessible
     description: Verify nii_make_roi function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_make_roi; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_make_roi; exit(0);" 2>&1
     expected_output_contains: "nii_make_roi"
     expected_exit_code: 0
 
   - name: ROI to mm conversion accessible
     description: Verify nii_roi2mm function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_roi2mm; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_roi2mm; exit(0);" 2>&1
     expected_output_contains: "nii_roi2mm"
     expected_exit_code: 0
 
   - name: Array to ROI conversion accessible
     description: Verify nii_array2roi function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_array2roi; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_array2roi; exit(0);" 2>&1
     expected_output_contains: "nii_array2roi"
     expected_exit_code: 0
 
@@ -489,7 +502,7 @@ tests:
   # ==========================================================================
   - name: Fiber QA function accessible
     description: Verify nii_fiberQA function for DTI quality assessment
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_fiberQA; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_fiberQA; exit(0);" 2>&1
     expected_output_contains: "nii_fiberQA"
     expected_exit_code: 0
 
@@ -498,19 +511,19 @@ tests:
   # ==========================================================================
   - name: Structure merge function accessible
     description: Verify nii_mergestruct function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_mergestruct; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_mergestruct; exit(0);" 2>&1
     expected_output_contains: "nii_mergestruct"
     expected_exit_code: 0
 
   - name: MAT purge ROIs function accessible
     description: Verify nii_matPurgeRois function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_matPurgeRois; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_matPurgeRois; exit(0);" 2>&1
     expected_output_contains: "nii_matPurgeRois"
     expected_exit_code: 0
 
   - name: MAT version function accessible
     description: Verify nii_matver function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_matver; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_matver; exit(0);" 2>&1
     expected_output_contains: "nii_matver"
     expected_exit_code: 0
 
@@ -519,19 +532,19 @@ tests:
   # ==========================================================================
   - name: SPM normal CDF available
     description: Test SPM normal cumulative distribution function
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); p = spm_Ncdf(1.96); disp(p); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); p = spm_Ncdf(1.96); disp(p); exit(0);" 2>&1
     expected_output_contains: "0.97"
     expected_exit_code: 0
 
   - name: SPM inverse normal CDF available
     description: Test SPM inverse normal CDF function
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); z = spm_invNcdf(0.95); disp(z); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); z = spm_invNcdf(0.95); disp(z); exit(0);" 2>&1
     expected_output_contains: "1.64"
     expected_exit_code: 0
 
   - name: SPM F-distribution CDF available
     description: Test SPM F-distribution function
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); p = spm_Fcdf(4.0, 1, 10); disp(p); exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); p = spm_Fcdf(4.0, 1, 10); disp(p); exit(0);" 2>&1
     expected_output_contains: "0.9"
     expected_exit_code: 0
 
@@ -540,19 +553,51 @@ tests:
   # ==========================================================================
   - name: Create binary mask from T1
     description: Test creating a binary mask using SPM (copy to /tmp since SPM deletes .nii.gz)
-    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"');\n  img = spm_read_vols(hdr);\n  mask = img > mean(img(:));\n  hdr.fname = '\"'\"'test_output/t1w_mask.nii'\"'\"';\n  spm_write_vol(hdr, double(mask));\n  disp('\"'\"'Mask created successfully'\"'\"');\n  exit(0);\n\" 2>&1'"
+    command: |
+      cp ${t1w} /tmp/t1w.nii.gz
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        hdr = spm_vol('/tmp/t1w.nii.gz');
+        img = spm_read_vols(hdr);
+        mask = img > mean(img(:));
+        hdr.fname = 'test_output/t1w_mask.nii';
+        spm_write_vol(hdr, double(mask));
+        disp('Mask created successfully');
+        exit(0);
+      " 2>&1
     expected_output_contains: "Mask created successfully"
     validate:
       - output_exists: ${output_dir}/t1w_mask.nii
 
   - name: Extract ROI statistics
     description: Test extracting mean value from image using mask
-    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"');\n  img = spm_read_vols(hdr);\n  mask = img > mean(img(:));\n  roi_mean = mean(img(mask));\n  disp(['\"'\"'ROI mean: '\"'\"' num2str(roi_mean)]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      cp ${t1w} /tmp/t1w.nii.gz
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        hdr = spm_vol('/tmp/t1w.nii.gz');
+        img = spm_read_vols(hdr);
+        mask = img > mean(img(:));
+        roi_mean = mean(img(mask));
+        disp(['ROI mean: ' num2str(roi_mean)]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "ROI mean:"
 
   - name: Compute image statistics
     description: Calculate basic image statistics
-    command: "bash -lc 'cp ${t1w} /tmp/t1w.nii.gz\noctave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  hdr = spm_vol('\"'\"'/tmp/t1w.nii.gz'\"'\"');\n  img = spm_read_vols(hdr);\n  disp(['\"'\"'Min: '\"'\"' num2str(min(img(:)))]);\n  disp(['\"'\"'Max: '\"'\"' num2str(max(img(:)))]);\n  disp(['\"'\"'Mean: '\"'\"' num2str(mean(img(:)))]);\n  disp(['\"'\"'Std: '\"'\"' num2str(std(img(:)))]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      cp ${t1w} /tmp/t1w.nii.gz
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        hdr = spm_vol('/tmp/t1w.nii.gz');
+        img = spm_read_vols(hdr);
+        disp(['Min: ' num2str(min(img(:)))]);
+        disp(['Max: ' num2str(max(img(:)))]);
+        disp(['Mean: ' num2str(mean(img(:)))]);
+        disp(['Std: ' num2str(std(img(:)))]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "Mean:"
 
   # ==========================================================================
@@ -560,17 +605,52 @@ tests:
   # ==========================================================================
   - name: T-test computation
     description: Test two-sample t-statistic using base Octave (ttest2 requires statistics package)
-    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"');\n  x1 = [1 2 3 4 5];\n  x2 = [6 7 8 9 10];\n  mean_diff = mean(x2) - mean(x1);\n  pooled_se = sqrt(var(x1)/length(x1) + var(x2)/length(x2));\n  t_stat = mean_diff / pooled_se;\n  disp(['\"'\"'T-statistic: '\"'\"' num2str(t_stat)]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        addpath('/opt/niistat-1.0.20191216');
+        x1 = [1 2 3 4 5];
+        x2 = [6 7 8 9 10];
+        mean_diff = mean(x2) - mean(x1);
+        pooled_se = sqrt(var(x1)/length(x1) + var(x2)/length(x2));
+        t_stat = mean_diff / pooled_se;
+        disp(['T-statistic: ' num2str(t_stat)]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "T-statistic:"
 
   - name: Correlation computation
     description: Test Pearson correlation computation
-    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  x = [1 2 3 4 5];\n  y = [2 4 5 4 5];\n  r = corr(x'\"'\"', y'\"'\"');\n  disp(['\"'\"'Correlation: '\"'\"' num2str(r)]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        x = [1 2 3 4 5];
+        y = [2 4 5 4 5];
+        r = corr(x', y');
+        disp(['Correlation: ' num2str(r)]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "Correlation:"
 
   - name: Permutation test setup
     description: Test permutation testing infrastructure
-    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  rng(42);\n  x = randn(10, 1);\n  y = randn(10, 1);\n  nperm = 100;\n  orig_corr = corr(x, y);\n  perm_corrs = zeros(nperm, 1);\n  for i = 1:nperm\n    perm_y = y(randperm(length(y)));\n    perm_corrs(i) = corr(x, perm_y);\n  end\n  p = sum(abs(perm_corrs) >= abs(orig_corr)) / nperm;\n  disp(['\"'\"'Permutation p-value: '\"'\"' num2str(p)]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        rng(42);
+        x = randn(10, 1);
+        y = randn(10, 1);
+        nperm = 100;
+        orig_corr = corr(x, y);
+        perm_corrs = zeros(nperm, 1);
+        for i = 1:nperm
+          perm_y = y(randperm(length(y)));
+          perm_corrs(i) = corr(x, perm_y);
+        end
+        p = sum(abs(perm_corrs) >= abs(orig_corr)) / nperm;
+        disp(['Permutation p-value: ' num2str(p)]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "Permutation p-value:"
 
   # ==========================================================================
@@ -578,18 +658,18 @@ tests:
   # ==========================================================================
   - name: GUI helper functions present
     description: Verify NiiStatGUI helper functions are present
-    command: bash -lc 'ls /opt/niistat-1.0.20191216/NiiStatGUI/*.m 2>&1 | wc -l'
+    command: ls /opt/niistat-1.0.20191216/NiiStatGUI/*.m 2>&1 | wc -l
     expected_output_contains: "5"
 
   - name: GetROIFilesGivenDirectory accessible
     description: Verify GetROIFilesGivenDirectory function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/NiiStatGUI'\"'\"'); which GetROIFilesGivenDirectory; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/NiiStatGUI'); which GetROIFilesGivenDirectory; exit(0);" 2>&1
     expected_output_contains: "GetROIFilesGivenDirectory"
     expected_exit_code: 0
 
   - name: GetROINamesFromFile accessible
     description: Verify GetROINamesFromFile function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/NiiStatGUI'\"'\"'); which GetROINamesFromFile; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/NiiStatGUI'); which GetROINamesFromFile; exit(0);" 2>&1
     expected_output_contains: "GetROINamesFromFile"
     expected_exit_code: 0
 
@@ -598,7 +678,7 @@ tests:
   # ==========================================================================
   - name: MAT to ortho function accessible
     description: Verify nii_mat2ortho function for visualization
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_mat2ortho; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_mat2ortho; exit(0);" 2>&1
     expected_output_contains: "nii_mat2ortho"
     expected_exit_code: 0
 
@@ -607,13 +687,13 @@ tests:
   # ==========================================================================
   - name: XL to ROI function accessible
     description: Verify nii_xl2roi function for Excel-based ROI definition
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_xl2roi; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_xl2roi; exit(0);" 2>&1
     expected_output_contains: "nii_xl2roi"
     expected_exit_code: 0
 
   - name: xl_xls2mat function accessible
     description: Verify xl_xls2mat function in glm directory
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"'); which xl_xls2mat; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); addpath('/opt/niistat-1.0.20191216/glm'); which xl_xls2mat; exit(0);" 2>&1
     expected_output_contains: "xl_xls2mat"
     expected_exit_code: 0
 
@@ -622,7 +702,7 @@ tests:
   # ==========================================================================
   - name: Modality table function accessible
     description: Verify nii_modality_table function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_modality_table; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_modality_table; exit(0);" 2>&1
     expected_output_contains: "nii_modality_table"
     expected_exit_code: 0
 
@@ -631,7 +711,7 @@ tests:
   # ==========================================================================
   - name: NII to MAT report function accessible
     description: Verify nii_nii2matReport function is accessible
-    command: "bash -lc 'octave --no-gui --eval \"addpath('\"'\"'/opt/spm12-r7771'\"'\"'); addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"'); which nii_nii2matReport; exit(0);\" 2>&1'"
+    command: octave --no-gui --eval "addpath('/opt/spm12-r7771'); addpath('/opt/niistat-1.0.20191216'); which nii_nii2matReport; exit(0);" 2>&1
     expected_output_contains: "nii_nii2matReport"
     expected_exit_code: 0
 
@@ -640,12 +720,38 @@ tests:
   # ==========================================================================
   - name: Full environment setup test
     description: Test that all paths can be added and NiiStat reports version
-    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216/glm'\"'\"');\n  addpath('\"'\"'/opt/niistat-1.0.20191216/libsvm'\"'\"');\n  disp('\"'\"'All paths added successfully'\"'\"');\n  spm_ver = spm('\"'\"'Version'\"'\"');\n  disp(['\"'\"'SPM version: '\"'\"' spm_ver]);\n  [~, mods] = nii_modality_list();\n  disp(['\"'\"'Modalities: '\"'\"' mods]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        addpath('/opt/niistat-1.0.20191216');
+        addpath('/opt/niistat-1.0.20191216/glm');
+        addpath('/opt/niistat-1.0.20191216/libsvm');
+        disp('All paths added successfully');
+        spm_ver = spm('Version');
+        disp(['SPM version: ' spm_ver]);
+        [~, mods] = nii_modality_list();
+        disp(['Modalities: ' mods]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "All paths added successfully"
 
   - name: Memory and matrix operations test
     description: Test large matrix operations typical in neuroimaging
-    command: "bash -lc 'octave --no-gui --eval \"\n  addpath('\"'\"'/opt/spm12-r7771'\"'\"');\n  % Create a moderate-sized matrix (simulating voxel data)\n  X = randn(50, 1000);  % 50 subjects, 1000 voxels\n  Y = randn(50, 1);     % behavioral scores\n  % Compute correlation for each voxel\n  r = zeros(1, 1000);\n  for v = 1:1000\n    r(v) = corr(X(:,v), Y);\n  end\n  disp(['\"'\"'Max correlation: '\"'\"' num2str(max(r))]);\n  disp(['\"'\"'Min correlation: '\"'\"' num2str(min(r))]);\n  exit(0);\n\" 2>&1'"
+    command: |
+      octave --no-gui --eval "
+        addpath('/opt/spm12-r7771');
+        % Create a moderate-sized matrix (simulating voxel data)
+        X = randn(50, 1000);  % 50 subjects, 1000 voxels
+        Y = randn(50, 1);     % behavioral scores
+        % Compute correlation for each voxel
+        r = zeros(1, 1000);
+        for v = 1:1000
+          r(v) = corr(X(:,v), Y);
+        end
+        disp(['Max correlation: ' num2str(max(r))]);
+        disp(['Min correlation: ' num2str(min(r))]);
+        exit(0);
+      " 2>&1
     expected_output_contains: "Max correlation:"
 
 cleanup:


### PR DESCRIPTION
## Summary
- add aarch64 to the niistat recipe and update the SPM patch source used during setup
- pull in the cleaned-up fulltest from the arm64 branch
- make the fulltest architecture-neutral by checking libsvm/TFCE function resolution instead of hard-coded .mexa64 filenames

## Validation
- python3 builder/validation.py recipes/niistat/build.yaml
- python3 -m builder generate niistat --recreate
- python3 -m builder generate niistat --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->