### PR TITLE
Sync icons in apps.json update workflow

### DIFF
--- a/.github/workflows/update-apps-json.yml
+++ b/.github/workflows/update-apps-json.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install icon conversion dependencies
+        run: python -m pip install cairosvg
+
       - name: Generate apps.json
         run: |
           python3 tools/generate_apps_json.py --output apps.json
@@ -55,13 +58,17 @@ jobs:
 
           # Copy the generated apps.json
           cp ../apps.json neurodesk/apps.json
+          python .github/workflows/scripts/sync_neurocontainer_icons.py \
+            --neurocontainers-path .. \
+            --apps-json neurodesk/apps.json \
+            --icons-dir neurodesk/icons
 
           # Check if there are any changes
-          if ! git diff --quiet neurodesk/apps.json; then
+          if ! git diff --quiet neurodesk/apps.json neurodesk/icons; then
             echo "Changes detected in apps.json"
             
             # Add and commit changes
-            git add neurodesk/apps.json
+            git add neurodesk/apps.json neurodesk/icons
             git commit -m "Update apps.json from neurocontainers releases
             
             Auto-generated from release files in neurocontainers repo.
@@ -82,6 +89,7 @@ jobs:
           ## Changes
 
           - Updated apps.json with latest container releases
+          - Synced any missing icons from neurocontainers recipe metadata
           - Generated automatically from individual release files
 
           ## Test Plan

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -133,3 +133,13 @@ def test_nectar_registry_username_is_explicit() -> None:
 
     assert "username: s.bollmann@uq.edu.au" in push_nectar_job
     assert "REGISTRY_RC_NECTAR_ORG_AU_USERNAME" not in workflow
+
+
+def test_update_apps_json_syncs_neurocommand_icons() -> None:
+    workflow = Path(".github/workflows/update-apps-json.yml").read_text()
+
+    assert "python -m pip install cairosvg" in workflow
+    assert "python .github/workflows/scripts/sync_neurocontainer_icons.py" in workflow
+    assert "--neurocontainers-path .." in workflow
+    assert "git diff --quiet neurodesk/apps.json neurodesk/icons" in workflow
+    assert "git add neurodesk/apps.json neurodesk/icons" in workflow


### PR DESCRIPTION
## Summary

- Install cairosvg in the upstream apps.json update workflow
- Run neurocommand's icon sync helper after copying generated apps.json
- Stage neurodesk/icons alongside apps.json so SVG recipe icons are included in generated PRs
- Add a workflow contract test for the icon sync behavior

## Dependency

- neurodesk/neurocommand#701 is merged and provides SVG-to-PNG conversion in the icon sync helper.

## Validation

- PYENV_VERSION=3.12.13 python -m pytest -q builder/tests/test_workflow_contract.py builder/test_validation.py -k "update_apps_json_syncs_neurocommand_icons or icon or complex"
- YAML parse check for .github/workflows/update-apps-json.yml
