### PR TITLE
Add ARM64 support for dafne

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -7,6 +7,7 @@ copyright:
 
 architectures:
   - x86_64
+  - aarch64
 
 build:
   kind: neurodocker


### PR DESCRIPTION
## Summary
- add  to the dafne recipe architectures list
- keep the existing template-based Miniconda install path
- confirm both default and ARM64 Dockerfile generation succeed on current main

## Validation
- python3 builder/validation.py recipes/dafne/build.yaml
- python3 -m builder generate dafne --recreate
- python3 -m builder generate dafne --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->