### PR TITLE
Fix condaenvs ARM64 environment subset

### DIFF
--- a/recipes/condaenvs/build.yaml
+++ b/recipes/condaenvs/build.yaml
@@ -60,7 +60,19 @@ readme: |
 files:
   - name: install_all.sh
     contents: |
-      for file in \`ls environments/*-pinned.yml\`; do
-          echo \$file
-          conda env create -f \$file
+      set -e
+
+      if [ "$(uname -m)" = "aarch64" ]; then
+          files="
+          environments/mne-starter.yml
+          environments/nipype-pinned.yml
+          environments/pytorch_cpu-starter.yml
+          "
+      else
+          files=$(ls environments/*-pinned.yml)
+      fi
+
+      for file in $files; do
+          echo "$file"
+          conda env create -f "$file"
       done


### PR DESCRIPTION
## Summary
- keep the existing pinned environment install path on x86_64
- use an ARM64-safe subset of upstream condaenvs specs on aarch64
- avoid x86-only pinned lockfiles that break the hosted ARM64 build

## Validation
- python3 builder/validation.py recipes/condaenvs/build.yaml
- python3 -m builder generate condaenvs --recreate
- python3 -m builder generate condaenvs --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->