### PR TITLE
[codex] Fix code browser dependency

### DIFF
--- a/recipes/code/build.yaml
+++ b/recipes/code/build.yaml
@@ -20,7 +20,7 @@ build:
         pip_install: "osfclient"
 
     - install:
-        - midori
+        - firefox-esr
         - xdg-utils
         - python3-pyqt5
         - unzip


### PR DESCRIPTION
## Summary
- replace the unavailable Debian `midori` package with `firefox-esr` in the `code` recipe
- keep `xdg-utils` so the original browser-opening/inception-mode behavior still has a browser target

## Root Cause
The auto-build in #2495 failed because `recipes/code/build.yaml` installs `midori`, but `midori` is not available in the Debian Bookworm repositories used by the `code` image. History shows `midori` was originally added with `xdg-utils` for "inception mode", so `firefox-esr` preserves the browser dependency with a currently packaged Debian option.

Closes #2495.

## Validation
- `.venv/bin/python builder/validation.py recipes/code/build.yaml`
- `.venv/bin/python -m builder generate code --recreate --architecture x86_64`
- checked the generated Dockerfile contains `firefox-esr` and no `midori`
