### PR TITLE
[codex] Fix DAFNE GUI fulltest display

### DIFF
--- a/recipes/dafne/fulltest.yaml
+++ b/recipes/dafne/fulltest.yaml
@@ -95,9 +95,9 @@ tests:
     expected_output_contains: "enabled-image-types"
 
   - name: DAFNE GUI modules import
-    description: Verify GUI startup imports reach DAFNE UI modules under the packaged Python runtime
+    description: Verify GUI startup imports reach DAFNE UI modules under a virtual display
     command: |
-      python - <<'PY'
+      xvfb-run -a python - <<'PY'
       from dafne.ui.MuscleSegmentation import MuscleSegmentation
 
       print(MuscleSegmentation.__name__)


### PR DESCRIPTION
## Summary

Fix the DAFNE release fulltest failure seen on #2769 by running the GUI module import under Xvfb.

## Root cause

The `DAFNE GUI modules import` test imports `dafne.ui.MuscleSegmentation`, which forces Matplotlib to select the Qt5Agg backend. In the release PR workflow this ran without a display, so Matplotlib raised:

```text
ImportError: Cannot load backend 'Qt5Agg' which requires the 'qt' interactive framework, as 'headless' is currently running
```

## Changes

- Run the DAFNE GUI module import test with `xvfb-run -a python`.
- Update the test description to reflect that the GUI import requires a virtual display.

## Validation

- `env/bin/python builder/validation.py recipes/dafne/build.yaml`
- `env/bin/python -m builder generate dafne --recreate`
- `git diff --check HEAD~1..HEAD`

After this merges, #2769 should be rerun so the release PR picks up the updated fulltest from `main`.
