### PR TITLE
Enable fulltest configs in release PR testing

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "releases/*/**.json"
+      - "recipes/**/fulltest.yaml"
       - "recipes/**/test.yaml"
     branches:
       - master
@@ -59,10 +60,22 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          uv pip install --system datalad datalad-installer
+          datalad-installer --sudo ok git-annex -m datalad/packages
+          git-annex version
+          datalad --version
+
+      - name: Configure git for DataLad
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Verify container runtimes
         run: |
@@ -86,7 +99,10 @@ jobs:
           RECIPE_DIR="recipes/${{ matrix.release.name }}"
           TEST_CONFIG=""
 
-          if [ -f "$RECIPE_DIR/test.yaml" ]; then
+          if [ -f "$RECIPE_DIR/fulltest.yaml" ]; then
+            TEST_CONFIG="$RECIPE_DIR/fulltest.yaml"
+            echo "Found fulltest.yaml"
+          elif [ -f "$RECIPE_DIR/test.yaml" ]; then
             TEST_CONFIG="$RECIPE_DIR/test.yaml"
             echo "Found test.yaml"
           elif [ -f "$RECIPE_DIR/build.yaml" ]; then
@@ -113,46 +129,17 @@ jobs:
 
           mkdir -p builder
 
-          python - <<'PY'
-          from pathlib import Path
-          import os
-
-          from workflows.test_runner import ContainerTestRunner, TestRequest
-
-          recipe = os.environ["RECIPE"]
-          version = os.environ.get("VERSION") or None
-          release_file = os.environ.get("RELEASE_FILE") or None
-          test_config = os.environ.get("TEST_CONFIG") or None
-
-          runner = ContainerTestRunner()
-          request = TestRequest(
-              recipe=recipe,
-              version=version,
-              release_file=release_file,
-              test_config=test_config if test_config else None,
-              runtime="apptainer",
-              location="auto",
-              cleanup=True,
-              auto_cleanup=False,
-              verbose=True,
-              allow_missing_tests=True,
-              output_dir=Path("builder"),
-              results_path=Path(f"builder/test-results-{recipe}.json"),
-          )
-
-          outcome = runner.run(request)
-          print(f"Status: {outcome.status}")
-          if outcome.reason:
-              print(f"Reason: {outcome.reason}")
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-              handle.write(f"status={outcome.status}\n")
-              if outcome.reason:
-                  handle.write(f"reason={outcome.reason}\n")
-
-          import sys
-          sys.exit(0 if outcome.status != "failed" else 1)
-          PY
+          python -m workflows.release_test_runner \
+            --recipe "${RECIPE}" \
+            --version "${VERSION}" \
+            --release-file "${RELEASE_FILE}" \
+            --test-config "${TEST_CONFIG}" \
+            --runtime apptainer \
+            --location auto \
+            --output-dir builder \
+            --results-path "builder/test-results-${RECIPE}.json" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --verbose
         continue-on-error: true
 
       - name: Upload test results
@@ -163,6 +150,12 @@ jobs:
           path: |
             builder/test-results-${{ matrix.release.name }}.json
             builder/test-report-${{ matrix.release.name }}.md
+            builder/comment-${{ matrix.release.name }}.md
+            builder/status-${{ matrix.release.name }}.txt
+            builder/fulltest-raw-${{ matrix.release.name }}.json
+            builder/fulltest-${{ matrix.release.name }}.jsonl
+            builder/fulltest-${{ matrix.release.name }}.log
+            builder/fulltest-suite-${{ matrix.release.name }}.yaml
 
       - name: Comment test results on PR
         if: always()

--- a/builder/tests/test_release_pr_changes.py
+++ b/builder/tests/test_release_pr_changes.py
@@ -8,7 +8,6 @@ import pytest
 from workflows.release_pr_changes import (
     ReleaseChangeError,
     detect_release_pr_changes,
-    write_github_outputs,
 )
 
 
@@ -23,23 +22,26 @@ def write_release(root: Path, recipe: str, version: str, build_date: str = "2026
     return release_file
 
 
-def test_new_recipe_test_yaml_without_release_metadata_is_skipped(tmp_path: Path) -> None:
-    result = detect_release_pr_changes(
-        [
-            "recipes/mede/build.yaml",
-            "recipes/mede/test.yaml",
-        ],
-        repo_root=tmp_path,
-    )
-
-    assert result.entries == ()
-    assert result.skipped_new_recipe_tests == ("mede",)
-    assert result.has_changes is False
-    assert result.matrix() == []
-
-
-def test_existing_recipe_test_yaml_uses_latest_release_metadata(tmp_path: Path) -> None:
+def test_existing_recipe_fulltest_yaml_uses_latest_release_metadata(tmp_path: Path) -> None:
     write_release(tmp_path, "cat12", "26.0.rc2", build_date="20260520")
+    latest_release = write_release(tmp_path, "cat12", "26.0.rc3", build_date="20260521")
+
+    result = detect_release_pr_changes(["recipes/cat12/fulltest.yaml"], repo_root=tmp_path)
+
+    assert result.skipped_new_recipe_tests == ()
+    assert result.has_changes is True
+    assert result.matrix() == [
+        {
+            "name": "cat12",
+            "version": "26.0.rc3",
+            "file": latest_release.relative_to(tmp_path).as_posix(),
+        }
+    ]
+
+
+def test_existing_recipe_legacy_test_yaml_still_uses_latest_release_metadata(
+    tmp_path: Path,
+) -> None:
     latest_release = write_release(tmp_path, "cat12", "26.0.rc3", build_date="20260521")
 
     result = detect_release_pr_changes(["recipes/cat12/test.yaml"], repo_root=tmp_path)
@@ -51,6 +53,25 @@ def test_existing_recipe_test_yaml_uses_latest_release_metadata(tmp_path: Path) 
             "name": "cat12",
             "version": "26.0.rc3",
             "file": latest_release.relative_to(tmp_path).as_posix(),
+        }
+    ]
+
+
+def test_release_metadata_can_be_paired_with_fulltest_yaml(tmp_path: Path) -> None:
+    result = detect_release_pr_changes(
+        [
+            "releases/cat12/26.0.rc3.json",
+            "recipes/cat12/fulltest.yaml",
+        ],
+        repo_root=tmp_path,
+    )
+
+    assert result.skipped_new_recipe_tests == ()
+    assert result.matrix() == [
+        {
+            "name": "cat12",
+            "version": "26.0.rc3",
+            "file": "releases/cat12/26.0.rc3.json",
         }
     ]
 
@@ -69,15 +90,3 @@ def test_release_metadata_still_must_be_isolated_from_unrelated_files(tmp_path: 
     assert "Release metadata changes must be isolated from unrelated files." in message
     assert "Release files: releases/cat12/26.0.rc3.json" in message
     assert "Unrelated files: recipes/cat12/build.yaml" in message
-
-
-def test_github_outputs_are_written_for_skipped_new_recipe(tmp_path: Path) -> None:
-    result = detect_release_pr_changes(["recipes/mede/test.yaml"], repo_root=tmp_path)
-    output_path = tmp_path / "github-output.txt"
-
-    write_github_outputs(result, output_path)
-
-    assert output_path.read_text(encoding="utf-8").splitlines() == [
-        "has-changes=false",
-        "modified-releases=[]",
-    ]

--- a/builder/tests/test_release_test_runner.py
+++ b/builder/tests/test_release_test_runner.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from workflows.release_test_runner import (
+    _combine_results,
+    _load_jsonl_records,
+    _normalise_run_tests_output,
+    _release_build_date,
+)
+from workflows.reporting import build_report
+
+
+def test_release_build_date_reads_first_app_version(tmp_path: Path) -> None:
+    release_file = tmp_path / "release.json"
+    release_file.write_text(
+        json.dumps({"apps": {"sample": {"version": "20260603"}}}),
+        encoding="utf-8",
+    )
+
+    assert _release_build_date(release_file) == "20260603"
+
+
+def test_normalise_run_tests_output_matches_github_reporting_schema() -> None:
+    raw = {
+        "summary": {
+            "total_tests": 2,
+            "tests_passed": 1,
+            "tests_failed": 1,
+        },
+        "suites": [
+            {
+                "name": "sample",
+                "tests": [
+                    {"name": "help", "passed": True, "message": "OK"},
+                    {"name": "import", "passed": False, "message": "Import failed"},
+                ]
+            }
+        ],
+    }
+
+    result = _normalise_run_tests_output(
+        raw,
+        recipe="sample",
+        version="1.0",
+        container_ref="sample_1.0_20260603.simg",
+        jsonl_records=[
+            {
+                "suite": "sample",
+                "test": "help",
+                "stdout": "usage\n",
+                "stderr": "",
+                "exit_code": 0,
+            },
+            {
+                "suite": "sample",
+                "test": "import",
+                "stdout": "",
+                "stderr": "traceback\n",
+                "exit_code": 2,
+            },
+        ],
+    )
+
+    assert result["total_tests"] == 2
+    assert result["passed"] == 1
+    assert result["failed"] == 1
+    assert result["test_results"] == [
+        {
+            "name": "help",
+            "status": "passed",
+            "stdout": "usage\n",
+            "stderr": "",
+            "return_code": 0,
+            "duration": 0,
+            "message": "OK",
+        },
+        {
+            "name": "import",
+            "status": "failed",
+            "stdout": "",
+            "stderr": "traceback\n",
+            "return_code": 2,
+            "duration": 0,
+            "message": "Import failed",
+        },
+    ]
+
+
+def test_load_jsonl_records_ignores_invalid_lines(tmp_path: Path) -> None:
+    jsonl = tmp_path / "results.jsonl"
+    jsonl.write_text('{"test": "help"}\nnot-json\n{"test": "import"}\n', encoding="utf-8")
+
+    assert _load_jsonl_records(jsonl) == [{"test": "help"}, {"test": "import"}]
+
+
+def test_combine_results_prepends_deploy_check_and_sums_counts() -> None:
+    fulltest = {
+        "total_tests": 2,
+        "passed": 2,
+        "failed": 0,
+        "skipped": 0,
+        "test_results": [{"name": "fulltest", "status": "passed"}],
+    }
+    deploy = {
+        "total_tests": 1,
+        "passed": 0,
+        "failed": 1,
+        "skipped": 0,
+        "test_results": [{"name": "deploy", "status": "failed"}],
+    }
+
+    result = _combine_results(fulltest, deploy)
+
+    assert result["total_tests"] == 3
+    assert result["passed"] == 2
+    assert result["failed"] == 1
+    assert result["test_results"] == [
+        {"name": "deploy", "status": "failed"},
+        {"name": "fulltest", "status": "passed"},
+    ]
+
+
+def test_build_report_includes_fulltest_summary_and_artifacts() -> None:
+    report = build_report(
+        {
+            "total_tests": 1,
+            "passed": 1,
+            "failed": 0,
+            "test_results": [],
+            "fulltest_summary": {
+                "total_suites": 1,
+                "suites_passed": 1,
+                "total_tests": 1,
+                "tests_passed": 1,
+                "duration": 2.5,
+            },
+            "fulltest_artifacts": {
+                "raw_json": "builder/fulltest-raw-sample.json",
+                "log": "builder/fulltest-sample.log",
+            },
+        },
+        "sample",
+        "1.0",
+    )
+
+    assert "### Fulltest Summary" in report
+    assert "- Suites: 1/1 passed" in report
+    assert "- raw_json: `builder/fulltest-raw-sample.json`" in report

--- a/builder/tests/test_test_utils.py
+++ b/builder/tests/test_test_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflows.test_utils import discover_test_config
+
+
+def test_discover_test_config_prefers_fulltest_yaml(tmp_path: Path) -> None:
+    recipe_dir = tmp_path / "recipes" / "cat12"
+    recipe_dir.mkdir(parents=True)
+    fulltest_yaml = recipe_dir / "fulltest.yaml"
+    test_yaml = recipe_dir / "test.yaml"
+    fulltest_yaml.write_text("tests: []\n", encoding="utf-8")
+    test_yaml.write_text("tests: []\n", encoding="utf-8")
+
+    assert discover_test_config(recipe_dir) == fulltest_yaml
+
+
+def test_discover_test_config_keeps_legacy_test_yaml_fallback(tmp_path: Path) -> None:
+    recipe_dir = tmp_path / "recipes" / "cat12"
+    recipe_dir.mkdir(parents=True)
+    test_yaml = recipe_dir / "test.yaml"
+    test_yaml.write_text("tests: []\n", encoding="utf-8")
+
+    assert discover_test_config(recipe_dir) == test_yaml

--- a/workflows/release_pr_changes.py
+++ b/workflows/release_pr_changes.py
@@ -44,7 +44,7 @@ class DetectionResult:
 
 
 RELEASE_PATTERN = re.compile(r"^releases/([^/]+)/([^/]+)\.json$")
-TEST_PATTERN = re.compile(r"^recipes/([^/]+)/test\.yaml$")
+TEST_CONFIG_PATTERN = re.compile(r"^recipes/([^/]+)/(?:fulltest|test)\.yaml$")
 
 
 def _relative_posix(path: Path, repo_root: Path) -> str:
@@ -106,9 +106,10 @@ def detect_release_pr_changes(
 ) -> DetectionResult:
     """Return released container test targets for changed release/test files.
 
-    A new recipe can add ``recipes/<name>/test.yaml`` before release metadata
-    exists. That should not fail this workflow because there is no published
-    container for the release-test job to download yet.
+    A new recipe can add ``recipes/<name>/fulltest.yaml`` before release
+    metadata exists. That should not fail this workflow because there is no
+    published container for the release-test job to download yet. Legacy
+    ``test.yaml`` files are still accepted during the migration to fulltests.
     """
 
     root = Path(repo_root)
@@ -118,7 +119,7 @@ def detect_release_pr_changes(
     unrelated_to_release = [
         path
         for path in paths
-        if not RELEASE_PATTERN.match(path) and not TEST_PATTERN.match(path)
+        if not RELEASE_PATTERN.match(path) and not TEST_CONFIG_PATTERN.match(path)
     ]
 
     if release_files and unrelated_to_release:
@@ -142,7 +143,7 @@ def detect_release_pr_changes(
     skipped_new_recipe_tests: list[str] = []
     skipped_seen: set[str] = set()
     for path in paths:
-        match = TEST_PATTERN.match(path)
+        match = TEST_CONFIG_PATTERN.match(path)
         if not match:
             continue
 
@@ -195,11 +196,11 @@ def _escape_notice(text: str) -> str:
 def print_skipped_notices(result: DetectionResult) -> None:
     for recipe in result.skipped_new_recipe_tests:
         message = (
-            f"recipes/{recipe}/test.yaml changed, but releases/{recipe}/*.json does not exist. "
+            f"recipes/{recipe}/fulltest.yaml or test.yaml changed, but "
+            f"releases/{recipe}/*.json does not exist. "
             "Skipping release-container tests for this new or unreleased recipe; "
             "this workflow only retests already released containers. "
-            "Use fulltest.yaml for new recipe smoke tests or let the release workflow "
-            "generate metadata first."
+            "Let the release workflow generate metadata first."
         )
         print(f"::notice::{_escape_notice(message)}")
 

--- a/workflows/release_test_runner.py
+++ b/workflows/release_test_runner.py
@@ -1,0 +1,317 @@
+"""Run release PR container tests with fulltest-aware integration output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from workflows.container_tester import ContainerTester
+from workflows.reporting import build_comment, build_report, determine_status, write_text
+from workflows.summarize_deploy_results import summarise_results_file
+from workflows.test_runner import ContainerTestRunner, TestRequest
+
+
+def _release_build_date(release_file: Path) -> str:
+    data = json.loads(release_file.read_text(encoding="utf-8"))
+    apps = data.get("apps", {}) or {}
+    if not isinstance(apps, dict) or not apps:
+        raise RuntimeError(f"No app entry in release file: {release_file}")
+    first_value = next(iter(apps.values()))
+    build_date = str(first_value.get("version", "")).strip()
+    if not build_date:
+        raise RuntimeError(f"Build date missing in release file: {release_file}")
+    return build_date
+
+
+def _normalise_run_tests_output(
+    raw: dict[str, Any],
+    *,
+    recipe: str,
+    version: str,
+    container_ref: str,
+    jsonl_records: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    summary = raw.get("summary", {}) or {}
+    suites = raw.get("suites", []) or []
+    record_lookup: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for record in jsonl_records or []:
+        key = (str(record.get("suite", "")), str(record.get("test", "")))
+        record_lookup.setdefault(key, []).append(record)
+
+    test_results: list[dict[str, Any]] = []
+    for suite in suites:
+        suite_name = str(suite.get("name", ""))
+        for test in suite.get("tests", []) or []:
+            test_name = str(test.get("name", "unnamed"))
+            records = record_lookup.get((suite_name, test_name), [])
+            record = records.pop(0) if records else {}
+            passed = bool(test.get("passed"))
+            message = str(test.get("message", "") or "")
+            stdout = str(record.get("stdout", "") or "")
+            stderr = str(record.get("stderr", "") or "")
+            if not passed and message and not stderr:
+                stderr = message
+            test_results.append(
+                {
+                    "name": test_name,
+                    "status": "passed" if passed else "failed",
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "return_code": int(record.get("exit_code", 0 if passed else 1) or 0),
+                    "duration": test.get("duration", 0),
+                    "message": message,
+                }
+            )
+
+    total = int(summary.get("total_tests", len(test_results)) or 0)
+    passed = int(summary.get("tests_passed", 0) or 0)
+    failed = int(summary.get("tests_failed", 0) or 0)
+
+    return {
+        "container": container_ref,
+        "runtime": "apptainer",
+        "recipe": recipe,
+        "version": version,
+        "total_tests": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": max(0, total - passed - failed),
+        "test_results": test_results,
+        "fulltest_summary": summary,
+    }
+
+
+def _load_jsonl_records(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def _combine_results(
+    fulltest_results: dict[str, Any],
+    deploy_results: dict[str, Any],
+) -> dict[str, Any]:
+    combined = dict(fulltest_results)
+    combined["test_results"] = list(deploy_results.get("test_results", [])) + list(
+        fulltest_results.get("test_results", [])
+    )
+    combined["total_tests"] = int(deploy_results.get("total_tests", 0) or 0) + int(
+        fulltest_results.get("total_tests", 0) or 0
+    )
+    combined["passed"] = int(deploy_results.get("passed", 0) or 0) + int(
+        fulltest_results.get("passed", 0) or 0
+    )
+    combined["failed"] = int(deploy_results.get("failed", 0) or 0) + int(
+        fulltest_results.get("failed", 0) or 0
+    )
+    combined["skipped"] = int(deploy_results.get("skipped", 0) or 0) + int(
+        fulltest_results.get("skipped", 0) or 0
+    )
+    return combined
+
+
+def _write_integration_outputs(
+    *,
+    recipe: str,
+    version: str,
+    results: dict[str, Any],
+    results_path: Path,
+    output_dir: Path,
+) -> str:
+    write_text(results_path, json.dumps(results, indent=2) + "\n")
+    summarise_results_file(results_path)
+
+    data = json.loads(results_path.read_text(encoding="utf-8"))
+    report = build_report(data, recipe, version)
+    write_text(output_dir / f"test-report-{recipe}.md", report)
+
+    comment, status = build_comment(data, recipe, version)
+    write_text(output_dir / f"comment-{recipe}.md", comment)
+    write_text(output_dir / f"status-{recipe}.txt", status + "\n")
+    return status
+
+
+def run_fulltest_release(args: argparse.Namespace) -> str:
+    release_file = Path(args.release_file)
+    test_config = Path(args.test_config)
+    output_dir = Path(args.output_dir)
+    results_path = Path(args.results_path)
+    containers_dir = output_dir / "fulltest-containers"
+    raw_results_path = output_dir / f"fulltest-raw-{args.recipe}.json"
+    fulltest_log_path = output_dir / f"fulltest-{args.recipe}.log"
+    fulltest_jsonl_path = output_dir / f"fulltest-{args.recipe}.jsonl"
+    suite_path = output_dir / f"fulltest-suite-{args.recipe}.yaml"
+    containers_dir.mkdir(parents=True, exist_ok=True)
+
+    build_date = _release_build_date(release_file)
+    tester = ContainerTester()
+    runtime = tester.select_runtime(args.runtime)
+    if runtime.name != "apptainer":
+        raise RuntimeError("fulltest.yaml release tests currently require Apptainer/Singularity")
+
+    if args.docker_to_simg:
+        container_ref = tester.convert_docker_image_to_simg(
+            args.recipe,
+            args.version,
+            release_file=str(release_file),
+            docker_registry=args.docker_registry,
+            converter_source=args.docker_save_to_simg,
+            verbose=args.verbose,
+        )
+    else:
+        container_ref = tester.release_downloader.download_from_release(
+            args.recipe,
+            args.version,
+            build_date,
+        )
+        if not container_ref:
+            raise RuntimeError(
+                f"Unable to download release container {args.recipe}:{args.version}"
+            )
+    source = Path(container_ref)
+    target = containers_dir / source.name
+    if source.resolve() != target.resolve():
+        shutil.copy2(source, target)
+    container_ref = str(target)
+
+    suite = yaml.safe_load(test_config.read_text(encoding="utf-8")) or {}
+    suite["name"] = suite.get("name") or args.recipe
+    suite["version"] = args.version
+    suite["container"] = Path(container_ref).name
+    write_text(suite_path, yaml.safe_dump(suite, sort_keys=False))
+
+    deploy_results = tester.run_test_suite(
+        container_ref,
+        {"tests": [{"name": "Simple Deploy Bins/Path Test", "builtin": "test_deploy.sh"}]},
+        verbose=args.verbose,
+    )
+
+    command = [
+        "uv",
+        "run",
+        "builder/run_tests.py",
+        str(suite_path),
+        "-c",
+        str(containers_dir),
+        "-o",
+        str(raw_results_path),
+        "--log",
+        str(fulltest_log_path),
+        "--jsonl",
+        str(fulltest_jsonl_path),
+    ]
+    proc = subprocess.run(command, cwd=args.repo_root, text=True, check=False)
+    if proc.returncode != 0 and not raw_results_path.is_file():
+        raise RuntimeError(f"run_tests.py failed before writing results: exit {proc.returncode}")
+
+    raw = json.loads(raw_results_path.read_text(encoding="utf-8"))
+    fulltest_results = _normalise_run_tests_output(
+        raw,
+        recipe=args.recipe,
+        version=args.version,
+        container_ref=container_ref,
+        jsonl_records=_load_jsonl_records(fulltest_jsonl_path),
+    )
+    fulltest_results["fulltest_artifacts"] = {
+        "raw_json": str(raw_results_path),
+        "jsonl": str(fulltest_jsonl_path),
+        "log": str(fulltest_log_path),
+        "suite": str(suite_path),
+    }
+    results = _combine_results(fulltest_results, deploy_results)
+    status = _write_integration_outputs(
+        recipe=args.recipe,
+        version=args.version,
+        results=results,
+        results_path=results_path,
+        output_dir=output_dir,
+    )
+    if proc.returncode != 0:
+        return "failed"
+    return status
+
+
+def run_legacy_release(args: argparse.Namespace) -> str:
+    runner = ContainerTestRunner(repo_root=Path(args.repo_root))
+    request = TestRequest(
+        recipe=args.recipe,
+        version=args.version,
+        release_file=args.release_file,
+        test_config=args.test_config,
+        runtime=args.runtime,
+        location=args.location,
+        cleanup=True,
+        auto_cleanup=False,
+        docker_to_simg=args.docker_to_simg,
+        docker_registry=args.docker_registry,
+        docker_save_to_simg=args.docker_save_to_simg,
+        verbose=args.verbose,
+        allow_missing_tests=True,
+        output_dir=Path(args.output_dir),
+        results_path=Path(args.results_path),
+    )
+    outcome = runner.run(request)
+    return outcome.status
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--release-file", required=True)
+    parser.add_argument("--test-config", required=True)
+    parser.add_argument("--runtime", default="apptainer")
+    parser.add_argument("--location", default="auto")
+    parser.add_argument("--output-dir", default="builder")
+    parser.add_argument("--results-path", required=True)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+    parser.add_argument("--docker-to-simg", action="store_true")
+    parser.add_argument("--docker-registry", default="neurodesk")
+    parser.add_argument("--docker-save-to-simg", default="builder/docker-save-to-simg.go")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    test_config = Path(args.test_config)
+
+    try:
+        if test_config.name == "fulltest.yaml":
+            status = run_fulltest_release(args)
+        else:
+            status = run_legacy_release(args)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.github_output:
+        with Path(args.github_output).open("a", encoding="utf-8") as handle:
+            handle.write(f"status={status}\n")
+
+    print(f"Status: {status}")
+    return 0 if status != "failed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/reporting.py
+++ b/workflows/reporting.py
@@ -170,6 +170,29 @@ def build_report(data: Dict, recipe: str, version: str) -> str:
         "",
     ]
 
+    fulltest_summary = data.get("fulltest_summary")
+    if isinstance(fulltest_summary, dict):
+        try:
+            duration = float(fulltest_summary.get("duration", 0) or 0)
+        except (TypeError, ValueError):
+            duration = 0.0
+        header.extend(
+            [
+                "### Fulltest Summary",
+                f"- Suites: {fulltest_summary.get('suites_passed', 0)}/{fulltest_summary.get('total_suites', 0)} passed",
+                f"- Fulltest tests: {fulltest_summary.get('tests_passed', 0)}/{fulltest_summary.get('total_tests', 0)} passed",
+                f"- Duration: {duration:.1f}s",
+                "",
+            ]
+        )
+
+    fulltest_artifacts = data.get("fulltest_artifacts")
+    if isinstance(fulltest_artifacts, dict):
+        header.append("### Fulltest Artifacts")
+        for label, path in fulltest_artifacts.items():
+            header.append(f"- {label}: `{path}`")
+        header.append("")
+
     sections: List[str] = []
     failed_tests = [entry for entry in data.get("test_results", []) if entry.get("status") == "failed"]
     passed_tests = [entry for entry in data.get("test_results", []) if entry.get("status") == "passed"]

--- a/workflows/test_utils.py
+++ b/workflows/test_utils.py
@@ -81,6 +81,10 @@ def discover_test_config(recipe_dir: str | Path) -> Optional[Path]:
     """Return the default test configuration file for a recipe, if available."""
 
     recipe_path = Path(recipe_dir)
+    fulltest_yaml = recipe_path / "fulltest.yaml"
+    if fulltest_yaml.is_file():
+        return fulltest_yaml
+
     test_yaml = recipe_path / "test.yaml"
     if test_yaml.is_file():
         return test_yaml


### PR DESCRIPTION
## Summary
- trigger release-container PR testing when recipe fulltest.yaml files change
- prefer fulltest.yaml over legacy test.yaml when selecting a recipe test config
- route fulltest.yaml through the real builder/run_tests.py runner so existing fulltest semantics are preserved
- generate temporary fulltest suite files that point at the release container under test, avoiding stale container fields in recipes
- append the deploy bin/path check to fulltest results and normalize everything into the existing test-results-*.json/report/comment integration format
- preserve fulltest JSONL stdout/stderr/exit-code details in normalized GitHub reports where available
- upload raw fulltest JSON, JSONL, log, and generated suite artifacts for debugging
- keep legacy test.yaml/build.yaml tests on the existing ContainerTestRunner path during the compatibility phase

## Tests
- uv run --with pytest pytest builder/tests/test_release_pr_changes.py builder/tests/test_test_utils.py builder/tests/test_release_test_runner.py
- python3 -m compileall workflows/release_test_runner.py workflows/reporting.py workflows/release_pr_changes.py workflows/test_utils.py
- python3 -m workflows.release_test_runner --help