### PR TITLE
Update OpenADS container recipe

### DIFF
--- a/recipes/openads/README.md
+++ b/recipes/openads/README.md
@@ -1,6 +1,6 @@
 # OpenADS
 
-OpenADS is an end to end medical imaging pipeline for stroke analysis, covering preprocessing, registration, segmentation, and report generation for DWI and PWI workflows.
+OpenADS is a versatile medical imaging pipeline for stroke analysis, covering preprocessing, registration, segmentation, and report generation for DWI and PWI workflows.
 
 ![OpenADS UI](server/ui.png)
 

--- a/recipes/openads/README.md
+++ b/recipes/openads/README.md
@@ -1,0 +1,443 @@
+# OpenADS
+
+OpenADS is an end to end medical imaging pipeline for stroke analysis, covering preprocessing, registration, segmentation, and report generation for DWI and PWI workflows.
+
+![OpenADS UI](server/ui.png)
+
+## What OpenADS does
+
+OpenADS runs standardized pipelines that take a single subject folder and produce:
+- Preprocessed volumes
+- Brain masks and skull stripped images
+- MNI registration outputs
+- Model inference masks
+- Postprocessed results and metrics
+- Human readable text reports and PNG visualizations
+
+Supported workflows:
+- DWI only pipeline
+- PWI only pipeline
+- Combined DWI plus PWI pipeline for matched subjects
+
+## Quickstart
+
+Run commands from the OpenADS project root.
+
+Create and activate your environment:
+
+```bash
+python -m venv openads
+source openads/bin/activate
+
+python -m pip install -U pip
+python -m pip install torch==2.5.1 numpy==2.0.1 antspyx==0.5.4 pandas==2.2.3 matplotlib==3.9.2 scikit-image==0.24.0 scipy==1.13.1 nibabel==5.3.2 tqdm==4.67.1 scikit-learn==1.7.2 surfa==0.6.3 shap==0.50.0
+```
+
+Run a full DWI pipeline on an example subject:
+
+```bash
+./scripts/run_dwi.sh assets/examples/dwi/sub-02e8eb42 --all --gpu 1
+```
+
+Run a full PWI pipeline on an example subject:
+
+```bash
+./scripts/run_pwi.sh assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+```
+
+Run the combined pipeline:
+
+```bash
+./scripts/run_combined.sh \
+  --dwi assets/examples/dwi/sub-02e8eb42 \
+  --pwi assets/examples/pwi/sub-02e8eb42 \
+  --all \
+  --gpu 1
+```
+
+
+
+## Installation
+
+OpenADS can be run as:
+
+* Local scripts and Python entrypoints
+* A package CLI via `python -m ads.cli`
+* A web API and GUI launcher via Uvicorn
+* Docker images (CPU and GPU)
+
+### Option A: Install from source (recommended)
+
+Clone the repository and create a dedicated virtual environment:
+
+```bash
+git clone https://github.com/farialab/OpenADS.git
+cd OpenADS
+
+python -m venv openads
+source openads/bin/activate
+
+python -m pip install -U pip
+python -m pip install .
+```
+Sanity check:
+
+```bash
+ads --help
+```
+### Option B: Editable install (for development)
+
+Use editable mode if you are making changes to the code:
+```bash
+git clone https://github.com/farialab/OpenADS.git
+cd OpenADS
+
+python -m venv openads
+source openads/bin/activate
+
+python -m pip install -U pip
+python -m pip install -e .
+```
+Developer sanity checks:
+
+```bash
+python -c "import ads; print('ads import OK')"
+ads --help
+```
+
+## Input data expectations
+
+* Provide a single subject folder as the subject path, for example `.../sub-xxxx`.
+* Do not pass a dataset root to `--subject-path`. 
+
+## Outputs and output root
+
+By default, output is written under `output/{subject_id}/DWI/...` and `output/{subject_id}/PWI/...`. 
+
+You can override the output base with `--output-root` in:
+
+* `scripts/run_dwi.sh`, `scripts/run_pwi.sh`, `scripts/run_combined.sh`
+* `scripts/run_ads_dwi.py`, `scripts/run_ads_pwi.py`, `scripts/run_ads_combined.py` 
+
+Cleanup and keep behavior is controlled by `configs/keep_files.yaml`. 
+
+## Example output tree
+
+This is a real example tree for `output/sub-05a971ae` (trimmed for display):
+
+```
+output/sub-05a971ae
+├── DWI
+│   ├── preprocess
+│   ├── registration
+│   ├── reporting
+│   └── segment
+└── PWI
+    ├── preprocess
+    ├── registration
+    ├── reporting
+    └── segmentation
+```
+
+## Running OpenADS
+
+OpenADS provides multiple entry options depending on how you want to integrate it.
+
+### Option 1: Local shell wrappers
+
+DWI single subject:
+
+```bash
+./scripts/run_dwi.sh assets/examples/dwi/sub-02e8eb42 --all --gpu 1
+./scripts/run_dwi.sh assets/examples/dwi/sub-02e8eb42 --stages prepdata,gen_mask,skull_strip,registration,inference,report --gpu 1
+./scripts/run_dwi.sh /data/dwi/sub-0037761d --stages prepdata,gen_mask,skull_strip,registration,inference,report --gpu 1 --output-root /output
+```
+
+PWI single subject:
+
+```bash
+./scripts/run_pwi.sh assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+./scripts/run_pwi.sh assets/examples/pwi/sub-02e8eb42 --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report --gpu 1
+./scripts/run_pwi.sh /data/pwi/sub-0037761d --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report --gpu 1 --output-root /output
+```
+
+### Option 2: Combined wrapper
+
+Combined DWI plus PWI:
+
+```bash
+./scripts/run_combined.sh \
+  --dwi assets/examples/dwi/sub-02e8eb42 \
+  --pwi assets/examples/pwi/sub-02e8eb42 \
+  --all \
+  --gpu 1
+```
+
+Custom stage selection:
+
+```bash
+./scripts/run_combined.sh \
+  --dwi assets/examples/dwi/sub-02e8eb42 \
+  --pwi assets/examples/pwi/sub-02e8eb42 \
+  --dwi-stages prepdata,gen_mask,skull_strip,registration,inference,report \
+  --pwi-stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report \
+  --gpu 1 \
+  --output-root /data/openads_output
+```
+
+Run only PWI stages in the combined wrapper:
+
+```bash
+./scripts/run_combined.sh \
+  --dwi assets/examples/dwi/sub-02e8eb42 \
+  --pwi assets/examples/pwi/sub-02e8eb42 \
+  --pwi-stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report \
+  --gpu 1
+```
+
+Combined wrapper behavior:
+
+* Executes DWI first, then PWI.
+* With `--all` runs both full pipelines.
+* Without `--all`, DWI runs only when `--dwi-stages` is provided and PWI runs only when `--pwi-stages` is provided.
+* If both stage lists are empty, it exits with an error.
+* `--output-root` sends both modalities to the same output base.
+* `--no-mask-copy` is accepted for compatibility but is a no op in this wrapper. 
+
+### Option 3: Batch wrappers
+
+DWI batch:
+
+```bash
+./scripts/batch_run_dwi.sh --subjects-root assets/examples/dwi --all --gpu 1
+./scripts/batch_run_dwi.sh --subjects-root assets/examples/dwi --parallel --max-jobs 2 --all --gpu 1
+./scripts/batch_run_dwi.sh --subjects-file /abs/path/dwi_subjects.txt --stages prepdata,gen_mask,skull_strip,registration,inference,report --gpu 1
+```
+
+PWI batch:
+
+```bash
+./scripts/batch_run_pwi.sh --subjects-root assets/examples/pwi --all --gpu 1
+./scripts/batch_run_pwi.sh --subjects-root assets/examples/pwi --parallel --max-jobs 2 --all --gpu 1
+./scripts/batch_run_pwi.sh --subjects-file /abs/path/pwi_subjects.txt --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report --gpu 1
+```
+
+Combined batch:
+
+```bash
+./scripts/batch_run_combined.sh \
+  --dwi-root assets/examples/dwi \
+  --pwi-root assets/examples/pwi \
+  --all \
+  --gpu 1
+```
+
+
+
+### Option 4: Python entrypoints
+
+```bash
+python scripts/run_ads_dwi.py --subject-path assets/examples/dwi/sub-02e8eb42 --config configs/dwi_pipeline.yaml --all --gpu 1
+python scripts/run_ads_pwi.py --subject-path assets/examples/pwi/sub-02e8eb42 --config configs/pwi_pipeline.yaml --all --gpu 1
+python scripts/run_ads_combined.py --dwi-subject-path assets/examples/dwi/sub-02e8eb42 --pwi-subject-path assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+```
+
+Custom output root:
+
+```bash
+python scripts/run_ads_dwi.py --subject-path /data/dwi/sub-0037761d --config configs/dwi_pipeline.yaml --stages prepdata,gen_mask,skull_strip,registration,inference,report --gpu 1 --output-root /data/openads_output
+```
+
+
+
+### Option 5: Package CLI
+
+```bash
+PYTHONPATH=src python -m ads.cli dwi --subject-path assets/examples/dwi/sub-02e8eb42 --all --gpu 1
+PYTHONPATH=src python -m ads.cli pwi --subject-path assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+```
+
+
+
+## Web API and GUI
+
+Launch the server:
+
+```bash
+uvicorn server.app:app --host 0.0.0.0 --port 8000 --reload
+```
+
+Open:
+
+* `http://127.0.0.1:8000/`
+* `http://127.0.0.1:8000/gui_launcher.html`
+
+Notes:
+
+* The web launcher forwards user provided subject paths and output root to backend scripts.
+* Report file listing and download in the web launcher uses the selected output root. 
+
+You can also lauch the GUI after install PyQt5
+```bash
+python GUI_launcher.py
+```
+
+## Docker
+
+Install at least one Docker image:
+
+```bash
+docker build -f docker/Dockerfile.gpu -t openads:gpu .
+docker build -f docker/Dockerfile.cpu -t openads:cpu .
+```
+
+Wrapper scripts are under `docker/` and are the preferred Docker interface.
+
+Image selection rule used by the wrappers. It uses `openads:gpu` if it exists, otherwise use `openads:cpu`
+
+Default host output directory used by the wrappers:
+
+* `docker_ads_output`
+
+Preferred wrapper commands:
+
+```bash
+docker/run_dwi.sh --subject-path /app/assets/examples/dwi/sub-02e8eb42 --all --gpu 1
+docker/run_pwi.sh --subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+docker/run_combined.sh --dwi-subject-path /app/assets/examples/dwi/sub-02e8eb42 --pwi-subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+```
+
+The pipeline wrappers automatically pass:
+
+* `--output-root /app/output`
+
+If you want another host output directory, use the wrapper flag:
+
+```bash
+docker/run_dwi.sh --subject-path /app/assets/examples/dwi/sub-02e8eb42 --all --gpu 1 --host-output /abs_path
+```
+
+Raw container entrypoint commands:
+
+* `ads api`
+* `ads dwi ...`
+* `ads pwi ...`
+* `ads combined ...`
+* `ads cli ...`
+* `ads gui` 
+
+You can also run pipelines directly:
+
+```bash
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd)/docker_ads_output:/app/output" openads:cpu dwi --subject-path /app/assets/examples/dwi/sub-02e8eb42 --all --gpu 1
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd)/docker_ads_output:/app/output" openads:cpu pwi --subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd)/docker_ads_output:/app/output" openads:cpu combined --dwi-subject-path /app/assets/examples/dwi/sub-02e8eb42 --pwi-subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+```
+
+GPU containers:
+
+* Add `--gpus all`
+* Use `openads:gpu` 
+
+## Pipeline stages
+
+OpenADS pipelines are composed of named stages. These names appear in `--stages` arguments and represent a stable contract for orchestration. 
+
+### DWI stages
+
+1. `prepdata`
+   Loads raw DWI and B0, computes ADC if needed, fixes volume order if required, and saves preprocessed files. 
+
+2. `gen_mask`
+   Generates a brain mask (SynthStrip). 
+
+3. `skull_strip`
+   Applies the mask to DWI, B0, and ADC and saves skull stripped images. 
+
+4. `registration`
+   Registers to MNI152 (affine plus SyN), applies transforms, and saves normalized outputs and transform files. 
+
+5. `inference`
+   Runs stroke lesion segmentation (DAGMNet) in MNI space. 
+
+6. `postprocessing`
+   Creates additional space variants, transforms back to native space, and computes metrics. 
+
+7. `report`
+   Computes atlas overlaps and QFV features and generates text reports and PNG visualizations. 
+
+### PWI stages
+
+1. `prepdata`
+   Loads PWI 4D and related volumes, preserves JSON sidecar metadata, and saves standardized outputs. 
+
+2. `gen_mask`
+   Brain masking (reuses DWI method). 
+
+3. `skull_strip`
+   Skull stripping (reuses DWI method). 
+
+4. `gen_ttp`
+   Computes time to peak maps from PWI 4D and saves TTP. 
+
+5. `registration`
+   Registers to MNI152 and normalizes DWI, ADC, and TTP variants. 
+
+6. `ttpadc_coreg`
+   Coregisters TTP into ADC or DWI space and saves transform matrices. 
+
+7. `inference`
+   Runs hypoperfusion segmentation and outputs HP masks. 
+
+8. `postprocessing`
+   Transforms back to native space and computes metrics. 
+
+9. `report`
+   Generates atlas overlap features, QFV outputs, mismatch statements, and PNG visualizations. 
+
+## Architecture overview
+
+OpenADS follows a clean architecture style with unidirectional dependencies: entrypoints call pipelines, pipelines orchestrate domain and services, services use adapters, and the domain layer remains dependency free. 
+
+High level layers:
+
+* Entrypoints layer: CLI, argument parsing, logging setup
+* Pipelines layer: stage orchestration and workflow control
+* Domain layer: pure data objects
+* Services layer: business logic and algorithms
+* Adapters layer: I O, filesystem, external systems 
+
+## Configuration
+
+Pipeline behavior is controlled by configuration files such as:
+
+* `configs/dwi_pipeline.yaml`
+* `configs/pwi_pipeline.yaml`
+* `configs/keep_files.yaml` 
+
+## Troubleshooting
+
+Common gotchas:
+
+* Pass a single subject folder to `--subject-path`, not a dataset root. 
+* Use `--output-root` if you want outputs outside the default `output/` tree. 
+* If running Docker and you want outputs on the host, mount a host directory into the container and set `--output-root` to that mount point if needed. 
+
+## Contributing
+
+Contributions are welcome.
+
+## Reference  
+
+For stroke segmentaion and quantification: Liu CF, Hsu J, Xu X, Ramachandran S, Wang V, Miller MI, Hillis AE, Faria AV. Deep learning-based detection and segmentation of diffusion abnormalities in acute ischemic stroke. Commun Med 1, 61 (2021) https://doi.org/10.1038/s43856-021-00062-8
+
+For ASPECTS calculation: Liu CF, Li J, Kim G, Miller MI, Hillis AE, Faria AV. Automatic comprehensive aspects reports in clinical acute stroke MRIs. Sci Rep 13, 3784 (2023). https://doi.org/10.1038/s41598-023-30242-6
+
+For automatic radiological reports: Liu CF, Zhao Y, Yedavalli V, Leigh R, Falcao V, Miller MI, Hillis AE, Faria AV. Automatic comprehensive radiological reports for clinical acute stroke MRIs. Commun Med 3, 95 (2023). https://doi.org/10.1038/s43856-023-00327-4
+
+For the dataset: Liu CF, Leigh R, Johnson B, Urrutia V, Hsu J, Xu X, Li X, Mori S, Hillis AE, Faria AV. A large public dataset of annotated clinical MRIs and metadata of patients with acute stroke. Sci Data 10, 548 (2023). https://doi.org/10.1038/s41597-023-02457-9
+
+For the dataset source: Faria, Andreia V. Annotated Clinical MRIs and Linked Metadata of Patients with Acute Stroke, Baltimore, Maryland, 2009-2019. Inter-university Consortium for Political and Social Research [distributor], 2022-12-12. https://doi.org/10.3886/ICPSR38464.v5
+
+## License 
+This work is licensed under JHU Non-Profit Research Software License Agreement, as found in the LICENSE file.

--- a/recipes/openads/build.yaml
+++ b/recipes/openads/build.yaml
@@ -1,61 +1,127 @@
 name: openads
 version: 1.0.0
+
 copyright:
-  - license: MIT
+  - license: JHU Non-Profit Research Software License Agreement
     url: https://github.com/farialab/OpenADS/blob/main/LICENSE
+
 architectures:
   - x86_64
+
 structured_readme:
-  description: OpenADS is an all-in-one end-to-end stroke imaging analysis pipeline for diffusion-weighted (DWI) and perfusion-weighted (PWI) MRI. It provides preprocessing, registration, segmentation, and reporting workflows, and supports CLI, API, and GUI interfaces.
+  description: OpenADS is a multi-task stroke imaging analysis pipeline for diffusion-weighted (DWI) and perfusion-weighted (PWI) MRI. It provides preprocessing, registration, segmentation, and reporting workflows for acute stroke MRI, and supports CLI, API, and GUI interfaces.
   example: |-
-    ### Example usage
-
-    Run a DWI pipeline using the container:
+    Check the command-line interface:
 
     ```bash
-    docker run --rm -it \
-      --user "$(id -u):$(id -g)" \
-      -v "$(pwd)/docker_ads_output:/app/output" \
-      openads:gpu \
-      dwi \
+    ads --help
+    ```
+
+    Run the DWI workflow:
+
+    ```bash
+    ads dwi --subject-path /app/assets/examples/dwi/sub-02e8eb42 --all --gpu 1
+    ```
+
+    Run selected DWI stages:
+
+    ```bash
+    ads dwi \
       --subject-path /app/assets/examples/dwi/sub-02e8eb42 \
-      --all \
+      --stages prepdata,gen_mask,skull_strip,registration,inference,report \
       --gpu 1
     ```
 
-    Run a PWI pipeline:
+    Run the PWI workflow:
 
     ```bash
-    docker run --rm -it \
-      --user "$(id -u):$(id -g)" \
-      -v "$(pwd)/docker_ads_output:/app/output" \
-      openads:gpu \
-      pwi \
+    ads pwi --subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+    ```
+
+    Run selected PWI stages:
+
+    ```bash
+    ads pwi \
       --subject-path /app/assets/examples/pwi/sub-02e8eb42 \
+      --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report \
+      --gpu 1
+    ```
+
+    Run the combined DWI plus PWI workflow:
+
+    ```bash
+    ads combined \
+      --dwi-subject-path /app/assets/examples/dwi/sub-02e8eb42 \
+      --pwi-subject-path /app/assets/examples/pwi/sub-02e8eb42 \
       --all \
       --gpu 1
     ```
+
+    Run the API backend:
+
+    ```bash
+    ads api
+    ```
+
+    Run the GUI launcher, if display forwarding is available:
+
+    ```bash
+    ads gui
+    ```
+  documentation: https://github.com/farialab/OpenADS
+  citation: |-
+    Liu CF, Hsu J, Xu X, Ramachandran S, Wang V, Miller MI, Hillis AE, Faria AV. Deep learning-based detection and segmentation of diffusion abnormalities in acute ischemic stroke. Communications Medicine, 2021. https://doi.org/10.1038/s43856-021-00062-8
+
+    Liu CF, Li J, Kim G, Miller MI, Hillis AE, Faria AV. Automatic comprehensive ASPECTS reports in clinical acute stroke MRIs. Scientific Reports, 2023. https://doi.org/10.1038/s41598-023-30242-6
+
+    Liu CF, Zhao Y, Yedavalli V, Leigh R, Falcao V, Miller MI, Hillis AE, Faria AV. Automatic comprehensive radiological reports for clinical acute stroke MRIs. Communications Medicine, 2023. https://doi.org/10.1038/s43856-023-00327-4
+
+    Liu CF, Leigh R, Johnson B, Urrutia V, Hsu J, Xu X, Li X, Mori S, Hillis AE, Faria AV. A large public dataset of annotated clinical MRIs and metadata of patients with acute stroke. Scientific Data, 2023. https://doi.org/10.1038/s41597-023-02457-9
+
+    Faria AV. Annotated Clinical MRIs and Linked Metadata of Patients with Acute Stroke, Baltimore, Maryland, 2009-2019. ICPSR, 2022. https://doi.org/10.3886/ICPSR38464.v5
+
 build:
   kind: neurodocker
-  base-image: sljhlab/openads:1.0.0-gpu
+  base-image: docker.io/sljhlab/openads:{{ context.version }}-gpu
   pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
   directives:
+    - entrypoint: bash
+
+    - environment:
+        OPENADS_ENABLE_WEB_UI: "0"
+
+    - deploy:
+        path: []
+        bins:
+          - ads
+
     - test:
-        name: verify_installation
+        name: verify_openads_installation
         script: |-
           #!/usr/bin/env bash
           set -euo pipefail
 
-          echo "[1/3] Check ads binary"
+          echo "[1/4] Check ads binary"
           command -v ads
 
-          echo "[2/3] Check ads --help"
+          echo "[2/4] Check ads help"
           ads --help >/dev/null
 
-          echo "[3/3] Check python import"
+          echo "[3/4] Check Python import"
           python3 -c "import ads; print('import ads: OK')"
 
-          echo "OpenADS installation verified successfully."
+          echo "[4/4] Check PyTorch CUDA visibility"
+          python3 - <<'PY'
+          import torch
+          print("torch:", torch.__version__)
+          print("cuda_available:", torch.cuda.is_available())
+          print("device_count:", torch.cuda.device_count())
+          PY
+
+          echo "OpenADS GPU container smoke test completed."
+
 categories:
   - diffusion imaging
   - structural imaging
@@ -64,50 +130,33 @@ categories:
   - visualization
   - machine learning
   - workflows
-icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAEXklEQVR4AbSVa0wUVxTHfzO7wLKACLg+EIriq0qwiYYsQlHQUmh8ALFqKsZ+aGIlJG1atKUxBISUDxja2AfaaIylin1ZDWlaralBpcREq7S6QDFgSrHQdhF2oTyy7EzvzC4YJUtJWm/mnDNzz+N/zrlncuWXdjnUqVL+K061Kn9IPbBjcMok85iXHLTor8cGMbjUhXx1zUECkm7/7yC2VCfvJdxDtrscnFv0EV3WbzGZpP8MFBQqoQWvibTTP6owfgYtT37DbxuOM326Z0tRRhke7mFkpA9VVaYErAX/NOMPtOBjDp5o3q/b5uv8uLqQ23eLOHUilo67L2L7OZvTnyfQZDvC3wO/U3frMHtPmCfQ8Z+2U2w5wtWRbm80j3gAoIKrw8H18lpK96xncLCXy5cvc+PGDXp7W8nPm039lbcYGLJTUFAgqlIfou8vHCa3rx33J++Do9cTXfBxALdzBMfpXzhXcYr09HRKS0sJCgoiNDSUQ4cOkZuby4GKnbR1/YAkec4qPj6euLg4UlJScDqdVFZW4nflHEp7C3jb6gHQsv/VwcxOA8nJyVRXV1NSUoI72oRfjIX8/Hzq6+vJysrC7mwXeXme5uZmmpqadF1hYSGyLLN+bSr82QVut26kA6huBVdnP6vjrPpmVVUV4XkrmPNBBtMOJrJ0Tzo1NTV65rOignUbjc2YMYOIiAhWrVpFWVkZiqJQW1sLAQEg6aG9U6SoKKJF0dHRaOuevZuAJRHIJiMYZXqChxkdHdVUhIeH61Jj3d3d2O12GhoaiI2Npby8nNH5S5CeWAiiGs1G1hiS4CJQS4vonXjdvnkbyqALs2xiZa+FxR1mcnJyhAYaGxt1qbF169aRmppKUlISgYGBFBUVYdiUixQ1DyQtKN4KBJoxIpC6ujq0tWXLFhYcu0/JvjA2lgzS+4UNq9VKX18fwUaXZqLTpUuXCGltZZkCWRs282x5Fcs3iET8RYt0CwHwXFcMRxvW8I7taeYp03SQhIQEdry+m1fvnGS/4zvePX1Mb01xcTELZomJ8Dpb/P3ZFRlJRbCZ48MOPrv4FRcr99Jw4WOqbXW80XoNef/RKJ6qc7PGPoccy0oyMzN1kLy8PDo7O2lra0NrhTYlX4oZXx6loqoPQLxY40IdGmLBrZtknD9LwdcnvS0SapPBj+fnWNk3fxNpaWmEhISQnZ1NYmIiBoOBDw9WsH+zP/Mskj7vkiSJSXQLz8kfzyF7bab7mXk5Zi3XVpdRGpPNYpuorMfC0a3J3Hw7kK1WI2nLDJx9zcSZ3Qs5LH6yWHG4sgDzhpggHgLQtAZJZr55JjujU3hz4UYKrdt4IbORyDAJowHiomTS4w1kJPfzzPIw5ppMmptPmgDwqKVf3PlHt/Rv1TWAcUWf/j4ZmxRAjjAjzz7j018KFxfKXDGjPi3EmE6iw1f2Yz5TqcJnBVr2xmV3xmL5lHoVYWE+9T4BtOyV+/9+V2tVGCY5i38AAAD//4ccfwIAAAAGSURBVAMA7OTCgedT6+gAAAAASUVORK5CYII=
+
 readme: |-
   ----------------------------------
   ## openads/{{ context.version }} ##
 
-  OpenADS is an all-in-one end-to-end stroke imaging analysis pipeline for diffusion-weighted (DWI) and perfusion-weighted (PWI) MRI. It provides preprocessing, registration, segmentation, and reporting workflows, and supports CLI, API, and GUI interfaces.
+  OpenADS is a multi-task stroke imaging analysis pipeline for diffusion-weighted (DWI) and perfusion-weighted (PWI) MRI. It provides preprocessing, registration, segmentation, and reporting workflows for acute stroke MRI, and supports CLI, API, and GUI interfaces.
 
   Example:
   ```
-  ### Example usage
+  ads --help
 
-  Run a DWI pipeline using the container:
+  ads dwi --subject-path /app/assets/examples/dwi/sub-02e8eb42 --all --gpu 1
 
-  ```bash
-  docker run --rm -it \
-    --user "$(id -u):$(id -g)" \
-    -v "$(pwd)/docker_ads_output:/app/output" \
-    openads:gpu \
-    dwi \
-    --subject-path /app/assets/examples/dwi/sub-02e8eb42 \
-    --all \
-    --gpu 1
+  ads dwi --subject-path /app/assets/examples/dwi/sub-02e8eb42 --stages prepdata,gen_mask,skull_strip,registration,inference,report --gpu 1
+
+  ads pwi --subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
+
+  ads pwi --subject-path /app/assets/examples/pwi/sub-02e8eb42 --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report --gpu 1
+
+  ads combined --dwi-subject-path /app/assets/examples/dwi/sub-02e8eb42 --pwi-subject-path /app/assets/examples/pwi/sub-02e8eb42 --all --gpu 1
   ```
 
-  Run a PWI pipeline:
+  More documentation can be found here: https://github.com/farialab/OpenADS
 
-  ```bash
-  docker run --rm -it \
-    --user "$(id -u):$(id -g)" \
-    -v "$(pwd)/docker_ads_output:/app/output" \
-    openads:gpu \
-    pwi \
-    --subject-path /app/assets/examples/pwi/sub-02e8eb42 \
-    --all \
-    --gpu 1
-  ```
-  ```
+  Citation metadata is included in this recipe's structured_readme section.
 
-  More documentation can be found here: 
-
-  Citation:
-  ```
-
-  ```
+  License: JHU Non-Profit Research Software License Agreement
 
   To run container outside of this environment: ml openads/{{ context.version }}
 

--- a/recipes/openads/build.yaml
+++ b/recipes/openads/build.yaml
@@ -103,24 +103,13 @@ build:
           #!/usr/bin/env bash
           set -euo pipefail
 
-          echo "[1/4] Check ads binary"
+          echo "[1/2] Check ads binary"
           command -v ads
 
-          echo "[2/4] Check ads help"
+          echo "[2/2] Check ads help"
           ads --help >/dev/null
 
-          echo "[3/4] Check Python import"
-          python3 -c "import ads; print('import ads: OK')"
-
-          echo "[4/4] Check PyTorch CUDA visibility"
-          python3 - <<'PY'
-          import torch
-          print("torch:", torch.__version__)
-          print("cuda_available:", torch.cuda.is_available())
-          print("device_count:", torch.cuda.device_count())
-          PY
-
-          echo "OpenADS GPU container smoke test completed."
+          echo "OpenADS container smoke test completed."
 
 categories:
   - diffusion imaging

--- a/recipes/openads/build.yaml
+++ b/recipes/openads/build.yaml
@@ -82,7 +82,7 @@ structured_readme:
 
 build:
   kind: neurodocker
-  base-image: docker.io/sljhlab/openads:{{ context.version }}-gpu
+  base-image: docker.io/sljhlab/openads:gpu
   pkg-manager: apt
   add-default-template: false
   add-tzdata: false

--- a/recipes/openads/fulltest.yaml
+++ b/recipes/openads/fulltest.yaml
@@ -1,0 +1,80 @@
+name: openads
+version: 1.0.0
+container: openads_1.0.0.simg
+
+environment:
+  OPENADS_ENABLE_WEB_UI: "0"
+
+tests:
+  - name: Show ads help
+    script: |
+      set -e
+      ads --help
+
+  - name: Check Python import
+    script: |
+      set -e
+      python3 -c "import ads; print('import ads: OK')"
+
+  - name: Check PyTorch and CUDA state
+    script: |
+      set -e
+      python3 - <<'PY'
+      import torch
+      print("torch:", torch.__version__)
+      print("cuda_available:", torch.cuda.is_available())
+      print("device_count:", torch.cuda.device_count())
+      PY
+
+  - name: Run DWI example workflow
+    script: |
+      set -e
+      rm -rf /tmp/openads_test_output
+      mkdir -p /tmp/openads_test_output
+      ads dwi \
+        --subject-path /app/assets/examples/dwi/sub-02e8eb42 \
+        --all \
+        --gpu 1 \
+        --output-root /tmp/openads_test_output
+      test -d /tmp/openads_test_output/sub-02e8eb42/DWI
+
+  - name: Run PWI example workflow
+    script: |
+      set -e
+      rm -rf /tmp/openads_test_output
+      mkdir -p /tmp/openads_test_output
+      ads pwi \
+        --subject-path /app/assets/examples/pwi/sub-02e8eb42 \
+        --all \
+        --gpu 1 \
+        --output-root /tmp/openads_test_output
+      test -d /tmp/openads_test_output/sub-02e8eb42/PWI
+
+  - name: Run selected DWI stages
+    script: |
+      set -e
+      rm -rf /tmp/openads_test_output
+      mkdir -p /tmp/openads_test_output
+      ads dwi \
+        --subject-path /app/assets/examples/dwi/sub-02e8eb42 \
+        --stages prepdata,gen_mask,skull_strip,registration,inference,report \
+        --gpu 1 \
+        --output-root /tmp/openads_test_output
+      test -d /tmp/openads_test_output/sub-02e8eb42/DWI
+
+  - name: Run selected PWI stages
+    script: |
+      set -e
+      rm -rf /tmp/openads_test_output
+      mkdir -p /tmp/openads_test_output
+      ads pwi \
+        --subject-path /app/assets/examples/pwi/sub-02e8eb42 \
+        --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report \
+        --gpu 1 \
+        --output-root /tmp/openads_test_output
+      test -d /tmp/openads_test_output/sub-02e8eb42/PWI
+
+cleanup:
+  script: |
+    rm -rf /tmp/openads_test_output
+    echo "OpenADS full test cleanup complete."

--- a/recipes/openads/test.yaml
+++ b/recipes/openads/test.yaml
@@ -6,16 +6,3 @@ tests:
   - name: Check ads help
     script: |
       ads --help
-
-  - name: Check Python import
-    script: |
-      python3 -c "import ads; print('import ads: OK')"
-
-  - name: Check PyTorch CUDA visibility
-    script: |
-      python3 - <<'PY'
-      import torch
-      print("torch:", torch.__version__)
-      print("cuda_available:", torch.cuda.is_available())
-      print("device_count:", torch.cuda.device_count())
-      PY

--- a/recipes/openads/test.yaml
+++ b/recipes/openads/test.yaml
@@ -1,0 +1,21 @@
+tests:
+  - name: Check ads binary
+    script: |
+      command -v ads
+
+  - name: Check ads help
+    script: |
+      ads --help
+
+  - name: Check Python import
+    script: |
+      python3 -c "import ads; print('import ads: OK')"
+
+  - name: Check PyTorch CUDA visibility
+    script: |
+      python3 - <<'PY'
+      import torch
+      print("torch:", torch.__version__)
+      print("cuda_available:", torch.cuda.is_available())
+      print("device_count:", torch.cuda.device_count())
+      PY


### PR DESCRIPTION
Updated the OpenADS Neurocontainers recipe to use the GPU Docker image and added supporting README, test, and fulltest files.

Local validation completed:
- Validated the build recipe with builder/validation.py
- Generated the Dockerfile with the local Neurocontainers builder
- Built the generated Docker image successfully
- Verified the OpenADS CLI with ads --help
- Verified Python package import with import ads
- Verified GPU visibility with torch.cuda.is_available() using --gpus all

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->