### PR TITLE
Add release for startrack 20250920

### DIFF
--- a/releases/startrack/20250920.json
+++ b/releases/startrack/20250920.json
@@ -1,0 +1,18 @@
+{
+  "apps": {
+    "startrack 20250920": {
+      "version": "20260526",
+      "exec": "",
+      "apptainer_args": []
+    },
+    "StarTrack-startrack 20250920": {
+      "version": "20260526",
+      "exec": "startrack",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "diffusion imaging",
+    "tractography"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **startrack 20250920**.

## Changes

- Add `releases/startrack/20250920.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh startrack 20250920 20260526
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/startrack_20250920_20260526.simg -O
singularity shell --overlay /tmp/apptainer_overlay startrack_20250920_20260526.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/neurodesk/codesmith/neurocontainers/pr/2442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782452620&installation_id=131548984&pr_number=2442&repository=neurodesk%2Fneurocontainers&return_to=https%3A%2F%2Fgithub.com%2Fneurodesk%2Fneurocontainers%2Fpull%2F2442&signature=03e7e099f7aaf02f1d8e36b8f13ba0d0728c0885c1cca26f17df3d1e0125d007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->