### PR TITLE
Add BCBTOOLKIT_ROOT to environment variables

### DIFF
--- a/recipes/bcbtoolkit/build.yaml
+++ b/recipes/bcbtoolkit/build.yaml
@@ -100,6 +100,7 @@ build:
         FSLDIR: /opt/BCBToolKit/Tools/binaries
         LD_LIBRARY_PATH: /opt/BCBToolKit/Tools/libraries/lib
         FSLOUTPUTTYPE: NIFTI_GZ
+        BCBTOOLKIT_ROOT: /opt/BCBToolKit
 
     - run:
         - |-


### PR DESCRIPTION
Add BCBTOOLKIT_ROOT environment variable to build config

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->