### PR TITLE
Use variable-backed Globus fulltest version

### DIFF
--- a/builder/run_tests.py
+++ b/builder/run_tests.py
@@ -123,11 +123,43 @@ def substitute_variables(text: str, variables: dict[str, str]) -> str:
         return text
 
     result = text
-    for key, value in variables.items():
-        result = result.replace(f"${{{key}}}", str(value))
-        result = result.replace(f"${key}", str(value))
+    for _ in range(10):
+        previous = result
+        for key, value in variables.items():
+            result = result.replace(f"${{{key}}}", str(value))
+            result = result.replace(f"${key}", str(value))
+        if result == previous:
+            break
 
     return result
+
+
+def collect_top_level_variables(config: dict[str, Any]) -> dict[str, str]:
+    """Extract top-level scalar values available for fulltest substitution."""
+    reserved_keys = {
+        "name",
+        "version",
+        "container",
+        "test_data",
+        "setup",
+        "cleanup",
+        "tests",
+        "env_setup",
+        "default_timeout",
+        "matlab_runtime",
+        "script_runner",
+        "script_ext",
+        "required_files",
+    }
+    variables = {
+        key: str(value)
+        for key, value in config.items()
+        if key not in reserved_keys and isinstance(value, (str, int, float))
+    }
+    return {
+        key: substitute_variables(value, variables)
+        for key, value in variables.items()
+    }
 
 
 def check_file_exists(path: str) -> bool:
@@ -404,6 +436,7 @@ def run_single_test(
                 expected_list = expected_output
 
             for expected in expected_list:
+                expected = substitute_variables(str(expected), variables)
                 if expected and expected not in combined_output:
                     return TestResult(
                         name=name,
@@ -597,8 +630,12 @@ def run_test_suite(
         config = yaml.safe_load(f)
 
     suite_name = config.get("name", yaml_path.stem)
-    container_name = config.get("container", "")
     default_timeout = config.get("default_timeout", 120)  # Default 2 minutes
+    top_level_variables = collect_top_level_variables(config)
+    container_name = substitute_variables(
+        str(config.get("container", "")),
+        top_level_variables,
+    )
 
     # Find container
     container_path = find_container(container_name, containers_dir)
@@ -653,13 +690,9 @@ def run_test_suite(
             variables[key] = str(path)
 
     # Extract top-level simple values as variables (e.g. mitk_path)
-    reserved_keys = {"name", "version", "container", "test_data", "setup", "cleanup",
-                     "tests", "env_setup", "default_timeout", "matlab_runtime",
-                     "script_runner", "script_ext", "required_files"}
-    for key, value in config.items():
-        if key not in reserved_keys and isinstance(value, (str, int, float)):
-            if key not in variables:
-                variables[key] = str(value)
+    for key, value in top_level_variables.items():
+        if key not in variables:
+            variables[key] = value
 
     # Extract script runner config for script: directive support
     script_runner = config.get("script_runner")

--- a/builder/tests/test_run_tests_runtime.py
+++ b/builder/tests/test_run_tests_runtime.py
@@ -25,3 +25,37 @@ def test_container_runtime_command_keeps_existing_error_path(monkeypatch) -> Non
     monkeypatch.setattr(run_tests.shutil, "which", lambda command: None)
 
     assert run_tests.container_runtime_command() == "apptainer"
+
+
+def test_substitute_variables_expands_nested_values() -> None:
+    variables = {
+        "tool_version": "3.2.8",
+        "tool_dir": "/opt/tool-${tool_version}",
+    }
+
+    assert (
+        run_tests.substitute_variables("${tool_dir}/bin/tool", variables)
+        == "/opt/tool-3.2.8/bin/tool"
+    )
+
+
+def test_top_level_variables_support_container_patterns() -> None:
+    config = {
+        "name": "tool",
+        "version": "${tool_version}",
+        "container": "tool_${tool_version}_*.simg",
+        "tool_version": "3.2.8",
+        "tool_dir": "/opt/tool-${tool_version}",
+        "tests": [],
+    }
+
+    variables = run_tests.collect_top_level_variables(config)
+
+    assert variables == {
+        "tool_version": "3.2.8",
+        "tool_dir": "/opt/tool-3.2.8",
+    }
+    assert (
+        run_tests.substitute_variables(config["container"], variables)
+        == "tool_3.2.8_*.simg"
+    )

--- a/recipes/globus/fulltest.yaml
+++ b/recipes/globus/fulltest.yaml
@@ -1,15 +1,16 @@
 # Globus Connect Personal container test suite
-# Tests for Globus Connect Personal v3.2.2 - secure data transfer endpoint software
+# Tests for Globus Connect Personal - secure data transfer endpoint software
 #
 # Globus Connect Personal allows users to create personal endpoints for
 # transferring files between local systems and Globus-connected endpoints.
 # It includes the GridFTP server for high-performance data transfer.
 
 name: globus
-version: "3.2.8"
-container: globus_3.2.8_20260514.simg
+globus_version: "3.2.8"
+version: "${globus_version}"
+container: globus_${globus_version}_*.simg
 
-globus_dir: /opt/globusconnectpersonal-3.2.8
+globus_dir: /opt/globusconnectpersonal-${globus_version}
 
 tests:
   # ==========================================================================
@@ -255,7 +256,7 @@ tests:
   - name: Version file exists
     description: Verify VERSION file exists and contains version
     command: "bash -lc 'cat ${globus_dir}/VERSION 2>&1'"
-    expected_output_contains: "3.2.8"
+    expected_output_contains: "${globus_version}"
 
   - name: README file exists
     description: Verify README file exists


### PR DESCRIPTION
## Summary
- add nested top-level variable expansion support to `builder/run_tests.py`
- expand variables in fulltest `container:` patterns and expected output assertions
- refactor `recipes/globus/fulltest.yaml` so `globus_version` is the single update point for the suite version, container reference, install directory, and VERSION assertion

## Context
The staged Globus fulltest update refreshed the suite for 3.2.8, but the version still appeared in several places. This makes the Globus suite easier to update while keeping the runner behavior reusable for other fulltest suites.

## Tests
- `python3` YAML/substitution smoke check for `recipes/globus/fulltest.yaml`
- `uv run --with pytest --with rich pytest builder/tests/test_run_tests_runtime.py`
- `git diff --check`