### PR TITLE
[codex] Pin HD-BET setuptools below SIF-breaking release

### DIFF
--- a/recipes/hdbet/build.yaml
+++ b/recipes/hdbet/build.yaml
@@ -19,7 +19,7 @@ build:
     - template:
         name: miniconda
         version: latest
-        conda_install: python=3.10 pip
+        conda_install: "python=3.10 pip setuptools<82"
         env_name: hdbet
         env_exists: "false"
 


### PR DESCRIPTION
## Summary

Pin HD-BET's conda `setuptools` dependency below 82 during image build.

The current published `hdbet_2.0.1:20260612` image installs `setuptools 82.0.1`, and Apptainer/Singularity conversion fails while unpacking that package:

`opt/miniconda-latest/pkgs/setuptools-82.0.1-pyh332efcf_0/site-packages/setuptools/launcher manifest.xml: link: unpriv.link: unpriv.wrap target: no such file or directory`

Pinning `setuptools<82` resolves that conversion blocker while preserving the HD-BET runtime surface.

## Evidence

- Reproduced current published SIF conversion failure:
  - First `singularity build ... docker://ghcr.io/neurodesk/hdbet_2.0.1:20260612` hit a transient GHCR stream error.
  - Retry reached extraction and failed on the `setuptools-82.0.1` launcher path above.
- Docker control check on published image passed the fulltest-equivalent assertions:
  - Python 3.10 available.
  - `HD_BET` imports from `/opt/HD-BET/HD_BET/__init__.py`.
  - bundled `fold_all/checkpoint_final.pth` exists and `maybe_download_parameters()` skips download.
  - `hd-bet` is on PATH and `hd-bet --help` starts.
- Validation for this branch:
  - `python3 -m builder.validation recipes/hdbet/build.yaml`
  - `python3 -m builder generate hdbet --architecture x86_64 --output-root worklogs/hdbet-setuptools-pin-20260627/generated`
  - YAML/JSON parse for HD-BET build/fulltest/release metadata
  - `git diff --check`
- Real x86_64 Docker build passed:
  - `sudo env PATH="$PATH" python3 -m builder build hdbet --output-root worklogs/hdbet-setuptools-pin-20260627/build-output --recreate --method docker`
- Runtime smoke on rebuilt image `hdbet:2.0.1` passed and confirmed `setuptools 81.0.0`.
- SIF conversion from the rebuilt Docker archive passed:
  - `singularity build -F worklogs/hdbet-setuptools-pin-20260627/hdbet_2.0.1_setuptools_pin_archive.simg docker-archive://.../hdbet_2.0.1_setuptools_pin.docker.tar`
- Full HD-BET fulltest passed against the rebuilt SIF:
  - 5/5 tests passed in 6.9s.

## Confidence

High for the x86_64 Docker build, Apptainer/SIF conversion path, and HD-BET fulltest surface. No real MRI inference dataset was run; the existing fulltest covers environment, package import, bundled model availability, PATH, and command help.


## Local validation

- `env/bin/python builder/validation.py recipes/hdbet/build.yaml`
- `git diff --check`
