### PR TITLE
Use release image basename for SIF downloads

### DIFF
--- a/builder/tests/test_container_tester_release_download.py
+++ b/builder/tests/test_container_tester_release_download.py
@@ -67,6 +67,169 @@ def test_release_downloader_can_refresh_existing_cache(
     ]
 
 
+def test_release_downloader_prefers_image_basename_from_release_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    downloader = ReleaseContainerDownloader(cache_dir=str(tmp_path))
+    calls: list[str] = []
+
+    def fake_urlretrieve(url: str, filename: str) -> tuple[str, None]:
+        calls.append(url)
+        if "neurodesktop_20260428_arm64_20260519.simg" not in url:
+            raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        Path(filename).write_text("arm64 simg", encoding="utf-8")
+        return filename, None
+
+    monkeypatch.setattr(
+        container_tester.urllib.request, "urlretrieve", fake_urlretrieve
+    )
+
+    path = downloader.download_from_release(
+        "neurodesktop",
+        "20260428-arm64",
+        "20260519",
+        image_basename="neurodesktop_20260428_arm64",
+    )
+
+    assert path == str(tmp_path / "neurodesktop_20260428_arm64_20260519.simg")
+    assert Path(path).read_text(encoding="utf-8") == "arm64 simg"
+    assert calls == [
+        "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/neurodesktop_20260428_arm64_20260519.simg",
+    ]
+
+
+def test_release_downloader_falls_back_to_computed_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    downloader = ReleaseContainerDownloader(cache_dir=str(tmp_path))
+    calls: list[str] = []
+
+    def fake_urlretrieve(url: str, filename: str) -> tuple[str, None]:
+        calls.append(url)
+        if "custom_globus_20260514.simg" in url:
+            raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        Path(filename).write_text("fallback simg", encoding="utf-8")
+        return filename, None
+
+    monkeypatch.setattr(
+        container_tester.urllib.request, "urlretrieve", fake_urlretrieve
+    )
+
+    path = downloader.download_from_release(
+        "globus",
+        "3.2.8",
+        "20260514",
+        image_basename="custom_globus",
+    )
+
+    assert path == str(tmp_path / "globus_3.2.8_20260514.simg")
+    assert calls == [
+        "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/custom_globus_20260514.simg",
+        "https://neurocontainers.s3.us-east-2.amazonaws.com/custom_globus_20260514.simg",
+        "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/globus_3.2.8_20260514.simg",
+    ]
+
+
+def test_release_downloader_extracts_sanitized_image_basename(
+    tmp_path: Path,
+) -> None:
+    release_file = tmp_path / "20260428-arm64.json"
+    release_file.write_text(
+        """
+        {
+          "apps": {
+            "neurodesktop 20260428 arm64": {
+              "version": "20260519",
+              "image": "https://example.invalid/nested/neurodesktop_20260428_arm64.simg?download=1"
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    downloader = ReleaseContainerDownloader(cache_dir=str(tmp_path / "cache"))
+
+    assert (
+        downloader.extract_image_basename_from_release(str(release_file))
+        == "neurodesktop_20260428_arm64"
+    )
+
+
+def test_release_downloader_accepts_image_basename_with_build_date(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    downloader = ReleaseContainerDownloader(cache_dir=str(tmp_path))
+    calls: list[str] = []
+
+    def fake_urlretrieve(url: str, filename: str) -> tuple[str, None]:
+        calls.append(url)
+        Path(filename).write_text("simg", encoding="utf-8")
+        return filename, None
+
+    monkeypatch.setattr(
+        container_tester.urllib.request, "urlretrieve", fake_urlretrieve
+    )
+
+    path = downloader.download_from_release(
+        "neurodesktop",
+        "20260428-arm64",
+        "20260519",
+        image_basename="neurodesktop_20260428_arm64_20260519.simg",
+    )
+
+    assert path == str(tmp_path / "neurodesktop_20260428_arm64_20260519.simg")
+    assert calls == [
+        "https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/neurodesk/neurodesktop_20260428_arm64_20260519.simg",
+    ]
+
+
+def test_auto_location_passes_release_image_basename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release_file = tmp_path / "release.json"
+    release_file.write_text(
+        """
+        {
+          "apps": {
+            "neurodesktop": {
+              "version": "20260519",
+              "image": "neurodesktop_20260428_arm64"
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    tester = ContainerTester()
+    tester.release_downloader = ReleaseContainerDownloader(cache_dir=str(tmp_path))
+    tester.selected_runtime = type("Runtime", (), {"name": "apptainer"})()
+    calls: list[dict[str, object]] = []
+
+    def fake_download(*args, **kwargs) -> None:
+        calls.append({"args": args, "kwargs": kwargs})
+        return None
+
+    monkeypatch.setattr(tester.cvmfs, "is_available", lambda: False)
+    monkeypatch.setattr(tester.release_downloader, "download_from_release", fake_download)
+
+    assert (
+        tester.find_container(
+            "neurodesktop",
+            "20260428-arm64",
+            location="release",
+            release_file=str(release_file),
+        )
+        is None
+    )
+    assert calls == [
+        {
+            "args": ("neurodesktop", "20260428-arm64", "20260519"),
+            "kwargs": {"image_basename": "neurodesktop_20260428_arm64"},
+        }
+    ]
+
+
 def test_auto_location_does_not_return_docker_tag_for_apptainer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -76,7 +239,7 @@ def test_auto_location_does_not_return_docker_tag_for_apptainer(
 
     monkeypatch.setattr(tester.cvmfs, "is_available", lambda: False)
     monkeypatch.setattr(
-        tester.release_downloader, "download_from_release", lambda *args: None
+        tester.release_downloader, "download_from_release", lambda *args, **kwargs: None
     )
 
     assert tester.find_container("globus", "3.2.8", location="auto") is None
@@ -91,7 +254,7 @@ def test_auto_location_can_return_docker_tag_for_docker_runtime(
 
     monkeypatch.setattr(tester.cvmfs, "is_available", lambda: False)
     monkeypatch.setattr(
-        tester.release_downloader, "download_from_release", lambda *args: None
+        tester.release_downloader, "download_from_release", lambda *args, **kwargs: None
     )
 
     assert tester.find_container("globus", "3.2.8", location="auto") == "globus:3.2.8"

--- a/builder/tests/test_release_test_runner.py
+++ b/builder/tests/test_release_test_runner.py
@@ -11,6 +11,7 @@ from workflows.release_test_runner import (
     _normalise_run_tests_output,
     _release_build_date,
     main,
+    run_fulltest_release,
 )
 from workflows.reporting import build_report
 
@@ -178,6 +179,116 @@ def test_main_writes_failure_outputs_when_fulltest_adapter_errors(
     assert results_path.is_file()
     assert (tmp_path / "builder" / "test-report-niimath.md").is_file()
     assert "status=failed" in github_output.read_text(encoding="utf-8")
+
+
+def test_run_fulltest_release_uses_release_image_basename(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "cache" / "neurodesktop_20260428_arm64_20260519.simg"
+    source.parent.mkdir()
+    source.write_text("simg", encoding="utf-8")
+    release_file = tmp_path / "20260428-arm64.json"
+    release_file.write_text(
+        json.dumps(
+            {
+                "apps": {
+                    "neurodesktop 20260428 arm64": {
+                        "version": "20260519",
+                        "image": "neurodesktop_20260428_arm64",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    test_config = tmp_path / "fulltest.yaml"
+    test_config.write_text("tests: []\n", encoding="utf-8")
+    output_dir = tmp_path / "builder"
+
+    calls: list[dict[str, object]] = []
+
+    class FakeDownloader:
+        def extract_image_basename_from_release(self, release_file: str) -> str:
+            return "neurodesktop_20260428_arm64"
+
+        def download_from_release(self, *args, **kwargs) -> str:
+            calls.append({"args": args, "kwargs": kwargs})
+            return str(source)
+
+    class FakeTester:
+        def __init__(self) -> None:
+            self.release_downloader = FakeDownloader()
+
+        def select_runtime(self, runtime: str) -> SimpleNamespace:
+            return SimpleNamespace(name="apptainer")
+
+        def run_test_suite(self, *args, **kwargs) -> dict[str, object]:
+            return {
+                "total_tests": 1,
+                "passed": 1,
+                "failed": 0,
+                "skipped": 0,
+                "test_results": [{"name": "deploy", "status": "passed"}],
+            }
+
+    def fake_run(command, **kwargs) -> SimpleNamespace:
+        raw_path = Path(command[command.index("-o") + 1])
+        log_path = Path(command[command.index("--log") + 1])
+        jsonl_path = Path(command[command.index("--jsonl") + 1])
+        raw_path.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "total_tests": 0,
+                        "tests_passed": 0,
+                        "tests_failed": 0,
+                    },
+                    "suites": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        log_path.write_text("", encoding="utf-8")
+        jsonl_path.write_text("", encoding="utf-8")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("workflows.release_test_runner.ContainerTester", FakeTester)
+    monkeypatch.setattr("workflows.release_test_runner.subprocess.run", fake_run)
+
+    status = run_fulltest_release(
+        SimpleNamespace(
+            recipe="neurodesktop",
+            version="20260428-arm64",
+            release_file=str(release_file),
+            test_config=str(test_config),
+            output_dir=str(output_dir),
+            results_path=str(output_dir / "results.json"),
+            runtime="apptainer",
+            docker_to_simg=False,
+            docker_registry="neurodesk",
+            docker_save_to_simg="builder/docker-save-to-simg.go",
+            verbose=False,
+            repo_root=str(tmp_path),
+        )
+    )
+
+    assert status == "passed"
+    assert calls == [
+        {
+            "args": ("neurodesktop", "20260428-arm64", "20260519"),
+            "kwargs": {
+                "image_basename": "neurodesktop_20260428_arm64",
+                "use_cache": False,
+            },
+        }
+    ]
+    assert (
+        "container: neurodesktop_20260428_arm64_20260519.simg"
+        in (output_dir / "fulltest-suite-neurodesktop.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
 
 
 def test_build_report_includes_fulltest_summary_and_artifacts() -> None:

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -400,6 +400,7 @@ class ReleaseContainerDownloader:
         version: str,
         build_date: Optional[str],
         *,
+        image_basename: Optional[str] = None,
         use_cache: bool = True,
     ) -> Optional[str]:
         """Download container using release build information"""
@@ -412,9 +413,12 @@ class ReleaseContainerDownloader:
 
         # The primary format for release containers includes the build date:
         # {base_url}/{name}_{version}_{build_date}.simg
-        filenames = [
-            f"{name}_{version}_{build_date}.simg",  # Primary format for releases
-        ]
+        filenames = []
+        image_basename = self.normalise_image_basename(image_basename)
+        if image_basename:
+            filenames.append(self.release_filename(image_basename, build_date))
+        filenames.append(f"{name}_{version}_{build_date}.simg")
+        filenames = list(dict.fromkeys(filenames))
 
         for filename in filenames:
             cache_path = os.path.join(self.cache_dir, filename)
@@ -450,6 +454,46 @@ class ReleaseContainerDownloader:
                     print(f"Failed to download from {source_name} ({url}): {e}")
                     continue
 
+        return None
+
+    @staticmethod
+    def normalise_image_basename(image: Optional[str]) -> Optional[str]:
+        """Return a safe SIF image basename from release metadata."""
+        if not image:
+            return None
+
+        image_text = str(image).strip()
+        parsed = urllib.parse.urlparse(image_text)
+        image_path = parsed.path if parsed.scheme and parsed.path else image_text
+        basename = image_path.replace("\\", "/").rsplit("/", 1)[-1]
+        if basename.endswith(".simg"):
+            basename = basename[:-5]
+        elif basename.endswith(".sif"):
+            basename = basename[:-4]
+        basename = basename.strip()
+        if not basename or basename in {".", ".."}:
+            return None
+        return basename
+
+    @staticmethod
+    def release_filename(image_basename: str, build_date: str) -> str:
+        """Return the release SIF filename for an image basename and build date."""
+        if image_basename.endswith(f"_{build_date}"):
+            return f"{image_basename}.simg"
+        return f"{image_basename}_{build_date}.simg"
+
+    def extract_image_basename_from_release(self, release_file: str) -> Optional[str]:
+        """Extract the release image basename from release JSON metadata."""
+        try:
+            with open(release_file, "r") as f:
+                release_data = json.load(f)
+
+            apps = release_data.get("apps", {})
+            if apps:
+                first_app = list(apps.values())[0]
+                return self.normalise_image_basename(first_app.get("image"))
+        except Exception:
+            pass
         return None
 
     def extract_build_date_from_release(self, release_file: str) -> Optional[str]:
@@ -753,13 +797,22 @@ class ContainerTester:
         if location == "auto" or location == "release":
             # Try to download using release information
             build_date = None
+            image_basename = None
             if release_file and os.path.exists(release_file):
                 build_date = self.release_downloader.extract_build_date_from_release(
                     release_file
                 )
+                image_basename = (
+                    self.release_downloader.extract_image_basename_from_release(
+                        release_file
+                    )
+                )
 
             downloaded_path = self.release_downloader.download_from_release(
-                name, version, build_date
+                name,
+                version,
+                build_date,
+                image_basename=image_basename,
             )
             if downloaded_path:
                 self.downloaded_container_path = downloaded_path  # Track for cleanup

--- a/workflows/release_test_runner.py
+++ b/workflows/release_test_runner.py
@@ -192,6 +192,9 @@ def run_fulltest_release(args: argparse.Namespace) -> str:
 
     build_date = _release_build_date(release_file)
     tester = ContainerTester()
+    image_basename = tester.release_downloader.extract_image_basename_from_release(
+        str(release_file)
+    )
     runtime = tester.select_runtime(args.runtime)
     if runtime.name != "apptainer":
         raise RuntimeError("fulltest.yaml release tests currently require Apptainer/Singularity")
@@ -210,6 +213,7 @@ def run_fulltest_release(args: argparse.Namespace) -> str:
             args.recipe,
             args.version,
             build_date,
+            image_basename=image_basename,
             use_cache=False,
         )
         if not container_ref:


### PR DESCRIPTION
## Summary
- prefer the sanitized `apps.*.image` basename from release JSON when downloading release SIFs
- keep the computed `<recipe>_<version>_<build_date>.simg` filename as a fallback
- preserve `use_cache` semantics for release PR fulltests
- wire the image basename through both legacy `ContainerTester.find_container` and the fulltest-aware `release_test_runner` path

## Context
Arm64 release versions can include `-arm64`, while the uploaded SIF basename can use `_arm64` from release metadata. For example, the release version may be `20260428-arm64`, but the actual artifact is `neurodesktop_20260428_arm64_20260519.simg`. Computing the filename from version alone misses that artifact.

## Tests
- `uv run --with pytest pytest builder/tests/test_container_tester_release_download.py builder/tests/test_release_test_runner.py`
- `python3 -m py_compile workflows/container_tester.py workflows/release_test_runner.py`
- `git diff --check`