### PR TITLE
mne: update to 1.12.1 and modernize the conda bootstrap

### DIFF
--- a/recipes/mne/build.yaml
+++ b/recipes/mne/build.yaml
@@ -1,5 +1,5 @@
 name: mne
-version: 1.7.1
+version: 1.12.1
 
 copyright:
   - license: BSD-3-Clause
@@ -46,14 +46,10 @@ build:
 
     - template:
         name: miniconda
-        env_name: base
-        version: 4.7.12
-
-    - run:
-        - conda install -c conda-forge -n base mamba=0.24.0
-
-    - run:
-        - mamba create --override-channels --channel=conda-forge --name=mne-1.7.1 urllib3=2.2.1 mne=1.7.1
+        version: latest
+        env_name: mne-1.12.1
+        env_exists: "false"
+        conda_install: mne=1.12.1 python=3.13
 
     - run:
         - cp {{ get_file("download") }} vscode.deb
@@ -105,7 +101,7 @@ readme: |-
   ```
   Or:
   ```
-  source /opt/miniconda-4.7.12/etc/profile.d/conda.sh
+  source /opt/miniconda-latest/etc/profile.d/conda.sh
   conda activate mne-{{ context.version }}
   ```
 
@@ -113,7 +109,7 @@ readme: |-
   To cite MNE Python see here: https://mne.tools/stable/overview/cite.html
 
 
-  To run applications outside of this container: ml mne/1.0.3
+  To run applications outside of this container: ml mne/1.12.1
   Note the use of the module system does not currently interface with MNE and conda environments in this container
   ----------------------------------
 


### PR DESCRIPTION
## Summary
Updates the `mne` recipe from 1.7.1 to 1.12.1 and modernizes the conda
bootstrap so the container builds again.

## Motivation
The recipe can no longer be built. Its bootstrap pins **Miniconda 4.7.12 +
mamba 0.24.0**, whose bundled OpenSSL/CA certificates are too old to complete a
TLS handshake with the package repositories, `conda install` fails with
`certificate verify failed`, so nothing installs.

## Changes
- Bump `version` 1.7.1 → **1.12.1**.
- Replace the unusable `Miniconda 4.7.12 → mamba 0.24.0 → mamba create`
  sequence with the standard `miniconda` template path used across current
  recipes (`version: latest`, conda-forge strict priority, `conda tos accept`,
  env creation + `conda_install`).
- Pin `python=3.13` (MNE 1.12.1 requires ≥3.10).
- Drop the obsolete `urllib3=2.2.1` workaround pin.
- Refresh README references (`/opt/miniconda-latest`, `ml mne/1.12.1`).

The diff is limited to `recipes/mne/build.yaml`; the base image
(`ubuntu:20.04`), the VS Code/IDE layer, and `mne-bids-pipeline` are unchanged.

## Validation
Built natively with `python -m builder build mne`, then the **same deterministic
MNE pipeline was run on two operating systems / architectures**, both with the
identical scientific stack (`mne 1.12.1`, `numpy 2.4.6`, `scipy 1.17.1`,
`scikit-learn 1.9.0`):

- **Linux x86_64**: this container (Ubuntu 20.04 base), Python 3.13.13.
- **macOS / Apple Silicon (arm64)**: independent native conda env, Python 3.11.

Pipeline: synthetic raw → FIR filter → Welch PSD, and a real EDF read → montage
→ filter → epoch → evoked (PhysioNet eegbci). Across the two operating systems
the outputs are **numerically equivalent within tolerance**, scale-free
relative error ≤ 6e-16 (rtol = 1e-6), i.e. differences only at the level of
float64 machine epsilon, attributable to CPU architecture rather than the
container.

## Notes
- `architectures` unchanged (`x86_64`).
- `version: latest` for the Miniconda *installer* matches current recipes
  (e.g. topaz, fsqc); the MNE and Python package versions are explicitly pinned.