### PR TITLE
Fix XCP-D AFNI libpng runtime

### DIFF
--- a/recipes/xcpd/build.yaml
+++ b/recipes/xcpd/build.yaml
@@ -17,6 +17,14 @@ build:
   base-image: pennlinc/xcp_d:0.10.7
   pkg-manager: apt
   directives:
+    - run:
+        - |
+          rm -rf /tmp/libpng12
+          mkdir -p /tmp/libpng12
+          dpkg-deb -x {{ get_file("libpng12_deb") }} /tmp/libpng12
+          rm -f /usr/lib/x86_64-linux-gnu/libpng12.so.0
+          cp -a /tmp/libpng12/lib/x86_64-linux-gnu/libpng12.so.0* /usr/lib/x86_64-linux-gnu/
+          rm -rf /tmp/libpng12
     - deploy:
         path: []
         bins:
@@ -53,3 +61,6 @@ readme: |-
 copyright:
   - license: BSD-3-Clause
     url: https://github.com/PennLINC/xcp_d?tab=BSD-3-Clause-1-ov-file#readme
+files:
+  - name: libpng12_deb
+    url: https://snapshot.debian.org/archive/debian-security/20160113T213056Z/pool/updates/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb


### PR DESCRIPTION
## Summary
- install the real libpng12 compatibility payload from a declared file
- replace the broken base-image libpng12 symlink before deploy testing
- keep the staged fix HTTPS-only for the declared Debian snapshot file

## Validation
- `python3 builder/validation.py recipes/xcpd/build.yaml --verbose`
- `git diff --check origin/main..HEAD`