### PR TITLE
Fix OSHy-X Python PATH for builds and fulltests

### DIFF
--- a/recipes/oshyx/build.yaml
+++ b/recipes/oshyx/build.yaml
@@ -15,8 +15,7 @@ deploy:
     - julia
   path:
     - /opt/ants-2.3.1/
-    - /opt/miniconda-latest/bin/python
-    - /opt/miniconda-latest/bin/julia
+    - /opt/miniconda-latest/bin
 
 readme: |-
   ----------------------------------

--- a/recipes/oshyx/fulltest.yaml
+++ b/recipes/oshyx/fulltest.yaml
@@ -28,6 +28,9 @@ test_data:
   box_7t: /OSHy/templates/7T_box.nii.gz
   output_dir: test_output
 
+env_setup: |
+  export PATH=/opt/miniconda-latest/bin:/opt/ants-2.3.1:$PATH
+
 setup:
   script: |
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- expose `/opt/miniconda-latest/bin` as the OSHy-X deploy path instead of individual executable paths
- add fulltest PATH setup for the conda and ANTs runtime directories

## Validation
- `python3 builder/validation.py recipes/oshyx/build.yaml --verbose`
- `git diff --check origin/main..HEAD`