### PR TITLE
Install VTK from conda for dafne on ARM64

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -14,7 +14,7 @@ variables:
     try:
       - value: "python=3.8 numpy tensorflow"
         condition: arch=="x86_64"
-      - value: "python=3.8 numpy pyqt=5.15"
+      - value: "python=3.8 numpy pyqt=5.15 vtk"
         condition: arch=="aarch64"
   pip_install:
     try:


### PR DESCRIPTION
## Summary
- install vtk from conda on ARM64 before pip dependencies
- avoid the unsupported ARM64 PyPI wheel path under pyvista/pyvistaqt
- keep the earlier ARM64 TensorFlow, numpy, and PyQt fixes intact

## Validation
- python3 builder/validation.py recipes/dafne/build.yaml
- python3 -m builder generate dafne --recreate
- python3 -m builder generate dafne --recreate --architecture aarch64 --ignore-architectures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->