### PR TITLE
[codex] Use temp npm cache for neurodesktop launcher

### DIFF
--- a/recipes/neurodesktop/extensions/neurodesk-launcher/pyproject.toml
+++ b/recipes/neurodesktop/extensions/neurodesk-launcher/pyproject.toml
@@ -37,12 +37,12 @@ ensured-targets = [
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
-npm = ["npm"]
+npm = ["npm", "--cache", "/tmp/neurodesk-launcher-npm-cache"]
 source_dir = "src"
 build_dir = "neurodesk_launcher/labextension"
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 build_cmd = "build"
-npm = ["npm"]
+npm = ["npm", "--cache", "/tmp/neurodesk-launcher-npm-cache"]
 source_dir = "src"
 build_dir = "neurodesk_launcher/labextension"


### PR DESCRIPTION
## Summary
- make the Neurodesktop launcher hatch build use `/tmp/neurodesk-launcher-npm-cache` for npm

## Root cause
After switching the launcher extension build from `jlpm` to `npm`, the manual arm64 Neurodesktop build progressed past the previous webpack/license error but failed during `npm install` because the build ran as `jovyan` while npm tried to use `/home/jovyan/.npm`, which contained root-owned files from earlier image layers.

Using a temporary build cache avoids the mixed-ownership home cache during `pip install .`.

## Validation
- `env/bin/python builder/validation.py recipes/neurodesktop/build.yaml`
- `npm --cache /tmp/neurodesk-launcher-npm-cache ci --ignore-scripts` in the launcher directory
- `env/bin/python -m builder build neurodesktop --recreate --generate-release --dry-run --architecture aarch64`

The full Docker build is being validated by rerunning the manual arm64 workflow after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782370729&installation_id=131548984&pr_number=2436&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2436&signature=fe4df4be441978c59cbbb76dee502c3e8ed78dbacdb964722fcb823484cab77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->