### PR TITLE
Fix BrainageR SPM runtime wrapper

### DIFF
--- a/recipes/brainager/brainager_segment.py
+++ b/recipes/brainager/brainager_segment.py
@@ -89,9 +89,14 @@ def main():
     print(f"[INFO] Working directory: {workdir}")
     print(f"[INFO] Running SPM12 with T1: {t1_dst}")
 
-    # Run spm12 standalone
-    cmd = ["run_spm12.sh", "/opt/mcr/v97", "script", batch_copy]
-    subprocess.run(cmd, check=True, cwd=workdir)
+    # Run spm12 standalone. The deployed SPM12 build in this recipe uses the
+    # R2017b MCR; preloading system FreeType avoids the MCR-bundled library
+    # shadowing Ubuntu's fontconfig at runtime.
+    spm_env = os.environ.copy()
+    spm_env["LD_PRELOAD"] = "/usr/lib/x86_64-linux-gnu/libfreetype.so.6"
+    mcr_root = os.environ.get("MCRROOT", "/opt/mcr/v93")
+    cmd = ["run_spm12.sh", mcr_root, "script", batch_copy]
+    subprocess.run(cmd, check=True, cwd=workdir, env=spm_env)
 
     print(f"[INFO] SPM12 finished, now running prediction")
 

--- a/recipes/brainager/build.yaml
+++ b/recipes/brainager/build.yaml
@@ -83,6 +83,7 @@ build:
         - osf -p azwmg fetch pca_scale.rds
 
     - copy: dependencies.R /opt
+    - copy: brainager_segment.py /opt/brainageR/brainager_segment.py
     - copy: predict_age_patched.py /opt/brainageR/predict_age.py
 
     - run:


### PR DESCRIPTION
## Summary

Fix the BrainageR runtime wrapper used by the recipe so the SPM12 segmentation pipeline can run in the built container.

Changes:
- copy the recipe-local `brainager_segment.py` into `/opt/brainageR` during the build
- run SPM12 with the recipe's MCR root instead of the stale hard-coded `/opt/mcr/v97`
- preload Ubuntu's FreeType library for the SPM subprocess to avoid the MCR-bundled FreeType shadowing system `fontconfig`

## Evidence

- Reproduced current released image failure against `brainager_2.1.0_20251220.simg`: fulltest 38/48 passed, 10 failed; both real pipeline commands exited 1.
- Manual failure log showed SPM12 crash:
  `/opt/spm12/spm12: symbol lookup error: /lib/x86_64-linux-gnu/libfontconfig.so.1: undefined symbol: FT_Done_MM_Var`.
- Manual SPM rerun with system FreeType preloaded completed segmentation/DARTEL/normalization/tissue volume output.
- Patched wrapper bind-mounted over the released image completed the full example-data BrainageR pipeline and wrote `brainage_prediction.csv`.
- Patched wrapper bind-mounted over the released image completed the ds000001 T1w pipeline and wrote `brainage_prediction.csv`.
- `python3 -m py_compile recipes/brainager/brainager_segment.py` passed.
- PyYAML parse passed for `recipes/brainager/build.yaml` and `recipes/brainager/fulltest.yaml`.
- `python3 -m builder generate recipes/brainager --architecture x86_64 --output-root /tmp/brainager-generate --recreate` passed and generated a Dockerfile with the wrapper copy.
- `git diff --check` passed.

## Confidence

Medium-high. The affected runtime path was exercised inside the released Singularity image using the patched wrapper, including both failing fulltest pipeline inputs. A fresh Docker/SIF rebuild was not practical on this host because Docker/buildx is unavailable.