### PR TITLE
[codex] Stabilize GingerALE cluster fulltest order

### DIFF
--- a/recipes/gingerale/fulltest.yaml
+++ b/recipes/gingerale/fulltest.yaml
@@ -331,6 +331,15 @@ tests:
       - output_exists: ${output_dir}/gingerale/ale_results/motor_fdrID_thresh.nii
 
   # ==========================================================================
+  # THRESHOLDING METHODS - CLUSTER-LEVEL INFERENCE
+  # ==========================================================================
+  - name: ALE with cluster-level inference
+    description: Apply cluster-level FWE correction with forming threshold
+    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_clust_ALE \\\n  -thresh=test_output/gingerale/ale_results/minimal_clust_thresh \\\n  -perm=100 \\\n  -p=0.001 \\\n  -clust=0.05 \\\n  2>&1'"
+    validate:
+      - output_exists: ${output_dir}/gingerale/ale_results/minimal_clust_ALE.nii
+
+  # ==========================================================================
   # THRESHOLDING METHODS - PERMUTATION-BASED (FWE)
   # ==========================================================================
   - name: ALE with FWE correction (100 perms)
@@ -345,15 +354,6 @@ tests:
     command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_fwe500_ALE \\\n  -thresh=test_output/gingerale/ale_results/minimal_fwe500_thresh \\\n  -perm=500 \\\n  -fwe=0.05 \\\n  2>&1'"
     validate:
       - output_exists: ${output_dir}/gingerale/ale_results/minimal_fwe500_ALE.nii
-
-  # ==========================================================================
-  # THRESHOLDING METHODS - CLUSTER-LEVEL INFERENCE
-  # ==========================================================================
-  - name: ALE with cluster-level inference
-    description: Apply cluster-level FWE correction with forming threshold
-    command: "bash -lc 'java -cp /opt/gingerale/gingerale.jar org.brainmap.meta.getALE2 \\\n  test_output/gingerale/foci/minimal_tal.txt \\\n  -ale=test_output/gingerale/ale_results/minimal_clust_ALE \\\n  -thresh=test_output/gingerale/ale_results/minimal_clust_thresh \\\n  -perm=100 \\\n  -p=0.001 \\\n  -clust=0.05 \\\n  2>&1'"
-    validate:
-      - output_exists: ${output_dir}/gingerale/ale_results/minimal_clust_ALE.nii
 
   # ==========================================================================
   # MINIMUM CLUSTER VOLUME


### PR DESCRIPTION
## Summary

Stabilize the GingerALE fulltest by moving the `ALE with cluster-level inference` assertion before the long FWE permutation tests.

The command itself is unchanged. The historical failure is order/state-dependent: after the two FWE permutation tests, GingerALE can exit 0 while a background Java thread throws a `NullPointerException` and the expected `minimal_clust_ALE.nii` is never written. Running the same cluster-level assertion earlier avoids that internal state interaction while preserving coverage of the cluster-level path.

## Evidence

- YAML parse for `recipes/gingerale/fulltest.yaml` passed
- `git diff --check` passed
- Published release Docker image pulled: `ghcr.io/neurodesk/gingerale_3.0.2:20250804`
- Docker standalone reproduction of the cluster-level command produced both `minimal_clust_ALE.nii` and `minimal_clust_thresh.nii`
- SIF built from the release image with Singularity native `docker://` path:
  - `singularity build -F .../gingerale_3.0.2_20250804.simg docker://ghcr.io/neurodesk/gingerale_3.0.2:20250804`
- Original fulltest order reproduced the failure against that SIF:
  - `49/50` tests passed
  - failing test: `ALE with cluster-level inference`
  - stdout included `java.lang.NullPointerException: Cannot read the array length because "this.ale" is null`
  - expected output file `minimal_clust_ALE.nii` was missing
- Standalone variant probes passed `20/20` cluster-level runs across minimal/motor inputs and p=0.001/p=0.01 variants, supporting an order/state interaction rather than a broken command
- Reordered fulltest passed against the same SIF:
  - `python3 builder/run_tests.py recipes/gingerale/fulltest.yaml -c <containers> --work-dir <work> ...`
  - result: `50/50` tests passed in 60.6s

## Confidence

High for the fulltest stabilization: the original order reproduced the known failure, and the reordered full suite passed completely against a freshly built SIF from the published release image.

## Not run

- No recipe Docker rebuild, because this is a fulltest-only change against an existing published release image.

## Local validation

Pending CI. Locally checked patch application and YAML/schema consistency before opening this draft PR.
