### PR TITLE
Add ARM64 condaenvs solver and Nipype fallback

### DIFF
--- a/recipes/condaenvs/build.yaml
+++ b/recipes/condaenvs/build.yaml
@@ -70,12 +70,17 @@ files:
               if [ "$file" = "environments/mne-starter.yml" ]; then
                   tmpfile=$(mktemp)
                   sed '/^[[:space:]]*-[[:space:]]*pyEDFlib[[:space:]]*$/d' "$file" > "$tmpfile"
-                  conda env create -f "$tmpfile"
+                  conda env create --solver libmamba -f "$tmpfile"
                   rm -f "$tmpfile"
                   conda run -n mne-eeg-meg python -m ensurepip --upgrade
                   conda run -n mne-eeg-meg python -m pip install pyEDFlib
+              elif [ "$file" = "environments/nipype-pinned.yml" ]; then
+                  tmpfile=$(mktemp)
+                  sed 's/^[[:space:]]*-[[:space:]]*nipype=1\.7\.0[[:space:]]*$/  - nipype=1.10.0/' "$file" > "$tmpfile"
+                  conda env create --solver libmamba -f "$tmpfile"
+                  rm -f "$tmpfile"
               else
-                  conda env create -f "$file"
+                  conda env create --solver libmamba -f "$file"
               fi
           done
       else


### PR DESCRIPTION
## Summary
- use libmamba for the ARM64 condaenv creation path
- replace the unavailable ARM64 nipype 1.7.0 pin with an explicit nipype 1.10.0 fallback
- keep the x86_64 env creation path unchanged

## Validation
- python3 builder/validation.py recipes/condaenvs/build.yaml
- python3 -m builder generate condaenvs --recreate --architecture aarch64 --ignore-architectures
- local ARM64 build path progressed into the updated conda solve path without reproducing the previous nipype=1.7.0 failure

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->