### PR TITLE
Fix automated build issue handling

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -399,7 +399,7 @@ jobs:
               echo "Cache image ${CACHE_REF} is unavailable; building without --cache-from"
             fi
             if [ "${DISABLE_AUTO_UPLOAD}" != "true" ]; then
-              CACHE_TO_ARGS+=(--cache-to "type=registry,ref=${CACHE_REF},mode=max")
+              CACHE_TO_ARGS+=(--cache-to "type=registry,ref=${CACHE_REF},mode=max,ignore-error=true")
             else
               echo "Auto-upload is disabled. Skipping registry cache export."
             fi
@@ -637,6 +637,10 @@ jobs:
   push-dockerhub:
     needs: [config, build-image]
     if: ${{ needs.build-image.outputs.IMGDIFFERS == 'true' || inputs.force_push_dockerhub == 'true' }}
+    # Docker Hub is a public mirror. GHCR, SIF generation, and object storage are
+    # the release-critical outputs, so transient Docker Hub failures should not
+    # block release PR creation.
+    continue-on-error: true
     runs-on: ubuntu-22.04
     permissions:
       packages: write

--- a/recipes/cpac/build.yaml
+++ b/recipes/cpac/build.yaml
@@ -19,7 +19,7 @@ build:
     - run:
         - chmod +x /usr/local/bin/cpac-run
         - pip install --no-cache-dir "setuptools<81"
-        - rm -rf /root/.cache/pip
+        - rm -rf /root/.cache/pip /var/lib/apt/lists/* /var/cache/apt/* /var/log/dpkg.log /var/log/apt
   add-default-template: false
   add-tzdata: false
 

--- a/recipes/xcpd/build.yaml
+++ b/recipes/xcpd/build.yaml
@@ -26,7 +26,7 @@ build:
           dpkg-deb -x {{ get_file("libpng12_deb") }} /tmp/libpng12
           rm -f /usr/lib/x86_64-linux-gnu/libpng12.so.0
           cp -a /tmp/libpng12/lib/x86_64-linux-gnu/libpng12.so.0* /usr/lib/x86_64-linux-gnu/
-          rm -rf /tmp/libpng12
+          rm -rf /tmp/libpng12 /root/.cache/pip /home/xcp_d/.cache/pip /usr/local/miniconda/pkgs/* /var/lib/apt/lists/* /var/cache/apt/* /var/log/dpkg.log /var/log/apt
     - deploy:
         path: []
         bins:


### PR DESCRIPTION
## Summary

This follow-up addresses the open automated build issues from #2637, #2652, #2662, #2641, and #2644.

- Make BuildKit registry cache export best-effort with `ignore-error=true`, so a successful image build is not failed by GHCR cache permission/transient errors. This is the root cause seen in #2652 for matlabruntime: the image built, then cache export returned 403.
- Make Docker Hub mirror pushes best-effort, matching the existing Nectar mirror behavior. This addresses #2662 where BrainNetViewer built, produced a SIF, and uploaded to object storage, but Docker Hub login timed out and blocked release PR creation.
- Add final-layer cleanup to the CPAC and XCP-D wrapper recipes for pip, apt, dpkg, and conda package caches that Dive reported as wasted space in #2641 and #2644. The heavier inherited TemplateFlow/runtime data remains in place because it is runtime data and removing it in a wrapper layer would not shrink the base image.

HCP-ASL #2637 was caused by an older generated Miniconda Dockerfile containing comments in a backslash-continued `RUN` command. Current `main` now generates that section without those comments; I verified current HCP-ASL generation no longer contains the bad comment lines.

## Validation

- `python3 builder/validation.py recipes/cpac/build.yaml`
- `python3 builder/validation.py recipes/xcpd/build.yaml`
- `python3 builder/validation.py recipes/hcpasl/build.yaml`
- `python3 builder/validation.py recipes/matlabruntime/build.yaml`
- `python3 builder/validation.py recipes/brainnetviewer/build.yaml`
- `python3 -m builder generate cpac --recreate`
- `python3 -m builder generate xcpd --recreate`
- `python3 -m builder generate hcpasl --recreate`
- `python3 -m builder generate matlabruntime --recreate`
- `python3 -m builder generate brainnetviewer --recreate`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/build-app.yml') ... PY`
- `git diff --check`
- `python3 -m builder stage matlabruntime --recreate && docker build -f build/matlabruntime/matlabruntime_2025b.Dockerfile build/matlabruntime`

Fixes #2652
Fixes #2662
Fixes #2641
Fixes #2644
Fixes #2637
