### PR TITLE
Fix SAMRI atlas source archive download

### DIFF
--- a/recipes/samri/build.yaml
+++ b/recipes/samri/build.yaml
@@ -43,7 +43,7 @@ files:
   - name: ants_archive
     url: https://zenodo.org/api/records/15230173/files/ants-Linux-centos6_x86_64-v{{ context.ants_version }}.tar.gz/content
   - name: mouse_brain_atlases_generator_source
-    url: https://github.com/IBT-FMI/mouse-brain-atlases_generator/archive/{{ context.mouse_brain_atlases_generator_commit }}.tar.gz
+    url: https://codeload.github.com/IBT-FMI/mouse-brain-atlases_generator/tar.gz/{{ context.mouse_brain_atlases_generator_commit }}
 
 build:
   kind: neurodocker


### PR DESCRIPTION
## Summary
- Switch the SAMRI mouse-brain-atlases_generator source archive to GitHub's direct codeload endpoint
- Keep the same pinned upstream commit and declared-file cache behavior

## Root cause
The manual SAMRI build failed before Docker build while staging declared files. The builder could not download the GitHub-generated archive URL for mouse-brain-atlases_generator after retries because GitHub returned HTTP 504 Gateway Time-out.

Failed run: https://github.com/neurodesk/neurocontainers/actions/runs/27121742659

## Testing
- python3 -m builder stage samri --recreate --download --architecture x86_64
- python3 builder/validation.py recipes/samri/build.yaml
- git diff --check