### PR TITLE
Fix openreconi2iexample staging and add fulltest

### DIFF
--- a/recipes/openreconi2iexample/build.yaml
+++ b/recipes/openreconi2iexample/build.yaml
@@ -33,8 +33,9 @@ build:
 
     - include: macros/openrecon/neurodocker.yaml
 
-    - copy: openreconi2iexample.py /opt/code/python-ismrmrd-server/openreconi2iexample.py
-    - copy: OpenReconLabel.json /opt/code/python-ismrmrd-server/OpenReconLabel.json
+    - run:
+        - cp {{ get_file("openreconi2iexample.py") }} /opt/code/python-ismrmrd-server/openreconi2iexample.py
+        - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
     - environment:
         OPENRECONI2IEXAMPLE_VERSION: "{{ context.version }}"
     - run:

--- a/recipes/openreconi2iexample/fulltest.yaml
+++ b/recipes/openreconi2iexample/fulltest.yaml
@@ -1,0 +1,44 @@
+# openreconi2iexample container test suite
+# Focused verification for the wrapper, OpenRecon runtime, and declared assets.
+
+name: openreconi2iexample
+version: 1.0.89
+container: openreconi2iexample_1.0.89.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: CLI wrapper version
+    description: Verify the deployed wrapper reports the recipe version
+    script: |
+      openreconi2iexample | grep -x 'openreconi2iexample 1.0.89'
+
+  - name: OpenRecon server help
+    description: Verify the python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: OpenRecon label is installed
+    description: Verify the scanner label JSON is copied into the runtime server directory
+    script: |
+      python - <<'PY'
+      import json
+      from pathlib import Path
+
+      label = Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json")
+      data = json.loads(label.read_text())
+      assert data
+      print(label)
+      PY
+
+  - name: openreconi2iexample module imports
+    description: Verify the reconstruction module imports with server-side helpers
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import openreconi2iexample, ismrmrd, numpy; print(openreconi2iexample.__file__)" | grep -x '/opt/code/python-ismrmrd-server/openreconi2iexample.py'


### PR DESCRIPTION
## Summary
- apply the staged openreconi2iexample recipe/fulltest fix from yolo onto current main
- keep the PR scoped to openreconi2iexample only

## Validation
- `python3 builder/validation.py recipes/openreconi2iexample/build.yaml --verbose`
- `git diff --check origin/main..HEAD`