### PR TITLE
Use Ubuntu 24.04 for condaenvs ARM64 build

### DIFF
--- a/recipes/condaenvs/build.yaml
+++ b/recipes/condaenvs/build.yaml
@@ -7,7 +7,7 @@ architectures:
 
 build:
   kind: neurodocker
-  base-image: ubuntu:22.04
+  base-image: ubuntu:24.04
   pkg-manager: apt
 
   directives:


### PR DESCRIPTION
## Summary
- move condaenvs from ubuntu:22.04 to ubuntu:24.04
- avoid the ARM64 libc-bin/locale crash happening in the current jammy base setup
- keep the earlier ARM-safe environment subset logic intact

## Validation
- python3 builder/validation.py recipes/condaenvs/build.yaml
- python3 -m builder generate condaenvs --recreate
- python3 -m builder generate condaenvs --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->