### PR TITLE
[codex] Fix PreQual FSL conda ToS install

### DIFF
--- a/builder/templates/fsl.yaml
+++ b/builder/templates/fsl.yaml
@@ -10,6 +10,7 @@ binaries:
       install_path: /opt/fsl-{{ self.version }}
       exclude_paths: ''
       fslpython_debug: 'false'
+      fslpython_accept_tos: 'false'
   urls:
     6.0.7.22: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
     6.0.7.18: https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py
@@ -97,6 +98,15 @@ binaries:
       {%- endfor %}
       {%- endif %}
       {% if self.version not in ("5.0.9", "5.0.8") -%}
+      {% if self.fslpython_accept_tos.lower() in ["true", "y", "1"] -%}
+      fslpython_installer={{ self.install_path }}/etc/fslconf/fslpython_install.sh
+      grep -q 'env create -f .*fslpython_environment.yml' "$fslpython_installer"
+      sed -i '/env create -f .*fslpython_environment.yml/i\
+      if "${miniconda_bin_dir}/conda" tos --help >/dev/null; then\
+        "${miniconda_bin_dir}/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main;\
+        "${miniconda_bin_dir}/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r;\
+      fi' "$fslpython_installer"
+      {% endif -%}
       echo "Installing FSL conda environment ..."
       {% if self.fslpython_debug.lower() in ["true", "y", "1"] -%}
       bash {{ self.install_path }}/etc/fslconf/fslpython_install.sh -f {{ self.install_path }} || \

--- a/recipes/prequal/build.yaml
+++ b/recipes/prequal/build.yaml
@@ -70,6 +70,7 @@ build:
         version: 6.0.4
         install_path: /APPS/fsl
         fslpython_debug: "true"
+        fslpython_accept_tos: "true"
     - template:
         name: convert3d
         version: 1.0.0


### PR DESCRIPTION
## Summary
- add an explicit `fslpython_accept_tos` option to the legacy FSL template
- enable it for PreQual so FSL 6.0.4 accepts the required Anaconda `pkgs/main` and `pkgs/r` channels before creating the bundled fslpython environment
- keep the existing debug logging enabled for any future FSL installer failures

## Root Cause
Issue #2487 failed after the previous debug logging exposed the actual installer error: FSL 6.0.4's bundled `fslpython_install.sh` now hits Conda's noninteractive Anaconda Terms of Service check during `conda env create`.

Closes #2487.

## Validation
- `.venv/bin/python builder/validation.py recipes/prequal/build.yaml`
- `.venv/bin/python -m builder generate prequal --recreate --architecture x86_64`

Note: I did not add a regression test because this is a recipe/template rendering fix and the generated Dockerfile check covers the behavior without adding a brittle string-only test.
