### PR TITLE
Add release for openads 1.0.0

### DIFF
--- a/releases/openads/1.0.0.json
+++ b/releases/openads/1.0.0.json
@@ -1,0 +1,18 @@
+{
+  "apps": {
+    "openads 1.0.0": {
+      "version": "20260527",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "diffusion imaging",
+    "structural imaging",
+    "image registration",
+    "image segmentation",
+    "visualization",
+    "machine learning",
+    "workflows"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **openads 1.0.0**.

## Changes

- Add `releases/openads/1.0.0.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh openads 1.0.0 20260527
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/openads_1.0.0_20260527.simg -O
singularity shell --overlay /tmp/apptainer_overlay openads_1.0.0_20260527.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz