### PR TITLE
Fix ARM64 dcm2niix superbuild dependency

### DIFF
--- a/recipes/dcm2niix/build.yaml
+++ b/recipes/dcm2niix/build.yaml
@@ -28,6 +28,7 @@ build:
       install:
         - build-essential
         - cmake
+        - git
         - pkg-config
         - libjpeg-dev
         - libopenjp2-7-dev


### PR DESCRIPTION
## Summary
- add the missing git dependency for the ARM64 dcm2niix source build
- keep the existing amd64 path unchanged
- unblock the ARM64 manual build after the CMake superbuild failure

## Validation
- python3 builder/validation.py recipes/dcm2niix/build.yaml
- python3 -m builder generate dcm2niix --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->