### PR TITLE
Add ARM64 support for spmpython

### DIFF
--- a/recipes/spmpython/build.yaml
+++ b/recipes/spmpython/build.yaml
@@ -5,6 +5,7 @@ copyright:
     url: https://github.com/spm/spm-python/blob/main/LICENCE
 architectures:
   - x86_64
+  - aarch64
 build:
   kind: neurodocker
   base-image: ubuntu:24.04
@@ -15,7 +16,11 @@ build:
         conda_install: python=3.12
         version: py312_25.5.1-0
         install_path: /opt/miniconda
-        pip_install: spm-python
+        env_name: spmpython
+        env_exists: "false"
+        pip_install: spm-python=={{ context.version }}
+    - environment:
+        PATH: /opt/miniconda/envs/spmpython/bin:$PATH
 readme: |-
   ----------------------------------
   ## spmpython/{{ context.version }} ##

--- a/recipes/spmpython/fulltest.yaml
+++ b/recipes/spmpython/fulltest.yaml
@@ -15,7 +15,7 @@
 
 name: spmpython
 version: 25.1.2.post1
-container: spmpython_25.1.2.post1_20250905.simg
+container: spmpython_25.1.2.post1.simg
 
 required_files:
   - dataset: ds000001
@@ -48,7 +48,7 @@ tests:
   - name: Python executable path
     description: Check Python is from miniconda
     command: which python
-    expected_output_contains: "/opt/miniconda/bin/python"
+    expected_output_contains: "/opt/miniconda/envs/spmpython/bin/python"
 
   - name: Pip version check
     description: Verify pip is available


### PR DESCRIPTION
## Summary
- add aarch64 support to the spmpython recipe
- switch the miniconda template usage to a dedicated env for ARM64-safe pip installation
- update the fulltest container name and expected python path for the env layout

## Validation
- python3 builder/validation.py recipes/spmpython/build.yaml
- python3 -m builder generate spmpython --recreate
- python3 -m builder generate spmpython --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->