### PR TITLE
Fix dcm2niix README version heading

### DIFF
--- a/recipes/dcm2niix/build.yaml
+++ b/recipes/dcm2niix/build.yaml
@@ -64,7 +64,7 @@ deploy:
 
 readme: |-
   ----------------------------------
-  ## dcm2niix/{{ context.version }}' ##
+  ## dcm2niix/{{ context.version }} ##
   dcm2niix is designed to convert neuroimaging data from the DICOM format to the NIfTI format. This web page hosts the developmental source code - a compiled version for Linux, MacOS, and Windows of the most recent stable release is included with MRIcroGL. A full manual for this software is available in the form of a NITRC wiki.
 
   Example:


### PR DESCRIPTION
## Summary

- remove a stray apostrophe from the generated dcm2niix README version heading

## Evidence

- `python3` + `yaml.safe_load` parsed `recipes/dcm2niix/build.yaml` and `recipes/dcm2niix/fulltest.yaml`
- `python3 builder/validation.py recipes/dcm2niix/build.yaml`
- `python3 -m builder generate dcm2niix --recreate --architecture x86_64`
- `python3 -m builder generate dcm2niix --recreate --architecture aarch64`
- `python3 -m builder test dcm2niix --dry-run --architecture x86_64`
- `git diff --check`

## Not run

- Full Docker/SIF build; this is a generated README text cleanup only.