### PR TITLE
[codex] Fix release PR upload race

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1008,7 +1008,7 @@ jobs:
           fi
 
   create-pr:
-    needs: [config, build-image, push-dockerhub, upload-s3]
+    needs: [config, build-image, push-dockerhub, upload-nectar, upload-s3]
     if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_create_pr == 'true'}}
     runs-on: ubuntu-22.04
     permissions:

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -60,16 +60,6 @@ def test_simg_upload_jobs_are_skipped_when_simg_build_is_skipped() -> None:
     assert "inputs.skip_simg_build != 'true'" in upload_s3_header
 
 
-def test_create_pr_job_does_not_wait_for_nectar_mirrors() -> None:
-    workflow = Path(".github/workflows/build-app.yml").read_text()
-    create_pr_header = workflow.split("  create-pr:", 1)[1].split("    steps:", 1)[0]
-
-    assert "push-dockerhub" in create_pr_header
-    assert "upload-s3" in create_pr_header
-    assert "push-nectar-registry" not in create_pr_header
-    assert "upload-nectar" not in create_pr_header
-
-
 def test_nectar_registry_username_is_explicit() -> None:
     workflow = Path(".github/workflows/build-app.yml").read_text()
     push_nectar_job = workflow.split("  push-nectar-registry:", 1)[1].split("  build-simg:", 1)[0]

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -381,8 +381,8 @@ class ReleaseContainerDownloader:
         )
         os.makedirs(self.cache_dir, exist_ok=True)
 
-        # Prefer Nectar, but fall back to the AWS S3 mirror because release PR
-        # tests can start before the best-effort Nectar upload is available.
+        # Prefer Nectar, matching NeuroDesk's public release path, and fall back
+        # to the AWS S3 mirror if Nectar is unavailable.
         self.base_urls = [
             (
                 "Nectar Object Storage",


### PR DESCRIPTION
## Summary

- Make the release-file PR job wait for the Nectar SIF upload before opening release PRs.
- Keep the release test runner's Nectar-first behavior, but update the comment now that PR creation waits for that public release path.
- Remove the old brittle workflow-string test that asserted release PRs should not wait for Nectar.

## Root cause

PR #2483 opened after the S3 upload finished but before the Nectar upload finished. The release PR test downloads from Nectar first, so it tested a stale same-day SIF and reproduced the old DAFNE home/cache failure.

## Validation

- `.venv/bin/python` workflow dependency assertion for `create-pr` needs
- `.venv/bin/python` YAML parse for `.github/workflows/build-app.yml`
- `git diff --check`

Note: full pytest was not available locally because neither `.venv/bin/python -m pytest` nor `uv run pytest` could find an installed `pytest` executable.

Refs #2483
