### PR TITLE
[codex] Fix DAFNE headless startup test

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -18,9 +18,9 @@ variables:
         condition: arch=="aarch64"
   pip_install:
     try:
-      - value: "pyradiomics dafne==1.8a4"
+      - value: "SimpleITK==2.4.1 pyradiomics dafne==1.8a4"
         condition: arch=="x86_64"
-      - value: "tensorflow==2.13.1 pyradiomics dafne==1.8a4"
+      - value: "tensorflow==2.13.1 SimpleITK==2.4.1 pyradiomics dafne==1.8a4"
         condition: arch=="aarch64"
 
 build:
@@ -45,6 +45,8 @@ build:
         - libsm6
         - libxrender1
         - libxext6
+        - xauth
+        - xvfb
 
     - template:
         name: miniconda

--- a/recipes/dafne/test.yaml
+++ b/recipes/dafne/test.yaml
@@ -1,4 +1,13 @@
 tests:
   - name: Test dafne
     script: |
-      dafne
+      python -c "import SimpleITK; import dafne; print(dafne.__version__)"
+      set +e
+      timeout 20s xvfb-run -a dafne >/tmp/dafne.log 2>&1
+      status=$?
+      set -e
+      if [ "$status" -eq 0 ] || [ "$status" -eq 124 ]; then
+        exit 0
+      fi
+      cat /tmp/dafne.log
+      exit "$status"


### PR DESCRIPTION
## Summary

- Preinstall `SimpleITK==2.4.1` in the DAFNE recipe so Flexidep does not prompt interactively at import time.
- Add `xauth` and `xvfb` so the DAFNE GUI can be smoke-tested under a virtual display.
- Update the existing DAFNE smoke test to verify import-time dependency setup and run a bounded GUI startup probe with `xvfb-run`.

## Root cause

After the runtime cache-dir fix, the release test for #2483 got further and failed because DAFNE's Flexidep dependency manager tried to open a Tk dialog in headless CI while asking which `SimpleITK` alternative to install.

## Validation

- `.venv/bin/python builder/validation.py recipes/dafne/build.yaml`
- `.venv/bin/python -m builder generate dafne --recreate --architecture x86_64`
- `.venv/bin/python -m builder generate dafne --recreate --architecture aarch64`
- Verified `SimpleITK==2.4.1` has Python 3.8 wheels for x86_64 and aarch64 with `pip download`
- `git diff --check`

Refs #2483
