### PR TITLE
Add ARM64 support for segmentator

### DIFF
--- a/recipes/segmentator/build.yaml
+++ b/recipes/segmentator/build.yaml
@@ -2,6 +2,7 @@ name: segmentator
 version: 1.6.1
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: 3D MRI data exploration and segmentation tool.
   example: segmentator --help
@@ -21,15 +22,20 @@ build:
         name: miniconda
         version: py310_25.5.1-0
         install_path: /opt/miniconda
-        conda_install: matplotlib=3.1.1 numpy=1.22.0 nibabel=2.5.1 scipy=1.3.1 python=3.6
-        pip_install: compoda=0.3.5
+        env_name: segmentator
+        env_exists: "false"
+        conda_install: matplotlib numpy=1.26 nibabel scipy python=3.10
+        pip_install: compoda==0.3.5
         mamba: true
+    - run:
+        - apt-get -o Acquire::Retries=3 update
+        - DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential
     - run:
         - cp {{ get_file("v1_6_1_tar_gz") }} /tmp/segmentator.tar.gz
         - mkdir -p /opt
         - tar -xzf /tmp/segmentator.tar.gz -C /opt
         - mv /opt/segmentator-1.6.1 /opt/segmentator
-        - pip install -e /opt/segmentator
+        - bash -c "source activate segmentator && python -m pip install --no-build-isolation -e /opt/segmentator"
         - rm /tmp/segmentator.tar.gz
     - group:
         - file:

--- a/recipes/segmentator/fulltest.yaml
+++ b/recipes/segmentator/fulltest.yaml
@@ -1,0 +1,41 @@
+# segmentator container test suite
+# Minimal no-rebuild verification for the shipped source tree payload.
+
+name: segmentator
+version: 1.6.1
+container: segmentator_1.6.1.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: Python runtime available
+    description: Verify the shipped Python runtime matches the image
+    command: python --version
+    expected_output_contains: "Python 3.10.18"
+
+  - name: Segmentator source tree present
+    description: Verify the built source tree exists under /opt
+    command: test -f /opt/segmentator/segmentator/__main__.py && echo "/opt/segmentator/segmentator/__main__.py"
+    expected_output_contains: "/opt/segmentator/segmentator/__main__.py"
+
+  - name: Segmentator setup metadata version
+    description: Verify the shipped source metadata still declares version 1.6.1
+    command: grep -n "version='1.6.1'" /opt/segmentator/setup.py
+    expected_output_contains: "version='1.6.1',"
+
+  - name: Segmentator entrypoint metadata
+    description: Verify the shipped setup metadata still declares the segmentator console entrypoint
+    command: grep -n "segmentator = segmentator.__main__:main" /opt/segmentator/setup.py
+    expected_output_contains: "segmentator = segmentator.__main__:main"
+
+  - name: Segmentator native extension payload
+    description: Verify the built native deriche extension is present for python 3.10 aarch64
+    command: test -f /opt/segmentator/segmentator/deriche_3D.cpython-310-aarch64-linux-gnu.so && echo "/opt/segmentator/segmentator/deriche_3D.cpython-310-aarch64-linux-gnu.so"
+    expected_output_contains: "/opt/segmentator/segmentator/deriche_3D.cpython-310-aarch64-linux-gnu.so"


### PR DESCRIPTION
## Summary
- add aarch64 support to the segmentator recipe
- rebuild the miniconda environment around a dedicated ARM64-safe Python 3.10 env
- add a focused fulltest that checks the shipped source tree and native extension payload

## Validation
- python3 builder/validation.py recipes/segmentator/build.yaml
- python3 -m builder generate segmentator --recreate
- python3 -m builder generate segmentator --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->