### PR TITLE
Update Makevars creation method in build.yaml

### DIFF
--- a/recipes/mimosa/build.yaml
+++ b/recipes/mimosa/build.yaml
@@ -80,15 +80,10 @@ build:
   - run:
       # Write the same flags into ~/.R/Makevars so individual R packages
       # that don't honour the environment variables still pick them up.
-      - mkdir -p /root/.R
-      - |
-        cat > /root/.R/Makevars <<'EOF'
-        CFLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error
-        CXXFLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error
-        CXX11FLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error
-        CXX14FLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error
-        CXX17FLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error
-        EOF
+      # Avoid heredoc syntax here -- neurodocker re-serializes this block
+      # into a JSON spec file via 'echo', and an embedded <<EOF ... EOF
+      # would terminate the outer shell heredoc that wraps it.
+      - mkdir -p /root/.R && printf '%s\n' 'CFLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error' 'CXXFLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error' 'CXX11FLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error' 'CXX14FLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error' 'CXX17FLAGS = -O2 -g -fpic -Wno-incompatible-pointer-types -Wno-error=incompatible-pointer-types -Wno-error' > /root/.R/Makevars
 
       # CRAN packages -- pulled as prebuilt binaries from Posit PM.
       - |


### PR DESCRIPTION
Replaced heredoc syntax with printf to avoid JSON serialization issues in Makevars creation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->