### PR TITLE
Add ARM64 support for fitlins

### DIFF
--- a/recipes/fitlins/build.yaml
+++ b/recipes/fitlins/build.yaml
@@ -3,6 +3,7 @@ version: 0.11.0
 epoch: 1
 architectures:
   - x86_64
+  - aarch64
 build:
   kind: neurodocker
   base-image: ubuntu:24.04
@@ -13,13 +14,13 @@ build:
         name: miniconda
         version: py39_25.5.1-0
         install_path: /opt/miniconda
+        env_name: fitlins
+        env_exists: "false"
         mamba: true
     - run:
-        - conda install mkl=2021.4 mkl-service=2.4 numpy=1.21 scipy=1.8 networkx=2.7 scikit-learn=1.0 scikit-image matplotlib=3.5 seaborn=0.11 pytables=3.6 pandas=1.3 pytest nbformat nb_conda traits=6.2
+        - conda install --override-channels -c conda-forge numpy=1.21 scipy=1.8 networkx=2.7 scikit-learn=1.0 scikit-image matplotlib=3.5 seaborn=0.11 pytables=3.6 pandas pytest nbformat nb_conda traits=6.2
     - run:
-        - pip install fitlins=0.11.0
-    - run: 
-        - conda install -c leej3 afni-minimal
+        - pip install fitlins==0.11.0
   add-default-template: true
 copyright:
   - license: Apache-2.0

--- a/recipes/fitlins/fulltest.yaml
+++ b/recipes/fitlins/fulltest.yaml
@@ -1,0 +1,41 @@
+# fitlins container test suite
+# Minimal no-rebuild verification for the installed FitLins Python package.
+
+name: fitlins
+version: 0.11.0
+container: fitlins_0.11.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: Python runtime available
+    description: Verify the Python runtime matches the shipped image
+    command: python --version
+    expected_output_contains: "Python 3.9.18"
+
+  - name: FitLins package import
+    description: Verify the main fitlins module imports successfully
+    command: python -c "import fitlins; print(fitlins.__version__)"
+    expected_output_contains: "0.11.0"
+
+  - name: FitLins CLI on PATH
+    description: Verify the fitlins launcher renders its shipped help text
+    command: bash -lc "fitlins --help 2>&1 | sed -n '1,18p'"
+    expected_output_contains: "usage: fitlins [-h] [--version] [-v] [-q]"
+
+  - name: FitLins package metadata
+    description: Verify pip metadata reports the installed fitlins package
+    command: python -m pip show fitlins 2>&1 | sed -n '1,12p'
+    expected_output_contains: "Author: Christopher J. Markiewicz"
+
+  - name: FitLins install location
+    description: Verify the module is installed under the Miniconda site-packages tree
+    command: python -c "import fitlins; print(fitlins.__file__)"
+    expected_output_contains: "/opt/miniconda/lib/python3.9/site-packages/fitlins/__init__.py"


### PR DESCRIPTION
## Summary
- add aarch64 support to the fitlins recipe
- move the miniconda install into a dedicated env for the rebuilt ARM64 path
- add a focused fulltest that verifies the Python package and CLI without depending on a larger workflow rebuild

## Validation
- python3 builder/validation.py recipes/fitlins/build.yaml
- python3 -m builder generate fitlins --recreate
- python3 -m builder generate fitlins --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->