### PR TITLE
Add Fury to PreQual GradTensor environment

### DIFF
--- a/recipes/prequal/build.yaml
+++ b/recipes/prequal/build.yaml
@@ -118,7 +118,7 @@ build:
         install_path: /APPS/gradtensor/conda
         env_name: gradvenv
         env_exists: "false"
-        conda_install: python=3.8 pip=23.3.2 dipy=1.5.0 fpdf imageio pypng freetype-py
+        conda_install: python=3.8 pip=23.3.2 dipy=1.5.0 fpdf fury=0.7.1 imageio pypng freetype-py
         mamba: "true"
     - run:
         - . /APPS/gradtensor/conda/etc/profile.d/conda.sh


### PR DESCRIPTION
## Summary
- add `fury=0.7.1` to the PreQual GradTensor conda environment
- keep scilpy installed with `--no-deps`, but explicitly install the missing runtime dependency it imports

## Root cause
PR #2554 failed in the GradTensor fulltest because `/APPS/gradtensor/scilpy/scilpy/io/utils.py` imports `from fury import window`, but the recipe installed scilpy 1.4.0 with `pip install --no-deps -e .` and did not include `fury` in the conda environment. Upstream scilpy 1.4.0 requires `fury==0.7.*`; conda-forge provides `fury=0.7.1`.

DAFNE PR #2551 was caused by a test expectation mismatch and is already fixed by merged PR #2552.

## Tests
- `python3 builder/validation.py recipes/prequal/build.yaml`
- `uv run sf-generate prequal`
- inspected generated `build/prequal/prequal_1.1.0.Dockerfile` for `fury=0.7.1`
- `git diff --check`