### PR TITLE
Use cached source archive for condaenvs

### DIFF
--- a/recipes/condaenvs/build.yaml
+++ b/recipes/condaenvs/build.yaml
@@ -20,13 +20,11 @@ build:
         env_name: condaenvs
         env_exists: "false"
 
-    - install:
-        - git
-
     - workdir: /opt
 
     - run:
-        - GIT_TERMINAL_PROMPT=0 git -c credential.helper= clone https://github.com/NeuroDesk/condaenvs.git /opt/condaenvs
+        - mkdir -p /opt/condaenvs
+        - tar -xz -C /opt/condaenvs --strip-components 1 -f {{ get_file("condaenvs") }}
 
     - copy:
         - install_all.sh
@@ -58,6 +56,8 @@ readme: |
   ----------------------------------
 
 files:
+  - name: condaenvs
+    url: https://github.com/NeuroDesk/condaenvs/archive/62701ffbf9d38ea6110a84aa9787fc78de679b78.tar.gz
   - name: install_all.sh
     contents: |
       set -e


### PR DESCRIPTION
## Summary
- replace the in-build git clone with a declared cached source tarball
- extract the condaenvs source from the staged archive during the build
- keep the ARM64 subset and ubuntu:24.04 fixes in place

## Validation
- python3 builder/validation.py recipes/condaenvs/build.yaml
- python3 -m builder generate condaenvs --recreate
- python3 -m builder generate condaenvs --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->