### PR TITLE
[codex] Fix tgvqsm dcm2niix install

### DIFF
--- a/recipes/tgvqsm/build.yaml
+++ b/recipes/tgvqsm/build.yaml
@@ -23,7 +23,6 @@ build:
     - template:
         name: dcm2niix
         version: latest
-        method: source
     - workdir: /
     - run:
         - wget https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh
@@ -49,7 +48,7 @@ deploy:
   path:
     - /opt/tgvqsm-{{ context.version }}/
     - /bet2/
-    - /opt/dcm2niix-latest/bin
+    - /opt/dcm2niix-latest
 
 readme: |-
   


### PR DESCRIPTION
## Summary
- switch `tgvqsm`'s `dcm2niix` template usage from source build to the prebuilt binary install
- update the deployed `dcm2niix` path to match the binary template layout

## Root cause
The auto-build failure for `tgvqsm` moved past the earlier missing `make` issue and failed while compiling latest upstream `dcm2niix` from source on `ubuntu:16.04`. The current `dcm2niix` source CMake configuration uses `check_ipo_supported`, which is unavailable in the old CMake provided by Ubuntu 16.04.

Using the template's binary install avoids compiling current upstream source with the old base image toolchain.

## Validation
- `env/bin/python builder/validation.py recipes/tgvqsm/build.yaml`
- `env/bin/python -m builder build tgvqsm --recreate --generate-release --dry-run --architecture x86_64`
- confirmed the rendered Dockerfile downloads `dcm2niix_lnx.zip` instead of running CMake for `dcm2niix`
- confirmed the latest release zip resolves and contains the `dcm2niix` executable

Full local Docker build could not be run because the Docker daemon is not available locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782279420&installation_id=131548984&pr_number=2433&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2433&signature=977c9b26c97cba56c256b60849ef91ee610037fd392969d267894decb2c20b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->