### PR TITLE
Avoid pip cache in CPAC build layer

### DIFF
--- a/recipes/cpac/build.yaml
+++ b/recipes/cpac/build.yaml
@@ -18,7 +18,8 @@ build:
     - copy: cpac-run /usr/local/bin/cpac-run
     - run:
         - chmod +x /usr/local/bin/cpac-run
-        - pip install "setuptools<81"
+        - pip install --no-cache-dir "setuptools<81"
+        - rm -rf /root/.cache/pip
   add-default-template: false
   add-tzdata: false
 


### PR DESCRIPTION
## Summary
- install the CPAC setuptools pin with `--no-cache-dir`
- remove `/root/.cache/pip` in the same layer to reduce image cache waste

## Validation
- `python3 builder/validation.py recipes/cpac/build.yaml --verbose`
- `git diff --check origin/main..HEAD`