### PR TITLE
Fix ARM64 dcm2niix source directory

### DIFF
--- a/recipes/dcm2niix/build.yaml
+++ b/recipes/dcm2niix/build.yaml
@@ -10,7 +10,7 @@ architectures:
   - aarch64
 
 variables:
-  dcm2niix_source_dir: dcm2niix-{{ context.version }}
+  dcm2niix_source_dir: dcm2niix-{{ context.version | replace('v', '', 1) }}
 
 build:
   kind: neurodocker


### PR DESCRIPTION
## Summary\n- fix the ARM64 dcm2niix source directory name to match the extracted GitHub tag archive\n\n## Why\nThe ARM64 manual build failed in config because the archive extracted to  while the recipe tried to .\n\n## Validation\n- python3 builder/validation.py recipes/dcm2niix/build.yaml\n- python3 -m builder generate dcm2niix --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->