### PR TITLE
Install tcsh for RELION deploy path

### DIFF
--- a/recipes/relion/build.yaml
+++ b/recipes/relion/build.yaml
@@ -48,6 +48,7 @@ build:
         - libxft-dev
         - libwxgtk3.0-gtk3-dev
         - lmod
+        - tcsh
 
     - workdir: /tmp
 


### PR DESCRIPTION
## Summary
- install tcsh in the RELION image so deployed RELION bin entries that resolve to /bin/tcsh are valid at runtime
- leaves the generated release metadata untouched

## Validation
- python3 builder/validation.py recipes/relion/build.yaml --verbose
- python -m builder generate relion --recreate

Follow-up for #2574.