### PR TITLE
Add ARM64 support for mipav

### DIFF
--- a/recipes/mipav/build.yaml
+++ b/recipes/mipav/build.yaml
@@ -2,6 +2,7 @@ name: mipav
 version: 11.3.3
 architectures:
   - x86_64
+  - aarch64
 build:
   kind: neurodocker
   base-image: ubuntu:22.04
@@ -15,11 +16,11 @@ build:
         - libxtst6
         - libxi6
     - file:
-        name: mipav_unix_{{ context.version }}.sh
+        name: installer
         url: >-
           https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/build/mipav_unix_11_3_3.sh
     - run:
-      - sh {{ get_file("mipav_unix_"+ context.version +".sh") }} -q
+      - sh {{ get_file("installer") }} -q
     - environment:
         PATH: /usr/local/mipav:${PATH}
 copyright:


### PR DESCRIPTION
## Summary
- add aarch64 to the recipe architectures list
- simplify the installer file reference to a stable declared-file key
- keep the existing recipe flow otherwise unchanged

## Validation
- python3 builder/validation.py recipes/mipav/build.yaml
- python3 -m builder generate mipav --recreate
- python3 -m builder generate mipav --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->