### PR TITLE
Normalize release test workspace permissions

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -160,6 +160,17 @@ jobs:
             --verbose
         continue-on-error: true
 
+      - name: Normalize test workspace permissions
+        if: always()
+        working-directory: source
+        run: |
+          for path in builder work; do
+            if [ -e "$path" ]; then
+              sudo chown -R "$(id -u):$(id -g)" "$path" || true
+              chmod -R u+rwX "$path" || true
+            fi
+          done
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()


### PR DESCRIPTION
## Summary
- normalize ownership and user write permissions for release-test builder/work directories after each test run
- reduces self-hosted runner failures caused by DataLad/container-created files that later checkout cleanup cannot remove

## Validation
- parsed .github/workflows/test-release-pr.yml with PyYAML
- git diff --check

Follow-up for #2572.