### PR TITLE
Fix MFCSC binary download

### DIFF
--- a/recipes/mfcsc/build.yaml
+++ b/recipes/mfcsc/build.yaml
@@ -26,6 +26,7 @@ build:
     - workdir: /opt/mfcsc-{{ context.version }}/
     - run:
         - cp {{ get_file("mfcsc_binary") }} mfcsc
+        - od -An -tx1 -N4 mfcsc | grep -q '7f 45 4c 46'
     - environment:
         XAPPLRESDIR: /opt/MCR/v98/x11/app-defaults
     - run:
@@ -82,6 +83,6 @@ categories:
 
 files:
   - name: mfcsc_binary
-    url: https://www.dropbox.com/s/rc8rysdwqxgxcfn/mfcsc?dl=0
+    url: https://www.dropbox.com/s/rc8rysdwqxgxcfn/mfcsc?dl=1
 
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABP0lEQVR42u3azRHCIBCG4ZRhEx5swCYswZMNWYnFOY4zOrkbQuDbH+J72KM/+2SBBTI9X+/PP8cEAAAAAAAAAAAAAAAAAACgiOP1YfqHD6dLPoA56aVQJb0U4QCl5BUIpeQVCAB4AJzvt+ZIDVCTfA9CTfK9CFSAN0DNd+4aoAQxZAWsIayV+FLitQjDdIIt43+YTnBLtCa+i81Q79MfFqBnGUwPUGp1tyTXChGyCqz1/T1PteazylVh8uz8FMNG3Re4ACjnjyEBlBEKYL37i9gdUgHZToC8T4gAyHgK7HlKLOkEPdvXX3NC+F4gEiDNZigCINVu0KMKLH7DDEA9Ic5jPTWAxepgeRYoB1D3B9anwQBEAGS6EXK7F2hB8LgTpAKYAwCgDzC9GLHoBHlPEAAAAAAAAAAAAAAAAABQxRdgu/0O6G9E3wAAAABJRU5ErkJggg==


### PR DESCRIPTION
## Summary

Fix the MFCSC recipe so it downloads the compiled executable rather than Dropbox's HTML preview page.

## Root Cause

Release PR #2538 ran the existing MFCSC fulltest suite and every real `mfcsc` invocation failed with:

```text
/opt/mfcsc-1.1/mfcsc: line 1: syntax error near unexpected token `newline'
/opt/mfcsc-1.1/mfcsc: line 1: `<!DOCTYPE html>'
```

The recipe used the Dropbox URL with `?dl=0`, which can resolve to an HTML landing/preview page. That HTML was copied into `/opt/mfcsc-1.1/mfcsc`, marked executable, and passed the deploy existence check, but failed as soon as the fulltest suite invoked it.

## Changes

- Change the `mfcsc_binary` URL from `?dl=0` to `?dl=1` so Dropbox returns the raw executable download.
- Add a build-time ELF magic check after copying the file, so a future HTML/download failure stops the build immediately instead of producing a broken release.

## Testing

- `python3 builder/validation.py recipes/mfcsc/build.yaml`
- `uv run sf-generate mfcsc`
- Confirmed the updated URL returns ELF bytes:

```bash
curl -fsSL 'https://www.dropbox.com/s/rc8rysdwqxgxcfn/mfcsc?dl=1' -r 0-3 | od -An -tx1
#  7f 45 4c 46
```
