### PR TITLE
Add ARM64 support for gouhfi

### DIFF
--- a/recipes/gouhfi/build.yaml
+++ b/recipes/gouhfi/build.yaml
@@ -2,6 +2,8 @@ name: gouhfi
 version: 0.0.1
 architectures:
   - x86_64
+  - aarch64
+
 structured_readme:
   description: GOUHFI is a fully automatic, contrast- and resolution-agnostic, DL-based brain segmentation tool optimized for Ultra-High Field MRI (UHF-MRI)
   example: |
@@ -28,15 +30,22 @@ build:
         name: miniconda
         version: py310_25.5.1-0
         install_path: /opt/miniconda
-        pip_install: torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
         conda_install: python=3.10
     - install:
         - git
         - unzip
+        - build-essential
+    - condition: arch=="x86_64"
+      run:
+        - bash -c "source activate base && python -m pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118"
+    - condition: arch=="aarch64"
+      run:
+        - bash -c "source activate base && python -m pip install --no-cache-dir torch torchvision torchaudio"
     - run:
         - cd /opt
         - git clone https://github.com/mafortin/GOUHFI.git
         - cd GOUHFI
+        - pip install antspyx==0.4.2 antspynet==0.3.1
         - pip install -e .
     - file:
         name: GOUHFI.zip


### PR DESCRIPTION
## Summary\n- add aarch64 to the gouhfi recipe\n- keep the existing amd64 CUDA wheel path for torch while using generic wheels on arm64\n- add missing native build deps plus antspyx/antspynet before editable install\n\n## Validation\n- python3 builder/validation.py recipes/gouhfi/build.yaml\n- python3 -m builder generate gouhfi --recreate\n- python3 -m builder generate gouhfi --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->