### PR TITLE
Fix openmsk staging and add fulltest

### DIFF
--- a/recipes/openmsk/build.yaml
+++ b/recipes/openmsk/build.yaml
@@ -14,6 +14,12 @@ files:
     filename: OpenReconLabel.json
   - name: OpenReconREADME.md
     filename: OpenReconREADME.md
+  - name: enhanceddicom2mrd.py
+    filename: enhanceddicom2mrd.py
+  - name: nifti2mrd.py
+    filename: nifti2mrd.py
+  - name: enhanced2singleframe.py
+    filename: enhanced2singleframe.py
   - name: dosma_qdess_model
     url: "{{ context.dosma_model_url }}"
   - name: openmsk
@@ -185,15 +191,16 @@ build:
         # that runs natively; on CPU-only hosts oneDNN is required for NCHW
         # Conv2D, so enable it (harmless on GPU).
         TF_ENABLE_ONEDNN_OPTS: "1"
-    - copy: openmsk.py /opt/code/python-ismrmrd-server/openmsk.py
-    - copy: OpenReconLabel.json /opt/code/python-ismrmrd-server/OpenReconLabel.json
-    - copy: OpenReconREADME.md /opt/code/python-ismrmrd-server/OpenReconREADME.md
-    - copy: enhanceddicom2mrd.py /opt/code/python-ismrmrd-server/enhanceddicom2mrd.py
-    - copy: nifti2mrd.py /opt/code/python-ismrmrd-server/nifti2mrd.py
+    - run:
+        - cp {{ get_file("openmsk.py") }} /opt/code/python-ismrmrd-server/openmsk.py
+        - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
+        - cp {{ get_file("OpenReconREADME.md") }} /opt/code/python-ismrmrd-server/OpenReconREADME.md
+        - cp {{ get_file("enhanceddicom2mrd.py") }} /opt/code/python-ismrmrd-server/enhanceddicom2mrd.py
+        - cp {{ get_file("nifti2mrd.py") }} /opt/code/python-ismrmrd-server/nifti2mrd.py
+        - cp {{ get_file("enhanced2singleframe.py") }} /opt/code/python-ismrmrd-server/enhanced2singleframe.py
     # Utility: expand Siemens qDESS Enhanced (multi-frame) DICOM into classic
     # single-frame DICOM so the direct `run_pipeline.py <dicom_dir>` path (DOSMA
     # QDess.from_dicom: qDESS RSS segmentation + T2) can read it.
-    - copy: enhanced2singleframe.py /opt/code/python-ismrmrd-server/enhanced2singleframe.py
 
 deploy:
   bins:

--- a/recipes/openmsk/fulltest.yaml
+++ b/recipes/openmsk/fulltest.yaml
@@ -1,0 +1,54 @@
+# openmsk container test suite
+# Focused verification for OpenRecon runtime packaging and lightweight entrypoints.
+
+name: openmsk
+version: 0.1.2
+container: openmsk_0.1.2.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: openmsk wrapper
+    description: Verify the NeuroContainers version wrapper is installed
+    script: |
+      openmsk | grep -x 'openmsk 0.1.2'
+
+  - name: OpenRecon server help
+    description: Verify the python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: OpenRecon assets
+    description: Verify packaged OpenRecon label and README assets are present and readable
+    script: |
+      python - <<'PY'
+      import json
+      from pathlib import Path
+
+      label = Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json")
+      readme = Path("/opt/code/python-ismrmrd-server/OpenReconREADME.md")
+      data = json.loads(label.read_text())
+      parameters = {parameter["id"] for parameter in data["parameters"]}
+      assert {"sendoriginal", "segmodel", "computethickness"} <= parameters
+      assert "OpenMSK" in readme.read_text()
+      print(label)
+      PY
+
+  - name: OpenMSK module imports
+    description: Verify the OpenRecon module imports with its runtime dependencies
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import openmsk, ismrmrd, nibabel, numpy; print(openmsk.OPENMSK_VERSION)" | grep -x '0.1.2'
+
+  - name: Helper scripts render help
+    description: Verify conversion helper scripts start and expose command line help
+    script: |
+      python /opt/code/python-ismrmrd-server/enhanceddicom2mrd.py -h 2>&1 | grep 'usage:'
+      python /opt/code/python-ismrmrd-server/nifti2mrd.py -h 2>&1 | grep 'usage:'
+      python /opt/code/python-ismrmrd-server/enhanced2singleframe.py -h 2>&1 | grep 'usage:'


### PR DESCRIPTION
## Summary
- apply the staged openmsk recipe/fulltest fix from yolo onto current main
- keep the PR scoped to openmsk only

## Validation
- `python3 builder/validation.py recipes/openmsk/build.yaml --verbose`
- `git diff --check origin/main..HEAD`