### PR TITLE
Install DAFNE TensorFlow with pip on x86

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -12,13 +12,13 @@ architectures:
 variables:
   conda_install:
     try:
-      - value: "python=3.8 numpy=1.24.3 protobuf=3.20.3 tensorflow=2.13.1"
+      - value: "python=3.8 numpy=1.24.3 protobuf=3.20.3"
         condition: arch=="x86_64"
       - value: "python=3.8 numpy=1.24.3 protobuf=3.20.3 pyqt=5.15 vtk"
         condition: arch=="aarch64"
   pip_install:
     try:
-      - value: "SimpleITK==2.4.1 pyradiomics==3.1.0 protobuf==3.20.3 dafne=={{ context.version }}"
+      - value: "tensorflow==2.13.1 SimpleITK==2.4.1 pyradiomics==3.1.0 protobuf==3.20.3 dafne=={{ context.version }}"
         condition: arch=="x86_64"
       - value: "tensorflow==2.13.1 SimpleITK==2.4.1 pyradiomics==3.1.0 protobuf==3.20.3 dafne=={{ context.version }}"
         condition: arch=="aarch64"


### PR DESCRIPTION
## Summary

Fixes the DAFNE auto-build failure reported in #2537.

The x86_64 recipe currently asks conda/libmamba to solve `tensorflow=2.13.1` together with `protobuf=3.20.3`. Conda-forge's CPU TensorFlow build wants a newer `libprotobuf`, so the solver falls through to CUDA TensorFlow candidates and fails because Docker builds do not provide the `__cuda` virtual package.

This PR moves TensorFlow to pip for x86_64, matching the existing ARM64 strategy, while keeping the protobuf runtime pin.

## Changes

- Remove `tensorflow=2.13.1` from x86_64 `conda_install`.
- Add `tensorflow==2.13.1` to x86_64 `pip_install`.

## Testing

- `python3 builder/validation.py recipes/dafne/build.yaml`
- `uv run sf-generate dafne`
- Verified the generated Dockerfile keeps `protobuf=3.20.3` in conda and installs `tensorflow==2.13.1` with pip.
- `git diff --check`
- Reproduced the original conda failure with micromamba: `python=3.8 numpy=1.24.3 protobuf=3.20.3 tensorflow=2.13.1` fails with missing `__cuda`; the same conda solve without TensorFlow succeeds.

