### PR TITLE
Fix deploy checks for slim Apptainer images

### DIFF
--- a/builder/tests/test_container_tester_runtime.py
+++ b/builder/tests/test_container_tester_runtime.py
@@ -25,7 +25,17 @@ def test_apptainer_runtime_uses_cleanenv_when_requested(monkeypatch) -> None:
     runtime.run_test("container.simg", "true", clean_env=True)
 
     assert commands == [
-        ["apptainer", "exec", "--cleanenv", "container.simg", "bash", "-c", "true"]
+        [
+            "apptainer",
+            "exec",
+            "--cleanenv",
+            "--no-mount",
+            "hostfs",
+            "container.simg",
+            "bash",
+            "-c",
+            "true",
+        ]
     ]
     assert envs[0] is not None
     assert "APPTAINER_BINDPATH" not in envs[0]

--- a/builder/tests/test_deploy_script_contract.py
+++ b/builder/tests/test_deploy_script_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -61,6 +62,60 @@ def test_deploy_script_accepts_world_accessible_executable(tmp_path: Path) -> No
 
     assert returncode == 0
     assert payload["failed"] == 0
+
+
+def test_deploy_script_checks_directory_access_without_find(tmp_path: Path) -> None:
+    tmp_path.chmod(
+        stat.S_IRUSR
+        | stat.S_IWUSR
+        | stat.S_IXUSR
+        | stat.S_IRGRP
+        | stat.S_IXGRP
+        | stat.S_IROTH
+        | stat.S_IXOTH
+    )
+    deploy_dir = tmp_path / "tool"
+    deploy_dir.mkdir()
+    deploy_dir.chmod(
+        stat.S_IRUSR
+        | stat.S_IWUSR
+        | stat.S_IXUSR
+        | stat.S_IRGRP
+        | stat.S_IXGRP
+        | stat.S_IROTH
+        | stat.S_IXOTH
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for command in ("mktemp", "rm", "stat", "dirname", "tr", "sort"):
+        command_path = shutil.which(command)
+        assert command_path is not None
+        (bin_dir / command).symlink_to(command_path)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "DEPLOY_BINS": "",
+            "DEPLOY_PATH": str(deploy_dir),
+            "PATH": str(bin_dir),
+        }
+    )
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT)],
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert {
+        "name": f"directory.access.arbitrary_user:{deploy_dir}",
+        "status": "passed",
+        "message": f"Directory {deploy_dir} is traversable by arbitrary runtime users.",
+    } in payload["tests"]
 
 
 def test_deploy_summary_preserves_runtime_user_access_failures() -> None:

--- a/workflows/container_tester.py
+++ b/workflows/container_tester.py
@@ -159,6 +159,7 @@ class ApptainerRuntime(ContainerRuntime):
 
         if clean_env:
             cmd.append("--cleanenv")
+            cmd.extend(["--no-mount", "hostfs"])
             env = os.environ.copy()
             for key in (
                 "APPTAINER_BIND",

--- a/workflows/test_deploy.sh
+++ b/workflows/test_deploy.sh
@@ -104,9 +104,24 @@ mark_visited_file() {
 
 path_has_other_bit() {
     local path="$1"
-    local mode="$2"
+    local mask="$2"
+    local mode
+    local other_digit
+    local mask_digit
 
-    [ -n "$(find "$path" -maxdepth 0 -perm "$mode" -print -quit 2>/dev/null)" ]
+    if command -v find >/dev/null 2>&1; then
+        [ -n "$(find "$path" -maxdepth 0 -perm "$mask" -print -quit 2>/dev/null)" ]
+        return
+    fi
+
+    mode=$(stat -c "%a" "$path" 2>/dev/null || true)
+    if [ -z "$mode" ]; then
+        return 1
+    fi
+
+    other_digit="${mode: -1}"
+    mask_digit="${mask: -1}"
+    [ $((8#$other_digit & 8#$mask_digit)) -ne 0 ]
 }
 
 resolve_path_best_effort() {


### PR DESCRIPTION
## Summary
- run clean Apptainer deploy tests without hostfs mounts
- make test_deploy.sh fall back to stat when find is unavailable
- add regression coverage for clean Apptainer invocation and no-find deploy directory checks

## Validation
- python3 -m py_compile workflows/container_tester.py builder/tests/test_container_tester_runtime.py builder/tests/test_deploy_script_contract.py
- git diff --check
- reproduced the failing TeraStitcher deploy check against terastitcher_1.11.10_20260619.simg; patched script returns 0
- simulated DEPLOY_PATH check with find absent; patched script returns 0

Fixes the release-test failure seen in #2754.