### PR TITLE
[codex] Fix Code Qt console runtime dependencies

### DIFF
--- a/recipes/code/build.yaml
+++ b/recipes/code/build.yaml
@@ -15,8 +15,9 @@ build:
 
     - template:
         name: miniconda
-        version: latest
-        conda_install: "python=3.11 nipype jupyter nb_conda_kernels h5py seaborn numpy"
+        version: py311_25.5.1-0
+        mamba: "true"
+        conda_install: "python=3.11 nipype jupyter nb_conda_kernels h5py seaborn numpy pyqt=5 qtconsole"
         pip_install: "osfclient"
 
     - install:


### PR DESCRIPTION
## Summary

Fixes the `code` recipe's Python Qt runtime dependencies so the container provides the `PyQt5` and `qtconsole` imports covered by the existing fulltest.

Changes:
- Pins the Miniconda installer to `py311_25.5.1-0` instead of the moving `latest` installer.
- Enables the recipe template's mamba/libmamba solver path.
- Adds `pyqt=5` and `qtconsole` to the installed Conda environment.

## Evidence

- `python3 -m builder.validation recipes/code/build.yaml` passed.
- `python3 -m builder generate code --recreate --architecture x86_64` passed.
- `git diff --check -- recipes/code/build.yaml` passed.
- Real Docker build passed:
  - `sudo env PATH="$PATH" python3 -m builder test code --recreate --build`
- Runtime smoke against the built `code:240320` image passed:
  - `from PyQt5 import QtCore`
  - `import qtconsole`
  - observed `PyQt5 version: 5.15.2`
  - observed `qtconsole: 5.7.2`
- Existing Code tools still smoke-test:
  - `code --version` reported `1.125.0`
  - `singularity --version` reported `singularity-ce version 3.9.3`

## Confidence

Medium-high for the x86_64 build/runtime issue. The exact failing fulltest commands for `PyQt5 import` and `QtConsole available` were run successfully inside the rebuilt Docker image.

I did not convert this large image to SIF for a YAML runner subset because the final Docker image is about 9.8 GB and the host root filesystem had about 24 GB free; converting through a Docker archive plus SIF risked exhausting disk during the maintenance window.

## Local validation

Pending CI. Locally checked patch application and YAML/schema consistency before opening this draft PR.
