### PR TITLE
Fix OpenADS fulltest timeouts

### DIFF
--- a/recipes/openads/fulltest.yaml
+++ b/recipes/openads/fulltest.yaml
@@ -5,6 +5,8 @@ container: openads_1.0.0.simg
 environment:
   OPENADS_ENABLE_WEB_UI: "0"
 
+default_timeout: 600
+
 tests:
   - name: Show ads help
     script: |
@@ -36,7 +38,9 @@ tests:
         --all \
         --gpu 1 \
         --output-root /tmp/openads_test_output
-      test -d /tmp/openads_test_output/sub-02e8eb42/DWI
+      test -f /tmp/openads_test_output/sub-02e8eb42/DWI/segment/sub-02e8eb42_metrics.json
+      test -f /tmp/openads_test_output/sub-02e8eb42/DWI/reporting/sub-02e8eb42_automatic_radiological_report.txt
+      test -f /tmp/openads_test_output/sub-02e8eb42/DWI/reporting/sub-02e8eb42_DWIstroke.png
 
   - name: Run PWI example workflow
     script: |
@@ -48,7 +52,9 @@ tests:
         --all \
         --gpu 1 \
         --output-root /tmp/openads_test_output
-      test -d /tmp/openads_test_output/sub-02e8eb42/PWI
+      test -f /tmp/openads_test_output/sub-02e8eb42/PWI/segmentation/sub-02e8eb42_metrics.json
+      test -f /tmp/openads_test_output/sub-02e8eb42/PWI/reporting/sub-02e8eb42_automatic_radiological_report.txt
+      test -f /tmp/openads_test_output/sub-02e8eb42/PWI/reporting/sub-02e8eb42_HP.png
 
   - name: Run selected DWI stages
     script: |
@@ -57,10 +63,10 @@ tests:
       mkdir -p /tmp/openads_test_output
       ads dwi \
         --subject-path /app/assets/examples/dwi/sub-02e8eb42 \
-        --stages prepdata,gen_mask,skull_strip,registration,inference,report \
+        --stages prepdata,gen_mask \
         --gpu 1 \
         --output-root /tmp/openads_test_output
-      test -d /tmp/openads_test_output/sub-02e8eb42/DWI
+      test -f /tmp/openads_test_output/sub-02e8eb42/DWI/preprocess/sub-02e8eb42_DWIbrain-mask.nii.gz
 
   - name: Run selected PWI stages
     script: |
@@ -69,10 +75,11 @@ tests:
       mkdir -p /tmp/openads_test_output
       ads pwi \
         --subject-path /app/assets/examples/pwi/sub-02e8eb42 \
-        --stages prepdata,gen_mask,skull_strip,gen_ttp,registration,ttpadc_coreg,inference,report \
+        --stages prepdata,gen_mask,gen_ttp \
         --gpu 1 \
         --output-root /tmp/openads_test_output
-      test -d /tmp/openads_test_output/sub-02e8eb42/PWI
+      test -f /tmp/openads_test_output/sub-02e8eb42/PWI/preprocess/sub-02e8eb42_DWIbrain-mask.nii.gz
+      test -f /tmp/openads_test_output/sub-02e8eb42/PWI/preprocess/sub-02e8eb42_TTP.nii.gz
 
 cleanup:
   script: |


### PR DESCRIPTION
## Summary

Fixes the OpenADS release fulltest failure seen on #2764 by giving the real example workflows enough time to complete and by avoiding duplicate full-pipeline work in the selected-stage tests.

## Root cause

#2764 failed because the OpenADS DWI/PWI workflow tests inherited the fulltest runner default timeout of 120 seconds. The container itself is functional: both full example workflows complete successfully, but each takes about 3.5 minutes on CPU because they run ANTs registration, inference, reporting, and visualization.

## Changes

- Set `default_timeout: 600` for the OpenADS fulltest suite.
- Strengthen full DWI/PWI assertions to check generated metrics, reports, and visualizations instead of only output directories.
- Keep selected-stage coverage, but limit those tests to shorter stage subsets so CI does not run the same full CPU pipeline four times.

## Validation

- `python3 builder/validation.py recipes/openads/build.yaml`
- `git diff --check`
- Local release image test against `openads_1.0.0_20260527.simg`: patched fulltest passed 7/7 in 495.1s
- Manual local runs against the same SIF:
  - DWI all-stages example completed successfully in 206s
  - PWI all-stages example completed successfully in 206s

After this merges, #2764 should be retriggered so the release PR picks up the updated fulltest from `main`.