### PR TITLE
Reduce code extension layer waste

### DIFF
--- a/recipes/code/build.yaml
+++ b/recipes/code/build.yaml
@@ -87,6 +87,8 @@ build:
         - code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-toolsai.jupyter-keymap
         - code --extensions-dir=/opt/vscode-extensions --user-data-dir=/opt/vscode-data --install-extension ms-toolsai.jupyter-renderers
         - rm -rf /opt/vscode-data/CachedExtensionVSIXs/
+        - chmod a+rwx /opt/vscode-extensions/ -R
+        - chmod a+rwx /opt/vscode-data -R
 
     - environment:
         DONT_PROMPT_WSL_INSTALL: "1"
@@ -118,8 +120,6 @@ build:
 
     - run:
         - chmod a+x /usr/local/sbin/code
-        - chmod a+rwx /opt/vscode-extensions/ -R
-        - chmod a+rwx /opt/vscode-data -R
 
     - copy:
         - module.sh


### PR DESCRIPTION
## Summary

Fixes the current Dive wasted-space report for `code_240320` (#2503) by moving recursive permission changes for VS Code extension/data directories into the same Docker layer that creates those directories.

The Dive report shows duplicate large files under `/opt/vscode-extensions/...` with count `2`, including Python, Pylance, Jupyter, and Julia extension payloads. The recipe installed those extensions in one layer and later ran `chmod -R` over `/opt/vscode-extensions` and `/opt/vscode-data` in a separate layer, which rewrites file metadata for the whole extension tree and leaves the prior layer's copies as wasted space.

## Change

- Keep the existing `chmod a+rwx` behavior.
- Run the two recursive chmod commands immediately after extension installation and VSIX cache cleanup.
- Remove the later separate recursive chmod layer, leaving only `chmod a+x /usr/local/sbin/code` in the final small chmod step.

## Validation

- `python3 -m builder.validation recipes/code/build.yaml`
- `python3 -m builder generate code --output-root /tmp/code-generate-layer-waste-fix --recreate`
- `git diff --check`

## Notes

This is based on staged fix `b66a0cc4ccd64912`.
