### PR TITLE
Fix TeraStitcher deploy path permissions

### DIFF
--- a/recipes/terastitcher/build.yaml
+++ b/recipes/terastitcher/build.yaml
@@ -21,6 +21,8 @@ build:
 
     - run:
         - tar -xz -C /opt/terastitcher-{{ context.version }} --strip-components 1 -f {{ get_file("TeraStitcher_portable_1_11_10_Linux_tar_gz") }}
+        - chmod a+rx /opt
+        - chmod -R a+rX /opt/terastitcher-{{ context.version }}
 
     - environment:
         PATH: $PATH:/opt/terastitcher-{{ context.version }}


### PR DESCRIPTION
## Summary
- make /opt explicitly traversable after unpacking TeraStitcher
- make the TeraStitcher install tree world-readable/traversable for arbitrary runtime users

## Root cause
The refreshed release test for #2716 passed the fulltest commands but failed the deploy path check because the release image reported /opt as not traversable by arbitrary runtime users. This normalizes permissions in the recipe so the deployed /opt/terastitcher-{{ context.version }} path is usable outside root-owned build context assumptions.

SOOP-CT failures in #2718 came from the stale release image built before #2722 landed. The runtime fixes are already on main; that release needs to be regenerated/retested rather than patched in this PR.

## Testing
- python3 builder/validation.py recipes/terastitcher/build.yaml
- python3 -m builder generate terastitcher --recreate
- python3 -m builder test terastitcher --recreate --build
- docker run --rm --user 12345:12345 terastitcher:1.11.10 /bin/sh -lc 'test -x /opt && test -r /opt/terastitcher-1.11.10 && test -x /opt/terastitcher-1.11.10 && /opt/terastitcher-1.11.10/terastitcher --help >/tmp/terastitcher-help.txt 2>&1 && grep -q USAGE /tmp/terastitcher-help.txt'