### PR TITLE
Revise example usage and update synthstroke script

### DIFF
--- a/recipes/synthstroke/build.yaml
+++ b/recipes/synthstroke/build.yaml
@@ -22,13 +22,10 @@ structured_readme:
     # Example usage
 
     ```bash
-    python test.py \
-        --weights ./synthstroke_model/checkpoint.pt \
+    synthstroke \
+        --files "/path/to/input.nii.gz" \
         --tta \
-        --mb \
-        --patch 128 \
-        --savedir /path/to/output/ \
-        --files "/path/to/input/*.nii.gz"
+        --savedir /path/to/output/
     ```
   documentation: |-
     This container includes:
@@ -101,7 +98,8 @@ build:
     - install: git libgl1 curl ca-certificates
     - run:
         - git clone https://github.com/liamchalcroft/SynthStroke.git /opt/synthstroke
-        - printf '#!/bin/bash\npython /opt/synthstroke/test.py "$@"\n' > /usr/local/bin/synthstroke && chmod +x /usr/local/bin/synthstroke
+        - huggingface-cli download liamchalcroft/synthstroke-baseline --local-dir /opt/synthstroke/weights/baseline
+        - printf '#!/bin/bash\npython /opt/synthstroke/test.py --weights /opt/synthstroke/weights/baseline/model.safetensors "$@"\n' > /usr/local/bin/synthstroke && chmod +x /usr/local/bin/synthstroke
     - deploy:
         bins:
           - synthstroke


### PR DESCRIPTION
Updated example usage in build.yaml and modified the script to load model weights.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->