### PR TITLE
[codex] Use npm for neurodesktop launcher build

### DIFF
--- a/recipes/neurodesktop/extensions/neurodesk-launcher/build_ext.js
+++ b/recipes/neurodesktop/extensions/neurodesk-launcher/build_ext.js
@@ -1,0 +1,58 @@
+/**
+ * Build helper for the neurodesk-launcher JupyterLab extension.
+ *
+ * This script finds the JupyterLab staging directory via Python, then calls
+ * build-labextension with the correct --core-path. This avoids shell-specific
+ * quoting issues in package manager wrappers.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+function getStagingPath() {
+  const pythonCmd = [
+    'import importlib.util, pathlib',
+    'spec = importlib.util.find_spec("jupyterlab")',
+    'print(pathlib.Path(next(iter(spec.submodule_search_locations))) / "staging")'
+  ].join('; ');
+  const candidates = ['python3', 'python'];
+  for (const py of candidates) {
+    try {
+      const result = execFileSync(py, ['-c', pythonCmd], { encoding: 'utf8' });
+      const path = result.trim();
+      if (path) {
+        return path;
+      }
+    } catch (_) {
+      // Try the next Python executable.
+    }
+  }
+  return null;
+}
+
+const corePath = getStagingPath();
+if (!corePath) {
+  console.error('ERROR: Could not determine JupyterLab staging path. Is jupyterlab installed?');
+  process.exit(1);
+}
+
+console.log('Building neurodesk-launcher with --core-path: ' + corePath);
+
+let buildLabextensionPath;
+try {
+  buildLabextensionPath = require.resolve('@jupyterlab/builder/lib/build-labextension');
+} catch (error) {
+  console.error('ERROR: Could not resolve @jupyterlab/builder/lib/build-labextension:', error.message);
+  process.exit(1);
+}
+
+try {
+  execFileSync(
+    'node',
+    [buildLabextensionPath, '--core-path', corePath, '.'],
+    { stdio: 'inherit', cwd: __dirname }
+  );
+} catch (error) {
+  process.exit(error.status || 1);
+}

--- a/recipes/neurodesktop/extensions/neurodesk-launcher/package.json
+++ b/recipes/neurodesktop/extensions/neurodesk-launcher/package.json
@@ -11,8 +11,8 @@
     "style/**/*.css"
   ],
   "scripts": {
-    "build": "tsc && jupyter labextension build .",
-    "build:prod": "tsc && jupyter labextension build .",
+    "build": "tsc && node build_ext.js",
+    "build:prod": "tsc && node build_ext.js",
     "clean": "rimraf lib tsconfig.tsbuildinfo"
   },
   "dependencies": {

--- a/recipes/neurodesktop/extensions/neurodesk-launcher/pyproject.toml
+++ b/recipes/neurodesktop/extensions/neurodesk-launcher/pyproject.toml
@@ -16,7 +16,9 @@ requires-python = ">=3.9"
 [tool.hatch.build.targets.sdist]
 include = [
     "neurodesk_launcher/**",
+    "build_ext.js",
     "package.json",
+    "package-lock.json",
     "tsconfig.json",
     "src/**",
     "style/**",
@@ -35,12 +37,12 @@ ensured-targets = [
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
-npm = ["jlpm"]
+npm = ["npm"]
 source_dir = "src"
 build_dir = "neurodesk_launcher/labextension"
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 build_cmd = "build"
-npm = ["jlpm"]
+npm = ["npm"]
 source_dir = "src"
 build_dir = "neurodesk_launcher/labextension"


### PR DESCRIPTION
## Summary
- switch the Neurodesktop launcher extension build from `jlpm` to `npm`
- add the upstream `build_ext.js` helper used by `neurodesk/neurodesktop`
- include `build_ext.js` and `package-lock.json` in the launcher sdist inputs

## Root cause
The manual `neurodesktop` build failed while running `pip install .` for `/tmp/neurodesk-launcher`. The extension build was configured to use `jlpm`, but the extension only commits `package-lock.json`, not `yarn.lock`. That let Yarn resolve fresh JavaScript dependencies in CI and pull a newer webpack stack, which failed inside `license-webpack-plugin` during `jupyter labextension build`.

This mirrors the current `neurodesk/neurodesktop` launcher build path, where `hatch-jupyter-builder` invokes npm and the package script calls `node build_ext.js`.

## Validation
- `env/bin/python builder/validation.py recipes/neurodesktop/build.yaml`
- `npm ci --ignore-scripts` in `recipes/neurodesktop/extensions/neurodesk-launcher`
- `env/bin/python -m builder build neurodesktop --recreate --generate-release --dry-run --architecture aarch64`
- checked the generated Dockerfile still copies `extensions/neurodesk-launcher` and runs `pip install .`

`npm run build:prod` gets through TypeScript locally, then stops because this host Python environment does not have JupyterLab installed. The actual Neurodesktop base image provides JupyterLab for that helper.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782369824&installation_id=131548984&pr_number=2435&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2435&signature=c6b016a242a2d308c055f018baec261f63379d9d3895e35e7aa9720bae84e2cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->