### PR TITLE
Detect release image config changes

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -67,7 +67,7 @@ jobs:
       ARCHITECTURE: ${{ steps.envars.outputs.ARCHITECTURE }}
       IMAGE_SUFFIX: ${{ steps.envars.outputs.IMAGE_SUFFIX }}
       RELEASE_VERSION: ${{ steps.envars.outputs.RELEASE_VERSION }}
-      ROOTFS_CACHE: ${{ steps.getrootfs.outputs.ROOTFS_CACHE }}
+      IMAGE_FINGERPRINT_CACHE: ${{ steps.getfingerprint.outputs.IMAGE_FINGERPRINT_CACHE }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -210,14 +210,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull latest image from registry and get rootfs
-        id: getrootfs
+      - name: Pull latest image from registry and get fingerprint
+        id: getfingerprint
         if: inputs.skip_docker_build != 'true'
         env:
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
         run: |
-          docker pull ghcr.io/${GH_REGISTRY}/${{ env.IMAGENAME }}:latest && ROOTFS_CACHE=$(docker inspect --format='{{.RootFS}}' ghcr.io/${GH_REGISTRY}/${{ env.IMAGENAME }}:latest) || true
-          echo "ROOTFS_CACHE=$ROOTFS_CACHE" >> $GITHUB_OUTPUT
+          IMAGE_FINGERPRINT_CACHE=""
+          IMAGE_REF="ghcr.io/${GH_REGISTRY}/${{ env.IMAGENAME }}:latest"
+          if docker pull "$IMAGE_REF"; then
+            IMAGE_FINGERPRINT_CACHE=$(python3 builder/image_fingerprint.py "$IMAGE_REF")
+          fi
+          echo "IMAGE_FINGERPRINT_CACHE=$IMAGE_FINGERPRINT_CACHE" >> "$GITHUB_OUTPUT"
 
   build-image:
     needs: config
@@ -234,7 +238,7 @@ jobs:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
       IMAGETAG: ${{ needs.config.outputs.IMAGETAG }}
-      ROOTFS_CACHE: ${{ needs.config.outputs.ROOTFS_CACHE }}
+      IMAGE_FINGERPRINT_CACHE: ${{ needs.config.outputs.IMAGE_FINGERPRINT_CACHE }}
       SHORT_SHA: ${{ needs.config.outputs.SHORT_SHA }}
       ARCHITECTURE: ${{ needs.config.outputs.ARCHITECTURE }}
       IMAGE_SUFFIX: ${{ needs.config.outputs.IMAGE_SUFFIX }}
@@ -448,13 +452,14 @@ jobs:
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
         run: |
           # Check if the image exists before trying to inspect it
-          if docker inspect ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE} >/dev/null 2>&1; then
-            ROOTFS_NEW=$(docker inspect --format='{{.RootFS}}' ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE})
-            echo "ROOTFS_NEW=$ROOTFS_NEW" >> $GITHUB_ENV
+          IMAGE_REF="ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE}"
+          if docker inspect "$IMAGE_REF" >/dev/null 2>&1; then
+            IMAGE_FINGERPRINT_NEW=$(python3 builder/image_fingerprint.py "$IMAGE_REF")
+            echo "IMAGE_FINGERPRINT_NEW=$IMAGE_FINGERPRINT_NEW" >> "$GITHUB_ENV"
 
             if [ "$DISABLE_AUTO_UPLOAD" = "true" ]; then
               echo "Auto-upload is disabled. Skipping push to registry."
-            elif [ "$ROOTFS_NEW" = "$ROOTFS_CACHE" ]; then
+            elif [ -n "$IMAGE_FINGERPRINT_CACHE" ] && [ "$IMAGE_FINGERPRINT_NEW" = "$IMAGE_FINGERPRINT_CACHE" ]; then
               echo "No changes found. Skipping push to registry. "
             else
               echo "Pushing to registry. Changes found"

--- a/builder/image_fingerprint.py
+++ b/builder/image_fingerprint.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+VOLATILE_LABELS = {
+    "GITHUB_REPOSITORY",
+    "GITHUB_SHA",
+}
+
+
+def normalize_inspect_data(image: dict[str, Any]) -> dict[str, Any]:
+    config = dict(image.get("Config") or {})
+    labels = dict(config.get("Labels") or {})
+    for label in VOLATILE_LABELS:
+        labels.pop(label, None)
+    config["Labels"] = labels
+
+    return {
+        "Config": config,
+        "RootFS": image.get("RootFS"),
+    }
+
+
+def fingerprint_inspect_data(image: dict[str, Any]) -> str:
+    payload = normalize_inspect_data(image)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def inspect_image(image_ref: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["docker", "inspect", image_ref],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    inspected = json.loads(result.stdout)
+    if not inspected:
+        raise ValueError(f"No docker inspect data found for {image_ref}")
+    return inspected[0]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Print a stable Docker image fingerprint for release build comparisons."
+    )
+    parser.add_argument("image", help="Docker image reference to inspect")
+    args = parser.parse_args(argv)
+
+    try:
+        print(fingerprint_inspect_data(inspect_image(args.image)))
+    except (subprocess.CalledProcessError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Failed to fingerprint {args.image}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builder/tests/test_image_fingerprint.py
+++ b/builder/tests/test_image_fingerprint.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from builder.image_fingerprint import fingerprint_inspect_data
+
+
+def _inspect_data(env: list[str], github_sha: str = "abc123") -> dict[str, object]:
+    return {
+        "Config": {
+            "Cmd": ["/bin/bash"],
+            "Env": env,
+            "Labels": {
+                "GITHUB_REPOSITORY": "neurodesk/neurocontainers",
+                "GITHUB_SHA": github_sha,
+                "recipe": "samri",
+            },
+        },
+        "RootFS": {
+            "Type": "layers",
+            "Layers": ["sha256:layer"],
+        },
+    }
+
+
+def test_image_fingerprint_includes_runtime_config_env() -> None:
+    original = _inspect_data(["DEPLOY_PATH=/opt/bru2:/opt/ants"])
+    changed = _inspect_data(["DEPLOY_PATH=/opt/bru2:/opt/ants:/opt/miniconda/bin"])
+
+    assert fingerprint_inspect_data(original) != fingerprint_inspect_data(changed)
+
+
+def test_image_fingerprint_ignores_workflow_identity_labels() -> None:
+    original = _inspect_data(["DEPLOY_PATH=/opt/bru2"], github_sha="abc123")
+    rebuilt = _inspect_data(["DEPLOY_PATH=/opt/bru2"], github_sha="def456")
+
+    assert fingerprint_inspect_data(original) == fingerprint_inspect_data(rebuilt)

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -17,6 +17,19 @@ def test_build_app_workflow_uses_version_stable_build_cache_ref() -> None:
     assert "CACHE_REF=ghcr.io/${GH_REGISTRY}/${IMAGENAME}:buildcache" not in workflow
 
 
+def test_build_app_workflow_compares_image_config_not_only_rootfs() -> None:
+    workflow = Path(".github/workflows/build-app.yml").read_text()
+    config_job = workflow.split("  config:", 1)[1].split("  build-image:", 1)[0]
+    build_image_job = workflow.split("  build-image:", 1)[1].split("  push-dockerhub:", 1)[0]
+
+    assert "IMAGE_FINGERPRINT_CACHE" in config_job
+    assert "IMAGE_FINGERPRINT_NEW" in build_image_job
+    assert "python3 builder/image_fingerprint.py" in config_job
+    assert "python3 builder/image_fingerprint.py" in build_image_job
+    assert "ROOTFS_CACHE" not in workflow
+    assert "ROOTFS_NEW" not in workflow
+
+
 def test_create_pr_job_generates_release_without_rebuilding() -> None:
     workflow = Path(".github/workflows/build-app.yml").read_text()
     create_pr_job = workflow.split("  create-pr:", 1)[1]


### PR DESCRIPTION
## Summary

PR #2539 showed SAMRI fulltests passing but the deploy bin/path check failing against stale deploy metadata. The SAMRI recipe on `main` already had the deploy path fix, but the release workflow decided whether to push/upload by comparing only Docker `RootFS`. Changes that only affect image config/env, including `DEPLOY_PATH`, can therefore be missed.

This PR changes the release build comparison to use a normalized Docker image fingerprint containing both `RootFS` and image `Config`, while ignoring volatile GitHub labels added during the workflow.

## Changes

- Add `builder/image_fingerprint.py` for stable Docker inspect fingerprinting.
- Use image fingerprints instead of RootFS-only comparison in `build-app.yml`.
- Add regression coverage for config/env-only changes and workflow contract checks.

## Testing

- `uv run --with pytest pytest builder/tests/test_image_fingerprint.py builder/tests/test_workflow_contract.py`
- `python3 -m py_compile builder/image_fingerprint.py`
- Parsed `.github/workflows/build-app.yml` with `yaml.safe_load`
- `git diff --check`
