### PR TITLE
Fix SOOP-CT BrainChop runtime cache

### DIFF
--- a/recipes/soopct/build.yaml
+++ b/recipes/soopct/build.yaml
@@ -51,6 +51,10 @@ build:
   base-image: ubuntu:24.04
   pkg-manager: apt
   directives:
+    - environment:
+        HOME: /tmp/soopct-home
+        MPLCONFIGDIR: /tmp/soopct-matplotlib
+        XDG_CACHE_HOME: /tmp/soopct-cache
     - install:
         - clang
         - dcm2niix

--- a/recipes/soopct/fulltest.yaml
+++ b/recipes/soopct/fulltest.yaml
@@ -58,12 +58,17 @@ tests:
     description: Verify the BrainChop CLI and TinyGrad compiler dependency are available
     command: |
       set -e
+      test "$HOME" = "/tmp/soopct-home"
+      test "$XDG_CACHE_HOME" = "/tmp/soopct-cache"
+      test "$MPLCONFIGDIR" = "/tmp/soopct-matplotlib"
+      mkdir -p "$HOME" "$XDG_CACHE_HOME" "$MPLCONFIGDIR"
       command -v clang
-      brainchop --help 2>&1 | sed -n '1,40p'
-    expected_output_contains:
-      - "/usr/bin/clang"
-      - "--border MM"
-      - "--no-optimize"
+      command -v brainchop
+      brainchop --help > "${output_dir}/brainchop-help.txt" 2>&1
+      grep -F -- "--border" "${output_dir}/brainchop-help.txt"
+      grep -F -- "--no-optimize" "${output_dir}/brainchop-help.txt"
+      echo "brainchop runtime dependencies ok"
+    expected_output_contains: "brainchop runtime dependencies ok"
 
   - name: SOOP-CT BrainChop command matches current CLI
     description: Verify 3best2anon.py calls BrainChop using the current positional-input CLI without running model inference


### PR DESCRIPTION
## Summary
- set SOOP-CT runtime cache/home locations under /tmp so BrainChop and Matplotlib do not depend on an unavailable user home directory
- update the BrainChop fulltest to verify those runtime env defaults and check the CLI options via a real help invocation

## Root cause
The fresh SOOP-CT release PR #2727 used the rebuilt image and passed most of the workflow, but BrainChop failed during CLI initialization because it tried to create cache files under /home/ubuntu/.cache. NeuroContainers cannot rely on a user home directory being available at runtime, so the recipe should point caches at writable /tmp locations.

## Testing
- python3 builder/validation.py recipes/soopct/build.yaml
- python3 -m builder generate soopct --recreate
- python3 -m builder test soopct --recreate --build
- docker run --rm soopct:0.0.0 /bin/sh -lc 'set -e; test "$HOME" = "/tmp/soopct-home"; test "$XDG_CACHE_HOME" = "/tmp/soopct-cache"; test "$MPLCONFIGDIR" = "/tmp/soopct-matplotlib"; mkdir -p "$HOME" "$XDG_CACHE_HOME" "$MPLCONFIGDIR"; command -v clang; command -v brainchop; brainchop --help > /tmp/brainchop-help.txt 2>&1; grep -F -- "--border" /tmp/brainchop-help.txt; grep -F -- "--no-optimize" /tmp/brainchop-help.txt; echo "brainchop runtime dependencies ok"'
