### PR TITLE
Fix sodiumnufft staging and add fulltest

### DIFF
--- a/recipes/sodiumnufft/build.yaml
+++ b/recipes/sodiumnufft/build.yaml
@@ -45,18 +45,12 @@ build:
     - run:
         - pip3 install --no-cache-dir sigpy==0.1.27 twixtools
     - workdir: /opt/sodiumnufft
-    - copy:
-        - sodiumnufft.py
-        - /opt/code/python-ismrmrd-server/sodiumnufft.py
-    - copy:
-        - twix2mrd.py
-        - /opt/code/python-ismrmrd-server/twix2mrd.py
-    - copy:
-        - siemens_twix2mrd.py
-        - /opt/code/python-ismrmrd-server/siemens_twix2mrd.py
-    - copy:
-        - mrd2nifti.py
-        - /opt/code/python-ismrmrd-server/mrd2nifti.py
+    - run:
+        - cp {{ get_file("sodiumnufft.py") }} /opt/code/python-ismrmrd-server/sodiumnufft.py
+        - cp {{ get_file("twix2mrd.py") }} /opt/code/python-ismrmrd-server/twix2mrd.py
+        - cp {{ get_file("siemens_twix2mrd.py") }} /opt/code/python-ismrmrd-server/siemens_twix2mrd.py
+        - cp {{ get_file("mrd2nifti.py") }} /opt/code/python-ismrmrd-server/mrd2nifti.py
+        - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
     - run:
         - cp {{ get_file("sodium_trajectory") }} /opt/sodiumnufft/23NA_n50_trajectory.h5
 

--- a/recipes/sodiumnufft/fulltest.yaml
+++ b/recipes/sodiumnufft/fulltest.yaml
@@ -1,0 +1,51 @@
+# sodiumnufft container test suite
+# Focused verification for OpenRecon runtime assets and sodium NUFFT imports.
+
+name: sodiumnufft
+version: 0.1.0
+container: sodiumnufft_0.1.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: OpenRecon server help
+    description: Verify the python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: Sodium trajectory and label assets
+    description: Verify the packaged trajectory and OpenRecon label are present and readable
+    script: |
+      python - <<'PY'
+      import json
+      from pathlib import Path
+      import h5py
+
+      trajectory = Path("/opt/sodiumnufft/23NA_n50_trajectory.h5")
+      label = Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json")
+      with h5py.File(trajectory, "r") as handle:
+          assert "k" in handle, list(handle.keys())
+          print("trajectory", handle["k"].shape)
+      data = json.loads(label.read_text())
+      assert data
+      print(label)
+      PY
+
+  - name: Sodium NUFFT module imports
+    description: Verify the reconstruction module imports with its runtime dependencies
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import sodiumnufft, ismrmrd, h5py, scipy, sigpy, twixtools; print(sodiumnufft.__file__)" | grep -x '/opt/code/python-ismrmrd-server/sodiumnufft.py'
+
+  - name: Helper scripts render help
+    description: Verify conversion helper scripts start and expose command line help
+    script: |
+      python /opt/code/python-ismrmrd-server/twix2mrd.py -h 2>&1 | grep 'usage:'
+      python /opt/code/python-ismrmrd-server/siemens_twix2mrd.py -h 2>&1 | grep 'usage:'
+      python /opt/code/python-ismrmrd-server/mrd2nifti.py -h 2>&1 | grep 'usage:'


### PR DESCRIPTION
## Summary
- apply the staged sodiumnufft recipe/fulltest fix from yolo onto current main
- keep the PR scoped to sodiumnufft only

## Validation
- `python3 builder/validation.py recipes/sodiumnufft/build.yaml --verbose`
- `git diff --check origin/main..HEAD`