### PR TITLE
Fix self-hosted release test checkout cleanup

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -30,18 +30,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          clean: false
-
-      - name: Prepare release test workspace
-        run: |
-          rm -rf \
-            builder/test-results-* \
-            builder/test-report-* \
-            builder/comment-* \
-            builder/status-* \
-            builder/fulltest-* \
-            builder/fulltest-containers || true
-          mkdir -p builder
 
       - name: Detect release and test-only changes
         id: detect
@@ -66,6 +54,18 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          clean: false
+
+      - name: Prepare release test workspace
+        run: |
+          rm -rf \
+            builder/test-results-* \
+            builder/test-report-* \
+            builder/comment-* \
+            builder/status-* \
+            builder/fulltest-* \
+            builder/fulltest-containers || true
+          mkdir -p builder
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- move `clean: false` from the hosted detect job to the self-hosted release test checkout
- move the release test workspace cleanup to the self-hosted job, where the stale DataLad cache failure happens

## Root cause
PR #2574 failed before tests started because `actions/checkout` still ran with `clean: true` on the self-hosted runner and attempted to unlink stale `work/.data_cache/ds000001` git-annex files. The previous hardening PR added the intended setting to the wrong checkout step.

## Tests
- git diff --check