### PR TITLE
[codex] Add MEDE container recipe

### DIFF
--- a/recipes/mede/build.yaml
+++ b/recipes/mede/build.yaml
@@ -1,0 +1,155 @@
+name: mede
+version: 0.0.12
+
+copyright:
+  - license: LicenseRef-Apache-2.0-Commons-Clause
+    url: https://github.com/TIO-IKIM/medical_image_deidentification/blob/main/LICENSE
+
+architectures:
+  - x86_64
+  - aarch64
+
+auto_update:
+  method: github_release
+  repo: TIO-IKIM/medical_image_deidentification
+
+build:
+  kind: neurodocker
+  base-image: python:3.11-slim-bookworm
+  pkg-manager: apt
+
+  directives:
+    - environment:
+        DEBIAN_FRONTEND: noninteractive
+        EASYOCR_MODULE_PATH: /opt/easyocr
+        HF_HOME: /tmp/huggingface-mede
+        MPLCONFIGDIR: /tmp/matplotlib-mede
+        TORCH_HOME: /tmp/torch-mede
+        XDG_CACHE_HOME: /tmp/cache-mede
+
+    - install:
+        - ca-certificates
+        - libgomp1
+        - libtesseract-dev
+        - tesseract-ocr
+
+    - run:
+        - python -m pip install --no-cache-dir -r {{ get_file("requirements_lock") }}
+        - mkdir -p "${EASYOCR_MODULE_PATH}/model" "${EASYOCR_MODULE_PATH}/user_network"
+        - python -c 'import easyocr; easyocr.Reader(["en"], gpu=False)'
+        - chmod -R a+rX "${EASYOCR_MODULE_PATH}"
+        - rm -rf /root/.cache/pip /tmp/cache-mede /tmp/huggingface-mede /tmp/matplotlib-mede /tmp/torch-mede
+
+deploy:
+  bins:
+    - mede-deidentify
+
+files:
+  - name: requirements_lock
+    contents: |
+      Deprecated==1.3.1
+      ImageIO==2.37.3
+      Jinja2==3.1.6
+      MarkupSafe==3.0.3
+      PyYAML==6.0.3
+      Pygments==2.20.0
+      annotated-doc==0.0.4
+      certifi==2026.5.20
+      charset-normalizer==3.4.7
+      click==8.4.0
+      contourpy==1.3.3
+      cycler==0.12.1
+      deid==0.4.12
+      easyocr==1.7.2
+      einops==0.8.2
+      filelock==3.29.0
+      fonttools==4.63.0
+      fsspec==2026.4.0
+      hf-xet==1.5.0
+      huggingface_hub==0.36.2
+      humanize==4.15.0
+      idna==3.15
+      importlib_resources==7.1.0
+      jaxtyping==0.3.9
+      kiwisolver==1.5.0
+      lazy-loader==0.5
+      markdown-it-py==4.2.0
+      matplotlib==3.10.9
+      mdurl==0.1.2
+      mede=={{ context.version }}
+      mpmath==1.3.0
+      networkx==3.6.1
+      nibabel==5.4.2
+      ninja==1.13.0
+      numpy==1.26.4
+      opencv-python-headless==4.11.0.86
+      packaging==26.2
+      pandas==3.0.3
+      pillow==12.2.0
+      pyclipper==1.4.0
+      pydicom==3.0.1
+      pyparsing==3.3.2
+      pytesseract==0.3.13
+      python-bidi==0.6.10
+      python-dateutil==2.9.0.post0
+      requests==2.34.2
+      rich==15.0.0
+      safetensors==0.5.3
+      scikit-image==0.26.0
+      scipy==1.17.1
+      shapely==2.1.2
+      shellingham==1.5.4
+      simpleitk==2.5.5
+      six==1.17.0
+      sympy==1.14.0
+      tifffile==2026.3.3
+      timm==1.0.7
+      torch==2.2.2
+      torchio==1.2.0
+      torchvision==0.17.2
+      tqdm==4.67.3
+      typer==0.25.1
+      typing_extensions==4.15.0
+      urllib3==2.7.0
+      wadler_lindig==0.1.7
+      wrapt==2.2.0
+
+categories:
+  - data organisation
+  - preprocessing
+
+structured_readme:
+  description: |
+    MEDE de-identifies medical imaging data including MRI, CT, ultrasound, whole slide images, and MRI raw data. It supports metadata de-identification, defacing, skull stripping, text removal, and file renaming.
+  example: |
+    mede-deidentify -i /data/input -o /data/output -d basicProfile
+
+    mede-deidentify -i /data/input -o /data/output -s -de -d basicProfile
+  documentation: https://github.com/TIO-IKIM/medical_image_deidentification
+  citation: |
+    Rempe M, Heine L, Seibold C, Horst F, Kleesiek J. De-identification of medical imaging data: a comprehensive tool for ensuring patient privacy. European Radiology. 2025.
+
+readme: |
+  ----------------------------------
+  ## mede/{{ context.version }} ##
+
+  MEDE de-identifies medical imaging data including MRI, CT, ultrasound, whole slide images, and MRI raw data. It supports metadata de-identification, defacing, skull stripping, text removal, and file renaming.
+
+  Example:
+  ```
+  mede-deidentify -i /data/input -o /data/output -d basicProfile
+  mede-deidentify -i /data/input -o /data/output -s -de -d basicProfile
+  ```
+
+  More documentation can be found here: https://github.com/TIO-IKIM/medical_image_deidentification
+
+  Citation:
+  ```
+  Rempe M, Heine L, Seibold C, Horst F, Kleesiek J. De-identification of medical imaging data: a comprehensive tool for ensuring patient privacy. European Radiology. 2025.
+  ```
+
+  To run container outside of this environment: ml mede/{{ context.version }}
+
+  ----------------------------------
+
+icon: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iNSIgZmlsbD0iIzBmNzY2ZSIvPjxwYXRoIGQ9Ik0xMiAzLjUgMTggNnY1LjJjMCAzLjgtMi40IDcuMi02IDguMy0zLjYtMS4xLTYtNC41LTYtOC4zVjZsNi0yLjVaIiBmaWxsPSIjZWNmZWZmIi8+PHBhdGggZD0iTTEyIDd2OE04IDExaDgiIHN0cm9rZT0iIzBmNzY2ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMTcuNSAxOC41IDIxIDIyIiBzdHJva2U9IiMxNjRlNjMiIHN0cm9rZS13aWR0aD0iMS44IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48Y2lyY2xlIGN4PSIxNi41IiBjeT0iMTcuNSIgcj0iMi44IiBmaWxsPSJub25lIiBzdHJva2U9IiMxNjRlNjMiIHN0cm9rZS13aWR0aD0iMS42Ii8+PC9zdmc+

--- a/recipes/mede/fulltest.yaml
+++ b/recipes/mede/fulltest.yaml
@@ -1,0 +1,19 @@
+tests:
+  - name: MEDE command line help
+    script: |
+      set -eu
+      command -v mede-deidentify
+      mede-deidentify --help | grep -F "deidentification-profile"
+
+  - name: MEDE Python package and cached OCR models
+    script: |
+      set -eu
+      python - <<'PY'
+      from importlib.metadata import version
+      import importlib.resources
+
+      print(version("mede"))
+      print(importlib.resources.files("mede") / "models" / "mednext_deface.pth")
+      PY
+      test -s /opt/easyocr/model/craft_mlt_25k.pth
+      test -s /opt/easyocr/model/english_g2.pth


### PR DESCRIPTION
## Summary
- add a new MEDE recipe for TIO-IKIM medical image de-identification
- pin the Python dependency set through a declared requirements file
- add full smoke tests for the CLI and cached EasyOCR models

## Validation
- env/bin/python builder/validation.py recipes/mede/build.yaml
- env/bin/python -m builder generate mede --recreate --architecture x86_64
- env/bin/python -m builder generate mede --recreate --architecture aarch64
- docker buildx build --check -f build/mede/mede_0.0.12.Dockerfile --build-context neurocontainer-cache=build/mede/cache build/mede
- env/bin/python -m builder build mede --recreate --architecture aarch64
- env/bin/python workflows/container_tester.py mede:0.0.12 --runtime docker --location docker --test-config recipes/mede/fulltest.yaml --verbose -o /tmp/neurocontainers-test-results/mede.json