### PR TITLE
Fix DAFNE fulltest runtime version expectation

### DIFF
--- a/recipes/dafne/fulltest.yaml
+++ b/recipes/dafne/fulltest.yaml
@@ -41,7 +41,7 @@ tests:
       print("SimpleITK", SimpleITK.__version__)
       PY
     expected_output_contains:
-      - "dafne 1.8a4"
+      - "dafne 1.8-alpha4"
       - "numpy 1.24.3"
       - "SimpleITK"
 


### PR DESCRIPTION
## Summary
- update the DAFNE import fulltest to expect the module runtime version string `1.8-alpha4`
- keep the separate package metadata test asserting the distribution version `1.8a4`

## Root cause
PR #2551 failed because `dafne.__version__` prints `1.8-alpha4`, while `importlib.metadata.version("dafne")` prints `1.8a4`. The import test was asserting the distribution spelling against the module runtime output.

## Tests
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `uv run --with pytest pytest builder/tests/test_release_test_runner.py`
- `git diff --check`