### PR TITLE
Fix FitLins PyTables runtime stack

### DIFF
--- a/recipes/fitlins/build.yaml
+++ b/recipes/fitlins/build.yaml
@@ -18,16 +18,19 @@ build:
         env_exists: "false"
         mamba: true
     - run:
-        - conda install --override-channels -c conda-forge numpy=1.21 scipy=1.8 networkx=2.7 scikit-learn=1.0 scikit-image matplotlib=3.5 seaborn=0.11 pytables=3.6 pandas pytest nbformat nb_conda traits=6.2
+        - conda install --override-channels -c conda-forge numpy=1.23 pandas=1.4 scipy=1.8 networkx=2.7 scikit-learn=1.0 scikit-image matplotlib=3.5 seaborn=0.11 pytables=3.6 pytest nbformat nb_conda traits=6.2
     - run:
-        - pip install fitlins==0.11.0
+        - pip install fitlins=={{ context.version }}
   add-default-template: true
+deploy:
+  bins:
+    - fitlins
 copyright:
   - license: Apache-2.0
     url: https://github.com/poldracklab/fitlins/blob/master/LICENSE
 readme: |-
   ----------------------------------
-  ## fitlins/0.11.0 ##
+  ## fitlins/{{ context.version }} ##
 
   FitLins is a tool for estimating linear models, defined by the BIDS Stats-Models specification proposal, to BIDS-formatted datasets.
 
@@ -45,7 +48,7 @@ readme: |-
   https://zenodo.org/records/7217447
   ```
 
-  To run container outside of this environment: ml fitlins/0.11.0
+  To run container outside of this environment: ml fitlins/{{ context.version }}
 
   ----------------------------------
 categories:

--- a/recipes/fitlins/fulltest.yaml
+++ b/recipes/fitlins/fulltest.yaml
@@ -3,7 +3,7 @@
 
 name: fitlins
 version: 0.11.0
-container: fitlins_0.11.0.simg
+container: fitlins_${version}_REFERENCE.simg
 
 test_data:
   output_dir: test_output
@@ -23,7 +23,7 @@ tests:
   - name: FitLins package import
     description: Verify the main fitlins module imports successfully
     command: python -c "import fitlins; print(fitlins.__version__)"
-    expected_output_contains: "0.11.0"
+    expected_output_contains: "${version}"
 
   - name: FitLins CLI on PATH
     description: Verify the fitlins launcher renders its shipped help text
@@ -34,6 +34,22 @@ tests:
     description: Verify pip metadata reports the installed fitlins package
     command: python -m pip show fitlins 2>&1 | sed -n '1,12p'
     expected_output_contains: "Author: Christopher J. Markiewicz"
+
+  - name: PyTables HDF5 writer available
+    description: Verify the pandas/PyTables stack required by FitLins model loading works
+    command: |
+      python - <<'PY'
+      import pandas as pd
+      from pathlib import Path
+
+      path = Path("${output_dir}") / "fitlins_hdf_probe.h5"
+      frame = pd.DataFrame({"signal": [0.0, 1.0, 2.0]})
+      frame.to_hdf(path, key="dense")
+      loaded = pd.read_hdf(path, key="dense")
+      assert loaded.equals(frame)
+      print("pytables hdf roundtrip ok")
+      PY
+    expected_output_contains: "pytables hdf roundtrip ok"
 
   - name: FitLins install location
     description: Verify the module is installed under the Miniconda site-packages tree


### PR DESCRIPTION
## Summary

Follow-up to release PR #2720.

The current release image passes the existing smoke/fulltest checks, but a deeper FitLins workflow path fails when FitLins writes model data through pandas/PyTables.

Root cause: the image resolved to `tables 3.6.1` with `numpy 1.24.4`. PyTables 3.6 imports `numpy.typeDict`, which was removed in NumPy 1.24, so FitLins model loading reports PyTables as unavailable when it reaches `DataFrame.to_hdf(...)`.

This PR:
- pins the FitLins conda stack to compatible `numpy=1.23`, `pandas=1.4`, and `pytables=3.6`
- uses `{{ context.version }}` for the pip install and README module text
- adds `fitlins` to `deploy.bins`
- adds a fulltest HDF5 roundtrip probe that exercises the pandas/PyTables path FitLins needs
- switches the fulltest container reference to `fitlins_${version}_REFERENCE.simg`

## Testing

- `python3 builder/validation.py recipes/fitlins/build.yaml`
- `python3 -m builder generate fitlins --recreate`
- `python3 -m builder test fitlins --recreate --build`
- Docker runtime probe confirmed:
  - `numpy 1.23.5`
  - `pandas 1.4.4`
  - `tables 3.6.1`
  - `fitlins 0.11.0`
  - `tables import ok 3.6.1`
- HDF5 roundtrip probe passed inside the rebuilt image
- FitLins internal workflow test passed inside the rebuilt image:
  - `python -m pytest -q fitlins/workflows/tests/test_base.py -k nistats -s --tb=short`
  - `1 passed, 1 deselected`
