### PR TITLE
Add ARM64 support for workshopdemo

### DIFF
--- a/recipes/workshopdemo/build.yaml
+++ b/recipes/workshopdemo/build.yaml
@@ -2,6 +2,7 @@ name: workshopdemo
 version: 1.0.0
 architectures:
   - x86_64
+  - aarch64
 structured_readme:
   description: This tool was commited for the workshop.
   example: hello
@@ -12,9 +13,6 @@ build:
   base-image: ubuntu:24.04
   pkg-manager: apt
   directives:
-    - template:
-        name: matlabmcr
-        version: 2023b
     - install: hello
 categories:
   - functional imaging

--- a/recipes/workshopdemo/fulltest.yaml
+++ b/recipes/workshopdemo/fulltest.yaml
@@ -1,0 +1,38 @@
+# workshopdemo container test suite
+# Tests for workshopdemo v1.0.0 - Minimal hello-world workshop example
+#
+# This container includes:
+#   - hello: GNU hello example program
+#
+# Tests focus on the packaged runtime and documented example command.
+
+name: workshopdemo
+version: 1.0.0
+container: workshopdemo_1.0.0.simg
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p test_output/workshopdemo
+
+tests:
+  - name: hello on PATH
+    description: Verify the hello binary is available
+    command: command -v hello
+    expected_output_contains: "/usr/bin/hello"
+
+  - name: hello output
+    description: Verify the documented example command works
+    command: hello
+    expected_output_contains: "Hello, world!"
+
+  - name: hello version
+    description: Verify hello reports its version information
+    command: hello --version
+    expected_output_contains: "hello"
+
+cleanup:
+  script: |
+    #!/usr/bin/env bash
+    echo "Test outputs preserved in test_output/workshopdemo/"


### PR DESCRIPTION
## Summary\n- add aarch64 support to workshopdemo\n- remove the x86-only matlabmcr dependency from this hello-world example\n- add a focused fulltest for the packaged hello binary\n\n## Validation\n- python3 builder/validation.py recipes/workshopdemo/build.yaml\n- python3 -m builder generate workshopdemo --recreate\n- python3 -m builder generate workshopdemo --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->