### PR TITLE
[codex] Set DAFNE runtime config paths

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -53,6 +53,12 @@ build:
         pip_install: "{{ context.pip_install }}"
         version: py38_22.11.1-1
 
+    - environment:
+        HOME: /tmp
+        XDG_CACHE_HOME: /tmp/.cache
+        XDG_CONFIG_HOME: /tmp/.config
+        XDG_DATA_HOME: /tmp/.local/share
+
 deploy:
   bins:
     - dafne


### PR DESCRIPTION
## Summary

Sets DAFNE's runtime home/config/cache/data paths to writable `/tmp` locations.

## Why

PR #2476's release test failed because DAFNE resolves its appdirs cache/log path under `/home/ubuntu/.cache/Dafne` and tries to create that path at import time. The Apptainer runtime does not provide a writable `/home/ubuntu`, so `dafne` fails before it can start.

This recipe now sets `HOME`, `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` to `/tmp`-based paths so DAFNE can create its runtime directories without depending on `/home`.

Related to #2476.

## Validation

- `python3 builder/validation.py recipes/dafne/build.yaml`
- `python3 -m builder generate dafne --recreate --architecture x86_64`

Note: I could not run a local container test because Docker is not installed in this workspace.
