### PR TITLE
Fix fulltest release artifact references

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -315,32 +315,36 @@ jobs:
 
             summary += `*This comment will be updated as tests complete.*`;
 
-            // Find existing summary comment
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const summaryComment = comments.data.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('Container Test Summary')
-            );
-
-            if (summaryComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: summaryComment.id,
-                body: summary
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              // Find existing summary comment
+              const comments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: summary
               });
+
+              const summaryComment = comments.data.find(comment =>
+                comment.user.type === 'Bot' &&
+                comment.body.includes('Container Test Summary')
+              );
+
+              if (summaryComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: summaryComment.id,
+                  body: summary
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: summary
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to write container test summary comment: ${error.message}`);
             }
 
             // Fail the workflow if any tests failed

--- a/recipes/cpac/fulltest.yaml
+++ b/recipes/cpac/fulltest.yaml
@@ -1,6 +1,6 @@
 name: cpac
 version: 1.8.7
-container: cpac_1.8.7_20260521.simg
+container: cpac_1.8.7_20260608.simg
 default_timeout: 120
 tests:
 - name: Test C-PAC CLI version

--- a/recipes/dcm2bids/fulltest.yaml
+++ b/recipes/dcm2bids/fulltest.yaml
@@ -17,7 +17,7 @@
 
 name: dcm2bids
 version: 3.2.0
-container: dcm2bids_3.2.0_20250402.simg
+container: dcm2bids_3.2.0_20260527.simg
 
 required_files:
   - dataset: ds000001

--- a/recipes/matlabruntime/fulltest.yaml
+++ b/recipes/matlabruntime/fulltest.yaml
@@ -1,6 +1,6 @@
 name: matlabruntime
 version: 2025b
-container: matlabruntime_2025b_20260521.simg
+container: matlabruntime_2025b_20260606.simg
 default_timeout: 120
 tests:
 - name: Test MATLAB Runtime environment

--- a/recipes/segmentator/fulltest.yaml
+++ b/recipes/segmentator/fulltest.yaml
@@ -1,7 +1,7 @@
 # segmentator container test suite
 name: segmentator
 version: 1.6.1
-container: segmentator_1.6.1.simg
+container: segmentator_1.6.1_20260519.simg
 
 test_data:
   output_dir: test_output

--- a/recipes/tgvqsm/fulltest.yaml
+++ b/recipes/tgvqsm/fulltest.yaml
@@ -18,7 +18,7 @@
 
 name: tgvqsm
 version: 1.0.0
-container: tgvqsm_1.0.0_20210629.simg
+container: tgvqsm_1.0.0_20260601.simg
 
 required_files:
   - dataset: ds000001
@@ -266,53 +266,53 @@ tests:
   # ==========================================================================
   - name: dcm2niix help
     description: Verify dcm2niix binary runs and displays help
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "dcm2niiX"
 
   - name: dcm2niix version
     description: Check dcm2niix version information
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "Chris Rorden"
 
   - name: dcm2niix usage info
     description: Verify dcm2niix shows usage syntax
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "dcm2niix [options] <in_folder>"
 
   - name: dcm2niix output options
     description: Verify dcm2niix shows output directory option
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "-o : output directory"
 
   - name: dcm2niix filename format
     description: Verify dcm2niix shows filename format option
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "-f : filename"
 
   - name: dcm2niix compression option
     description: Verify dcm2niix shows compression option
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
-    expected_output_contains: "-z : gz compress"
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
+    expected_output_contains: "-z : compress images"
 
   - name: dcm2niix BIDS option
     description: Verify dcm2niix shows BIDS sidecar option
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "-b : BIDS sidecar"
 
   - name: dcm2niix verbose option
     description: Verify dcm2niix shows verbose option
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix -h 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix -h 2>&1'
     expected_output_contains: "-v : verbose"
 
   - name: dcm2niix version check
     description: Get dcm2niix version number
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix --version 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix --version 2>&1'
     ignore_exit_code: true
-    expected_output_contains: "v1.0.20210317"
+    expected_output_contains: "v1.0.20260416"
 
   - name: dcm2niix xml features
     description: Check dcm2niix XML output mode
-    command: bash -lc '/opt/dcm2niix-latest/bin/dcm2niix --xml 2>&1'
+    command: bash -lc '/opt/dcm2niix-latest/dcm2niix --xml 2>&1'
     expected_output_contains: "dcm2niix"
 
   # ==========================================================================
@@ -702,7 +702,7 @@ tests:
 
   - name: dcm2niix empty directory
     description: Test dcm2niix on directory with no DICOMs
-    command: bash -lc 'mkdir -p test_output/empty_dir && /opt/dcm2niix-latest/bin/dcm2niix -o test_output test_output/empty_dir 2>&1 || true'
+    command: bash -lc 'mkdir -p test_output/empty_dir && /opt/dcm2niix-latest/dcm2niix -o test_output test_output/empty_dir 2>&1 || true'
     expected_output_contains: "Unable to find"
 
   # ==========================================================================

--- a/recipes/tgvqsm/fulltest.yaml
+++ b/recipes/tgvqsm/fulltest.yaml
@@ -33,11 +33,28 @@ test_data:
   bold: ds000001/sub-01/func/sub-01_task-balloonanalogrisktask_run-01_bold.nii.gz
   output_dir: test_output
 
+env:
+  PYTHON_EGG_CACHE: ${output_dir}/python-eggs
+
 setup:
   script: |
     #!/usr/bin/env bash
     set -e
     mkdir -p test_output
+    mkdir -p ${output_dir}/python-eggs
+    export PYTHON_EGG_CACHE=${output_dir}/python-eggs
+    python2 -c "
+    import nibabel as nib
+    import numpy as np
+    img = nib.load('${t1w}')
+    data = img.get_data().astype(np.float32)
+    data = (data - data.min()) / (data.max() - data.min()) * 2 * np.pi - np.pi
+    nib.Nifti1Image(data, img.affine, img.header).to_filename('test_output/synthetic_phase.nii.gz')
+    mask = np.zeros(data.shape, dtype=np.uint8)
+    sx, sy, sz = data.shape
+    mask[sx//4:3*sx//4, sy//4:3*sy//4, sz//4:3*sz//4] = 1
+    nib.Nifti1Image(mask, img.affine, img.header).to_filename('test_output/t1w_brain_mask_mask.nii.gz')
+    "
 
 tests:
   # ==========================================================================

--- a/recipes/vesselvio/fulltest.yaml
+++ b/recipes/vesselvio/fulltest.yaml
@@ -10,7 +10,7 @@
 
 name: vesselvio
 version: 1.1.2
-container: vesselvio_1.1.2.simg
+container: vesselvio_1.1.2_20230428.simg
 
 test_data:
   sample_vertices: /opt/vesselvio-1.1.2/sample_data/demo_csv/vertices.csv

--- a/recipes/xcpd/fulltest.yaml
+++ b/recipes/xcpd/fulltest.yaml
@@ -1,6 +1,6 @@
 name: xcpd
 version: 0.10.7
-container: xcpd_0.10.7.simg
+container: xcpd_0.10.7_20260608.simg
 default_timeout: 120
 tests:
 - name: Test xcpd


### PR DESCRIPTION
## Summary
- update fulltest container artifact references for VesselVio, CPAC, Dcm2Bids, MATLAB Runtime, Segmentator, TGVQSM, and XCP-D
- fold the remaining staged fulltest artifact fixes into this single PR
- adjust TGVQSM dcm2niix checks to match the current artifact layout/version

## Validation
- parsed all touched fulltest YAML files with PyYAML
- git diff --check