### PR TITLE
Fix release fulltest canary failures

### DIFF
--- a/builder/tests/test_release_pr_changes.py
+++ b/builder/tests/test_release_pr_changes.py
@@ -39,6 +39,33 @@ def test_existing_recipe_fulltest_yaml_uses_latest_release_metadata(tmp_path: Pa
     ]
 
 
+def test_test_config_change_prefers_x86_release_over_arm64_metadata(
+    tmp_path: Path,
+) -> None:
+    latest_x86_release = write_release(
+        tmp_path,
+        "niimath",
+        "1.0.20250804",
+        build_date="20251016",
+    )
+    write_release(
+        tmp_path,
+        "niimath",
+        "1.0.20250804-arm64",
+        build_date="20251016",
+    )
+
+    result = detect_release_pr_changes(["recipes/niimath/fulltest.yaml"], repo_root=tmp_path)
+
+    assert result.matrix() == [
+        {
+            "name": "niimath",
+            "version": "1.0.20250804",
+            "file": latest_x86_release.relative_to(tmp_path).as_posix(),
+        }
+    ]
+
+
 def test_existing_recipe_legacy_test_yaml_still_uses_latest_release_metadata(
     tmp_path: Path,
 ) -> None:

--- a/builder/tests/test_release_test_runner.py
+++ b/builder/tests/test_release_test_runner.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from workflows.release_test_runner import (
     _combine_results,
+    _failure_results,
     _load_jsonl_records,
     _normalise_run_tests_output,
     _release_build_date,
+    main,
 )
 from workflows.reporting import build_report
 
@@ -120,6 +123,61 @@ def test_combine_results_prepends_deploy_check_and_sums_counts() -> None:
         {"name": "deploy", "status": "failed"},
         {"name": "fulltest", "status": "passed"},
     ]
+
+
+def test_failure_results_are_reportable() -> None:
+    result = _failure_results(
+        recipe="niimath",
+        version="1.0",
+        message="Unable to download release container",
+    )
+
+    assert result["failed"] == 1
+    assert result["test_results"][0]["name"] == "release_test_runner"
+    assert "Unable to download" in result["test_results"][0]["stderr"]
+
+
+def test_main_writes_failure_outputs_when_fulltest_adapter_errors(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def fail_fulltest(args: SimpleNamespace) -> str:
+        raise RuntimeError("Unable to download release container")
+
+    monkeypatch.setattr(
+        "workflows.release_test_runner.run_fulltest_release",
+        fail_fulltest,
+    )
+    test_config = tmp_path / "fulltest.yaml"
+    test_config.write_text("tests: []\n", encoding="utf-8")
+    release_file = tmp_path / "release.json"
+    release_file.write_text("{}", encoding="utf-8")
+    github_output = tmp_path / "github-output.txt"
+    results_path = tmp_path / "builder" / "test-results-niimath.json"
+
+    status = main(
+        [
+            "--recipe",
+            "niimath",
+            "--version",
+            "1.0",
+            "--release-file",
+            str(release_file),
+            "--test-config",
+            str(test_config),
+            "--results-path",
+            str(results_path),
+            "--output-dir",
+            str(tmp_path / "builder"),
+            "--github-output",
+            str(github_output),
+        ]
+    )
+
+    assert status == 1
+    assert results_path.is_file()
+    assert (tmp_path / "builder" / "test-report-niimath.md").is_file()
+    assert "status=failed" in github_output.read_text(encoding="utf-8")
 
 
 def test_build_report_includes_fulltest_summary_and_artifacts() -> None:

--- a/workflows/release_pr_changes.py
+++ b/workflows/release_pr_changes.py
@@ -54,13 +54,24 @@ def _relative_posix(path: Path, repo_root: Path) -> str:
         return path.as_posix()
 
 
-def find_latest_release_file(release_dir: str | Path) -> tuple[Path | None, str | None]:
+def _release_sort_key(version: str, build_date: str, *, prefer_x86_64: bool) -> tuple[int, str, str]:
+    architecture_priority = 1
+    if prefer_x86_64 and version.endswith("-arm64"):
+        architecture_priority = 0
+    return architecture_priority, build_date, version
+
+
+def find_latest_release_file(
+    release_dir: str | Path,
+    *,
+    prefer_x86_64: bool = False,
+) -> tuple[Path | None, str | None]:
     release_path = Path(release_dir)
     if not release_path.is_dir():
         return None, None
 
     latest_path: Path | None = None
-    latest_build_date = ""
+    latest_key: tuple[int, str, str] | None = None
     latest_version = ""
 
     for entry in sorted(release_path.iterdir()):
@@ -81,16 +92,22 @@ def find_latest_release_file(release_dir: str | Path) -> tuple[Path | None, str 
 
         if latest_path is None:
             latest_path = entry
-            latest_build_date = build_date
+            latest_key = _release_sort_key(
+                candidate_version,
+                build_date,
+                prefer_x86_64=prefer_x86_64,
+            )
             latest_version = candidate_version
             continue
 
-        if build_date and (not latest_build_date or build_date > latest_build_date):
+        candidate_key = _release_sort_key(
+            candidate_version,
+            build_date,
+            prefer_x86_64=prefer_x86_64,
+        )
+        if latest_key is None or candidate_key > latest_key:
             latest_path = entry
-            latest_build_date = build_date
-            latest_version = candidate_version
-        elif build_date == latest_build_date and candidate_version > latest_version:
-            latest_path = entry
+            latest_key = candidate_key
             latest_version = candidate_version
 
     if latest_path is None:
@@ -151,7 +168,10 @@ def detect_release_pr_changes(
         if recipe in entries:
             continue
 
-        release_file, version = find_latest_release_file(root / "releases" / recipe)
+        release_file, version = find_latest_release_file(
+            root / "releases" / recipe,
+            prefer_x86_64=True,
+        )
         if release_file and version:
             entries[recipe] = ReleaseEntry(
                 name=recipe,

--- a/workflows/release_test_runner.py
+++ b/workflows/release_test_runner.py
@@ -150,6 +150,34 @@ def _write_integration_outputs(
     return status
 
 
+def _failure_results(
+    *,
+    recipe: str,
+    version: str,
+    message: str,
+    container_ref: str = "unresolved",
+) -> dict[str, Any]:
+    return {
+        "container": container_ref,
+        "runtime": "apptainer",
+        "recipe": recipe,
+        "version": version,
+        "total_tests": 1,
+        "passed": 0,
+        "failed": 1,
+        "skipped": 0,
+        "test_results": [
+            {
+                "name": "release_test_runner",
+                "status": "failed",
+                "stdout": "",
+                "stderr": message,
+                "return_code": 1,
+            }
+        ],
+    }
+
+
 def run_fulltest_release(args: argparse.Namespace) -> str:
     release_file = Path(args.release_file)
     test_config = Path(args.test_config)
@@ -302,7 +330,26 @@ def main(argv: list[str] | None = None) -> int:
         else:
             status = run_legacy_release(args)
     except Exception as exc:
-        print(str(exc), file=sys.stderr)
+        message = str(exc)
+        print(message, file=sys.stderr)
+        try:
+            _write_integration_outputs(
+                recipe=args.recipe,
+                version=args.version,
+                results=_failure_results(
+                    recipe=args.recipe,
+                    version=args.version,
+                    message=message,
+                ),
+                results_path=Path(args.results_path),
+                output_dir=Path(args.output_dir),
+            )
+            if args.github_output:
+                with Path(args.github_output).open("a", encoding="utf-8") as handle:
+                    handle.write("status=failed\n")
+                    handle.write(f"reason={message}\n")
+        except Exception as write_exc:
+            print(f"Unable to write failure report: {write_exc}", file=sys.stderr)
         return 1
 
     if args.github_output:


### PR DESCRIPTION
## Summary
- prefer x86_64 release metadata for test-only fulltest/test.yaml changes so x86 release-test runners do not select arm64 release files
- keep explicit release JSON PR behavior unchanged; if an arm64 release JSON changes, that exact release remains selected
- make release_test_runner write normalized failed test results, report, comment, and status files even when setup/download fails before fulltest execution

## Canary failure addressed
The niimath canary selected releases/niimath/1.0.20250804-arm64.json and failed to download niimath_1.0.20250804-arm64_20251016.simg. Because the adapter failed before writing results, the workflow uploaded no artifacts and the summary job failed on a missing test-results directory.

## Tests
- uv run --with pytest pytest builder/tests/test_release_pr_changes.py builder/tests/test_release_test_runner.py
- python3 -m compileall workflows/release_pr_changes.py workflows/release_test_runner.py