### PR TITLE
[codex] Pin spm12bi Miniconda installer

### DIFF
--- a/recipes/spm12bi/build.yaml
+++ b/recipes/spm12bi/build.yaml
@@ -43,7 +43,7 @@ build:
         - chmod +x /opt/spm12/*
     - template:
         name: miniconda
-        version: latest
+        version: py38_4.12.0
         conda_install: python=3.8 traits nipype numpy scipy h5py scikit-image
     - environment:
         PATH: /opt/spm12:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
## Summary

- pin the `spm12bi` Miniconda template to `py38_4.12.0` instead of `latest`

## Root Cause

`spm12bi` needs the Ubuntu 16.04 / glibc 2.23 stack for SPM12 and MCR compatibility, but the current latest Miniconda installer requires glibc >= 2.28. Pinning an archived Python 3.8 Miniconda installer keeps the recipe compatible with the older base image.

## Validation

```bash
env/bin/python builder/validation.py recipes/spm12bi/build.yaml
env/bin/python -m builder build spm12bi --recreate --generate-release --dry-run --architecture x86_64
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782278812&installation_id=131548984&pr_number=2432&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2432&signature=b90b2c03b185bdda2f210e84231ddcadc69746eade620cefaa317e7ec8458876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->