### PR TITLE
Update build.yaml to filter matplotlib from requirements

### DIFF
--- a/recipes/pals/build.yaml
+++ b/recipes/pals/build.yaml
@@ -117,8 +117,8 @@ build:
     - run:
         - /opt/miniconda/bin/pip install --no-cache-dir 'matplotlib>=3.5' 'nibabel>=3.2' 'numpy>=1.21' 'scipy>=1.7' 'pandas>=1.3' 'Pillow>=8.0'
         - git clone --depth 1 --branch main https://github.com/npnl/PALS /opt/pals-2.0.1
-        - /opt/miniconda/bin/pip install --no-cache-dir -r /opt/pals-2.0.1/requirements.txt
-
+        - grep -iv matplotlib /opt/pals-2.0.1/requirements.txt | /opt/miniconda/bin/pip install --no-cache-dir -r /dev/stdin
+        
     # Copy pre-populated presets.json so PALS finds ANTs/FSL paths immediately
     - copy:
       - presets.json


### PR DESCRIPTION
Replace direct installation of requirements with filtered installation to exclude matplotlib.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->