### PR TITLE
Update release for cat12 26.0.rc3

### DIFF
--- a/releases/cat12/26.0.rc3.json
+++ b/releases/cat12/26.0.rc3.json
@@ -1,12 +1,12 @@
 {
   "apps": {
     "cat12 26.0.rc3": {
-      "version": "20260519",
+      "version": "20260520",
       "exec": "",
       "apptainer_args": []
     },
     "cat12GUI-cat12 26.0.rc3": {
-      "version": "20260519",
+      "version": "20260520",
       "exec": "bash /opt/cat12/run_spm25.sh /opt/mcr/R2023b/",
       "apptainer_args": []
     }


### PR DESCRIPTION
## Summary

This PR updates the release file for **cat12 26.0.rc3**.

## Changes

- Update `releases/cat12/26.0.rc3.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh cat12 26.0.rc3 20260520
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/cat12_26.0.rc3_20260520.simg -O
singularity shell --overlay /tmp/apptainer_overlay cat12_26.0.rc3_20260520.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781921329&installation_id=131548984&pr_number=2405&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2405&signature=ffaefb8127c02b74a90471cd3cb8ad78925b2b7645eee0a583bd1f928a5b0af7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->