### PR TITLE
Fix legacy FSL fslpython install

### DIFF
--- a/builder/templates/fsl.yaml
+++ b/builder/templates/fsl.yaml
@@ -98,11 +98,16 @@ binaries:
       {%- endfor %}
       {%- endif %}
       {% if self.version not in ("5.0.9", "5.0.8") -%}
-      {% if self.fslpython_accept_tos.lower() in ["true", "y", "1"] -%}
       fslpython_installer={{ self.install_path }}/etc/fslconf/fslpython_install.sh
-      grep -q 'env create -f .*fslpython_environment.yml' "$fslpython_installer"
-      sed -i '/env create -f .*fslpython_environment.yml/i\
-      if "${miniconda_bin_dir}/conda" tos --help >/dev/null; then\
+      fslpython_environment={{ self.install_path }}/etc/fslconf/fslpython_environment.yml
+      sed -i 's/Miniconda3-latest-Linux-x86_64.sh/Miniconda3-py39_24.7.1-0-Linux-x86_64.sh/' "$fslpython_installer"
+      if ! grep -q '^ - requests' "$fslpython_environment"; then
+        sed -i '/^ - pip:/i\ - requests<2.32' "$fslpython_environment";
+      fi
+      {% if self.fslpython_accept_tos.lower() in ["true", "y", "1"] -%}
+      grep -q 'conda" env create' "$fslpython_installer"
+      sed -i '/conda" env create/i\
+      if "${miniconda_bin_dir}/conda" tos --help >/dev/null 2>\&1; then\
         "${miniconda_bin_dir}/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main;\
         "${miniconda_bin_dir}/conda" tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r;\
       fi' "$fslpython_installer"


### PR DESCRIPTION
## Summary

Fixes legacy FSL 6.0.4 `fslpython_install.sh` failures currently blocking the PreQual auto-build.

The current FSL 6.0.4 installer no longer matches the old `env create -f .*fslpython_environment.yml` template patch point, so builds exit before running the installer. After repairing that patch point, the live installer also exposed two drift issues:

- `Miniconda3-latest-Linux-x86_64.sh` now installs a conda stack that can fail during solve with `sqlite3.OperationalError: database is locked`.
- the FSL Python 3.7 env can resolve `requests` too new for Python 3.7 during the `nidmfsl` pip install.

This pins the legacy FSL miniconda bootstrap to a concrete py39 installer, inserts `requests<2.32` before the FSL pip dependency, and keeps the guarded Anaconda TOS acceptance before the actual `conda env create` line used by FSL 6.0.4.

No one-off rendering regression test is included because recipe-only fixes should rely on validation/generation unless the test proves a reusable behavior beyond hardcoded diff strings.

## Validation

- `python3 -m builder.validation recipes/prequal/build.yaml`
- `python3 -m builder generate prequal --output-root /tmp/prequal-generate-fsl-fix --recreate`
- `git diff --check`

## Notes

This is based on staged fix `aaa29d0171b153d4`, with the AGENTS.md-violating test change intentionally dropped.
