### PR TITLE
[codex] Fix ANTs and tgvqsm autobuild failures

### DIFF
--- a/builder/templates/ants.yaml
+++ b/builder/templates/ants.yaml
@@ -11,6 +11,7 @@ binaries:
     2.6.2: https://github.com/ANTsX/ANTs/releases/download/v2.6.2/ants-2.6.2-centos7-X64-gcc.zip
     2.5.1: https://github.com/ANTsX/ANTs/releases/download/v2.5.1/ants-2.5.1-centos7-X64-gcc.zip
     2.4.3: https://github.com/ANTsX/ANTs/releases/download/v2.4.3/ants-2.4.3-centos7-X64-gcc.zip
+    2.3.4: https://zenodo.org/api/records/15230173/files/ants-Linux-centos6_x86_64-v2.3.4.tar.gz/content
     2.3.1: https://dl.dropbox.com/s/1xfhydsf4t4qoxg/ants-Linux-centos6_x86_64-v2.3.1.tar.gz
   dependencies:
     apt:

--- a/recipes/tgvqsm/build.yaml
+++ b/recipes/tgvqsm/build.yaml
@@ -10,12 +10,11 @@ build:
   pkg-manager: apt
   directives:
     - install:
-        - wget
-        - unzip
-        - gcc
+        - build-essential
         - cmake
         - git
-        - g++
+        - unzip
+        - wget
     - run:
         - git clone https://github.com/liangfu/bet2.git
     - workdir: /bet2/build


### PR DESCRIPTION
## Summary

- add ANTs 2.3.4 to the local ANTs template using the Zenodo mirror for the precompiled Linux amd64 tarball
- install `build-essential` in the `tgvqsm` recipe so `cmake .. && make` has a Makefiles build program available

## Root Cause

`mrtrix3src` requested ANTs 2.3.4, but the local template did not define a URL for that version. `tgvqsm` installed compilers and CMake, but not `make`, so the bet2 build failed with `CMAKE_MAKE_PROGRAM is not set`.

## Validation

```bash
env/bin/python -m builder build mrtrix3src --recreate --generate-release --dry-run --architecture x86_64
env/bin/python -m builder build tgvqsm --recreate --generate-release --dry-run --architecture x86_64
env/bin/python builder/validation.py recipes/mrtrix3src/build.yaml
env/bin/python builder/validation.py recipes/tgvqsm/build.yaml
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782277963&installation_id=131548984&pr_number=2431&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2431&signature=c8ef07f83834c5017ca49a73119b1851f746de89386fdba15cd7916b2a3e58f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->