### PR TITLE
[codex] Fix BIDS App HCP Pipelines entrypoint

### DIFF
--- a/recipes/bidsapphcppipelines/build.yaml
+++ b/recipes/bidsapphcppipelines/build.yaml
@@ -15,6 +15,23 @@ build:
         DEBIAN_FRONTEND: noninteractive
         PATH: $PATH:/
 
+    - file:
+        name: bidsapphcppipelines-entrypoint
+        contents: |-
+          #!/usr/bin/env bash
+          set -e
+
+          if [ "$#" -eq 0 ]; then
+            exec /bin/bash
+          fi
+
+          exec "$@"
+    - copy:
+        - bidsapphcppipelines-entrypoint
+        - /usr/local/bin/bidsapphcppipelines-entrypoint
+    - run:
+        - chmod +x /usr/local/bin/bidsapphcppipelines-entrypoint
+
     - install:
         - qt4-dev-tools
         - libxss1
@@ -22,7 +39,7 @@ build:
         - libxft2
         - libjpeg62-dev
 
-    - entrypoint: bash
+    - entrypoint: /usr/local/bin/bidsapphcppipelines-entrypoint
 
 deploy:
   path:


### PR DESCRIPTION
## Summary

Fix the BIDS App HCP Pipelines Docker entrypoint so the image keeps an interactive shell when run without arguments, while still allowing Docker command overrides used by builder deploy smoke tests and downstream automation.

The previous recipe used `entrypoint: bash`, which caused Docker-supplied commands to be passed as bash arguments rather than executed as commands. This adds a tiny wrapper at `/usr/local/bin/bidsapphcppipelines-entrypoint`:

- no arguments: `exec /bin/bash`
- one or more arguments: `exec "$@"`

## Evidence

- `python3 builder/validation.py recipes/bidsapphcppipelines/build.yaml`: passed.
- YAML parse for `recipes/bidsapphcppipelines/build.yaml` and `recipes/bidsapphcppipelines/fulltest.yaml`: passed.
- `git diff --check`: passed.
- `python3 -m builder generate bidsapphcppipelines --output-root /tmp/neurocontainers-bidsapphcppipelines-20260626-generate --recreate --architecture x86_64 --ignore-architectures`: passed.
- Real x86_64 Docker build passed:
  - `python3 -m builder test bidsapphcppipelines --output-root /tmp/neurocontainers-bidsapphcppipelines-20260626-build --recreate --architecture x86_64 --ignore-architectures --build`
  - produced and loaded `bidsapphcppipelines:4.3.0`
  - builder deploy smoke succeeded with the default Docker command override path.
- Runtime smoke against `bidsapphcppipelines:4.3.0` passed:
  - wrapper exists and starts with `#!/usr/bin/env bash`
  - `DEPLOY_PATH` is populated
  - `run.py --help` prints HCP Pipelines BIDS App help
  - `wb_command -version` reports `1.5.0`
  - `flirt -version` reports `6.0`
  - `bet` usage is reachable
  - `mri_convert --version` reports FreeSurfer `stable6`
  - expected HCP/FSL/Workbench/FreeSurfer directories exist
- Explicit entrypoint command smoke passed:
  - `docker run --entrypoint /usr/local/bin/bidsapphcppipelines-entrypoint ... /bin/sh -lc 'echo explicit-command-ok'`
- Version smoke passed:
  - `python3 /run.py --version` reports `HCP Pipelines BIDS App version dev`
  - `/opt/HCP-Pipelines/version.txt` reports `v4.3.0`
  - `/opt/HCP-Pipelines/show_version` reports `HCP Pipeline Scripts v4.3.0`

## Caveats

- Confidence: high for the entrypoint/build behavior this change targets.
- This was validated with a real x86_64 Docker build and runtime command smokes, but not a full HCP Pipelines BIDS dataset execution and not an Apptainer/SIF rebuild.
- The earlier disk-space blocker for this recipe was cleared before this run; the build now completes locally.

## Local validation

Pending CI. Locally checked patch application and YAML/schema consistency before opening this draft PR.
