### PR TITLE
Add release for libreoffice 26.2.4

### DIFF
--- a/releases/libreoffice/26.2.4.json
+++ b/releases/libreoffice/26.2.4.json
@@ -1,0 +1,47 @@
+{
+  "apps": {
+    "libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "",
+      "apptainer_args": []
+    },
+    "libreofficeGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "libreoffice",
+      "apptainer_args": []
+    },
+    "libreofficeWriterGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "lowriter",
+      "apptainer_args": []
+    },
+    "libreofficeCalcGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "localc",
+      "apptainer_args": []
+    },
+    "libreofficeImpressGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "loimpress",
+      "apptainer_args": []
+    },
+    "libreofficeDrawGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "lodraw",
+      "apptainer_args": []
+    },
+    "libreofficeBaseGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "lobase",
+      "apptainer_args": []
+    },
+    "libreofficeMathGUI-libreoffice 26.2.4": {
+      "version": "20260613",
+      "exec": "lomath",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "data organisation"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **libreoffice 26.2.4**.

## Changes

- Add `releases/libreoffice/26.2.4.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh libreoffice 26.2.4 20260613
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/libreoffice_26.2.4_20260613.simg -O
singularity shell --overlay /tmp/apptainer_overlay libreoffice_26.2.4_20260613.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @stebo85