### PR TITLE
Use reference DAFNE fulltest container pattern

### DIFF
--- a/recipes/dafne/fulltest.yaml
+++ b/recipes/dafne/fulltest.yaml
@@ -5,7 +5,9 @@
 
 name: dafne
 version: 1.8a4
-container: dafne_1.8a4_20260602.simg
+# Reference pattern for direct local runs; release PR testing replaces this
+# with the release JSON build artifact before invoking builder/run_tests.py.
+container: dafne_1.8a4_*.simg
 
 default_timeout: 120
 


### PR DESCRIPTION
## Summary
- change the checked-in DAFNE fulltest container from a dated SIF filename to `dafne_1.8a4_*.simg`
- document that this value is only a direct-run reference and release PR testing replaces it with the actual release artifact filename

## Context
The release test runner already rewrites `suite["container"]` from the downloaded or converted release artifact before invoking `builder/run_tests.py`. Keeping a dated filename in `recipes/dafne/fulltest.yaml` made the file look stale after newer builds even though CI used the right container.

## Tests
- `python3` YAML load/assertion check for `recipes/dafne/fulltest.yaml`
- `uv run --with pytest pytest builder/tests/test_release_test_runner.py`
- `uv run --with rich python` direct `find_container('dafne_1.8a4_*.simg', ...)` check
- `git diff --check`