### PR TITLE
Add ARM64 support for vesselvio

### DIFF
--- a/recipes/vesselvio/build.yaml
+++ b/recipes/vesselvio/build.yaml
@@ -4,6 +4,15 @@ version: 1.1.2
 
 architectures:
   - x86_64
+  - aarch64
+
+variables:
+  miniforge_installer:
+    try:
+      - value: Miniforge3-Linux-x86_64.sh
+        condition: arch == "x86_64"
+      - value: Miniforge3-Linux-aarch64.sh
+        condition: arch == "aarch64"
 
 build:
   kind: neurodocker
@@ -17,17 +26,29 @@ build:
     - install:
         - git
         - ca-certificates
-        - curl
         - libqt5gui5
+        - qt5-qmake
+        - qtbase5-dev
 
-    - template:
-        name: miniconda
-        version: latest
-        conda_install: python=3.8.8
+    - environment:
+        CONDA_DIR: /opt/miniforge
+        PATH: /opt/miniforge/bin:/opt/miniforge/envs/vesselvio/bin:$PATH
+
+    - run:
+        - cp {{ get_file(context.miniforge_installer) }} /tmp/miniforge.sh
+        - bash /tmp/miniforge.sh -b -p /opt/miniforge
+        - rm -f /tmp/miniforge.sh
+        - conda config --system --prepend channels conda-forge
+        - conda config --set channel_priority strict
+        - conda config --system --set auto_update_conda false
+        - conda config --system --set show_channel_urls true
+        - conda create -y -n vesselvio python=3.10 pip pyqt=5.15
+        - conda clean --all --yes
 
     - run:
         - git clone https://github.com/JacobBumgarner/VesselVio.git /opt/vesselvio-{{ context.version }}/
-        - pip install -r /opt/vesselvio-{{ context.version }}/requirements.txt
+        - sed -i '/^PyQt5==/d;/^PyQt5-Qt5==/d;/^PyQt5-sip==/d' /opt/vesselvio-{{ context.version }}/requirements.txt
+        - conda run -n vesselvio python -m pip install -r /opt/vesselvio-{{ context.version }}/requirements.txt
 
     - copy:
         - vesselvio
@@ -44,6 +65,10 @@ deploy:
     - /opt/vesselvio-{{ context.version }}
 
 files:
+  - name: Miniforge3-Linux-x86_64.sh
+    url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+  - name: Miniforge3-Linux-aarch64.sh
+    url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
   - name: vesselvio
     contents: |
       #!/usr/bin/env bash

--- a/recipes/vesselvio/fulltest.yaml
+++ b/recipes/vesselvio/fulltest.yaml
@@ -10,7 +10,7 @@
 
 name: vesselvio
 version: 1.1.2
-container: vesselvio_1.1.2_20230428.simg
+container: vesselvio_1.1.2.simg
 
 test_data:
   sample_vertices: /opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv
@@ -28,14 +28,14 @@ tests:
   # PYTHON ENVIRONMENT VERIFICATION
   # ==========================================================================
   - name: Python version check
-    description: Verify Python 3.8 is available
+    description: Verify Python 3.10 is available
     command: python --version
-    expected_output_contains: "Python 3.8"
+    expected_output_contains: "Python 3.10"
 
   - name: Python executable path
-    description: Verify Python path is in miniconda
+    description: Verify Python path is in the Miniforge vesselvio environment
     command: which python
-    expected_output_contains: "/opt/miniconda-latest/bin/python"
+    expected_output_contains: "/opt/miniforge/envs/vesselvio/bin/python"
 
   # ==========================================================================
   # CORE SCIENTIFIC PYTHON PACKAGES
@@ -301,62 +301,62 @@ tests:
   # ==========================================================================
   - name: VesselVio image_processing module
     description: Test VesselVio image processing module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import image_processing as ImProc; print('\"'\"'image_processing imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import image_processing as ImProc; print('image_processing imported successfully')"
     expected_output_contains: "image_processing imported successfully"
 
   - name: VesselVio volume_processing module
     description: Test VesselVio volume processing module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import volume_processing as VolProc; print('\"'\"'volume_processing imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import volume_processing as VolProc; print('volume_processing imported successfully')"
     expected_output_contains: "volume_processing imported successfully"
 
   - name: VesselVio graph_processing module
     description: Test VesselVio graph processing module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import graph_processing as GProc; print('\"'\"'graph_processing imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import graph_processing as GProc; print('graph_processing imported successfully')"
     expected_output_contains: "graph_processing imported successfully"
 
   - name: VesselVio feature_extraction module
     description: Test VesselVio feature extraction module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import feature_extraction as FeatExt; print('\"'\"'feature_extraction imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import feature_extraction as FeatExt; print('feature_extraction imported successfully')"
     expected_output_contains: "feature_extraction imported successfully"
 
   - name: VesselVio graph_io module
     description: Test VesselVio graph I/O module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import graph_io as GIO; print('\"'\"'graph_io imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import graph_io as GIO; print('graph_io imported successfully')"
     expected_output_contains: "graph_io imported successfully"
 
   - name: VesselVio helpers module
     description: Test VesselVio helpers utility module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import helpers; print('\"'\"'helpers imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import helpers; print('helpers imported successfully')"
     expected_output_contains: "helpers imported successfully"
 
   - name: VesselVio input_classes module
     description: Test VesselVio input classes module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import input_classes as IC; print('\"'\"'input_classes imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import input_classes as IC; print('input_classes imported successfully')"
     expected_output_contains: "input_classes imported successfully"
 
   - name: VesselVio results_export module
     description: Test VesselVio results export module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import results_export as ResExp; print('\"'\"'results_export imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import results_export as ResExp; print('results_export imported successfully')"
     expected_output_contains: "results_export imported successfully"
 
   - name: VesselVio volume_visualization module
     description: Test VesselVio volume visualization module import
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import volume_visualization as VolVis; print('\"'\"'volume_visualization imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import volume_visualization as VolVis; print('volume_visualization imported successfully')"
     expected_output_contains: "volume_visualization imported successfully"
 
   - name: VesselVio lee94 skeletonization module
     description: Test VesselVio Lee94 skeletonization algorithm module
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import lee94; print('\"'\"'lee94 imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import lee94; print('lee94 imported successfully')"
     expected_output_contains: "lee94 imported successfully"
 
   - name: VesselVio pk12 module
     description: Test VesselVio PK12 algorithm module
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import pk12; print('\"'\"'pk12 imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import pk12; print('pk12 imported successfully')"
     expected_output_contains: "pk12 imported successfully"
 
   - name: VesselVio radii_corrections module
     description: Test VesselVio radii corrections module
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import radii_corrections as RadCor; print('\"'\"'radii_corrections imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import radii_corrections as RadCor; print('radii_corrections imported successfully')"
     expected_output_contains: "radii_corrections imported successfully"
 
   # ==========================================================================
@@ -364,17 +364,17 @@ tests:
   # ==========================================================================
   - name: VesselVio annotation labeling module
     description: Test VesselVio annotation labeling module
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library.annotation import labeling; print('\"'\"'annotation labeling imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library.annotation import labeling; print('annotation labeling imported successfully')"
     expected_output_contains: "annotation labeling imported successfully"
 
   - name: VesselVio annotation segmentation module
     description: Test VesselVio annotation segmentation module
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library.annotation import segmentation; print('\"'\"'annotation segmentation imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library.annotation import segmentation; print('annotation segmentation imported successfully')"
     expected_output_contains: "annotation segmentation imported successfully"
 
   - name: VesselVio annotation tree_processing module
     description: Test VesselVio annotation tree processing module
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library.annotation import tree_processing; print('\"'\"'annotation tree_processing imported successfully'\"'\"')\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library.annotation import tree_processing; print('annotation tree_processing imported successfully')"
     expected_output_contains: "annotation tree_processing imported successfully"
 
   # ==========================================================================
@@ -382,22 +382,22 @@ tests:
   # ==========================================================================
   - name: Sample vertices CSV exists
     description: Verify sample vertices CSV file exists
-    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv'"
+    command: ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv
     expected_output_contains: "vertices.csv"
 
   - name: Sample edges CSV exists
     description: Verify sample edges CSV file exists
-    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv'"
+    command: ls -la /opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv
     expected_output_contains: "edges.csv"
 
   - name: Load sample vertices with Pandas
     description: Test loading sample vertices CSV data
-    command: "bash -lc 'python -c \"import pandas as pd; df = pd.read_csv('\"'\"'/opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv'\"'\"', delimiter='\"'\"';'\"'\"'); print('\"'\"'Vertices shape:'\"'\"', df.shape); print('\"'\"'Columns:'\"'\"', list(df.columns))\"'"
+    command: python -c "import pandas as pd; df = pd.read_csv('/opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv', delimiter=';'); print('Vertices shape:', df.shape); print('Columns:', list(df.columns))"
     expected_output_contains: "Vertices shape:"
 
   - name: Load sample edges with Pandas
     description: Test loading sample edges CSV data
-    command: "bash -lc 'python -c \"import pandas as pd; df = pd.read_csv('\"'\"'/opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv'\"'\"', delimiter='\"'\"';'\"'\"'); print('\"'\"'Edges shape:'\"'\"', df.shape)\"'"
+    command: python -c "import pandas as pd; df = pd.read_csv('/opt/vesselvio-1.1.2/sample_data/demo_csv/edges.csv', delimiter=';'); print('Edges shape:', df.shape)"
     expected_output_contains: "Edges shape:"
 
   # ==========================================================================
@@ -582,17 +582,26 @@ tests:
   # ==========================================================================
   - name: VesselVio resolution preparation
     description: Test VesselVio resolution format preparation
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import image_processing as ImProc; res = ImProc.prep_resolution(1.0); print('\"'\"'Resolution:'\"'\"', res); res2 = ImProc.prep_resolution([1.0, 1.0, 1.0]); print('\"'\"'Resolution array:'\"'\"', res2)\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import image_processing as ImProc; res = ImProc.prep_resolution(1.0); print('Resolution:', res); res2 = ImProc.prep_resolution([1.0, 1.0, 1.0]); print('Resolution array:', res2)"
     expected_output_contains: "Resolution:"
 
   - name: VesselVio binary check
     description: Test VesselVio binary volume validation
-    command: "bash -lc 'python -c \"\nimport sys\nsys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"')\nimport numpy as np\nfrom library import image_processing as ImProc\nbinary_vol = np.array([[[0,1],[1,0]],[[1,0],[0,1]]], dtype=np.uint8)\nresult = ImProc.binary_check(binary_vol)\nprint('\"'\"'Binary check result:'\"'\"', result)\n\"'"
+    command: |
+      python -c "
+      import sys
+      sys.path.insert(0, '/opt/vesselvio-1.1.2')
+      import numpy as np
+      from library import image_processing as ImProc
+      binary_vol = np.array([[[0,1],[1,0]],[[1,0],[0,1]]], dtype=np.uint8)
+      result = ImProc.binary_check(binary_vol)
+      print('Binary check result:', result)
+      "
     expected_output_contains: "Binary check result: True"
 
   - name: VesselVio filename extraction
     description: Test VesselVio filename extraction utility
-    command: "bash -lc 'python -c \"import sys; sys.path.insert(0, '\"'\"'/opt/vesselvio-1.1.2'\"'\"'); from library import image_processing as ImProc; name = ImProc.get_filename('\"'\"'/path/to/vessel_data.nii.gz'\"'\"'); print('\"'\"'Extracted filename:'\"'\"', name)\"'"
+    command: python -c "import sys; sys.path.insert(0, '/opt/vesselvio-1.1.2'); from library import image_processing as ImProc; name = ImProc.get_filename('/path/to/vessel_data.nii.gz'); print('Extracted filename:', name)"
     expected_output_contains: "Extracted filename:"
 
   # ==========================================================================
@@ -600,17 +609,17 @@ tests:
   # ==========================================================================
   - name: VesselVio installation directory
     description: Verify VesselVio installation directory structure
-    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/'"
+    command: ls -la /opt/vesselvio-1.1.2/
     expected_output_contains: "VVTerminal.py"
 
   - name: VesselVio library directory
     description: Verify VesselVio library modules
-    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/library/'"
+    command: ls -la /opt/vesselvio-1.1.2/library/
     expected_output_contains: "feature_extraction.py"
 
   - name: VesselVio annotation directory
     description: Verify VesselVio annotation modules
-    command: "bash -lc 'ls -la /opt/vesselvio-1.1.2/library/annotation/'"
+    command: ls -la /opt/vesselvio-1.1.2/library/annotation/
     expected_output_contains: "labeling.py"
 
   - name: VesselVio executable script
@@ -620,7 +629,7 @@ tests:
 
   - name: VesselVio README exists
     description: Verify VesselVio documentation
-    command: "bash -lc 'head -5 /opt/vesselvio-1.1.2/README.md'"
+    command: head -5 /opt/vesselvio-1.1.2/README.md
     expected_output_contains: "VesselVio"
 
   - name: Container README


### PR DESCRIPTION
## Summary\n- add aarch64 to the vesselvio recipe\n- replace the old generic miniconda path with an architecture-aware Miniforge environment using declared installer files\n- install VesselVio requirements inside a dedicated conda env and drop pinned PyQt wheels in favor of conda pyqt\n- align fulltest expectations with the new Python environment and simplify brittle shell quoting\n\n## Validation\n- python3 builder/validation.py recipes/vesselvio/build.yaml\n- python3 -m builder generate vesselvio --recreate\n- python3 -m builder generate vesselvio --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->