### PR TITLE
Preinstall numpy for dafne package builds

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -12,9 +12,9 @@ architectures:
 variables:
   conda_install:
     try:
-      - value: "python=3.8 tensorflow"
+      - value: "python=3.8 numpy tensorflow"
         condition: arch=="x86_64"
-      - value: "python=3.8"
+      - value: "python=3.8 numpy"
         condition: arch=="aarch64"
   pip_install:
     try:


### PR DESCRIPTION
## Summary
- preinstall numpy in the dafne conda environment on both architectures
- keep the ARM64 pip TensorFlow path from the previous fix
- avoid pyradiomics sdist metadata failures caused by missing numpy

## Validation
- python3 builder/validation.py recipes/dafne/build.yaml
- python3 -m builder generate dafne --recreate
- python3 -m builder generate dafne --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->