### PR TITLE
Restore MFCSC recipe categories

### DIFF
--- a/recipes/mfcsc/build.yaml
+++ b/recipes/mfcsc/build.yaml
@@ -76,6 +76,8 @@ readme: |-
   ----------------------------------
 
 categories:
+  - functional imaging
+  - diffusion imaging
   - electrophysiology
 
 files:


### PR DESCRIPTION
## Summary

Restore the historical MFCSC categories in the recipe so generated release metadata keeps the old release categories.

## Details

Release PR #2497 generated `releases/mfcsc/1.1.json` with only `electrophysiology`, but the existing 1.0/1.1 release metadata also categorized MFCSC under:

- `functional imaging`
- `diffusion imaging`

This updates `recipes/mfcsc/build.yaml` instead of editing the release PR directly, so future release generation preserves all intended categories.

## Testing

- `python3 builder/validation.py recipes/mfcsc/build.yaml`
- `uv run sf-generate mfcsc`

I started a direct download of the #2497 SIF for local Apptainer testing, but stopped it after the direction changed to recipe-only work. The partial file was removed.
