### PR TITLE
Add command separator after miniconda tos guard

### DIFF
--- a/builder/templates/miniconda.yaml
+++ b/builder/templates/miniconda.yaml
@@ -47,7 +47,7 @@ binaries:
             curl -fsSL -o "$conda_installer" {{ self.urls["*"] }}
             bash "$conda_installer" -b -p {{ self.install_path }}
             rm -f "$conda_installer"
-            if conda tos --help >/dev/null 2>&1; then conda tos accept; fi
+            if conda tos --help >/dev/null 2>&1; then conda tos accept; fi &&
             {% if self.version == "latest" -%}
             conda update -yq -nbase conda
             {% endif -%}


### PR DESCRIPTION
## Summary
- add the missing shell command separator after the shared `conda tos` guard
- keep the optional `conda tos accept` behavior only when the command exists
- unblock the next ARM64 `dafne` rerun after the previous shell-join failure

## Validation
- python3 builder/validation.py recipes/dafne/build.yaml
- python3 -m builder generate dafne --recreate
- python3 -m builder generate dafne --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->