### PR TITLE
Fix cbsb0stats OpenRecon helper staging

### DIFF
--- a/recipes/cbsb0stats/build.yaml
+++ b/recipes/cbsb0stats/build.yaml
@@ -38,9 +38,8 @@ build:
               PATH: ${PATH}:/opt/code/FSL-BET2/bin
 
         #Copy Over cbsb0stats.py program
-        - copy:
-            - cbsb0stats.py
-            - /opt/code/python-ismrmrd-server/cbsb0stats.py
+        - run:
+              - cp {{ get_file("cbsb0stats.py") }} /opt/code/python-ismrmrd-server/cbsb0stats.py
 
 deploy:
     path:


### PR DESCRIPTION
## Summary
- apply the staged cbsb0stats recipe/fulltest fix from yolo onto current main
- keep the PR scoped to cbsb0stats only

## Validation
- `python3 builder/validation.py recipes/cbsb0stats/build.yaml --verbose`
- `git diff --check origin/main..HEAD`