### PR TITLE
[codex] Fix mneextended Debian Stretch base

### DIFF
--- a/recipes/mneextended/build.yaml
+++ b/recipes/mneextended/build.yaml
@@ -6,7 +6,7 @@ architectures:
 
 build:
   kind: neurodocker
-  base-image: debian:9
+  base-image: debian/eol:stretch
   pkg-manager: apt
   directives:
     - environment:


### PR DESCRIPTION
## Summary

Switch `mneextended` from `debian:9` to Docker's official `debian/eol:stretch` image.

## Why

The recipe intentionally remains on Debian 9 / Stretch, but the normal `debian:9` image points apt at repositories that now return 404s. The generated NeuroContainers default setup layer runs `apt-get update` before any recipe directives, so the recipe cannot repair sources later in the Dockerfile.

Using `debian/eol:stretch` keeps the container on Debian Stretch while using the maintained EOL image variant with archive-compatible apt metadata.

## Validation

```bash
python builder/validation.py recipes/mneextended/build.yaml --verbose
python -m builder stage mneextended --recreate --download --architecture x86_64
python -m builder build mneextended --recreate --architecture x86_64 --dry-run
pytest builder/tests/test_dockerfile_generation.py builder/tests/test_workflow_contract.py -q
```

Notes: I could not run a local Docker/Podman build because neither Docker Desktop nor the Podman VM/socket is running on this machine. The PR workflow should exercise the real build path.
