### PR TITLE
Fix MIPAV GUI runtime dependencies

### DIFF
--- a/recipes/mipav/build.yaml
+++ b/recipes/mipav/build.yaml
@@ -10,11 +10,15 @@ build:
   directives:
     - workdir: /opt
     - install:
+        - fontconfig
+        - fonts-dejavu-core
         - libfreetype6
         - libgl1-mesa-glx
         - libxrender1
         - libxtst6
         - libxi6
+        - xauth
+        - xvfb
     - file:
         name: installer
         url: >-
@@ -23,6 +27,9 @@ build:
       - sh {{ get_file("installer") }} -q
     - environment:
         PATH: /usr/local/mipav:${PATH}
+deploy:
+  bins:
+    - mipav
 copyright:
   - name: Medical Image Processing, Analysis and Visualization
     url: https://mipav.cit.nih.gov/clickwrap.php

--- a/recipes/mipav/fulltest.yaml
+++ b/recipes/mipav/fulltest.yaml
@@ -26,6 +26,38 @@ tests:
     command: test -f /usr/local/mipav/about.txt && test -f /usr/local/mipav/MipavMain.class && grep -i "Visualization (MIPAV)" /usr/local/mipav/about.txt
     expected_output_contains: "Visualization (MIPAV)"
 
+  - name: Xvfb runtime available
+    description: Verify headless display support is installed for GUI startup testing
+    command: |
+      command -v xvfb-run
+      command -v Xvfb
+      command -v xauth
+      echo "xvfb-runtime-ok"
+    expected_output_contains: "xvfb-runtime-ok"
+
+  - name: MIPAV launches under headless display
+    description: Verify Swing GUI startup reaches the event loop without Java font or display failures
+    command: |
+      export HOME="${output_dir}/gui-home"
+      export _JAVA_OPTIONS="-Duser.home=${output_dir}/gui-home"
+      mkdir -p "$HOME"
+      log="${output_dir}/mipav-xvfb.log"
+      set +e
+      timeout 25s xvfb-run -a mipav >"$log" 2>&1
+      status=$?
+      set -e
+      if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+        cat "$log"
+        exit "$status"
+      fi
+      if grep -Ei "Exception|UnsatisfiedLinkError|NoClassDefFoundError|Could not initialize|AWTError|Cannot open display|segmentation fault" "$log"; then
+        cat "$log"
+        exit 1
+      fi
+      echo "mipav-xvfb-startup-ok"
+    expected_output_contains: "mipav-xvfb-startup-ok"
+    timeout: 40
+
   - name: MIPAV starts with writable user home
     description: Verify startup reaches MIPAV code and extracts native libraries outside the host home
     command: |


### PR DESCRIPTION
## Summary
- add MIPAV runtime font packages so Java/Swing can initialize under a display
- add `xvfb`/`xauth` so fulltests can exercise GUI startup headlessly
- add missing `deploy.bins` metadata for the `mipav` launcher
- extend `recipes/mipav/fulltest.yaml` with Xvfb runtime and GUI startup checks

## Root cause
The release image from #2719 passed the existing fulltests, but a local Xvfb GUI smoke reproduced a Java font configuration startup crash:

```text
java.lang.InternalError: java.lang.reflect.InvocationTargetException
Caused by: java.lang.NullPointerException
  at java.desktop/sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
```

The image had the Java runtime and X libraries, but not the system font/fontconfig runtime needed by the AWT/Swing font manager.

## Validation
- `python3 builder/validation.py recipes/mipav/build.yaml`
- `python3 -m builder generate mipav --recreate`
- `python3 -m builder test mipav --recreate --build`
- Current #2719 release SIF: existing fulltest passed 4/4 locally
- Current #2719 release SIF: Xvfb GUI smoke reproduced the Java font crash
- Patched Docker image: headless GUI fulltest command passed with `mipav-xvfb-startup-ok`
