### PR TITLE
Fix MRSIProc Julia package install

### DIFF
--- a/recipes/mrsiproc/build.yaml
+++ b/recipes/mrsiproc/build.yaml
@@ -13,6 +13,7 @@ variables:
   julia_version: "1.10.4"
   freesurfer_version: "7.4.1"
   julia_minor_version: "1.10"
+  mrsi_pipeline_commit: 916b28dbb1828573173c5404dea2555389a610f6
   mcr_root: /opt/MATLAB_Runtime_R{{ context.matlab_version }}
   mcr_runtime: /opt/MATLAB_Runtime_R{{ context.matlab_version }}/v911
 
@@ -168,7 +169,7 @@ build:
             JULIA_DEPOT_PATH: /opt/julia_depot
         - run:
             - julia /opt/install_packages.jl
-            - chmod -R 755 /opt/julia_depot/packages/MRSI
+            - chmod -R 755 /opt/julia_depot
         - environment:
             JULIA_DEPOT_PATH: /opt/julia_depot
 
@@ -199,7 +200,7 @@ build:
         - run:
             - git clone https://github.com/korbinian90/mrsi_pipeline_neurodesk.git
             - cd mrsi_pipeline_neurodesk
-            - git checkout 02ed0178bf2d7be3ec0406fee92333ae86de377d
+            - git checkout {{ context.mrsi_pipeline_commit }}
         - environment:
             PATH: $PATH:/opt/mrsi_pipeline_neurodesk/Part1:/opt/mrsi_pipeline_neurodesk/Part2
         - copy:

--- a/recipes/mrsiproc/fulltest.yaml
+++ b/recipes/mrsiproc/fulltest.yaml
@@ -86,9 +86,9 @@ tests:
   # JULIA ENVIRONMENT
   # ==========================================================================
   - name: Julia version check
-    description: Verify Julia 1.9.3 is installed
+    description: Verify Julia 1.10 is installed
     command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'julia --version'\"'\"''"
-    expected_output_contains: "julia version 1.9"
+    expected_output_contains: "julia version 1.10"
 
   - name: Julia can run basic script
     description: Verify Julia can execute basic commands
@@ -170,11 +170,6 @@ tests:
     description: Verify LCModel basis file is present
     command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'ls -la /opt/mrsi_pipeline_neurodesk/Part1/fid_1.300000ms.basis | head -1'\"'\"''"
     expected_exit_code: 0
-
-  - name: Julia reconstruction script exists
-    description: Verify Julia reconstruction script is present
-    command: "bash -lc 'env LD_LIBRARY_PATH=/opt/MATLAB_Runtime_R2021b/v911/runtime/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/bin/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/os/glnxa64:/opt/MATLAB_Runtime_R2021b/v911/sys/opengl/lib/glnxa64 bash -lc '\"'\"'cat /opt/mrsi_pipeline_neurodesk/Part1/julia_reco.jl | head -5'\"'\"''"
-    expected_output_contains: "using MAT"
 
   # ==========================================================================
   # LCMODEL

--- a/recipes/mrsiproc/install_packages.jl
+++ b/recipes/mrsiproc/install_packages.jl
@@ -2,4 +2,3 @@ import Pkg
 ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0
 packages = ["MAT", "Comonicon"]
 Pkg.add(packages)
-Pkg.add(Pkg.PackageSpec(url="https://github.com/korbinian90/MRSI.jl"))


### PR DESCRIPTION
## Summary
- replace the pinned MRSI pipeline source with public R2021b-compatible commit `916b28dbb1828573173c5404dea2555389a610f6` from `korbinian90/mrsi_pipeline_neurodesk`
- remove the build-time Julia install of inaccessible `korbinian90/MRSI.jl`
- keep public Julia package installs `MAT` and `Comonicon`
- chmod the Julia depot rather than the removed `packages/MRSI` path
- update the MRSIProc fulltest Julia version expectation and remove the stale `julia_reco.jl` assertion

## Root cause
Fixes #2576. The Docker build failed in `julia /opt/install_packages.jl` because `Pkg.add(PackageSpec(url="https://github.com/korbinian90/MRSI.jl"))` attempted to clone a GitHub repository that is no longer publicly accessible and prompted for credentials.

I could not find a public `MRSI.jl` replacement by repository or code search. The closest compatible replacement is the public `mrsi_pipeline_neurodesk` commit `916b28dbb1828573173c5404dea2555389a610f6` on branch `no_water_weights_in_coil_comb`: it still targets MATLAB Runtime R2021b, keeps the shipped Part1/Part2 pipeline assets, and no longer includes `Part1/julia_reco.jl` or an import of `MRSI.jl`.

## Tests
- python -m builder generate mrsiproc --recreate
- python3 builder/validation.py recipes/mrsiproc/build.yaml
- git diff --check