### PR TITLE
Add ARM64 support for topaz

### DIFF
--- a/recipes/topaz/build.yaml
+++ b/recipes/topaz/build.yaml
@@ -3,6 +3,7 @@ version: 0.2.5
 
 architectures:
   - x86_64
+  - aarch64
 
 build:
   kind: neurodocker
@@ -23,8 +24,19 @@ build:
 
     - template:
         name: miniconda
-        version: 4.7.12.1
-        conda_install: python=3.6 topaz=0.2.5 cudatoolkit=10.2 -c tbepler -c pytorch
+        version: latest
+        env_name: topaz
+        env_exists: "false"
+        conda_install: python=3.10
+
+    - environment:
+        PATH: /opt/miniconda-latest/envs/topaz/bin:$PATH
+
+    - run:
+        - |
+          bash -lc "source activate topaz
+          python -m pip install --no-cache-dir topaz-em==0.2.5
+          "
 
 deploy:
   bins:


### PR DESCRIPTION
## Summary
- add aarch64 support to the topaz recipe
- switch the recipe to the current miniconda template pattern with an explicit env
- install topaz-em into the dedicated env so the builder can render both architectures consistently

## Validation
- python3 builder/validation.py recipes/topaz/build.yaml
- python3 -m builder generate topaz --recreate
- python3 -m builder generate topaz --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->