### PR TITLE
Clean Apptainer bind env for deploy tests

### DIFF
--- a/builder/tests/test_container_tester_runtime.py
+++ b/builder/tests/test_container_tester_runtime.py
@@ -8,11 +8,15 @@ from workflows.container_tester import ApptainerRuntime, ContainerTester
 
 def test_apptainer_runtime_uses_cleanenv_when_requested(monkeypatch) -> None:
     commands: list[list[str]] = []
+    envs: list[dict[str, str] | None] = []
 
     monkeypatch.setattr("workflows.container_tester.shutil.which", lambda name: name)
+    monkeypatch.setenv("APPTAINER_BINDPATH", "/opt:/opt")
+    monkeypatch.setenv("SINGULARITY_BINDPATH", "/opt:/opt")
 
     def fake_run(command, **kwargs):
         commands.append(command)
+        envs.append(kwargs.get("env"))
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
     monkeypatch.setattr("workflows.container_tester.subprocess.run", fake_run)
@@ -23,6 +27,9 @@ def test_apptainer_runtime_uses_cleanenv_when_requested(monkeypatch) -> None:
     assert commands == [
         ["apptainer", "exec", "--cleanenv", "container.simg", "bash", "-c", "true"]
     ]
+    assert envs[0] is not None
+    assert "APPTAINER_BINDPATH" not in envs[0]
+    assert "SINGULARITY_BINDPATH" not in envs[0]
 
 
 def test_builtin_tests_run_with_clean_apptainer_environment(monkeypatch) -> None:

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -155,9 +155,18 @@ class ApptainerRuntime(ContainerRuntime):
         clean_env: bool = False,
     ) -> subprocess.CompletedProcess:
         cmd = [self._get_command(), "exec"]
+        env = None
 
         if clean_env:
             cmd.append("--cleanenv")
+            env = os.environ.copy()
+            for key in (
+                "APPTAINER_BIND",
+                "APPTAINER_BINDPATH",
+                "SINGULARITY_BIND",
+                "SINGULARITY_BINDPATH",
+            ):
+                env.pop(key, None)
 
         # Add volumes (bind mounts)
         if volumes:
@@ -181,7 +190,7 @@ class ApptainerRuntime(ContainerRuntime):
 
         cmd.extend([container_ref, "bash", "-c", final_script])
 
-        return subprocess.run(cmd, capture_output=True, text=True)
+        return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
     def extract_file(
         self, container_ref: str, file_path: str, output_path: str


### PR DESCRIPTION
## Summary
- strip Apptainer/Singularity bind-path environment variables when `ApptainerRuntime.run_test(..., clean_env=True)` is requested
- extend the runtime unit test to cover inherited bind env cleanup

## Root cause
Release PR #2754 failed the built-in deploy check with:

```text
Parent directory /opt is not traversable by arbitrary runtime users.
```

The published SIF itself has `/opt` as `6777`, verified locally with:

```bash
apptainer exec terastitcher_1.11.10_20260619.simg bash -lc 'stat -c "%A %a %n" /opt'
# drwsrwsrwx 6777 /opt
```

That means the deploy check was not seeing the clean SIF filesystem. The likely cause is host Apptainer/Singularity bind configuration leaking into the runtime process. `--cleanenv` cleans the container process environment, but the Apptainer command itself can still consume `APPTAINER_BIND*`/`SINGULARITY_BIND*` variables from the host before launching the container.

The built-in deploy check already requests `clean_env=True`, so this patch makes that request actually isolate the test from host bind-path configuration.

## Validation
- `python3 -m py_compile workflows/container_tester.py builder/tests/test_container_tester_runtime.py`
- `git diff --check`
- Local reproduction with bad host bind env now sees the SIF `/opt` mode:
  ```bash
  APPTAINER_BINDPATH=/tmp:/opt python3 - <<'PY'
  from workflows.container_tester import ApptainerRuntime
  runtime = ApptainerRuntime()
  result = runtime.run_test('/tmp/neurocontainers-check/terastitcher_1.11.10_20260619.simg', 'stat -c "%A %a %n" /opt', clean_env=True)
  print(result.returncode)
  print(result.stdout)
  print(result.stderr)
  PY
  ```
- Could not run pytest locally because `pytest` is not installed in this workspace (`python3 -m pytest ...` and `uv run pytest ...` both unavailable).

Related: #2754
