### PR TITLE
Install pyEDFlib via pip for condaenvs ARM64

### DIFF
--- a/recipes/condaenvs/build.yaml
+++ b/recipes/condaenvs/build.yaml
@@ -61,16 +61,27 @@ files:
       set -e
 
       if [ "$(uname -m)" = "aarch64" ]; then
-          files="
-          environments/mne-starter.yml
-          environments/nipype-pinned.yml
-          environments/pytorch_cpu-starter.yml
-          "
+          for file in \
+              environments/mne-starter.yml \
+              environments/nipype-pinned.yml \
+              environments/pytorch_cpu-starter.yml
+          do
+              echo "$file"
+              if [ "$file" = "environments/mne-starter.yml" ]; then
+                  tmpfile=$(mktemp)
+                  sed '/^[[:space:]]*-[[:space:]]*pyEDFlib[[:space:]]*$/d' "$file" > "$tmpfile"
+                  conda env create -f "$tmpfile"
+                  rm -f "$tmpfile"
+                  conda run -n mne-eeg-meg python -m ensurepip --upgrade
+                  conda run -n mne-eeg-meg python -m pip install pyEDFlib
+              else
+                  conda env create -f "$file"
+              fi
+          done
       else
           files=$(ls environments/*-pinned.yml)
+          for file in $files; do
+              echo "$file"
+              conda env create -f "$file"
+          done
       fi
-
-      for file in $files; do
-          echo "$file"
-          conda env create -f "$file"
-      done


### PR DESCRIPTION
## Summary
- work around missing `pyEDFlib` conda package on `linux-aarch64`
- keep the existing x86_64 condaenvs path unchanged
- in the ARM64 `mne-starter` env path, remove `pyEDFlib` from the conda solve and install it with `pip`

## Testing
- `python3 builder/validation.py recipes/condaenvs/build.yaml`
- `python3 -m builder generate condaenvs --recreate --architecture aarch64 --ignore-architectures`
- verified PyPI has an aarch64 wheel for `pyEDFlib`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->