### PR TITLE
[codex] Add local OpenRefine webapp icon

### DIFF
--- a/recipes/openrefine/build.yaml
+++ b/recipes/openrefine/build.yaml
@@ -71,7 +71,7 @@ deploy:
     - refine
   webapp:
     title: OpenRefine
-    icon: https://openrefine.org/img/openrefine_logo.svg
+    icon: icon.svg
     startup_command: "openrefine start"
     startup_timeout: 180
     description: "Data cleaning and transformation tool"

--- a/recipes/openrefine/icon.svg
+++ b/recipes/openrefine/icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 47.66 186.63 139.97">
+  <title>OpenRefine logo (2018)</title>
+  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <polygon id="Stroke-25" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="46.6561 94.3132 46.6561 47.6562 93.3131 47.6562" fill="#00dcff"/>
+    <polygon id="Stroke-27" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="46.6561 94.3132 46.6561 47.6562 0.0001 94.3132" fill="#00ffff"/>
+    <polygon id="Stroke-29" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="139.9696 94.3132 139.9696 47.6562 93.3136 47.6562" fill="#00b4ff"/>
+    <polygon id="Stroke-31" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="46.6561 94.3132 93.3131 47.6562 139.9691 94.3132" fill="#00c8ff"/>
+    <polygon id="Stroke-33" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="139.9696 94.3132 139.9696 47.6562 186.6256 94.3132" fill="#00a0ff"/>
+    <polygon id="Stroke-35" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="46.6561 94.3132 0.0001 94.3132 93.3131 187.6262" fill="#00c8ff"/>
+    <polygon id="Stroke-37" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="139.9696 94.3132 46.6566 94.3132 93.3136 187.6262" fill="#00a0ff"/>
+    <polygon id="Stroke-39" stroke="none" stroke-width="4px" stroke-linecap="round" stroke-linejoin="round" points="186.6258 94.3132 139.9698 94.3132 93.3138 187.6262" fill="#0078ff"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What changed

- Added the official OpenRefine logo as recipes/openrefine/icon.svg.
- Updated the OpenRefine webapp metadata to reference the checked-in local SVG.

## Why

The webapp metadata generator treats local icon paths as recipe files and rewrites them to raw GitHub URLs. The previous external OpenRefine icon URL was interpreted as a missing local file and stripped from generated webapps.json, causing Neurodesktop to fall back to the default Neurodesk icon.

## Validation

- env/bin/python builder/validation.py recipes/openrefine/build.yaml
- python3 tools/generate_webapps_json.py --recipes-dir recipes --releases-dir releases --output /tmp/neurocontainers-openrefine-webapps-check.json
