### PR TITLE
Harden release fulltest workspace cleanup

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -30,6 +30,18 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          clean: false
+
+      - name: Prepare release test workspace
+        run: |
+          rm -rf \
+            builder/test-results-* \
+            builder/test-report-* \
+            builder/comment-* \
+            builder/status-* \
+            builder/fulltest-* \
+            builder/fulltest-containers || true
+          mkdir -p builder
 
       - name: Detect release and test-only changes
         id: detect
@@ -218,6 +230,7 @@ jobs:
     steps:
       - name: Download all test results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           pattern: test-results-*
           merge-multiple: true
@@ -226,6 +239,7 @@ jobs:
       - name: Summarize test results
         id: summary
         run: |
+          mkdir -p test-results
           cd test-results
 
           TOTAL_RECIPES=0
@@ -246,6 +260,11 @@ jobs:
             fi
           done
 
+          if [ "$TOTAL_RECIPES" -eq 0 ]; then
+            FAILED_RECIPES=1
+            echo "No test result artifacts were produced"
+          fi
+
           echo "total=$TOTAL_RECIPES" >> $GITHUB_OUTPUT
           echo "passed=$PASSED_RECIPES" >> $GITHUB_OUTPUT
           echo "failed=$FAILED_RECIPES" >> $GITHUB_OUTPUT
@@ -261,13 +280,19 @@ jobs:
             const failed = parseInt('${{ steps.summary.outputs.failed }}');
 
             let summary = `## 🧪 Container Test Summary\n\n`;
-            summary += `**Results:** ${passed}/${total} recipes passed\n\n`;
-
-            if (failed > 0) {
-              summary += `❌ ${failed} recipe(s) failed testing\n`;
-              summary += `Please check the individual test results above for details.\n\n`;
+            if (total === 0) {
+              summary += `**Results:** no test result artifacts were produced\n\n`;
+              summary += `❌ Container testing did not reach the result upload step.\n`;
+              summary += `Please check the workflow logs for the infrastructure failure.\n\n`;
             } else {
-              summary += `✅ All modified containers passed testing!\n\n`;
+              summary += `**Results:** ${passed}/${total} recipes passed\n\n`;
+
+              if (failed > 0) {
+                summary += `❌ ${failed} recipe(s) failed testing\n`;
+                summary += `Please check the individual test results above for details.\n\n`;
+              } else {
+                summary += `✅ All modified containers passed testing!\n\n`;
+              }
             }
 
             summary += `*This comment will be updated as tests complete.*`;
@@ -302,5 +327,9 @@ jobs:
 
             // Fail the workflow if any tests failed
             if (failed > 0) {
-              core.setFailed(`${failed} out of ${total} container tests failed`);
+              if (total === 0) {
+                core.setFailed('No container test result artifacts were produced');
+              } else {
+                core.setFailed(`${failed} out of ${total} container tests failed`);
+              }
             }

--- a/builder/run_tests.py
+++ b/builder/run_tests.py
@@ -973,6 +973,12 @@ def main():
         help="Directory containing container files (default: containers)",
     )
     parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=Path("work"),
+        help="Directory for test scratch space and cached data (default: work)",
+    )
+    parser.add_argument(
         "-f", "--filter",
         type=str,
         help="Filter tests by name pattern (regex)",
@@ -1037,11 +1043,11 @@ def main():
 
     base_dir = Path.cwd()
     tests_dir = base_dir / "tests"
-    work_dir = base_dir / "work"
+    work_dir = args.work_dir.resolve()
     containers_dir = args.containers_dir.resolve()
 
     # Ensure work directory exists
-    work_dir.mkdir(exist_ok=True)
+    work_dir.mkdir(parents=True, exist_ok=True)
 
     # Parse --retry JSONL to build map of suite -> failed test names
     retry_map: dict[str, set[str]] | None = None

--- a/builder/tests/test_release_test_runner.py
+++ b/builder/tests/test_release_test_runner.py
@@ -232,7 +232,12 @@ def test_run_fulltest_release_uses_release_image_basename(
                 "test_results": [{"name": "deploy", "status": "passed"}],
             }
 
+    monkeypatch.setattr("workflows.release_test_runner.ContainerTester", FakeTester)
+
+    run_commands: list[list[str]] = []
+
     def fake_run(command, **kwargs) -> SimpleNamespace:
+        run_commands.append(command)
         raw_path = Path(command[command.index("-o") + 1])
         log_path = Path(command[command.index("--log") + 1])
         jsonl_path = Path(command[command.index("--jsonl") + 1])
@@ -253,7 +258,6 @@ def test_run_fulltest_release_uses_release_image_basename(
         jsonl_path.write_text("", encoding="utf-8")
         return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr("workflows.release_test_runner.ContainerTester", FakeTester)
     monkeypatch.setattr("workflows.release_test_runner.subprocess.run", fake_run)
 
     status = run_fulltest_release(
@@ -289,6 +293,24 @@ def test_run_fulltest_release_uses_release_image_basename(
             encoding="utf-8"
         )
     )
+    assert run_commands == [
+        [
+            "uv",
+            "run",
+            "builder/run_tests.py",
+            str(output_dir / "fulltest-suite-neurodesktop.yaml"),
+            "-c",
+            str(output_dir / "fulltest-containers"),
+            "-o",
+            str(output_dir / "fulltest-raw-neurodesktop.json"),
+            "--log",
+            str(output_dir / "fulltest-neurodesktop.log"),
+            "--jsonl",
+            str(output_dir / "fulltest-neurodesktop.jsonl"),
+            "--work-dir",
+            str(output_dir / "fulltest-work-neurodesktop"),
+        ]
+    ]
 
 
 def test_build_report_includes_fulltest_summary_and_artifacts() -> None:

--- a/workflows/release_test_runner.py
+++ b/workflows/release_test_runner.py
@@ -188,7 +188,9 @@ def run_fulltest_release(args: argparse.Namespace) -> str:
     fulltest_log_path = output_dir / f"fulltest-{args.recipe}.log"
     fulltest_jsonl_path = output_dir / f"fulltest-{args.recipe}.jsonl"
     suite_path = output_dir / f"fulltest-suite-{args.recipe}.yaml"
+    fulltest_work_dir = output_dir / f"fulltest-work-{args.recipe}"
     containers_dir.mkdir(parents=True, exist_ok=True)
+    fulltest_work_dir.mkdir(parents=True, exist_ok=True)
 
     build_date = _release_build_date(release_file)
     tester = ContainerTester()
@@ -251,6 +253,8 @@ def run_fulltest_release(args: argparse.Namespace) -> str:
         str(fulltest_log_path),
         "--jsonl",
         str(fulltest_jsonl_path),
+        "--work-dir",
+        str(fulltest_work_dir),
     ]
     proc = subprocess.run(command, cwd=args.repo_root, text=True, check=False)
     if proc.returncode != 0 and not raw_results_path.is_file():


### PR DESCRIPTION
## Summary
- disable the self-hosted release-test checkout clean step that was failing on stale DataLad cache permissions
- run release fulltests with an isolated per-recipe work directory under builder/ instead of the shared repo work/ path
- make the summary job report missing test artifacts clearly when infrastructure fails before upload

## Tests
- uv run --with pytest pytest builder/tests/test_release_test_runner.py
- git diff --check