### PR TITLE
Fix PreQual library path ordering

### DIFF
--- a/recipes/prequal/build.yaml
+++ b/recipes/prequal/build.yaml
@@ -143,13 +143,11 @@ build:
     - environment:
         ANTSPATH: /opt/ants-2.4.3/
         CUDA_HOME: /usr/local/cuda
-        DEPLOY_BINS: prequal,run_dtiQA.sh,mrinfo,flirt,c3d,antsRegistration
-        DEPLOY_PATH: /usr/local/bin:/CODE:/APPS/mrtrix3/bin:/APPS/fsl/bin:/APPS/c3d-1.0.0-Linux-x86_64/bin:/opt/ants-2.4.3
         FSLDIR: /APPS/fsl
         FREESURFER_HOME: /APPS/freesurfer
         MCRROOT: /opt/MCR/v92
         PATH: /usr/local/bin:/CODE:/APPS/gradtensor/conda/envs/gradvenv/bin:/APPS/gradtensor/conda/bin:/APPS/mrtrix3/bin:/APPS/fsl/bin:/APPS/c3d-1.0.0-Linux-x86_64/bin:/opt/ants-2.4.3:/APPS/freesurfer/bin:/opt/MCR/v92/runtime/glnxa64:/opt/MCR/v92/bin/glnxa64:/usr/local/cuda/bin:$PATH
-        LD_LIBRARY_PATH: /opt/MCR/v92/runtime/glnxa64:/opt/MCR/v92/bin/glnxa64:/opt/MCR/v92/sys/os/glnxa64:/opt/MCR/v92/extern/bin/glnxa64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+        LD_LIBRARY_PATH: /APPS/mrtrix3/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/opt/MCR/v92/runtime/glnxa64:/opt/MCR/v92/bin/glnxa64:/opt/MCR/v92/sys/os/glnxa64:/opt/MCR/v92/extern/bin/glnxa64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
     - deploy:
         path:
           - /usr/local/bin


### PR DESCRIPTION
## Summary

Fix PreQual's runtime library search order so MRtrix commands do not resolve MATLAB Runtime's old `libstdc++.so.6` first.

## Details

Release PR #2518 failed in `recipes/prequal/test.yaml` at `mrinfo --version` with missing `GLIBCXX_3.4.21`, `GLIBCXX_3.4.22`, `GLIBCXX_3.4.26`, and `CXXABI_1.3.11` symbols. The container was resolving `/opt/MCR/v92/sys/os/glnxa64/libstdc++.so.6` ahead of the system C++ runtime needed by MRtrix.

This updates PreQual's final `LD_LIBRARY_PATH` so MRtrix and system library directories come before MATLAB Runtime paths while still keeping MCR available for the MATLAB components.

It also removes redundant manual `DEPLOY_BINS` and `DEPLOY_PATH` env entries. The builder already emits those from the recipe's `deploy` directive, and generation confirms the resulting Dockerfile still contains:

- `DEPLOY_PATH="/usr/local/bin:/CODE:/APPS/mrtrix3/bin:/APPS/fsl/bin:/APPS/c3d-1.0.0-Linux-x86_64/bin:/opt/ants-2.4.3"`
- `DEPLOY_BINS="prequal:run_dtiQA.sh"`

## Testing

- `python3 builder/validation.py recipes/prequal/build.yaml`
- `uv run sf-generate prequal`

I attempted to run the existing PR #2518 SIF locally with the adjusted library path, but the PR body worker URL returned 404 from this environment.
