### PR TITLE
Tolerate release test comment timeouts

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -189,6 +189,7 @@ jobs:
       - name: Comment test results on PR
         if: always()
         uses: actions/github-script@v9
+        continue-on-error: true
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- mark the per-container release test PR comment step as non-blocking
- keep the summary job responsible for failing real test failures

## Validation
- `git diff --check origin/main..HEAD`