### PR TITLE
Run deploy builtin tests with clean Apptainer env

### DIFF
--- a/builder/tests/test_container_tester_runtime.py
+++ b/builder/tests/test_container_tester_runtime.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from workflows.container_tester import ApptainerRuntime, ContainerTester
+
+
+def test_apptainer_runtime_uses_cleanenv_when_requested(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr("workflows.container_tester.shutil.which", lambda name: name)
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("workflows.container_tester.subprocess.run", fake_run)
+
+    runtime = ApptainerRuntime()
+    runtime.run_test("container.simg", "true", clean_env=True)
+
+    assert commands == [
+        ["apptainer", "exec", "--cleanenv", "container.simg", "bash", "-c", "true"]
+    ]
+
+
+def test_builtin_tests_run_with_clean_apptainer_environment(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeRuntime:
+        name = "apptainer"
+
+        def run_test(self, container_ref, test_script, volumes=None, gpu=False, working_dir="/test", clean_env=False):
+            calls.append(
+                {
+                    "container_ref": container_ref,
+                    "volumes": volumes,
+                    "gpu": gpu,
+                    "working_dir": working_dir,
+                    "clean_env": clean_env,
+                }
+            )
+            return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    tester = ContainerTester()
+    tester.selected_runtime = FakeRuntime()
+    result = tester._run_builtin_test(
+        "container.simg",
+        {"name": "Simple Deploy Bins/Path Test", "builtin": "test_deploy.sh"},
+    )
+
+    assert result["status"] == "passed"
+    assert calls == [
+        {
+            "container_ref": "container.simg",
+            "volumes": [],
+            "gpu": False,
+            "working_dir": "/test",
+            "clean_env": True,
+        }
+    ]

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -45,6 +45,7 @@ class ContainerRuntime:
         volumes: List[Dict[str, str]] = None,
         gpu: bool = False,
         working_dir: str = "/test",
+        clean_env: bool = False,
     ) -> subprocess.CompletedProcess:
         """Run a test script in the container"""
         raise NotImplementedError
@@ -73,6 +74,7 @@ class DockerRuntime(ContainerRuntime):
         volumes: List[Dict[str, str]] = None,
         gpu: bool = False,
         working_dir: str = "/test",
+        clean_env: bool = False,
     ) -> subprocess.CompletedProcess:
         cmd = ["docker", "run", "--rm"]
 
@@ -150,8 +152,12 @@ class ApptainerRuntime(ContainerRuntime):
         volumes: List[Dict[str, str]] = None,
         gpu: bool = False,
         working_dir: str = "/test",
+        clean_env: bool = False,
     ) -> subprocess.CompletedProcess:
         cmd = [self._get_command(), "exec"]
+
+        if clean_env:
+            cmd.append("--cleanenv")
 
         # Add volumes (bind mounts)
         if volumes:
@@ -1084,7 +1090,7 @@ class ContainerTester:
 
         try:
             proc_result = self.selected_runtime.run_test(
-                container_ref, script_content, [], gpu
+                container_ref, script_content, [], gpu, clean_env=True
             )
 
             return {


### PR DESCRIPTION
## Summary
- run builtin container tests through Apptainer/Singularity with `--cleanenv`
- keep regular script tests on the existing environment behavior
- add coverage for the Apptainer command and builtin-test call path

## Root cause
PR #2574 had 125/125 fulltest checks pass, but the deploy bins/path check failed because it saw `DEPLOY_PATH=/bin/tcsh`. The current Relion recipe generates `DEPLOY_PATH=/opt/relion-4.0.1.sm75/bin/`, so the bad value is coming from the self-hosted runner environment overriding the container environment during `apptainer exec`. The deploy builtin should validate the image metadata, not host `DEPLOY_*` variables.

## Tests
- uv run --with pytest pytest builder/tests/test_container_tester_runtime.py builder/tests/test_release_test_runner.py
- python -m compileall workflows/container_tester.py builder/tests/test_container_tester_runtime.py
- git diff --check