### PR TITLE
Add fulltests for release candidates and fix SOOP-CT runtime

### DIFF
--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -1,0 +1,49 @@
+name: brainlesion
+version: 1.0.0
+container: brainlesion_${version}_REFERENCE.simg
+
+test_data:
+  output_dir: test_output/brainlesion
+
+setup:
+  script: |
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: Python runtime available
+    description: Verify the BrainLesion Suite runtime uses the expected Python series
+    command: python --version
+    expected_output_contains: "Python 3.10."
+
+  - name: BrainLesion packages installed
+    description: Verify the BrainLesion Suite packages are present in package metadata
+    command: python -m pip list | grep -Ei "^(brainles_aurora|brainles-preprocessing|brats|gliomoda|petu|panoptica)"
+    expected_output_contains:
+      - "brainles_aurora"
+      - "brainles-preprocessing"
+      - "brats"
+      - "gliomoda"
+      - "petu"
+      - "panoptica"
+
+  - name: BrainLesion Python modules import
+    description: Verify the installed suite modules import without loading model weights
+    command: |
+      python - <<'PY'
+      import importlib
+      modules = [
+          "brainles_aurora",
+          "brainles_preprocessing",
+          "brats",
+          "deep_quality_estimation",
+          "gliomoda",
+          "loguru",
+          "panoptica",
+          "petu",
+      ]
+      for module in modules:
+          importlib.import_module(module)
+      print("brainlesion imports ok")
+      PY
+    expected_output_contains: "brainlesion imports ok"

--- a/recipes/eharmonize/build.yaml
+++ b/recipes/eharmonize/build.yaml
@@ -29,7 +29,7 @@ build:
         - cd eharmonize
         # Replace git+ssh://git@ with https:// in setup.py to avoid SSH issues
         - sed -i "s/git+ssh:\/\/git@/git+https:\/\//" setup.py
-        - python -m pip install --no-cache-dir .
+        - python -m pip install --no-cache-dir "setuptools<81" .
     - deploy:
         path: []
         bins:

--- a/recipes/eharmonize/fulltest.yaml
+++ b/recipes/eharmonize/fulltest.yaml
@@ -3,7 +3,7 @@
 
 name: eharmonize
 version: 1.0.0
-container: eharmonize_1.0.0.simg
+container: eharmonize_${version}_REFERENCE.simg
 
 test_data:
   output_dir: test_output
@@ -23,7 +23,7 @@ tests:
   - name: eharmonize help output
     description: Verify the main CLI help text renders
     command: eharmonize --help 2>&1 | sed -n '1,20p'
-    expected_output_contains: "eharmonize (ENIGMA harmonization)"
+    expected_output_contains: "Usage: eharmonize [OPTIONS] COMMAND [ARGS]..."
 
   - name: harmonize-fa help output
     description: Verify the harmonize-fa subcommand is exposed

--- a/recipes/mipav/fulltest.yaml
+++ b/recipes/mipav/fulltest.yaml
@@ -1,0 +1,39 @@
+name: mipav
+version: 11.3.3
+container: mipav_${version}_REFERENCE.simg
+
+test_data:
+  output_dir: test_output/mipav
+
+setup:
+  script: |
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: MIPAV launcher available
+    description: Verify the installed MIPAV launcher is on PATH
+    command: command -v mipav
+    expected_output_contains: "/usr/local/mipav/mipav"
+
+  - name: Bundled Java runtime available
+    description: Verify MIPAV ships its bundled Java runtime
+    command: /usr/local/mipav/jre/bin/java -version 2>&1 | sed -n '1,3p'
+    expected_output_contains: "OpenJDK Runtime Environment"
+
+  - name: MIPAV application files present
+    description: Verify the installed application metadata and classes are present
+    command: test -f /usr/local/mipav/about.txt && test -f /usr/local/mipav/MipavMain.class && grep -i "Visualization (MIPAV)" /usr/local/mipav/about.txt
+    expected_output_contains: "Visualization (MIPAV)"
+
+  - name: MIPAV starts with writable user home
+    description: Verify startup reaches MIPAV code and extracts native libraries outside the host home
+    command: |
+      export HOME="${output_dir}/home"
+      export _JAVA_OPTIONS="-Duser.home=${output_dir}/home"
+      mkdir -p "$HOME"
+      timeout 12 mipav -version 2>&1 | sed -n '1,35p' || true
+      test -d "${output_dir}/home/mipav/native_library_tmpdir"
+      echo "mipav startup reached native loader"
+    expected_output_contains: "mipav startup reached native loader"
+    timeout: 30

--- a/recipes/soopct/build.yaml
+++ b/recipes/soopct/build.yaml
@@ -51,17 +51,21 @@ build:
   base-image: ubuntu:24.04
   pkg-manager: apt
   directives:
-    - install: git unzip
+    - install:
+        - clang
+        - dcm2niix
+        - git
+        - unzip
     - template:
         name: miniconda
-        version: latest
-        conda_install: python=3.13
+        version: py313_25.5.1-0
         pip_install: antspyx>=0.5.4 nibabel>=5.3.2 numpy>=2.3.0 scipy>=1.15.2 brainchop>=0.1.8
         install_path: /opt/miniconda
     - run:
         - git clone https://github.com/rordenlab/soop-ct.git
         - cd soop-ct
         - unzip DICOM.zip
+        - python -c 'from pathlib import Path; script = Path("3best2anon.py"); text = script.read_text(); text = text.replace("cmd = [\"brainchop\", \"-m\", model, \"-i\", input_path, \"-o\", out_path]", "cmd = [\"brainchop\", input_path, \"-m\", model, \"--no-optimize\", \"-o\", out_path]"); text = text.replace("cmd += [\"-b\", str(border)]", "cmd += [\"--border\", str(border)]"); script.write_text(text)'
     - deploy:
         bins:
           - python

--- a/recipes/soopct/fulltest.yaml
+++ b/recipes/soopct/fulltest.yaml
@@ -1,0 +1,93 @@
+name: soopct
+version: 0.0.0
+container: soopct_${version}_REFERENCE.simg
+
+test_data:
+  output_dir: test_output/soopct
+
+setup:
+  script: |
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: SOOP-CT scripts are installed
+    description: Verify the cloned SOOP-CT workflow scripts are available
+    command: |
+      set -e
+      test -f /soop-ct/1dcm2raw.py
+      test -f /soop-ct/2raw2best.py
+      test -f /soop-ct/3best2anon.py
+      test -f /soop-ct/4anon2bids.py
+      test -f /soop-ct/5bids2norm.py
+      echo "soopct scripts found"
+    expected_output_contains: "soopct scripts found"
+
+  - name: SOOP-CT Python dependencies import
+    description: Verify the scientific Python stack used by SOOP-CT imports
+    command: |
+      python - <<'PY'
+      import ants
+      import brainchop
+      import nibabel
+      import numpy
+      import scipy
+      print("soopct dependencies ok")
+      PY
+    expected_output_contains: "soopct dependencies ok"
+
+  - name: dcm2niix converter available
+    description: Verify the DICOM converter called by 1dcm2raw.py is installed
+    command: dcm2niix -h 2>&1 | sed -n '1,8p'
+    expected_output_contains: "Chris Rorden"
+
+  - name: Bundled sample DICOM conversion workflow
+    description: Run the DICOM conversion and best-image selection stages against the bundled SOOP-CT sample data
+    command: |
+      set -e
+      cd /soop-ct
+      python 1dcm2raw.py /soop-ct/DICOM "${output_dir}/raw"
+      python 2raw2best.py "${output_dir}/raw" "${output_dir}/best"
+      test -f "${output_dir}/best/3978620.nii"
+      test -f "${output_dir}/best/3978620.json"
+      echo "soopct conversion workflow ok"
+    expected_output_contains: "soopct conversion workflow ok"
+    timeout: 120
+
+  - name: BrainChop runtime dependencies available
+    description: Verify the BrainChop CLI and TinyGrad compiler dependency are available
+    command: |
+      set -e
+      command -v clang
+      brainchop --help 2>&1 | sed -n '1,40p'
+    expected_output_contains:
+      - "/usr/bin/clang"
+      - "--border MM"
+      - "--no-optimize"
+
+  - name: SOOP-CT BrainChop command matches current CLI
+    description: Verify 3best2anon.py calls BrainChop using the current positional-input CLI without running model inference
+    command: |
+      cd /soop-ct
+      python - <<'PY'
+      import importlib.util
+      from pathlib import Path
+
+      spec = importlib.util.spec_from_file_location("best2anon", "3best2anon.py")
+      module = importlib.util.module_from_spec(spec)
+      spec.loader.exec_module(module)
+
+      captured = {}
+      def fake_run(cmd, check):
+          captured["cmd"] = [str(item) for item in cmd]
+
+      module.subprocess.run = fake_run
+      module.do_brainchop(Path("/tmp/input.nii"), Path("/tmp/output.nii"), True, 25)
+      cmd = captured["cmd"]
+      assert cmd[:2] == ["brainchop", "/tmp/input.nii"], cmd
+      assert "-i" not in cmd, cmd
+      assert "--border" in cmd, cmd
+      assert "--no-optimize" in cmd, cmd
+      print("soopct brainchop command ok")
+      PY
+    expected_output_contains: "soopct brainchop command ok"

--- a/recipes/terastitcher/fulltest.yaml
+++ b/recipes/terastitcher/fulltest.yaml
@@ -1,0 +1,32 @@
+name: terastitcher
+version: 1.11.10
+container: terastitcher_${version}_REFERENCE.simg
+
+test_data:
+  output_dir: test_output/terastitcher
+
+setup:
+  script: |
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: TeraStitcher install tree exists
+    description: Verify the portable TeraStitcher distribution was unpacked under /opt
+    command: test -x /opt/terastitcher-1.11.10/terastitcher
+    expected_exit_code: 0
+
+  - name: terastitcher help renders
+    description: Verify the main stitching CLI starts and prints usage
+    command: terastitcher --help 2>&1 | sed -n '1,20p'
+    expected_output_contains: "terastitcher  [--isotropic]"
+
+  - name: teraconverter help renders
+    description: Verify the volume conversion CLI is available
+    command: teraconverter --help 2>&1 | sed -n '1,20p'
+    expected_output_contains: "teraconverter  -s=<string>"
+
+  - name: mdatagenerator help renders
+    description: Verify the metadata generator CLI is available
+    command: mdatagenerator --help 2>&1 | sed -n '1,20p'
+    expected_output_contains: "mdatagenerator"


### PR DESCRIPTION
## Summary
- Add fulltests for successful release candidates without coverage: `terastitcher`, `mipav`, `soopct`, and `brainlesion`.
- Fix `eharmonize` by installing `setuptools<81`, restoring `pkg_resources` for its CLI on Python 3.13, and switch its fulltest to the release override container naming convention.
- Fix `soopct` runtime issues found during local workflow testing:
  - install `dcm2niix`, which `1dcm2raw.py` calls directly;
  - pin the Miniconda py313 installer and remove the brittle redundant `conda install python=3.13` step;
  - install `clang` for TinyGrad/BrainChop CPU kernel compilation;
  - patch the cloned `3best2anon.py` BrainChop invocation for the current positional-input CLI and `--border` option.

## Local validation
- Downloaded and tested release SIFs locally from the manual build run.
- Passed against downloaded SIFs:
  - `python3 builder/run_tests.py recipes/terastitcher/fulltest.yaml -c /tmp/containers --work-dir /tmp/fulltest-terastitcher -o /tmp/fulltest-terastitcher.json --no-log --no-jsonl`
  - `python3 builder/run_tests.py recipes/mipav/fulltest.yaml -c /tmp/containers --work-dir /tmp/fulltest-mipav -o /tmp/fulltest-mipav.json --no-log --no-jsonl`
  - `python3 builder/run_tests.py recipes/brainlesion/fulltest.yaml -c /tmp/containers --work-dir /tmp/fulltest-brainlesion -o /tmp/fulltest-brainlesion.json --no-log --no-jsonl`
  - `python3 builder/run_tests.py recipes/fitlins/fulltest.yaml -c /tmp/containers --work-dir /tmp/fulltest-fitlins -o /tmp/fulltest-fitlins.json --no-log --no-jsonl`
- Confirmed old `soopct` SIF fails the new tests at the expected missing runtime integration points.
- Rebuilt `eharmonize` locally and verified both `eharmonize --help` and `eharmonize harmonize-fa --help` render.
- Rebuilt `soopct` locally and verified the DICOM conversion + best-image selection workflow, BrainChop CLI compatibility, and `clang` runtime dependency.
- Validated touched recipes with `python3 builder/validation.py`.
