### PR TITLE
Add ARM64 support for condaenvs

### DIFF
--- a/recipes/condaenvs/build.yaml
+++ b/recipes/condaenvs/build.yaml
@@ -3,6 +3,7 @@ version: 1.0.1
 
 architectures:
   - x86_64
+  - aarch64
 
 build:
   kind: neurodocker
@@ -16,6 +17,8 @@ build:
     - template:
         name: miniconda
         version: latest
+        env_name: condaenvs
+        env_exists: "false"
 
     - install:
         - git
@@ -23,7 +26,7 @@ build:
     - workdir: /opt
 
     - run:
-        - git clone https://github.com/NeuroDesk/condaenvs
+        - GIT_TERMINAL_PROMPT=0 git -c credential.helper= clone https://github.com/NeuroDesk/condaenvs.git /opt/condaenvs
 
     - copy:
         - install_all.sh


### PR DESCRIPTION
## Summary\n- add aarch64 support to condaenvs\n- create a dedicated condaenvs environment instead of mutating base\n- make the git clone non-interactive and explicit about the target path\n\n## Validation\n- python3 builder/validation.py recipes/condaenvs/build.yaml\n- python3 -m builder generate condaenvs --recreate\n- python3 -m builder generate condaenvs --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->