### PR TITLE
Fix SAMRI deploy path

### DIFF
--- a/recipes/samri/build.yaml
+++ b/recipes/samri/build.yaml
@@ -114,14 +114,11 @@ build:
 
     - environment:
         PATH: /opt/miniconda/envs/samri/bin:/opt/miniconda/bin:/opt/bru2:/opt/ants-{{ context.ants_version }}:$PATH
-        DEPLOY_PATH: /opt/miniconda/envs/samri/bin:/opt/bru2:/opt/ants-{{ context.ants_version }}
-        DEPLOY_BINS: SAMRI
 
 deploy:
   bins:
     - SAMRI
   path:
-    - /opt/miniconda/envs/samri/bin
     - /opt/bru2
     - /opt/ants-{{ context.ants_version }}
 


### PR DESCRIPTION
## Summary

Fix the SAMRI deploy surface so release PR deploy testing does not scan the entire conda environment bin directory.

## Details

PR #2532 showed that the fulltest suite passed, but the deploy bin/path check failed because `/opt/miniconda/envs/samri/bin` contains a broken conda build-time perl entry pointing at `/croot/openssl_1694464909176/_build_env/bin/perl`.

This keeps `SAMRI` exposed through `deploy.bins` and leaves the conda env on `PATH`, but removes the conda env bin directory from `deploy.path`/`DEPLOY_PATH`. The deploy path now only scans the runtime tool directories that are intended to be exposed:

- `/opt/bru2`
- `/opt/ants-{{ context.ants_version }}`

## Testing

- `python3 builder/validation.py recipes/samri/build.yaml`
- `uv run sf-generate samri`
