### PR TITLE
[codex] Avoid duplicate container builds in workflow

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -178,11 +178,11 @@ jobs:
           fi
           python3 -m pip install ${PIP_BREAK_SYSTEM_PACKAGES} -r requirements.txt
 
-      - name: Generate Dockerfile and Release file
+      - name: Generate Dockerfile and stage metadata
         id: generate
         run: |
           echo "APPLICATION: $APPLICATION"
-          python3 -m builder build "$APPLICATION" --recreate --generate-release
+          python3 -m builder stage "$APPLICATION" --recreate --architecture "$ARCHITECTURE"
 
       - name: Set image variables
         id: imgvars
@@ -323,11 +323,11 @@ jobs:
           fi
           python3 -m pip install ${PIP_BREAK_SYSTEM_PACKAGES} -r requirements.txt
 
-      - name: Generate Dockerfile and Release file
+      - name: Generate Dockerfile and stage build context
         id: generate
         run: |
           echo "APPLICATION: $APPLICATION"
-          python3 -m builder build "$APPLICATION" --recreate --generate-release --architecture "$ARCHITECTURE"
+          python3 -m builder stage "$APPLICATION" --recreate --download --architecture "$ARCHITECTURE"
 
       - name: Set image variables
         id: imgvars

--- a/builder/cli.py
+++ b/builder/cli.py
@@ -115,7 +115,14 @@ def cmd_generate(args: argparse.Namespace) -> int:
 def cmd_stage(args: argparse.Namespace) -> int:
     config, compiled = compile_from_args(args)
     output_root = args.output_root or config.output_root
-    build_dir, dockerfile_path = write_build_files(config.repo_root, compiled, output_root, recreate=args.recreate, stage=True)
+    build_dir, dockerfile_path = write_build_files(
+        config.repo_root,
+        compiled,
+        output_root,
+        recreate=args.recreate,
+        stage=True,
+        download=args.download,
+    )
     summary = {
         "name": compiled.name,
         "version": compiled.version,
@@ -318,6 +325,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     stage = subparsers.add_parser("stage", help="Generate a Dockerfile and stage files")
     add_common_recipe_args(stage)
+    stage.add_argument("--download", action="store_true", help="Download URL-backed declared files")
     stage.set_defaults(func=cmd_stage)
 
     release = subparsers.add_parser("release", help="Generate release JSON")

--- a/builder/tests/test_cli.py
+++ b/builder/tests/test_cli.py
@@ -36,3 +36,30 @@ def test_cmd_login_returns_docker_exit_code_without_traceback(
 
     assert cli.cmd_login(args) == 130
     assert commands == [["docker", "run", "--rm", "-it", "tool:1.0"]]
+
+
+def test_cmd_stage_can_download_declared_url_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    compiled = SimpleNamespace(
+        name="tool",
+        version="1.0",
+        architecture="x86_64",
+        staging_plan=SimpleNamespace(files={"archive": object()}),
+    )
+    config = SimpleNamespace(repo_root=object(), output_root=object())
+    build_dir = SimpleNamespace()
+    dockerfile_path = SimpleNamespace()
+
+    def fake_write_build_files(*args, **kwargs):
+        calls.append(kwargs)
+        return build_dir, dockerfile_path
+
+    monkeypatch.setattr(cli, "compile_from_args", lambda args: (config, compiled))
+    monkeypatch.setattr(cli, "write_build_files", fake_write_build_files)
+
+    args = argparse.Namespace(output_root=None, recreate=True, download=True)
+
+    assert cli.cmd_stage(args) == 0
+    assert calls == [{"recreate": True, "stage": True, "download": True}]

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -28,6 +28,18 @@ def test_create_pr_job_generates_release_without_rebuilding() -> None:
     )
 
 
+def test_build_app_workflow_stages_without_hidden_docker_builds() -> None:
+    workflow = Path(".github/workflows/build-app.yml").read_text()
+    config_job = workflow.split("  config:", 1)[1].split("  build-image:", 1)[0]
+    build_image_job = workflow.split("  build-image:", 1)[1].split("  push-dockerhub:", 1)[0]
+
+    assert 'python3 -m builder stage "$APPLICATION" --recreate --architecture "$ARCHITECTURE"' in config_job
+    assert 'python3 -m builder stage "$APPLICATION" --recreate --download --architecture "$ARCHITECTURE"' in build_image_job
+    assert "python3 -m builder build" not in config_job
+    assert "python3 -m builder build" not in build_image_job
+    assert "docker buildx build" in build_image_job
+
+
 def test_nectar_mirrors_are_best_effort() -> None:
     workflow = Path(".github/workflows/build-app.yml").read_text()
     push_nectar_job = workflow.split("  push-nectar-registry:", 1)[1].split("  build-simg:", 1)[0]


### PR DESCRIPTION
## Summary

This PR removes hidden duplicate Docker builds from the container build workflow.

## Root Cause

`build-app.yml` called `python3 -m builder build ...` in both the `config` and `build-image` jobs. With the new builder, `builder build` stages files and invokes Docker. The workflow then invoked `docker buildx build` again in the explicit `Build new image` step, so a container could be built multiple times across workflow stages.

In the referenced run, the hidden build in `config` failed on the Debian 9 apt repositories before the intended `build-image` job could run.

## Changes

- Replace hidden `builder build` calls in `config` and `build-image` with `builder stage`.
- Add `builder stage --download` so workflow staging can materialize URL-backed declared files without invoking Docker.
- Keep the single real image build in the existing `docker buildx build` step.
- Add workflow contract and CLI tests covering the new behavior.

## Validation

```bash
pytest builder/tests/test_workflow_contract.py builder/tests/test_cli.py builder/tests/test_staging.py -q
```

Result: `17 passed`.
