### PR TITLE
Add myopenrecon OpenRecon container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
   "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "privileged": true,
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
   },
   "customizations": {
     "vscode": {

--- a/recipes/myopenrecon/.gitignore
+++ b/recipes/myopenrecon/.gitignore
@@ -1,0 +1,4 @@
+dicom_data/
+*.h5
+*.nii
+*.nii.gz

--- a/recipes/myopenrecon/OpenReconLabel.json
+++ b/recipes/myopenrecon/OpenReconLabel.json
@@ -1,0 +1,60 @@
+{
+  "general": {
+    "name": { "en": "myopenrecon" },
+    "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+    "vendor": "neurodesk",
+    "information": { "en": "myopenrecon" },
+    "id": "myopenrecon",
+    "regulatory_information": {
+      "device_trade_name":"myopenrecon",
+      "production_identifier":"VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "manufacturer_address":"Erlangen, Germany",
+      "made_in":"DE",
+      "manufacture_date":"2023/02/14",
+      "material_number":"myopenrecon_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "gtin":"00860000171212",
+      "udi":"(01)00860000171212(21)1.3.0",
+      "safety_advices":"",
+      "special_operating_instructions":"Open Recon example",
+      "additional_relevant_information":""
+    }
+  },
+  "reconstruction": {
+    "transfer_protocol": {
+      "protocol": "ISMRMRD",
+      "version": "1.4.1"
+    },
+    "port": 9002,
+    "emitter": "image",
+    "injector": "image",
+    "can_process_adjustment_data": false,
+    "can_use_gpu": false,
+    "min_count_required_gpus": 0,
+    "min_required_gpu_memory": 2048,
+    "min_required_memory": 4096,
+    "min_count_required_cpu_cores": 1,
+    "content_qualification_type": "RESEARCH"
+  },
+  "parameters": [
+    {
+      "id": "config",
+      "label": { "en": "config" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "myopenrecon",
+          "name": { "en": "myopenrecon" }
+        }
+      ],
+      "default": "myopenrecon",
+      "information": { "en": "Define the config to be executed by MRD server" }
+    },
+    {
+      "id": "sendoriginal",
+      "label": { "en": "Send original images" },
+      "type": "boolean",
+      "information": { "en": "Send a copy of original unmodified images back too" },
+      "default": true
+    }
+  ]
+}

--- a/recipes/myopenrecon/build.yaml
+++ b/recipes/myopenrecon/build.yaml
@@ -1,0 +1,78 @@
+name: myopenrecon
+version: 1.0.0
+architectures:
+    - x86_64
+
+files:
+    - name: myopenrecon.py
+      filename: myopenrecon.py
+    - name: dicom2mrd.py
+      filename: dicom2mrd.py
+
+build:
+    kind: neurodocker
+    base-image: ubuntu:22.04
+    pkg-manager: apt
+
+    directives:
+        - environment:
+              DEBIAN_FRONTEND: noninteractive
+        - install: bzip2 ca-certificates git wget build-essential python3-pip python-is-python3
+
+        - include: macros/openrecon/neurodocker.yaml
+
+        #BET2 application
+        - install:
+              - gcc-aarch64-linux-gnu cmake make build-essential
+
+        - run:
+              - git clone https://github.com/Bostrix/FSL-BET2
+              - cd FSL-BET2
+              - mkdir build
+              - cd build
+              - cmake ..
+              - make
+
+        - environment:
+              PATH: ${PATH}:/opt/code/FSL-BET2/bin
+
+        #openrecon application
+        - copy: myopenrecon.py /opt/code/python-ismrmrd-server/myopenrecon.py
+        - copy: dicom2mrd.py /opt/code/python-ismrmrd-server/dicom2mrd.py
+
+deploy:
+    path:
+        - /opt/code/FSL-BET2/bin
+
+categories:
+    - image reconstruction
+
+readme: |-
+    ----------------------------------
+    ## myopenrecon/{{ context.version }} ##
+    Example for building an openrecon container in Neurodesk
+
+    make sure that docker is installed: https://www.docker.com/
+
+    make sure that neurodocker is installed:
+    ```
+    python -m pip install neurodocker
+    ```
+
+    #add it to the path, this depends on your python installation!, some examples below:
+    ```
+    export PATH=$PATH:~/.local/bin
+    export PATH=$PATH:~/.local/lib/python3.12/site-packages/bin
+    ```
+
+    make sure the requirements are installed:
+    ```
+    pip install -r requirements.txt
+    ```
+
+    you can build this recipe with:
+    ```bash
+    ./builder/build.py generate myopenrecon --recreate --build --login --architecture x86_64
+    ```
+
+    ----------------------------------

--- a/recipes/myopenrecon/dicom2mrd.py
+++ b/recipes/myopenrecon/dicom2mrd.py
@@ -1,0 +1,384 @@
+import pydicom
+import argparse
+import ismrmrd
+import numpy as np
+import os
+import ctypes
+import re
+import base64
+
+# Defaults for input arguments
+defaults = {
+    'outGroup':       'dataset',
+}
+
+# Lookup table between DICOM and MRD image types
+imtype_map = {'M': ismrmrd.IMTYPE_MAGNITUDE,
+              'P': ismrmrd.IMTYPE_PHASE,
+              'R': ismrmrd.IMTYPE_REAL,
+              'I': ismrmrd.IMTYPE_IMAG}
+
+# Lookup table between DICOM and Siemens flow directions
+venc_dir_map = {'rl'  : 'FLOW_DIR_R_TO_L',
+                'lr'  : 'FLOW_DIR_L_TO_R',
+                'ap'  : 'FLOW_DIR_A_TO_P',
+                'pa'  : 'FLOW_DIR_P_TO_A',
+                'fh'  : 'FLOW_DIR_F_TO_H',
+                'hf'  : 'FLOW_DIR_H_TO_F',
+                'in'  : 'FLOW_DIR_TP_IN',
+                'out' : 'FLOW_DIR_TP_OUT'}
+
+
+def _is_enhanced_mr(dset):
+    return dset.SOPClassUID.name == 'Enhanced MR Image Storage'
+
+
+def _normalize(vec):
+    arr = np.asarray(vec, dtype=float)
+    norm = np.linalg.norm(arr)
+    if norm == 0:
+        return arr
+    return arr / norm
+
+
+def _get_enhanced_group_item(dset, group_name):
+    if not _is_enhanced_mr(dset):
+        return None
+
+    try:
+        if group_name in dset.PerFrameFunctionalGroupsSequence[0]:
+            return dset.PerFrameFunctionalGroupsSequence[0][group_name][0]
+    except Exception:
+        pass
+
+    try:
+        if group_name in dset.SharedFunctionalGroupsSequence[0]:
+            return dset.SharedFunctionalGroupsSequence[0][group_name][0]
+    except Exception:
+        pass
+
+    return None
+
+
+def _get_pixel_spacing_and_thickness(dset):
+    pixel_spacing = None
+    slice_thickness = None
+
+    if _is_enhanced_mr(dset):
+        measures = _get_enhanced_group_item(dset, 'PixelMeasuresSequence')
+        if measures is not None:
+            pixel_spacing = getattr(measures, 'PixelSpacing', None)
+            slice_thickness = getattr(measures, 'SliceThickness', None)
+
+    if pixel_spacing is None:
+        pixel_spacing = dset.get('PixelSpacing', [1.0, 1.0])
+    if slice_thickness is None:
+        slice_thickness = dset.get('SliceThickness', 1.0)
+
+    row_spacing = float(pixel_spacing[0])
+    col_spacing = float(pixel_spacing[1])
+    return row_spacing, col_spacing, float(slice_thickness)
+
+
+def _get_image_orientation(dset):
+    iop = None
+
+    if _is_enhanced_mr(dset):
+        orient = _get_enhanced_group_item(dset, 'PlaneOrientationSequence')
+        if orient is not None:
+            iop = getattr(orient, 'ImageOrientationPatient', None)
+
+    if iop is None:
+        iop = dset.get('ImageOrientationPatient', [1.0, 0.0, 0.0, 0.0, 1.0, 0.0])
+
+    iop = np.asarray(iop, dtype=float)
+    if iop.size != 6:
+        iop = np.asarray([1.0, 0.0, 0.0, 0.0, 1.0, 0.0], dtype=float)
+
+    row_dir = _normalize(iop[0:3])
+    col_dir = _normalize(iop[3:6])
+    return row_dir, col_dir
+
+
+def _get_image_position(dset):
+    ipp = None
+
+    if _is_enhanced_mr(dset):
+        position = _get_enhanced_group_item(dset, 'PlanePositionSequence')
+        if position is not None:
+            ipp = getattr(position, 'ImagePositionPatient', None)
+
+    if ipp is None:
+        ipp = dset.get('ImagePositionPatient', [0.0, 0.0, 0.0])
+
+    ipp = np.asarray(ipp, dtype=float)
+    if ipp.size != 3:
+        ipp = np.asarray([0.0, 0.0, 0.0], dtype=float)
+
+    return ipp
+
+
+def _get_slice_location(dset):
+    row_dir, col_dir = _get_image_orientation(dset)
+    slice_dir = _normalize(np.cross(row_dir, col_dir))
+    if np.linalg.norm(slice_dir) == 0:
+        return float(dset.get('SliceLocation', 0.0))
+
+    position = _get_image_position(dset)
+    return float(np.dot(position, slice_dir))
+
+
+def _closest_index(values, value):
+    arr = np.asarray(values, dtype=float)
+    if arr.size == 0:
+        return 0
+    return int(np.argmin(np.abs(arr - float(value))))
+
+
+def _parse_acquisition_time_ms(acq_time):
+    acq_time = str(acq_time).strip()
+    if len(acq_time) < 6:
+        return 0
+
+    try:
+        h = int(acq_time[0:2])
+        m = int(acq_time[2:4])
+        s = int(acq_time[4:6])
+        frac = float(acq_time[6:]) if len(acq_time) > 6 else 0.0
+        return round((h*3600 + m*60 + s + frac) * 1000 / 2.5)
+    except Exception:
+        return 0
+
+
+def CreateMrdHeader(dset):
+    """Create MRD XML header from a DICOM file"""
+
+    mrdHead = ismrmrd.xsd.ismrmrdHeader()
+
+    mrdHead.measurementInformation                             = ismrmrd.xsd.measurementInformationType()
+    mrdHead.measurementInformation.measurementID               = dset.SeriesInstanceUID
+    mrdHead.measurementInformation.patientPosition             = dset.PatientPosition
+    mrdHead.measurementInformation.protocolName                = dset.SeriesDescription
+    mrdHead.measurementInformation.frameOfReferenceUID         = dset.FrameOfReferenceUID
+
+    mrdHead.acquisitionSystemInformation                       = ismrmrd.xsd.acquisitionSystemInformationType()
+    mrdHead.acquisitionSystemInformation.systemVendor          = dset.Manufacturer
+    mrdHead.acquisitionSystemInformation.systemModel           = dset.ManufacturerModelName
+    mrdHead.acquisitionSystemInformation.systemFieldStrength_T = float(dset.MagneticFieldStrength)
+    try:
+        mrdHead.acquisitionSystemInformation.institutionName       = dset.InstitutionName
+    except:
+        mrdHead.acquisitionSystemInformation.institutionName       = 'Virtual'
+    try:
+        mrdHead.acquisitionSystemInformation.stationName       = dset.StationName
+    except:
+        pass
+
+    mrdHead.experimentalConditions                             = ismrmrd.xsd.experimentalConditionsType()
+    mrdHead.experimentalConditions.H1resonanceFrequency_Hz     = int(dset.MagneticFieldStrength*4258e4)
+
+    enc = ismrmrd.xsd.encodingType()
+    enc.trajectory                                              = ismrmrd.xsd.trajectoryType('cartesian')
+    encSpace                                                    = ismrmrd.xsd.encodingSpaceType()
+    encSpace.matrixSize                                         = ismrmrd.xsd.matrixSizeType()
+    encSpace.matrixSize.x                                       = dset.Columns
+    encSpace.matrixSize.y                                       = dset.Rows
+    encSpace.matrixSize.z                                       = 1
+    encSpace.fieldOfView_mm                                     = ismrmrd.xsd.fieldOfViewMm()
+    row_spacing, col_spacing, slice_thickness                   = _get_pixel_spacing_and_thickness(dset)
+    # DICOM PixelSpacing is [row_spacing, col_spacing] => [y, x]
+    encSpace.fieldOfView_mm.x                                   = col_spacing * dset.Columns
+    encSpace.fieldOfView_mm.y                                   = row_spacing * dset.Rows
+    encSpace.fieldOfView_mm.z                                   = slice_thickness
+    enc.encodedSpace                                            = encSpace
+    enc.reconSpace                                              = encSpace
+    enc.encodingLimits                                          = ismrmrd.xsd.encodingLimitsType()
+    enc.parallelImaging                                         = ismrmrd.xsd.parallelImagingType()
+
+    enc.parallelImaging.accelerationFactor                      = ismrmrd.xsd.accelerationFactorType()
+    if _is_enhanced_mr(dset):
+        try:
+            mod = dset.SharedFunctionalGroupsSequence[0].MRModifierSequence[0]
+            enc.parallelImaging.accelerationFactor.kspace_encoding_step_1 = mod.ParallelReductionFactorInPlane
+            enc.parallelImaging.accelerationFactor.kspace_encoding_step_2 = mod.ParallelReductionFactorOutOfPlane
+        except Exception:
+            enc.parallelImaging.accelerationFactor.kspace_encoding_step_1 = 1
+            enc.parallelImaging.accelerationFactor.kspace_encoding_step_2 = 1
+    else:
+        enc.parallelImaging.accelerationFactor.kspace_encoding_step_1 = 1
+        enc.parallelImaging.accelerationFactor.kspace_encoding_step_2 = 1
+
+    mrdHead.encoding.append(enc)
+
+    mrdHead.sequenceParameters                                  = ismrmrd.xsd.sequenceParametersType()
+
+    return mrdHead
+
+def GetDicomFiles(directory):
+    """Get path to all DICOMs in a directory and its sub-directories"""
+    for entry in os.scandir(directory):
+        if entry.is_file() and (entry.path.lower().endswith(".dcm") or entry.path.lower().endswith(".ima")):
+            yield entry.path
+        elif entry.is_dir():
+            yield from GetDicomFiles(entry.path)
+
+
+def main(args):
+    dsetsAll = []
+    for entryPath in GetDicomFiles(args.folder):
+        dsetsAll.append(pydicom.dcmread(entryPath))
+
+    # Group by series number
+    uSeriesNum = np.unique([dset.SeriesNumber for dset in dsetsAll])
+
+    # Re-group series that were split during conversion from multi-frame to single-frame DICOMs
+    if all(uSeriesNum > 1000):
+        for i in range(len(dsetsAll)):
+            dsetsAll[i].SeriesNumber = int(np.floor(dsetsAll[i].SeriesNumber / 1000))
+    uSeriesNum = np.unique([dset.SeriesNumber for dset in dsetsAll])
+
+    print("Found %d unique series from %d files in folder %s" % (len(uSeriesNum), len(dsetsAll), args.folder))
+
+    print("Creating MRD XML header from file %s" % dsetsAll[0].filename)
+    mrdHead = CreateMrdHeader(dsetsAll[0])
+    print(mrdHead.toXML())
+
+    imgAll = [None]*len(uSeriesNum)
+
+    for iSer in range(len(uSeriesNum)):
+        dsets = [dset for dset in dsetsAll if dset.SeriesNumber == uSeriesNum[iSer]]
+
+        imgAll[iSer] = [None]*len(dsets)
+
+        # Sort images by instance number, as they may be read out of order
+        def get_instance_number(item):
+            return item.InstanceNumber
+        dsets = sorted(dsets, key=get_instance_number)
+
+        # Build a list of unique geometric slice locations and trigger times.
+        # SliceLocation can be absent/inconsistent; project ImagePositionPatient onto slice normal.
+        slice_locs = np.asarray([_get_slice_location(dset) for dset in dsets], dtype=float)
+        uSliceLoc = np.unique(slice_locs)
+        if (uSliceLoc.size > 1) and (not np.isclose(slice_locs[0], uSliceLoc[0])):
+            uSliceLoc = uSliceLoc[::-1]
+
+        try:
+            # This field may not exist for non-gated sequences
+            trig_times = np.asarray([float(dset.TriggerTime) for dset in dsets], dtype=float)
+            uTrigTime = np.unique(trig_times)
+            if (uTrigTime.size > 1) and (not np.isclose(trig_times[0], uTrigTime[0])):
+                uTrigTime = uTrigTime[::-1]
+        except Exception:
+            trig_times = np.zeros(len(dsets), dtype=float)
+            uTrigTime = np.asarray([0.0], dtype=float)
+
+        print("Series %d has %d images with %d slices and %d phases" % (uSeriesNum[iSer], len(dsets), len(uSliceLoc), len(uTrigTime)))
+
+        for iImg in range(len(dsets)):
+            tmpDset = dsets[iImg]
+
+            # Create new MRD image instance.
+            # pixel_array data has shape [row col], i.e. [y x].
+            # from_array() should be called with 'transpose=False' to avoid warnings, and when called
+            # with this option, can take input as: [cha z y x], [z y x], or [y x]
+            tmpMrdImg = ismrmrd.Image.from_array(tmpDset.pixel_array, transpose=False)
+            tmpMeta   = ismrmrd.Meta()
+
+            try:
+                tmpMrdImg.image_type                = imtype_map[tmpDset.ImageType[2]]
+            except:
+                print("Unsupported ImageType %s -- defaulting to IMTYPE_MAGNITUDE" % tmpDset.ImageType[2])
+                tmpMrdImg.image_type                = ismrmrd.IMTYPE_MAGNITUDE
+
+            row_spacing, col_spacing, slice_thickness = _get_pixel_spacing_and_thickness(tmpDset)
+            row_dir, col_dir = _get_image_orientation(tmpDset)
+            slice_dir = _normalize(np.cross(row_dir, col_dir))
+            image_position = _get_image_position(tmpDset)
+
+            tmpMrdImg.field_of_view            = (col_spacing*tmpDset.Columns, row_spacing*tmpDset.Rows, slice_thickness)
+            tmpMrdImg.position                 = tuple(image_position)
+
+            # Keep MRD direction mapping consistent with musclemap/enhanceddicom2mrd:
+            # read_dir follows DICOM row direction, phase_dir follows DICOM column direction.
+            tmpMrdImg.read_dir                 = tuple(row_dir)
+            tmpMrdImg.phase_dir                = tuple(col_dir)
+            tmpMrdImg.slice_dir                = tuple(slice_dir)
+            tmpMrdImg.acquisition_time_stamp   = _parse_acquisition_time_ms(tmpDset.get('AcquisitionTime', '000000.0'))
+            try:
+                tmpMrdImg.physiology_time_stamp[0] = round(int(tmpDset.TriggerTime/2.5))
+            except:
+                pass
+
+            try:
+                ImaAbsTablePosition = tmpDset.get_private_item(0x0019, 0x13, 'SIEMENS MR HEADER').value
+                tmpMrdImg.patient_table_position = (ctypes.c_float(ImaAbsTablePosition[0]), ctypes.c_float(ImaAbsTablePosition[1]), ctypes.c_float(ImaAbsTablePosition[2]))
+            except:
+                pass
+
+            tmpMrdImg.image_series_index     = uSeriesNum.tolist().index(tmpDset.SeriesNumber)
+            tmpMrdImg.image_index            = tmpDset.get('InstanceNumber', 0)
+            tmpMrdImg.slice                  = _closest_index(uSliceLoc, slice_locs[iImg])
+            try:
+                tmpMrdImg.phase              = _closest_index(uTrigTime, trig_times[iImg])
+            except Exception:
+                tmpMrdImg.phase              = 0
+
+            try:
+                res  = re.search(r'(?<=_v).*$',     tmpDset.SequenceName)
+                venc = re.search(r'^\d+',           res.group(0))
+                dir  = re.search(r'(?<=\d)[^\d]*$', res.group(0))
+
+                tmpMeta['FlowVelocity']   = float(venc.group(0))
+                tmpMeta['FlowDirDisplay'] = venc_dir_map[dir.group(0)]
+            except:
+                pass
+
+            try:
+                tmpMeta['ImageComments'] = tmpDset.ImageComments
+            except:
+                pass
+
+            tmpMeta['SequenceDescription'] = tmpDset.SeriesDescription
+
+            # Remove pixel data from pydicom class
+            del tmpDset['PixelData']
+
+            # Store the complete base64, json-formatted DICOM header so that non-MRD fields can be
+            # recapitulated when generating DICOMs from MRD images
+            tmpMeta['DicomJson'] = base64.b64encode(tmpDset.to_json().encode('utf-8')).decode('utf-8')
+
+            tmpMrdImg.attribute_string = tmpMeta.serialize()
+            imgAll[iSer][iImg] = tmpMrdImg
+
+    # Create an MRD file
+    print("Creating MRD file %s with group %s" % (args.outFile, args.outGroup))
+    mrdDset = ismrmrd.Dataset(args.outFile, args.outGroup)
+    mrdDset._file.require_group(args.outGroup)
+
+    # Write MRD Header
+    mrdDset.write_xml_header(bytes(mrdHead.toXML(), 'utf-8'))
+
+    # Write all images
+    for iSer in range(len(imgAll)):
+        for iImg in range(len(imgAll[iSer])):
+            mrdDset.append_image("image_%d" % imgAll[iSer][iImg].image_series_index, imgAll[iSer][iImg])
+
+    mrdDset.close()
+
+if __name__ == '__main__':
+    """Basic conversion of a folder of DICOM files to MRD .h5 format"""
+
+    parser = argparse.ArgumentParser(description='Convert DICOMs to MRD file',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('folder',            help='Input folder of DICOMs')
+    parser.add_argument('-o', '--outFile',  help='Output MRD file')
+    parser.add_argument('-g', '--outGroup', help='Group name in output MRD file')
+
+    parser.set_defaults(**defaults)
+
+    args = parser.parse_args()
+
+    if args.outFile is None:
+        args.outFile = os.path.basename(args.folder) + '.h5'
+
+    main(args)

--- a/recipes/myopenrecon/myopenrecon.py
+++ b/recipes/myopenrecon/myopenrecon.py
@@ -1,0 +1,480 @@
+import ismrmrd
+import os
+import itertools
+import logging
+import traceback
+import numpy as np
+import numpy.fft as fft
+import xml.dom.minidom
+import base64
+import json
+import ctypes
+import re
+import mrdhelper
+import constants
+from time import perf_counter
+import nibabel as nib
+import subprocess
+
+
+# Folder for debug output files
+debugFolder = "/tmp/share/debug"
+
+def process(connection, config, metadata):
+    logging.info("Config: \n%s", config)
+
+    # Metadata should be MRD formatted header, but may be a string
+    # if it failed conversion earlier
+    try:
+        # Disabled due to incompatibility between PyXB and Python 3.8:
+        # https://github.com/pabigot/pyxb/issues/123
+        # # logging.info("Metadata: \n%s", metadata.toxml('utf-8'))
+
+        logging.info("Incoming dataset contains %d encodings", len(metadata.encoding))
+        logging.info("First encoding is of type '%s', with a matrix size of (%s x %s x %s) and a field of view of (%s x %s x %s)mm^3", 
+            metadata.encoding[0].trajectory, 
+            metadata.encoding[0].encodedSpace.matrixSize.x, 
+            metadata.encoding[0].encodedSpace.matrixSize.y, 
+            metadata.encoding[0].encodedSpace.matrixSize.z, 
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.x, 
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.y, 
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.z)
+
+    except:
+        logging.info("Improperly formatted metadata: \n%s", metadata)
+
+    # Continuously parse incoming data parsed from MRD messages
+    currentSeries = 0
+    acqGroup = []
+    imgGroup = []
+    waveformGroup = []
+    try:
+        for item in connection:
+            # ----------------------------------------------------------
+            # Raw k-space data messages
+            # ----------------------------------------------------------
+            if isinstance(item, ismrmrd.Acquisition):
+                # Accumulate all imaging readouts in a group
+                if (not item.is_flag_set(ismrmrd.ACQ_IS_NOISE_MEASUREMENT) and
+                    not item.is_flag_set(ismrmrd.ACQ_IS_PARALLEL_CALIBRATION) and
+                    not item.is_flag_set(ismrmrd.ACQ_IS_PHASECORR_DATA) and
+                    not item.is_flag_set(ismrmrd.ACQ_IS_NAVIGATION_DATA)):
+                    acqGroup.append(item)
+
+
+            # ----------------------------------------------------------
+            # Image data messages
+            # ----------------------------------------------------------
+            elif isinstance(item, ismrmrd.Image):
+                # When this criteria is met, run process_group() on the accumulated
+                # data, which returns images that are sent back to the client.
+                # e.g. when the series number changes:
+                if item.image_series_index != currentSeries:
+                    logging.info("Processing a group of images because series index changed to %d", item.image_series_index)
+                    currentSeries = item.image_series_index
+                    image = process_image(imgGroup, connection, config, metadata)
+                    connection.send_image(image)
+                    imgGroup = []
+
+                # Only process magnitude images -- send phase images back without modification (fallback for images with unknown type)
+                if (item.image_type is ismrmrd.IMTYPE_MAGNITUDE) or (item.image_type == 0):
+                    imgGroup.append(item)
+                else:
+                    tmpMeta = ismrmrd.Meta.deserialize(item.attribute_string)
+                    tmpMeta['Keep_image_geometry']    = 1
+                    item.attribute_string = tmpMeta.serialize()
+
+                    connection.send_image(item)
+                    continue
+
+            # ----------------------------------------------------------
+            # Waveform data messages
+            # ----------------------------------------------------------
+            elif isinstance(item, ismrmrd.Waveform):
+                waveformGroup.append(item)
+
+            elif item is None:
+                break
+
+            else:
+                logging.error("Unsupported data type %s", type(item).__name__)
+
+        # Extract raw ECG waveform data. Basic sorting to make sure that data 
+        # is time-ordered, but no additional checking for missing data.
+        # ecgData has shape (5 x timepoints)
+        if len(waveformGroup) > 0:
+            waveformGroup.sort(key = lambda item: item.time_stamp)
+            ecgData = [item.data for item in waveformGroup if item.waveform_id == 0]
+            ecgData = np.concatenate(ecgData,1)
+
+        if len(imgGroup) > 0:
+            logging.info("Processing a group of images (untriggered)")
+            image = process_image(imgGroup, connection, config, metadata)
+            connection.send_image(image)
+            imgGroup = []
+
+    except Exception as e:
+        logging.error(traceback.format_exc())
+        connection.send_logging(constants.MRD_LOGGING_ERROR, traceback.format_exc())
+
+    finally:
+        connection.send_close()
+
+
+def compute_nifti_affine(image_header, voxel_size):
+    # MRD stores geometry in DICOM/LPS (x=Left, y=Posterior, z=Superior).
+    # NIfTI uses RAS (x=Right, y=Anterior, z=Superior), so negate x/y.
+    lps_to_ras = np.array([-1, -1, 1], dtype=float)
+
+    position = np.array(image_header.position) * lps_to_ras
+    read_dir = np.array(image_header.read_dir) * lps_to_ras
+    phase_dir = np.array(image_header.phase_dir) * lps_to_ras
+    slice_dir = np.array(image_header.slice_dir) * lps_to_ras
+
+    affine = np.eye(4)
+    affine[:3, :3] = np.column_stack([
+        voxel_size[0] * read_dir,
+        voxel_size[1] * phase_dir,
+        voxel_size[2] * slice_dir,
+    ])
+    affine[:3, 3] = position
+    return affine
+
+
+def compute_nifti_affine_expected_order(image_header, voxel_size, nifti_shape=None):
+    """
+    Build affine for NIfTI data arranged as [z, x, y].
+
+    To match scanner-style headers, the origin is shifted to the [0,0,0] voxel
+    in this reordered/flipped array layout.
+    """
+    lps_to_ras = np.array([-1, -1, 1], dtype=float)
+
+    position = np.array(image_header.position) * lps_to_ras
+    read_dir = np.array(image_header.read_dir) * lps_to_ras
+    phase_dir = np.array(image_header.phase_dir) * lps_to_ras
+    slice_dir = np.array(image_header.slice_dir) * lps_to_ras
+
+    affine = np.eye(4)
+    affine[:3, :3] = np.column_stack([
+        voxel_size[2] * slice_dir,   # NIfTI axis-0 (slices)
+        -voxel_size[0] * read_dir,   # NIfTI axis-1 (MRD x)
+        -voxel_size[1] * phase_dir,  # NIfTI axis-2 (MRD y)
+    ])
+
+    if nifti_shape is not None:
+        shape = np.asarray(nifti_shape[:3], dtype=float)
+        shape = np.maximum(shape - 1.0, 0.0)
+        affine[:3, 3] = position - affine[:3, :3].dot(shape)
+    else:
+        affine[:3, 3] = position
+
+    return affine
+
+
+def _meta_get_first(meta_obj, key):
+    value = meta_obj.get(key)
+    if isinstance(value, (list, tuple)):
+        if len(value) == 0:
+            return None
+        return value[0]
+    return value
+
+
+def _meta_dicom_json(meta_obj):
+    b64 = _meta_get_first(meta_obj, 'DicomJson')
+    if not b64:
+        return {}
+    try:
+        return json.loads(base64.b64decode(str(b64)).decode('utf-8'))
+    except Exception:
+        return {}
+
+
+def _dicom_tag_value(dicom_json, tag):
+    item = dicom_json.get(tag, {})
+    vals = item.get('Value', [])
+    if isinstance(vals, list) and len(vals) > 0:
+        return vals[0]
+    return None
+
+
+def _to_float_or_none(value):
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _format_dicom_time_hhmmss_msec(value):
+    if value is None:
+        return None
+    value = str(value).strip()
+    if len(value) < 6:
+        return None
+
+    hhmmss = value[:6]
+    if '.' not in value:
+        return hhmmss
+
+    frac = value.split('.', 1)[1]
+    frac = (frac + "000")[:3]
+    return f"{hhmmss}.{frac}"
+
+
+def process_image(images, connection, config, metadata):
+    if len(images) == 0:
+        return []
+    # Note: The MRD Image class stores data as [cha z y x]
+    # Extract image data into a 5D array of size [img cha z y x]
+    data = np.stack([img.data                              for img in images])
+    head = [img.getHead()                                  for img in images]
+    meta = [ismrmrd.Meta.deserialize(img.attribute_string) for img in images]
+
+    # Diagnostic info
+    matrix    = np.array(head[0].matrix_size  [:]) 
+    fov       = np.array(head[0].field_of_view[:])
+    if matrix[2] != len(images):
+        matrix[2] = len(images)
+    slice_thickness = fov[2]
+    fov[2] = slice_thickness * len(images)
+    voxelsize = fov/matrix
+    read_dir  = np.array(images[0].read_dir )
+    phase_dir = np.array(images[0].phase_dir)
+    slice_dir = np.array(images[0].slice_dir)
+    logging.info(f'MRD computed matrix [x y z] : {matrix   }')
+    logging.info(f'MRD computed fov     [x y z] : {fov      }')
+    logging.info(f'MRD computed voxel   [x y z] : {voxelsize}')
+    logging.info(f'MRD read_dir         [x y z] : {read_dir }')
+    logging.info(f'MRD phase_dir        [x y z] : {phase_dir}')
+    logging.info(f'MRD slice_dir        [x y z] : {slice_dir}')
+
+    logging.debug("Original image data before transposing is %s" % (data.shape,))
+
+    # Reformat data to [y x img cha z], i.e. [row col slice ...]
+    data = data.transpose((3, 4, 0, 1, 2))
+
+    logging.debug("Original image data after transposing is %s" % (data.shape,))
+
+    data = np.squeeze(data)
+    logging.debug("Squeezed to 3D: %s" % (data.shape,))
+
+    # Transpose from [y, x, z] to NIfTI [z, x, y].
+    if data.ndim == 2:
+        data_nifti = np.asarray(data[None, :, :], dtype=np.int16)
+    else:
+        data_nifti = np.asarray(data.transpose((2, 1, 0)), dtype=np.int16)
+    # Match scanner/reference voxel ordering.
+    data_nifti = np.ascontiguousarray(np.flip(data_nifti, axis=(0, 1, 2)))
+
+    # Build scanner-style affine for [z, x, y] data ordering.
+    affine = compute_nifti_affine_expected_order(head[0], voxelsize, nifti_shape=data_nifti.shape)
+
+    new_img = nib.nifti1.Nifti1Image(data_nifti, affine)
+
+    header = new_img.header
+    header.set_data_dtype(np.int16)
+    header.set_dim_info(freq=1, phase=0, slice=2)
+    header.set_xyzt_units(xyz='mm', t='sec')
+    header["pixdim"][0] = 1.0
+    header["pixdim"][1] = float(voxelsize[2])
+    header["pixdim"][2] = float(voxelsize[0])
+    header["pixdim"][3] = float(voxelsize[1])
+    header["pixdim"][5] = 0.0
+    header["pixdim"][6] = 0.0
+    header["pixdim"][7] = 0.0
+
+    # Populate scanner-style descriptive fields from DICOM metadata.
+    djson = _meta_dicom_json(meta[0]) if len(meta) > 0 else {}
+    te = _to_float_or_none(_dicom_tag_value(djson, "00180081"))  # EchoTime
+    tr = _to_float_or_none(_dicom_tag_value(djson, "00180080"))  # RepetitionTime
+    acq_time = _format_dicom_time_hhmmss_msec(_dicom_tag_value(djson, "00080032"))  # AcquisitionTime
+    aux_text = _dicom_tag_value(djson, "00204000")  # ImageComments
+    if aux_text is None and len(meta) > 0:
+        aux_text = _meta_get_first(meta[0], 'ImageComments')
+
+    # TE in many DICOMs is seconds for derived/converted datasets; convert to ms.
+    if te is not None and te < 1.0:
+        te = te * 1000.0
+    # NIfTI time units are seconds.
+    if tr is not None and tr > 100.0:
+        tr = tr / 1000.0
+    if tr is not None:
+        header["pixdim"][4] = float(tr)
+
+    desc_parts = []
+    if te is not None:
+        desc_parts.append(f"TE={round(te, 1):g}")
+    if acq_time:
+        desc_parts.append(f"Time={acq_time}")
+    header["descrip"] = ";".join(desc_parts)
+    aux_text = str(aux_text or "")
+    aux_text = re.sub(r"\(lambda\s*=\s*", "(lambda ", aux_text)
+    if aux_text.startswith("DENOISED IMAGE (lambda"):
+        aux_text = "DENOISED IMAGE (lambda "
+    header["aux_file"] = aux_text
+    header.set_slope_inter(1.0, 0.0)
+    new_img.set_qform(affine, code=1)
+    new_img.set_sform(affine, code=1)
+
+    nib.save(new_img, 't1_from_h5.nii')
+
+    # bet2 Usage: 
+    # bet2 <input_fileroot> <output_fileroot> [options]
+    # Optional arguments (You may optionally specify one or more of):
+        # -o,--outline    generate brain surface outline overlaid onto original image
+        # -m,--mask <m>   generate binary brain mask
+        # -s,--skull      generate approximate skull image
+        # -n,--nooutput   don't generate segmented brain image output
+        # -f <f>          fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates
+        # -g <g>          vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top
+        # -r,--radius <r> head radius (mm not voxels); initial surface sphere is set to half of this
+        # -w,--smooth <r> smoothness factor; default=1; values smaller than 1 produce more detailed brain surface, values larger than one produce smoother, less detailed surface
+        # -c <x y z>      centre-of-gravity (voxels not mm) of initial mesh surface.
+        # -t,--threshold  -apply thresholding to segmented brain image and mask
+        # -e,--mesh       generates brain surface as mesh in vtk format
+        # -v,--verbose    switch on diagnostic messages
+        # -h,--help       displays this help, then exits
+    subprocess.run(["bet2", "t1_from_h5.nii", "t1_from_h5_bet2.nii.gz", "-f", "0.65"])
+
+    data_img = nib.load('t1_from_h5_bet2.nii.gz')
+    data = data_img.get_fdata()
+    if data.ndim == 2:
+        data = data[:, :, None]
+    # Undo voxel flip applied at NIfTI write stage.
+    data = np.flip(data, axis=(0, 1, 2))
+    # Bring [z, x, y] from NIfTI back to [y, x, z].
+    if data.ndim >= 3:
+        data = data.transpose((2, 1, 0))
+    data = data[:, :, :, None, None]
+    data = data.transpose((0, 1, 3, 4, 2))
+
+    # Determine max value (12 or 16 bit)
+    BitsStored = 12
+    # if (mrdhelper.get_userParameterLong_value(metadata, "BitsStored") is not None):
+    #     BitsStored = mrdhelper.get_userParameterLong_value(metadata, "BitsStored")
+    maxVal = 2**BitsStored - 1
+
+    # Normalize Data and convert to int16
+    data = data.astype(np.float64)
+    data *= maxVal/data.max()
+    data = np.around(data)
+    data = data.astype(np.int16)
+
+    currentSeries = 0
+
+    # Re-slice image data back into 2D images
+    imagesOut = [None] * data.shape[-1]
+    # segmentationOut = [None] * data.shape[-1]
+    for iImg in range(data.shape[-1]):
+        # Create new MRD instance for the final image
+        # Transpose from convenience shape of [y x z cha] to MRD Image shape of [cha z y x]
+        # from_array() should be called with 'transpose=False' to avoid warnings, and when called
+        # with this option, can take input as: [cha z y x], [z y x], or [y x]
+        # imagesOut[iImg] = ismrmrd.Image.from_array(data[...,iImg].transpose((3, 2, 0, 1)), transpose=False)
+        imagesOut[iImg] = ismrmrd.Image.from_array(data[...,iImg].transpose((3, 2, 0, 1)), transpose=False)
+        # segmentationOut[iImg] = ismrmrd.Image.from_array(data[...,iImg].transpose((3, 2, 0, 1)), transpose=False)
+
+        # Create a copy of the original fixed header and update the data_type
+        # (we changed it to int16 from all other types)
+        oldHeader = head[iImg]
+        oldHeader.data_type = imagesOut[iImg].data_type
+
+        # Supported ISMRMRD Data Types:
+        #     ISMRMRD_USHORT   = 1, /**< corresponds to uint16_t */
+        #     ISMRMRD_SHORT    = 2, /**< corresponds to int16_t */
+        #     ISMRMRD_FLOAT    = 5, /**< corresponds to float */
+        #     ISMRMRD_CXFLOAT  = 7, /**< corresponds to complex float */
+
+        # NOT SUPPORTED:
+        # ISMRMRD_UINT     = 3, /**< corresponds to uint32_t */
+        # ISMRMRD_INT      = 4, /**< corresponds to int32_t */
+        # ISMRMRD_DOUBLE   = 6, /**< corresponds to double */
+        # ISMRMRD_CXDOUBLE = 8  /**< corresponds to complex double */
+
+        # check if datatype is supported and if not show an error and stop:
+        if imagesOut[iImg].data_type not in [ismrmrd.DATATYPE_USHORT, ismrmrd.DATATYPE_SHORT, ismrmrd.DATATYPE_FLOAT, ismrmrd.DATATYPE_CXFLOAT]:
+            logging.error(f"Unsupported data type {imagesOut[iImg].data_type} in output image {iImg}. Supported types are: uint16, int16, float32, complex float32.")
+            raise ValueError(f"Unsupported data type {imagesOut[iImg].data_type} in output image {iImg}. Supported types are: uint16, int16, float32, complex float32.")
+
+
+        # Unused example, as images are grouped by series before being passed into this function now
+        # oldHeader.image_series_index = currentSeries+1
+
+        # Increment series number when flag detected (i.e. follow ICE logic for splitting series)
+        if mrdhelper.get_meta_value(meta[iImg], 'IceMiniHead') is not None:
+            if mrdhelper.extract_minihead_bool_param(base64.b64decode(meta[iImg]['IceMiniHead']).decode('utf-8'), 'BIsSeriesEnd') is True:
+                currentSeries += 1
+
+        imagesOut[iImg].setHead(oldHeader)
+
+        # Create a copy of the original ISMRMRD Meta attributes and update
+        tmpMeta = meta[iImg]
+        tmpMeta['DataRole']                       = 'Image'
+        tmpMeta['ImageProcessingHistory']         = ['PYTHON', 'PROSTATEFIDUCIALSEG']
+        tmpMeta['WindowCenter']                   = str((maxVal+1)/2)
+        tmpMeta['WindowWidth']                    = str((maxVal+1))
+        tmpMeta['SequenceDescriptionAdditional']  = 'OpenRecon'
+        tmpMeta['Keep_image_geometry']            = 1
+
+        logging.info("Creating ROI_example")
+        tmpMeta['ROI_example'] = create_example_roi(data.shape)
+
+        # Add image orientation directions to MetaAttributes if not already present
+        if tmpMeta.get('ImageRowDir') is None:
+            tmpMeta['ImageRowDir'] = ["{:.18f}".format(oldHeader.read_dir[0]), "{:.18f}".format(oldHeader.read_dir[1]), "{:.18f}".format(oldHeader.read_dir[2])]
+
+        if tmpMeta.get('ImageColumnDir') is None:
+            tmpMeta['ImageColumnDir'] = ["{:.18f}".format(oldHeader.phase_dir[0]), "{:.18f}".format(oldHeader.phase_dir[1]), "{:.18f}".format(oldHeader.phase_dir[2])]
+
+        metaXml = tmpMeta.serialize()
+        # logging.debug("Image MetaAttributes: %s", xml.dom.minidom.parseString(metaXml).toprettyxml())
+        logging.debug("Image data has %d elements", imagesOut[iImg].data.size)
+
+        imagesOut[iImg].attribute_string = metaXml
+
+    # Send a copy of original (unmodified) images back too if selected
+    opre_sendoriginal = mrdhelper.get_json_config_param(config, 'sendoriginal', default=True, type='bool')
+    if opre_sendoriginal:
+        stack = traceback.extract_stack()
+        if stack[-2].name == 'process_raw':
+            logging.warning('sendOriginal is true, but input was raw data, so no original images to return!')
+        else:
+            logging.info('Sending a copy of original unmodified images due to sendOriginal set to True')
+            # In reverse order so that they'll be in correct order as we insert them to the front of the list
+            for image in reversed(images):
+                # Create a copy to not modify the original inputs
+                tmpImg = image
+
+                # Change the series_index to have a different series
+                tmpImg.image_series_index = 99
+
+                # Ensure Keep_image_geometry is set to not reverse image orientation
+                tmpMeta = ismrmrd.Meta.deserialize(tmpImg.attribute_string)
+                tmpMeta['Keep_image_geometry'] = 1
+                tmpImg.attribute_string = tmpMeta.serialize()
+
+                imagesOut.insert(0, tmpImg)
+
+    return imagesOut
+
+# Create an example ROI <3
+def create_example_roi(img_size):
+    t = np.linspace(0, 2*np.pi)
+    x = 16*np.power(np.sin(t), 3)
+    y = -13*np.cos(t) + 5*np.cos(2*t) + 2*np.cos(3*t) + np.cos(4*t)
+
+    # Place ROI in bottom right of image, offset and scaled to 10% of the image size
+    x = (x-np.min(x)) / (np.max(x) - np.min(x))
+    y = (y-np.min(y)) / (np.max(y) - np.min(y))
+    x = (x * 0.08*img_size[0]) + 0.82*img_size[0]
+    y = (y * 0.10*img_size[1]) + 0.80*img_size[1]
+
+    rgb = (1,0,0)  # Red, green, blue color -- normalized to 1
+    thickness  = 1 # Line thickness
+    style      = 0 # Line style (0 = solid, 1 = dashed)
+    visibility = 1 # Line visibility (0 = false, 1 = true)
+
+
+    roi = mrdhelper.create_roi(x, y, rgb, thickness, style, visibility)
+    return roi

--- a/recipes/myopenrecon/test.yaml
+++ b/recipes/myopenrecon/test.yaml
@@ -1,0 +1,30 @@
+tests:
+  - name: Test myopenrecon
+    manual: true
+    script: |
+      # build:
+      source .venv/bin/activate
+      ./builder/build.py generate myopenrecon --recreate --build --login --architecture x86_64
+
+      # Convert input DICOMs to ISMRMRD format
+      rm /buildhostdirectory/t1.h5
+      python /opt/code/python-ismrmrd-server/dicom2mrd.py \
+        -o /buildhostdirectory/t1.h5 \
+        /buildhostdirectory/dicom_data
+
+      # Start OpenRecon server
+      python3 /opt/code/python-ismrmrd-server/main.py -v -r -H=0.0.0.0 -p=9002 -s -S=/tmp/share/saved_data &
+      sleep 2
+
+      rm /buildhostdirectory/output.h5
+      python3 /opt/code/python-ismrmrd-server/client.py \
+        -G dataset \
+        -o /buildhostdirectory/output.h5 \
+        /buildhostdirectory/t1.h5 \
+        -c myopenrecon
+      
+      # inspect files
+      cp t1_from_h5.nii /buildhostdirectory/
+      cp t1_from_h5_bet2.nii.gz /buildhostdirectory/
+
+      # Check output h5 data in "H5Web" VS code plugin viewer


### PR DESCRIPTION
This PR adds a new OpenRecon container for the MRD server.

It includes:
- a new recipe under recipes/myopenrecon
- a customized MRD Python script
- build.yaml and test.yaml
- OpenReconLabel.json
- manual testing inside GitHub Codespaces using anonymized DICOM data converted to MRD/HDF5

The container was built successfully as myopenrecon:1.0.0 and tested with the MRD server/client workflow, producing output.h5.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->