### PR TITLE
Fix Miniconda template command chaining

### DIFF
--- a/builder/templates/miniconda.yaml
+++ b/builder/templates/miniconda.yaml
@@ -47,13 +47,13 @@ binaries:
             curl -fsSL -o "$conda_installer" {{ self.urls["*"] }}
             bash "$conda_installer" -b -p {{ self.install_path }}
             rm -f "$conda_installer"
-            if conda tos --help >/dev/null 2>&1; then conda tos accept; fi
+            if conda tos --help >/dev/null 2>&1; then conda tos accept; fi;
             {% if self.version == "latest" -%}
-            && conda update -yq -nbase conda
+            conda update -yq -nbase conda
             {% endif -%}
             {% if self.mamba == "true" -%}
-            && conda install -yq -nbase conda-libmamba-solver
-            && conda config --set solver libmamba
+            conda install -yq -nbase conda-libmamba-solver
+            conda config --set solver libmamba
             {% endif -%}
             # Prefer packages in conda-forge
             conda config --system --prepend channels conda-forge

--- a/builder/tests/test_template_rendering.py
+++ b/builder/tests/test_template_rendering.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from builder.ir import Env, Run
-from builder.dockerfile import render_dockerfile
+from builder.dockerfile import render_directive, render_dockerfile
 from builder.template import RenderContext, TemplateError, TemplateRenderer
 from builder.recipe import compile_recipe
 from builder.template_backend import apply_builtin_template
@@ -122,8 +122,49 @@ def test_miniconda_template_guards_conda_tos_for_older_installers() -> None:
         directives.append,
     )
     command = "\n".join(item.command for item in directives if isinstance(item, Run))
-    assert "if conda tos --help >/dev/null 2>&1; then conda tos accept; fi" in command
+    assert "if conda tos --help >/dev/null 2>&1; then conda tos accept; fi;" in command
     assert "\nconda tos accept\n" not in command
+
+
+def test_miniconda_template_latest_chains_update_after_tos_guard() -> None:
+    directives: list[Run] = []
+    apply_builtin_template(
+        "miniconda",
+        {
+            "version": "latest",
+            "arch": "x86_64",
+        },
+        "apt",
+        directives.append,
+    )
+    command = "\n".join(item.command for item in directives if isinstance(item, Run))
+    assert "if conda tos --help >/dev/null 2>&1; then conda tos accept; fi;" in command
+    assert "\nconda update -yq -nbase conda" in command
+    assert "\n&& conda update -yq -nbase conda" not in command
+    dockerfile_run = "\n".join(render_directive(next(item for item in directives if isinstance(item, Run))))
+    assert "then conda tos accept; fi; \\\n       conda update" in dockerfile_run
+
+
+def test_miniconda_template_mamba_chains_after_tos_guard() -> None:
+    directives: list[Run] = []
+    apply_builtin_template(
+        "miniconda",
+        {
+            "version": "py39_24.7.1-0",
+            "mamba": "true",
+            "arch": "x86_64",
+        },
+        "apt",
+        directives.append,
+    )
+    command = "\n".join(item.command for item in directives if isinstance(item, Run))
+    assert "\nconda install -yq -nbase conda-libmamba-solver" in command
+    assert "\nconda config --set solver libmamba" in command
+    assert "\n&& conda install -yq -nbase conda-libmamba-solver" not in command
+    assert "\n&& conda config --set solver libmamba" not in command
+    dockerfile_run = "\n".join(render_directive(next(item for item in directives if isinstance(item, Run))))
+    assert "then conda tos accept; fi; \\\n       conda install" in dockerfile_run
+    assert "\n    && conda config --set solver libmamba" in dockerfile_run
 
 
 def test_matlabmcr_template_uses_release_named_runtime_dirs_for_r2023b() -> None:


### PR DESCRIPTION
## Summary

Fixes generated Dockerfile command chaining in the built-in Miniconda template.

After the guarded `conda tos accept` line, recipes using either `version: latest`
or `mamba: true` could render a new shell line that began with `&&`. In the
Dockerfile this produced fragile/invalid shell syntax such as:

```text
if conda tos --help >/dev/null 2>&1; then conda tos accept; fi \
&& conda update -yq -nbase conda
```

This changes the template-owned follow-up commands to normal commands and adds a
semicolon after the one-line `if ... fi` guard so Dockerfile line folding keeps
the command block valid.

## Evidence

- `python3 -m pytest builder/tests/test_template_rendering.py builder/tests/test_dockerfile_generation.py`: 13 passed.
- `python3 -m builder.validation recipes/dafne/build.yaml`: valid.
- `python3 -m builder.validation recipes/hdbet/build.yaml`: valid.
- `python3 -m builder.validation recipes/prequal/build.yaml`: valid.
- `python3 -m builder.validation recipes/mrsiproc/build.yaml`: valid.
- `python3 -m builder generate dafne --output-root /tmp/neurocontainers-miniconda-chaining-20260605 --recreate`: generated.
- `python3 -m builder generate hdbet --output-root /tmp/neurocontainers-miniconda-chaining-20260605 --recreate`: generated.
- `python3 -m builder generate prequal --output-root /tmp/neurocontainers-miniconda-chaining-20260605 --recreate`: generated.
- `python3 -m builder generate mrsiproc --output-root /tmp/neurocontainers-miniconda-chaining-20260605 --recreate`: generated.
- Render inspection across those Dockerfiles found no `&& conda update` or `&& conda install -yq -nbase conda-libmamba-solver` immediately after the TOS guard.
- Real Docker build: `sudo docker buildx build --load --platform linux/amd64 -f build/hdbet/hdbet_1.0.0.Dockerfile -t neurocontainers-maint-hdbet:1.0.0 ...` completed successfully. The build exercised the fixed `version: latest` Miniconda path and reached image export without the previous shell syntax failure.
- `git diff --check`: clean.

## Caveats

- `hdbet` image smoke command `hd-bet --help` did not pass after the successful image build: `/neurodocker/startup.sh: line 4: hd-bet: command not found`. That appears to be a separate recipe deploy/PATH issue, not this Miniconda shell rendering fix.
- The smoke log file could not be written because the large CUDA-backed `hdbet` test image filled `/` during the smoke attempt. The test image and build cache were removed afterward, restoring free space.

Confidence: high for the builder template fix; medium for `hdbet` recipe health because the image builds but the deployed command still needs separate follow-up.