### PR TITLE
Add VertexWiseR build dependencies

### DIFF
--- a/recipes/vertexwiser/build.yaml
+++ b/recipes/vertexwiser/build.yaml
@@ -34,10 +34,12 @@ build:
         - libpng-dev
         - libssl-dev
         - libtiff5-dev
+        - libuv1-dev
         - libxml2-dev
         - make
         - pandoc
         - python3
+        - python3-dev
         - python3-pip
         - python3-venv
         - r-base


### PR DESCRIPTION
## Summary
- add libuv1-dev so the CRAN fs dependency can build during VertexWiseR installation
- add python3-dev so reticulate can load the Python shared library from the recipe venv

## Root cause
The failed VertexWiseR build in #2683 stopped while installing R dependencies because fs could not find libuv via pkg-config and failed with uv.h missing. After fixing that locally, the recipe's verification exposed that reticulate also needed the Python shared library, supplied by python3-dev on Ubuntu 24.04.

Fixes #2683.

## Validation
- python3 builder/validation.py recipes/vertexwiser/build.yaml
- python3 -m builder generate vertexwiser --recreate
- docker build -f build/vertexwiser/vertexwiser_1.5.1.Dockerfile build/vertexwiser -t vertexwiser-fixed:1.5.1
- docker run --rm vertexwiser-fixed:1.5.1 R --slave -e "library(VertexWiseR); library(reticulate); print(packageVersion('VertexWiseR')); print(py_config()[['python']])"
- docker run --rm vertexwiser-fixed:1.5.1 /opt/vertexwiser-python/bin/python -c "import brainstat, nilearn, nibabel, vtk; print(vtk.vtkVersion.GetVTKVersion())"
- git diff --check