### PR TITLE
[codex] Skip SIF uploads when SIF build is skipped

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -752,7 +752,7 @@ jobs:
 
   build-simg:
     needs: [config, build-image]
-    if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_nectar == 'true' || inputs.force_upload_s3 == 'true' || inputs.skip_simg_build == 'false' }}
+    if: ${{ inputs.skip_simg_build != 'true' && (needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_nectar == 'true' || inputs.force_upload_s3 == 'true' || inputs.skip_simg_build == 'false') }}
     runs-on: ${{ contains(inputs.runner, 'arm') && 'blacksmith-8vcpu-ubuntu-2404-arm' || 'ubuntu-22.04' }}
     permissions:
       packages: write
@@ -874,7 +874,7 @@ jobs:
 
   upload-nectar:
     needs: [config, build-image, build-simg]
-    if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_nectar == 'true' }}
+    if: ${{ inputs.skip_simg_build != 'true' && (needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_nectar == 'true') }}
     # Nectar object storage is a best-effort mirror; S3 remains the blocking upload.
     continue-on-error: true
     runs-on: ${{ fromJSON(inputs.runner) }}
@@ -961,7 +961,7 @@ jobs:
 
   upload-s3:
     needs: [config, build-image, build-simg]
-    if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_s3 == 'true' }}
+    if: ${{ inputs.skip_simg_build != 'true' && (needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_upload_s3 == 'true') }}
     runs-on: ubuntu-22.04
     permissions:
       packages: write

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -49,6 +49,17 @@ def test_nectar_mirrors_are_best_effort() -> None:
     assert "continue-on-error: true" in upload_nectar_job
 
 
+def test_simg_upload_jobs_are_skipped_when_simg_build_is_skipped() -> None:
+    workflow = Path(".github/workflows/build-app.yml").read_text()
+    build_simg_header = workflow.split("  build-simg:", 1)[1].split("    runs-on:", 1)[0]
+    upload_nectar_header = workflow.split("  upload-nectar:", 1)[1].split("    # Nectar", 1)[0]
+    upload_s3_header = workflow.split("  upload-s3:", 1)[1].split("    runs-on:", 1)[0]
+
+    assert "inputs.skip_simg_build != 'true'" in build_simg_header
+    assert "inputs.skip_simg_build != 'true'" in upload_nectar_header
+    assert "inputs.skip_simg_build != 'true'" in upload_s3_header
+
+
 def test_create_pr_job_does_not_wait_for_nectar_mirrors() -> None:
     workflow = Path(".github/workflows/build-app.yml").read_text()
     create_pr_header = workflow.split("  create-pr:", 1)[1].split("    steps:", 1)[0]


### PR DESCRIPTION
## Summary

Fixes manual builds with `skip_simg_build: true` so the SIF build and upload jobs are not eligible to run.

## Why

When a manual build skipped SIF creation but the Docker image differed, the downstream upload jobs could still run and fail late with missing `.simg` file errors. The upload jobs now share the same `inputs.skip_simg_build != 'true'` guard as the artifact-producing path.

Closes #2438.

## Validation

- Parsed `.github/workflows/build-app.yml` and `.github/workflows/manual-build.yml` with PyYAML
- `git diff --check`
- `uv run --with pytest pytest builder/tests/test_workflow_contract.py`
