### PR TITLE
Remove ARM64 tag from bidsappspm

### DIFF
--- a/recipes/bidsappspm/build.yaml
+++ b/recipes/bidsappspm/build.yaml
@@ -4,7 +4,6 @@ version: 0.0.20
 
 architectures:
   - x86_64
-  - aarch64
 
 build:
   kind: neurodocker


### PR DESCRIPTION
## Summary\n- remove the false aarch64 declaration from bidsappspm\n- keep the earlier fulltest cleanup, but stop advertising ARM64 support for an amd64-only upstream base image\n\n## Why\nThe ARM64 manual build failed in config because  resolves to an amd64-only image, causing an  during the first container layer.\n\n## Validation\n- python3 builder/validation.py recipes/bidsappspm/build.yaml\n- python3 -m builder generate bidsappspm --recreate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->