### PR TITLE
Canary: trigger niimath fulltest release testing

### DIFF
--- a/recipes/niimath/fulltest.yaml
+++ b/recipes/niimath/fulltest.yaml
@@ -1,5 +1,6 @@
 # niimath container test suite
 # Tests for niimath v1.0.20250804 - fslmaths-compatible image calculator
+# Canary change to exercise release PR fulltest integration.
 #
 # Test data: ds000001/sub-01 (OpenNeuro Balloon Analog Risk-taking Task)
 #   - T1w: 160x192x192, 1x1.33x1.33mm (3D structural)


### PR DESCRIPTION
## Summary
- comment-only niimath fulltest change to trigger the merged release PR fulltest workflow
- used after a successful manual niimath build to validate GitHub issue comments, artifacts, and deploy/fulltest result normalization

## Tests
- python3 builder/validation.py recipes/niimath/build.yaml