### PR TITLE
Fix openreconexample staging and add fulltest

### DIFF
--- a/recipes/openreconexample/build.yaml
+++ b/recipes/openreconexample/build.yaml
@@ -37,8 +37,9 @@ build:
               PATH: ${PATH}:/opt/code/FSL-BET2/bin
 
         #openrecon application
-        - copy: openreconexample.py /opt/code/python-ismrmrd-server/openreconexample.py
-        - copy: dicom2mrd.py /opt/code/python-ismrmrd-server/dicom2mrd.py
+        - run:
+              - cp {{ get_file("openreconexample.py") }} /opt/code/python-ismrmrd-server/openreconexample.py
+              - cp {{ get_file("dicom2mrd.py") }} /opt/code/python-ismrmrd-server/dicom2mrd.py
 
 deploy:
     path:

--- a/recipes/openreconexample/fulltest.yaml
+++ b/recipes/openreconexample/fulltest.yaml
@@ -1,0 +1,41 @@
+# openreconexample container test suite
+# Focused verification for the shipped BET2 binary and OpenRecon runtime.
+
+name: openreconexample
+version: 1.0.0
+container: openreconexample_1.0.0.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: BET2 binary in PATH
+    description: Verify the compiled BET2 executable is installed on PATH
+    script: |
+      command -v bet2 | grep -x '/opt/code/FSL-BET2/bin/bet2'
+
+  - name: BET2 help output
+    description: Verify the bundled BET2 CLI renders its usage text
+    script: |
+      bet2 2>&1 | sed -n '1,12p' | grep 'BET (Brain Extraction Tool) v2.1'
+
+  - name: OpenRecon server help
+    description: Verify the python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: DICOM to MRD converter help
+    description: Verify the dicom2mrd helper script is available
+    script: |
+      python /opt/code/python-ismrmrd-server/dicom2mrd.py -h 2>&1 | sed -n '1,12p' | grep 'Convert DICOMs to MRD file'
+
+  - name: openreconexample module imports
+    description: Verify the reconstruction module imports with server-side helpers
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import openreconexample, ismrmrd, nibabel, scipy, skimage; print(openreconexample.__file__)" | grep -x '/opt/code/python-ismrmrd-server/openreconexample.py'


### PR DESCRIPTION
## Summary
- apply the staged openreconexample recipe/fulltest fix from yolo onto current main
- keep the PR scoped to openreconexample only

## Validation
- `python3 builder/validation.py recipes/openreconexample/build.yaml --verbose`
- `git diff --check origin/main..HEAD`