### PR TITLE
Update HDBET recipe to 2.0.1

### DIFF
--- a/recipes/hdbet/build.yaml
+++ b/recipes/hdbet/build.yaml
@@ -1,5 +1,5 @@
 name: hdbet
-version: 1.0.0
+version: 2.0.1
 
 architectures:
   - x86_64
@@ -14,6 +14,7 @@ build:
     - install:
         - git
         - curl
+        - unzip
 
     - template:
         name: miniconda
@@ -25,22 +26,24 @@ build:
     - workdir: /opt
 
     - run:
-        - git clone https://github.com/MIC-DKFZ/HD-BET
+        - git clone --depth 1 --branch v{{ context.version }} https://github.com/MIC-DKFZ/HD-BET
 
     - workdir: /opt/HD-BET
 
     - run:
         - echo 'import os' > /opt/HD-BET/HD_BET/paths.py
-        - echo 'folder_with_parameter_files = "/opt/HD-BET/hd-bet_params"' >> /opt/HD-BET/HD_BET/paths.py
+        - echo 'folder_with_parameter_files = "/opt/HD-BET/hd-bet_params/release_2.0.0"' >> /opt/HD-BET/HD_BET/paths.py
+        - echo 'ZENODO_DOWNLOAD_URL = "https://zenodo.org/records/14445620/files/release_v1.5.0.zip?download=1"' >> /opt/HD-BET/HD_BET/paths.py
         - mkdir -p /opt/HD-BET/hd-bet_params
-        - cp {{ get_file("0_model") }} /opt/HD-BET/hd-bet_params/0.model
-        - cp {{ get_file("1_model") }} /opt/HD-BET/hd-bet_params/1.model
-        - cp {{ get_file("2_model") }} /opt/HD-BET/hd-bet_params/2.model
-        - cp {{ get_file("3_model") }} /opt/HD-BET/hd-bet_params/3.model
-        - cp {{ get_file("4_model") }} /opt/HD-BET/hd-bet_params/4.model
+        - unzip -q {{ get_file("release_v1_5_0_zip") }} -d /opt/HD-BET/hd-bet_params/release_2.0.0
         - /opt/miniconda-latest/envs/hdbet/bin/python -m pip install -e .
 
+    - environment:
+        PATH: /opt/miniconda-latest/envs/hdbet/bin:$PATH
+
 deploy:
+  path:
+    - /opt/miniconda-latest/envs/hdbet/bin
   bins:
     - hd-bet
 
@@ -56,13 +59,13 @@ readme: |
   Example:
   ```
   # Single file (CPU, fast mode):
-  hd-bet -i INPUT_FILENAME -device cpu -mode fast -tta 0
+  hd-bet -i INPUT_FILENAME -o OUTPUT_FILENAME -device cpu --disable_tta
 
   # Directory processing:
-  hd-bet -i INPUT_FOLDER -o OUTPUT_FOLDER -device cpu -mode fast -tta 0
+  hd-bet -i INPUT_FOLDER -o OUTPUT_FOLDER -device cpu --disable_tta
 
   # With GPU:
-  hd-bet -i INPUT_FILENAME
+  hd-bet -i INPUT_FILENAME -o OUTPUT_FILENAME
   ```
 
   More documentation can be found here: https://github.com/MIC-DKFZ/HD-BET
@@ -71,17 +74,5 @@ readme: |
   ----------------------------------
 
 files:
-  - name: 0_model
-    url: https://zenodo.org/record/2540695/files/0.model?download=1
-
-  - name: 1_model
-    url: https://zenodo.org/record/2540695/files/1.model?download=1
-
-  - name: 2_model
-    url: https://zenodo.org/record/2540695/files/2.model?download=1
-
-  - name: 3_model
-    url: https://zenodo.org/record/2540695/files/3.model?download=1
-
-  - name: 4_model
-    url: https://zenodo.org/record/2540695/files/4.model?download=1
+  - name: release_v1_5_0_zip
+    url: https://zenodo.org/records/14445620/files/release_v1.5.0.zip?download=1

--- a/recipes/hdbet/fulltest.yaml
+++ b/recipes/hdbet/fulltest.yaml
@@ -1,9 +1,9 @@
 # hdbet container test suite
-# Minimal no-rebuild verification for the shipped HD-BET project payload.
+# Minimal verification for the shipped HD-BET project payload.
 
 name: hdbet
-version: 1.0.0
-container: hdbet_1.0.0_20210318.simg
+version: 2.0.1
+container: hdbet_2.0.1_20260605.simg
 
 test_data:
   output_dir: test_output
@@ -17,29 +17,35 @@ setup:
 tests:
   - name: Python runtime available
     description: Verify the shipped HD-BET conda runtime matches the image
-    command: /opt/miniconda-latest/bin/python --version
-    expected_output_contains: "Python 3.6.13"
+    command: /opt/miniconda-latest/envs/hdbet/bin/python --version
+    expected_output_contains: "Python 3.10"
 
   - name: HD_BET import path
     description: Verify the HD_BET module imports from the shipped conda environment
     command: >-
-      /opt/miniconda-latest/bin/python -c "import HD_BET; print(HD_BET.__file__)"
+      /opt/miniconda-latest/envs/hdbet/bin/python -c "import HD_BET; print(HD_BET.__file__)"
     expected_output_contains: "/opt/HD-BET/HD_BET/__init__.py"
 
   - name: HD_BET package metadata version
     description: Verify the editable package metadata reports the shipped HD_BET version
     command: >-
-      grep -n "^Version: 1.0$" /opt/HD-BET/HD_BET.egg-info/PKG-INFO
-    expected_output_contains: "Version: 1.0"
+      /opt/miniconda-latest/envs/hdbet/bin/python -m pip show HD_BET
+    expected_output_contains: "Version: 2.0.1"
+
+  - name: HD-BET model checkpoint bundled
+    description: Verify the matching HD-BET 2.x model checkpoint is bundled in the configured path
+    command: >-
+      test -f /opt/HD-BET/hd-bet_params/release_2.0.0/fold_all/checkpoint_final.pth && echo checkpoint-ok
+    expected_output_contains: "checkpoint-ok"
 
   - name: HD-BET console entrypoint
     description: Verify the hd-bet console script is available on PATH
     command: >-
       which hd-bet
-    expected_output_contains: "/opt/miniconda-latest/bin/hd-bet"
+    expected_output_contains: "/opt/miniconda-latest/envs/hdbet/bin/hd-bet"
 
   - name: HD-BET help display
     description: Verify the shipped hd-bet command displays usage text
     command: >-
       hd-bet --help 2>&1 | head -20
-    expected_output_contains: "usage: hd-bet"
+    expected_output_contains: "usage:"

--- a/recipes/hdbet/fulltest.yaml
+++ b/recipes/hdbet/fulltest.yaml
@@ -1,9 +1,9 @@
 # hdbet container test suite
-# Minimal verification for the shipped HD-BET project payload.
+# Minimal no-rebuild verification for the shipped HD-BET project payload.
 
 name: hdbet
-version: 2.0.1
-container: hdbet_2.0.1_20260605.simg
+version: 1.0.0
+container: hdbet_1.0.0_20210318.simg
 
 test_data:
   output_dir: test_output
@@ -17,35 +17,29 @@ setup:
 tests:
   - name: Python runtime available
     description: Verify the shipped HD-BET conda runtime matches the image
-    command: /opt/miniconda-latest/envs/hdbet/bin/python --version
-    expected_output_contains: "Python 3.10"
+    command: /opt/miniconda-latest/bin/python --version
+    expected_output_contains: "Python 3.6.13"
 
   - name: HD_BET import path
     description: Verify the HD_BET module imports from the shipped conda environment
     command: >-
-      /opt/miniconda-latest/envs/hdbet/bin/python -c "import HD_BET; print(HD_BET.__file__)"
+      /opt/miniconda-latest/bin/python -c "import HD_BET; print(HD_BET.__file__)"
     expected_output_contains: "/opt/HD-BET/HD_BET/__init__.py"
 
   - name: HD_BET package metadata version
     description: Verify the editable package metadata reports the shipped HD_BET version
     command: >-
-      /opt/miniconda-latest/envs/hdbet/bin/python -m pip show HD_BET
-    expected_output_contains: "Version: 2.0.1"
-
-  - name: HD-BET model checkpoint bundled
-    description: Verify the matching HD-BET 2.x model checkpoint is bundled in the configured path
-    command: >-
-      test -f /opt/HD-BET/hd-bet_params/release_2.0.0/fold_all/checkpoint_final.pth && echo checkpoint-ok
-    expected_output_contains: "checkpoint-ok"
+      grep -n "^Version: 1.0$" /opt/HD-BET/HD_BET.egg-info/PKG-INFO
+    expected_output_contains: "Version: 1.0"
 
   - name: HD-BET console entrypoint
     description: Verify the hd-bet console script is available on PATH
     command: >-
       which hd-bet
-    expected_output_contains: "/opt/miniconda-latest/envs/hdbet/bin/hd-bet"
+    expected_output_contains: "/opt/miniconda-latest/bin/hd-bet"
 
   - name: HD-BET help display
     description: Verify the shipped hd-bet command displays usage text
     command: >-
       hd-bet --help 2>&1 | head -20
-    expected_output_contains: "usage:"
+    expected_output_contains: "usage: hd-bet"


### PR DESCRIPTION
## Summary
- update HDBET to upstream v2.0.1
- install the current model archive as a declared builder file
- expose the HDBET conda environment bin directory on deploy PATH

## Validation
- `python3 builder/validation.py recipes/hdbet/build.yaml --verbose`
- `git diff --check origin/main..HEAD`