### PR TITLE
Add ARM64 support for prostatefiducialseg

### DIFF
--- a/recipes/prostatefiducialseg/build.yaml
+++ b/recipes/prostatefiducialseg/build.yaml
@@ -2,6 +2,7 @@ name: prostatefiducialseg
 version: 7.0.0
 architectures:
     - x86_64
+    - aarch64
 
 readme_url: https://raw.githubusercontent.com/astewartau/prostate/refs/heads/main/README.md
 
@@ -11,6 +12,8 @@ variables:
         try:
             - value: "https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ context.conda_version }}-Linux-x86_64.sh"
               condition: arch=="x86_64"
+            - value: "https://repo.anaconda.com/miniconda/Miniconda3-py39_{{ context.conda_version }}-Linux-aarch64.sh"
+              condition: arch=="aarch64"
 
 files:
     - name: prostatefiducialseg.py


### PR DESCRIPTION
## Summary
- add aarch64 to the recipe architectures list
- add the ARM64 Miniconda installer URL selection
- keep the existing recipe flow otherwise unchanged

## Validation
- python3 builder/validation.py recipes/prostatefiducialseg/build.yaml
- python3 -m builder generate prostatefiducialseg --recreate
- python3 -m builder generate prostatefiducialseg --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->