### PR TITLE
Remove pip install dependencies from build.yaml

### DIFF
--- a/recipes/pals/build.yaml
+++ b/recipes/pals/build.yaml
@@ -112,13 +112,6 @@ build:
         version: py310_25.5.1-0
         install_path: /opt/miniconda
         mamba: true
-        pip_install:
-          - nibabel>=3.2
-          - numpy>=1.21
-          - scipy>=1.7
-          - matplotlib>=3.4
-          - pandas>=1.3
-          - Pillow>=8.0
 
     # ── PALS v2.0.1 ──────────────────────────────────────────────────────────
     - run:


### PR DESCRIPTION
Removed pip install dependencies for the miniconda package.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->