### PR TITLE
Add ARM64 support for spant

### DIFF
--- a/recipes/spant/build.yaml
+++ b/recipes/spant/build.yaml
@@ -5,6 +5,7 @@ copyright:
     url: https://github.com/martin3141/spant?tab=GPL-3.0-1-ov-file
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: "spant provides a full suite of tools to build automated analysis pipelines for Magnetic Resonance Spectroscopy (MRS) data. "
   example: |-


### PR DESCRIPTION
## Summary
- add aarch64 to the spant recipe to advertise ARM64 support

## Validation
- python3 builder/validation.py recipes/spant/build.yaml
- python3 -m builder generate spant --recreate
- python3 -m builder generate spant --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->