### PR TITLE
Fix TeraStitcher Dive wasted space

### DIFF
--- a/recipes/terastitcher/build.yaml
+++ b/recipes/terastitcher/build.yaml
@@ -13,10 +13,6 @@ build:
     - environment:
         DEBIAN_FRONTEND: noninteractive
 
-    - install:
-        - curl
-        - ca-certificates
-
     - workdir: /opt/terastitcher-{{ context.version }}
 
     - run:


### PR DESCRIPTION
## Summary
- remove the recipe-level `curl`/`ca-certificates` install from `terastitcher`
- keep the declared `get_file(...)` archive flow unchanged

## Root cause
Issue #2715 is still current for `terastitcher_1.11.10:20260611`: after the runtime-permission fix in #2723, Dive still reported wasted RPM/DNF database space. The TeraStitcher recipe does not download anything during container runtime/build commands; it already uses the declared archive via `{{ get_file("TeraStitcher_portable_1_11_10_Linux_tar_gz") }}`. The extra package install created an unnecessary DNF transaction and corresponding RPM/DNF database churn.

Neurodocker's baseline Fedora setup still provides the certificates/tools needed by the generated image, and the smoke checks confirm the TeraStitcher CLI remains available.

Fixes #2715.

## Validation
- `python3 builder/validation.py recipes/terastitcher/build.yaml`
- `python3 -m builder generate terastitcher --recreate`
- `python3 -m builder test terastitcher --recreate --build`
- `docker run --rm --user 12345:12345 terastitcher:1.11.10 /bin/sh -lc 'test -x /opt && test -r /opt/terastitcher-1.11.10 && test -x /opt/terastitcher-1.11.10 && /opt/terastitcher-1.11.10/terastitcher --help >/tmp/terastitcher-help.txt 2>&1 && grep -q USAGE /tmp/terastitcher-help.txt'`
- `docker run --rm terastitcher:1.11.10 /bin/sh -lc 'terastitcher --help 2>&1 | sed -n "1,8p"'`
