### PR TITLE
[codex] Build NiiStat LibSVM MEX files

### DIFF
--- a/recipes/niistat/build.yaml
+++ b/recipes/niistat/build.yaml
@@ -30,6 +30,17 @@ build:
     - run:
         - tar -xz -C /opt/niistat-{{ context.version }}/ --strip-components 1 -f {{ get_file("v") }}
 
+    - run:
+        - |
+          curl -L --fail -o /tmp/libsvm-v318.tar.gz https://github.com/cjlin1/libsvm/archive/refs/tags/v318.tar.gz
+          mkdir -p /tmp/libsvm-v318
+          tar -xzf /tmp/libsvm-v318.tar.gz -C /tmp/libsvm-v318 --strip-components 1
+          cp /tmp/libsvm-v318/svm.cpp /tmp/libsvm-v318/svm.h /opt/niistat-{{ context.version }}/
+          cd /opt/niistat-{{ context.version }}/libsvm
+          octave --no-gui --eval "make; exit(0);"
+          test -f svmtrain.mex -a -f svmpredict.mex -a -f libsvmread.mex -a -f libsvmwrite.mex
+          rm -rf /tmp/libsvm-v318 /tmp/libsvm-v318.tar.gz
+
     - workdir: /opt
 
     - copy:


### PR DESCRIPTION
Fix the NiiStat image build so Octave can use LibSVM.

Yesterday's fulltest investigation showed that the current published NiiStat SIF contains MATLAB/Linux `*.mexa64` LibSVM binaries, but Ubuntu Octave expects `.mex` files. The NiiStat tag includes the LibSVM MATLAB/Octave MEX sources, but not the parent `svm.cpp`/`svm.h` that its vendored `make.m` requires.

This change downloads matching upstream LibSVM v3.18 during the build, copies `svm.cpp` and `svm.h` into the location expected by NiiStat's `make.m`, compiles the Octave MEX files, and explicitly fails the build if `svmtrain.mex`, `svmpredict.mex`, `libsvmread.mex`, or `libsvmwrite.mex` are missing.

Evidence:

- `python3 -m builder.validation recipes/niistat/build.yaml` passed.
- `python3 -m builder generate niistat --recreate --architecture x86_64` passed.
- `git diff --check` passed.
- Real Docker build passed: `sudo env PATH="$PATH" python3 -m builder test niistat --recreate --build`.
- Docker runtime smoke confirmed Octave resolves:
  - `svmtrain` -> `/opt/niistat-1.0.20191216/libsvm/svmtrain.mex`
  - `svmpredict` -> `/opt/niistat-1.0.20191216/libsvm/svmpredict.mex`
  - `libsvmread` -> `/opt/niistat-1.0.20191216/libsvm/libsvmread.mex`
  - `libsvmwrite` -> `/opt/niistat-1.0.20191216/libsvm/libsvmwrite.mex`
- Converted the final Docker image to SIF through `docker-archive://`.
- Complete existing NiiStat fulltest against that built SIF passed `92/92` in `66.3s`, including the three previously failing LibSVM checks.

Confidence: high for x86_64 Docker/SIF/runtime/fulltest. I did not test the aarch64 build path locally.

## Local validation

Pending CI. Locally checked patch application and YAML/schema consistency before opening this draft PR.
