### PR TITLE
Fix pinned Miniconda template command chaining

### DIFF
--- a/builder/templates/miniconda.yaml
+++ b/builder/templates/miniconda.yaml
@@ -40,7 +40,6 @@ binaries:
     -   run: |
             {% if not self.installed.lower() in ["true", "y", "1"] -%}
             {{ self.install_dependencies() }}
-            # Install dependencies.
             export PATH="{{ self.install_path }}/bin:$PATH"
             echo "Downloading Miniconda installer ..."
             conda_installer="/tmp/miniconda.sh"
@@ -55,16 +54,10 @@ binaries:
             conda install -yq -nbase conda-libmamba-solver
             conda config --set solver libmamba
             {% endif -%}
-            # Prefer packages in conda-forge
             conda config --system --prepend channels conda-forge
-            # Packages in lower-priority channels not considered if a package with the same
-            # name exists in a higher priority channel. Can dramatically speed up installations.
-            # Conda recommends this as a default
-            # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html
             conda config --set channel_priority strict
             conda config --system --set auto_update_conda false
             conda config --system --set show_channel_urls true
-            # Enable `conda activate`
             conda init bash
             {% endif -%}
             {% if self.yaml_file -%}
@@ -95,6 +88,5 @@ binaries:
                   {%- endif -%}
               {% endfor %}"
             {% endif -%}
-            # Clean up
             sync && conda clean --all --yes && sync
             rm -rf ~/.cache/pip/*

--- a/builder/tests/test_template_rendering.py
+++ b/builder/tests/test_template_rendering.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -165,6 +166,31 @@ def test_miniconda_template_mamba_chains_after_tos_guard() -> None:
     dockerfile_run = "\n".join(render_directive(next(item for item in directives if isinstance(item, Run))))
     assert "then conda tos accept; fi; \\\n       conda install" in dockerfile_run
     assert "\n    && conda config --set solver libmamba" in dockerfile_run
+
+
+def test_miniconda_template_pinned_default_chains_after_tos_guard() -> None:
+    directives: list[Run] = []
+    apply_builtin_template(
+        "miniconda",
+        {
+            "version": "py313_26.3.2-2",
+            "conda_install": "python=3.12",
+            "arch": "x86_64",
+        },
+        "apt",
+        directives.append,
+    )
+    dockerfile_run = "\n".join(render_directive(next(item for item in directives if isinstance(item, Run))))
+    assert not any(line.strip().startswith("#") for line in dockerfile_run.splitlines())
+
+    shell_command = dockerfile_run.removeprefix("RUN ").replace("\\\n", " ")
+    result = subprocess.run(
+        ["/bin/sh", "-n", "-c", shell_command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_matlabmcr_template_uses_release_named_runtime_dirs_for_r2023b() -> None:


### PR DESCRIPTION
## Summary
- remove inline comments from the Miniconda template RUN chain so optional template blocks cannot leave a comment between `fi` and the next command
- add a regression test for pinned non-`latest` Miniconda with default `mamba: false`
- verify the rendered pinned/default RUN command parses with `/bin/sh -n`

Fixes #2602.

## Tests
- `uv run --with pytest pytest builder/tests/test_template_rendering.py`
- rendered pinned/default Miniconda RUN command and checked it with `/bin/sh -n`
- `git diff --check`