### PR TITLE
Fix DAFNE GUI runtime startup

### DIFF
--- a/recipes/dafne/build.yaml
+++ b/recipes/dafne/build.yaml
@@ -45,6 +45,18 @@ build:
         - libsm6
         - libxrender1
         - libxext6
+        - libdbus-1-3
+        - libfontconfig1
+        - libxcb-icccm4
+        - libxcb-image0
+        - libxcb-keysyms1
+        - libxcb-render-util0
+        - libxcb-render0
+        - libxcb-shape0
+        - libxcb-xinerama0
+        - libxcb-xkb1
+        - libxkbcommon-x11-0
+        - libxkbcommon0
         - xauth
         - xvfb
 
@@ -63,6 +75,28 @@ build:
         XDG_DATA_HOME: /tmp/.local/share
 
     - run:
+        - |
+          python - <<'PY'
+          from pathlib import Path
+          import ast
+
+          root = Path("/opt/miniconda-py38_22.11.1-1/lib/python3.8/site-packages/dafne_dl")
+          for path in root.rglob("*.py"):
+              text = path.read_text()
+              if "from __future__ import annotations" in text.splitlines()[:20]:
+                  continue
+              tree = ast.parse(text)
+              insert_line = 0
+              if (
+                  tree.body
+                  and isinstance(tree.body[0], ast.Expr)
+                  and isinstance(tree.body[0].value, ast.Str)
+              ):
+                  insert_line = tree.body[0].end_lineno or 0
+              lines = text.splitlines()
+              lines.insert(insert_line, "from __future__ import annotations")
+              path.write_text("\n".join(lines) + ("\n" if text.endswith("\n") else ""))
+          PY
         - dafne_bin="$(command -v dafne)"
         - mv "$dafne_bin" "${dafne_bin}.real"
         - printf '%s\n' '#!/usr/bin/env bash' 'export HOME=/tmp' 'export XDG_CACHE_HOME=/tmp/.cache' 'export XDG_CONFIG_HOME=/tmp/.config' 'export XDG_DATA_HOME=/tmp/.local/share' 'export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python' 'mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"' 'exec "$0.real" "$@"' > "$dafne_bin"

--- a/recipes/dafne/fulltest.yaml
+++ b/recipes/dafne/fulltest.yaml
@@ -94,6 +94,30 @@ tests:
       PY
     expected_output_contains: "enabled-image-types"
 
+  - name: DAFNE GUI modules import
+    description: Verify GUI startup imports reach DAFNE UI modules under the packaged Python runtime
+    command: |
+      python - <<'PY'
+      from dafne.ui.MuscleSegmentation import MuscleSegmentation
+
+      print(MuscleSegmentation.__name__)
+      PY
+    expected_output_contains: "MuscleSegmentation"
+    timeout: 60
+
+  - name: Qt XCB platform dependencies available
+    description: Verify the PyQt xcb platform plugin has all system libraries needed for Xvfb startup
+    command: |
+      set -euo pipefail
+      plugin="$(find /opt/miniconda-py38_22.11.1-1 -path '*/platforms/libqxcb.so' | head -1)"
+      test -n "$plugin"
+      ldd "$plugin" | tee /tmp/dafne-libqxcb-ldd.txt
+      if grep -F "not found" /tmp/dafne-libqxcb-ldd.txt; then
+        exit 1
+      fi
+      echo "qt-xcb-dependencies-ok"
+    expected_output_contains: "qt-xcb-dependencies-ok"
+
   - name: Runtime state uses configured temporary locations
     description: Verify DAFNE runtime state avoids persistent home-directory paths
     command: |


### PR DESCRIPTION
## Summary
- install missing Qt/XCB runtime libraries required by PyQt5 under Xvfb
- postpone `dafne_dl` annotation evaluation so DAFNE GUI imports work on the packaged Python 3.8 runtime
- strengthen fulltest coverage for GUI module imports and `libqxcb.so` shared-library dependencies

## Root Cause
Local testing of #2763 against `dafne_1.8a4_20260603.simg` exposed failures that CI missed because the runner hit the expected 25s GUI startup timeout before DAFNE reached these imports. On a faster local host, startup reached:

1. `TypeError` from Python 3.10/3.9-style annotations in `dafne_dl` while running under Python 3.8.
2. Qt `xcb` plugin load failure due missing system libraries such as `libxcb-icccm4`, `libxcb-image0`, `libxkbcommon-x11-0`, `libfontconfig1`, and `libdbus-1-3`.

## Validation
- `python3 builder/validation.py recipes/dafne/build.yaml`
- `python3 -m builder generate dafne --recreate`
- `git diff --check`
- local release-image testing:
  - `lqt_0.1.0_20260603.simg`: 5/5 fulltests passed
  - `cartool_5.06.04_20260605.simg`: 12/12 fulltests passed
  - `dafne_1.8a4_20260603.simg`: 7/8 fulltests passed; final GUI startup failed with the Python annotation/runtime Qt issues fixed here

After this merges, #2763 should be closed and a fresh DAFNE manual build/release PR should be generated.