### PR TITLE
Fix arfiproc staging and fulltest assertions

### DIFF
--- a/recipes/arfiproc/build.yaml
+++ b/recipes/arfiproc/build.yaml
@@ -7,6 +7,8 @@ architectures:
 files:
     - name: arfiproc.py
       filename: arfiproc.py
+    - name: OpenReconLabel.json
+      filename: OpenReconLabel.json
 
 build:
     kind: neurodocker
@@ -22,7 +24,9 @@ build:
         - include: macros/openrecon/neurodocker.yaml
 
         #openrecon application
-        - copy: arfiproc.py /opt/code/python-ismrmrd-server/arfiproc.py
+        - run:
+              - cp {{ get_file("arfiproc.py") }} /opt/code/python-ismrmrd-server/arfiproc.py
+              - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
 
 deploy:
     bins:

--- a/recipes/arfiproc/fulltest.yaml
+++ b/recipes/arfiproc/fulltest.yaml
@@ -1,5 +1,5 @@
 # arfiproc container test suite
-# Focused ARM64 verification for the shipped OpenRecon runtime and module import path.
+# Focused verification for the shipped OpenRecon runtime and module import path.
 
 name: arfiproc
 version: 1.0.0
@@ -15,22 +15,42 @@ setup:
     mkdir -p ${output_dir}
 
 tests:
-  - name: Native ARM64 runtime
-    description: Verify the local Docker image runs natively on ARM64
+  - name: Native runtime
+    description: Verify the local image runs on a supported architecture
     script: |
-      uname -m | grep -x 'aarch64'
+      uname -m | grep -E '^(x86_64|aarch64)$'
 
   - name: OpenRecon server help
     description: Verify the shipped python-ismrmrd server entrypoint starts correctly
     script: |
-      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+      python /opt/code/python-ismrmrd-server/main.py -h > openrecon-help.txt 2>&1
+      sed -n '1,20p' openrecon-help.txt
+      grep 'Example server for MRD streaming format' openrecon-help.txt
 
   - name: DICOM to MRD converter help
     description: Verify the dicom2mrd helper script is available
     script: |
-      python /opt/code/python-ismrmrd-server/dicom2mrd.py -h 2>&1 | sed -n '1,12p' | grep 'Convert DICOMs to MRD file'
+      python /opt/code/python-ismrmrd-server/dicom2mrd.py -h > dicom2mrd-help.txt 2>&1
+      sed -n '1,20p' dicom2mrd-help.txt
+      grep 'Convert DICOMs to MRD file' dicom2mrd-help.txt
+
+  - name: OpenRecon label
+    description: Verify the OpenRecon label is installed with the module
+    script: |
+      python - <<'PY'
+      import json
+      from pathlib import Path
+
+      label = Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json")
+      data = json.loads(label.read_text())
+      assert data["general"]["id"] == "arfiproc"
+      parameters = {parameter["id"] for parameter in data["parameters"]}
+      assert {"config"} <= parameters
+      print(label)
+      PY
 
   - name: arfiproc module imports
     description: Verify the shipped reconstruction module imports with its server-side helpers
     script: |
-      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import arfiproc, ismrmrd, nibabel, scipy, skimage; print(arfiproc.__file__)" | grep -x '/opt/code/python-ismrmrd-server/arfiproc.py'
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import arfiproc, ismrmrd, nibabel, scipy, skimage; print(arfiproc.__file__)" > arfiproc-import.txt
+      grep -x '/opt/code/python-ismrmrd-server/arfiproc.py' arfiproc-import.txt


### PR DESCRIPTION
## Summary
- apply the staged arfiproc recipe/fulltest fix from yolo onto current main
- keep the PR scoped to arfiproc only

## Validation
- `python3 builder/validation.py recipes/arfiproc/build.yaml --verbose`
- `git diff --check origin/main..HEAD`