### PR TITLE
Refresh release containers during PR tests

### DIFF
--- a/builder/tests/test_container_tester_release_download.py
+++ b/builder/tests/test_container_tester_release_download.py
@@ -36,6 +36,37 @@ def test_release_downloader_falls_back_to_s3_when_nectar_fails(
     ]
 
 
+def test_release_downloader_can_refresh_existing_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    downloader = ReleaseContainerDownloader(cache_dir=str(tmp_path))
+    cache_path = tmp_path / "globus_3.2.8_20260514.simg"
+    cache_path.write_text("stale", encoding="utf-8")
+    calls: list[str] = []
+
+    def fake_urlretrieve(url: str, filename: str) -> tuple[str, None]:
+        calls.append(url)
+        Path(filename).write_text("fresh", encoding="utf-8")
+        return filename, None
+
+    monkeypatch.setattr(
+        container_tester.urllib.request, "urlretrieve", fake_urlretrieve
+    )
+
+    path = downloader.download_from_release(
+        "globus",
+        "3.2.8",
+        "20260514",
+        use_cache=False,
+    )
+
+    assert path == str(cache_path)
+    assert cache_path.read_text(encoding="utf-8") == "fresh"
+    assert calls == [
+        "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/globus_3.2.8_20260514.simg",
+    ]
+
+
 def test_auto_location_does_not_return_docker_tag_for_apptainer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -395,7 +395,12 @@ class ReleaseContainerDownloader:
         ]
 
     def download_from_release(
-        self, name: str, version: str, build_date: Optional[str]
+        self,
+        name: str,
+        version: str,
+        build_date: Optional[str],
+        *,
+        use_cache: bool = True,
     ) -> Optional[str]:
         """Download container using release build information"""
         if not build_date:
@@ -414,10 +419,13 @@ class ReleaseContainerDownloader:
         for filename in filenames:
             cache_path = os.path.join(self.cache_dir, filename)
 
-            # Check cache first
-            if os.path.exists(cache_path):
+            # Check cache first. CI release tests bypass this because rebuilds
+            # on the same day share the same release filename.
+            if use_cache and os.path.exists(cache_path):
                 print(f"Using cached container: {cache_path}")
                 return cache_path
+            if not use_cache and os.path.exists(cache_path):
+                print(f"Refreshing cached container: {cache_path}")
 
             # Try downloading from each mirror.
             for source_name, base_url in self.base_urls:

--- a/workflows/release_test_runner.py
+++ b/workflows/release_test_runner.py
@@ -210,6 +210,7 @@ def run_fulltest_release(args: argparse.Namespace) -> str:
             args.recipe,
             args.version,
             build_date,
+            use_cache=False,
         )
         if not container_ref:
             raise RuntimeError(


### PR DESCRIPTION
## Summary
- bypass the release container cache for release PR fulltest runs
- keep cached release downloads enabled for normal/local downloader use
- add coverage that `use_cache=False` replaces a stale cached SIF

## Root cause
PR #2547 failed because the release-test job reused an existing cached `mfcsc_1.1_20260603.simg`. The fulltest artifact showed `/opt/mfcsc-1.1/mfcsc` began with `<!DOCTYPE html>`, while the current recipe URL now returns a valid ELF and the recipe has an ELF magic check. Since same-day rebuilds use the same release filename, release PR tests must not trust an existing cached SIF.

## Tests
- `uv run --with pytest pytest builder/tests/test_container_tester_release_download.py builder/tests/test_release_test_runner.py`
- `git diff --check`