### PR TITLE
Use pip TensorFlow for dafne on ARM64

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -9,6 +9,20 @@ architectures:
   - x86_64
   - aarch64
 
+variables:
+  conda_install:
+    try:
+      - value: "python=3.8 tensorflow"
+        condition: arch=="x86_64"
+      - value: "python=3.8"
+        condition: arch=="aarch64"
+  pip_install:
+    try:
+      - value: "pyradiomics dafne==1.8a4"
+        condition: arch=="x86_64"
+      - value: "tensorflow==2.13.1 pyradiomics dafne==1.8a4"
+        condition: arch=="aarch64"
+
 build:
   kind: neurodocker
 
@@ -34,9 +48,9 @@ build:
 
     - template:
         name: miniconda
-        conda_install: "python=3.8 tensorflow "
+        conda_install: "{{ context.conda_install }}"
         mamba: "true"
-        pip_install: pyradiomics dafne==1.8a4
+        pip_install: "{{ context.pip_install }}"
         version: py38_22.11.1-1
 
 deploy:


### PR DESCRIPTION
## Summary
- keep the existing x86_64 conda TensorFlow path unchanged
- remove TensorFlow from the ARM64 conda solve to avoid the hosted CUDA variant
- install a pinned ARM64 pip TensorFlow wheel before dafne==1.8a4

## Validation
- python3 builder/validation.py recipes/dafne/build.yaml
- python3 -m builder generate dafne --recreate
- python3 -m builder generate dafne --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->