### PR TITLE
[codex] Repair Connectome Mapper 3 build environment

### DIFF
--- a/builder/templates/afni.yaml
+++ b/builder/templates/afni.yaml
@@ -33,7 +33,6 @@ binaries:
         -   libssl-dev
         -   libudunits2-dev
         -   libxm4
-        -   multiarch-support
         -   netpbm
         -   python-is-python3
         -   python3-pip
@@ -71,7 +70,8 @@ binaries:
         -   unzip
         -   ncurses-compat-libs
         debs:
-        -   http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
+        -   http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1.6_amd64.deb
+        -   https://snapshot.debian.org/archive/debian/20140820T220424Z/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
         -   http://snapshot.debian.org/archive/debian-security/20160113T213056Z/pool/updates/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
     directives:
     -   environment:

--- a/builder/templates/matlabmcr.yaml
+++ b/builder/templates/matlabmcr.yaml
@@ -22,7 +22,7 @@ binaries:
     apt:
     - bc
     - curl
-    - libncurses5
+    - libncurses6
     - libxext6
     - libxmu6
     - libxpm-dev

--- a/recipes/connectomemapper3/build.yaml
+++ b/recipes/connectomemapper3/build.yaml
@@ -57,7 +57,7 @@ build:
         - libssl-dev
         - libxt-dev
         - libxext-dev
-        - libncurses5
+        - libncurses6
         - dc
     - template:
         name: freesurfer
@@ -78,14 +78,16 @@ build:
         method: binaries
     - template:
         name: miniconda
-        version: latest
+        version: py39_23.11.0-2
         env_name: cmp3
-        conda_install: python=3.9 pip=22.2 graphviz=2.50.0 dipy=1.3.0 fsleyes=1.3.3 indexed_gzip mrtrix3=3.0.3 git-annex qt=5.15.4 pyqt=5.15.4 pyqt5-sip=12.9.0
-        pip_install: numpy==1.23.5 matplotlib==3.5.2 configparser==5.2.0 nibabel==3.2.2 nipype==1.8.0 traits==6.3.2 traitsui==7.2.0 duecredit==0.9.1 obspy==1.2.2 mne==0.24.1 mne_connectivity==0.3 datalad[full]==0.17.2 datalad-container==1.1.6 datalad-neuroimaging==0.3.1 pybids==0.14.0 statsmodels==0.13.1 networkx==2.6.3 pydicom==2.2.2 pycartool==0.1.1 pyface==7.4.4 connectomemapper==3.2.0
+        env_exists: "false"
+        mamba: "true"
+        conda_install: python=3.9 pip=22.2 graphviz=2.50.0 dipy=1.3.0 fsleyes=1.3.3 indexed_gzip mrtrix3=3.0.3 git-annex qt=5.15.4 pyqt=5.15.4 pyqt5-sip=12.9.0 obspy=1.2.2
+        pip_install: numpy==1.23.5 matplotlib==3.5.2 configparser==5.2.0 nibabel==3.2.2 nipype==1.8.0 traits==6.3.2 traitsui==7.2.0 duecredit==0.9.1 mne==0.24.1 mne_connectivity==0.3 datalad[full]==0.17.2 datalad-container==1.1.6 datalad-neuroimaging==0.3.1 pybids==0.14.0 statsmodels==0.13.1 networkx==2.8.8 pydicom==2.3.1 pyparsing==2.4.7 pydot==1.4.2 fsleyes-props==1.12.2 pycartool==0.1.1 pyface==7.4.4 connectomemapper==3.2.0
         conda_opts: "--channel conda-forge --channel mrtrix3"
     - environment:
         FS_LICENSE: /opt/freesurfer/license.txt
-        PATH: /opt/miniconda-latest/envs/cmp3/bin:$PATH
+        PATH: /opt/miniconda-py39_23.11.0-2/envs/cmp3/bin:$PATH
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAEI0lEQVRIS+WUa0zVZRzHP/9zgwOcPwfkIh5BneOgAt4CFPASSoTL0rxVi3JZm7qiF7HWirR64dTWcpZbqKWVtbWac0vMG3kBA+SmHUCm3DkciANykYsHzv/SZPPCPPPS5qs+2/PmefZ8P3ue3/N7BJ4wwhPO/z8KOi+X/643KD7mGfGpj3K9D61BT2OjufP8hZ7GkhJM00RGxAD0og/d0nVCLTEkJL/4wIwHLtr2HVQNbV381dGLwdSA3uxHZJgvVQNg8TFS91seQxlvMH/RQpIiYj1meZyszc8PHswrcvaH3aSls4VjV5eyMb2GwkaRpPgh3PYuAqIXUFVehNZiQYsGXdRc1sYsuS/vvomS736qGa6unWZJDKSopY4g62RCJkzCbbex44epbN48hLv4LGbrDLbu05Oa0IQYFkTDSCiT50XwzqJVYzLvE1zZ9a163bue6cnx2L7cTYOi0orIgtQ4um6K9Lh6CRH1tDd1sHh1GueOn6elPx7/KVVMCZ/JgMnExsRld3LHCFrOFB4e6a5dteGAxOtLZCKlYkKaHZgz11FwqJSO8eEEiwZ0fX0MeatYn5qF7XQxwpy5NOefo08YR+Qz83k35W7hxwjOZn2lGuP+oXXEQoC2Hq2kwVsM5b2cQLJmn6Ct149c+xxeXaGhtsPF+lSR/IpWBiZOQh3sxnHkOP5r1pH9yibPJyjeu0ftdDWRvCKZa/Y6ND1uDD4BDFwso6nxBsGrNnDqnAP/PjuD5mGauqxMsLSREuomdyAE9coFJkf5kf3Rfs+C0zu3qUqowNRZwZw61Uv6nDDar+bhM3EKx2wWwkO7cLpnkzK9jNZGL0o7xiPs+YCShdsRIweJnGrB28/IJy+leRaUHz2sKu0VeE2MQGrvoebAz4SvSURrNKA1GAh79i0qbH+jae7lUHY27+f+St6mrVS9/QVBvnpkt8QLMb5SetxM/e0uH1MDp9Pp119b2W8yK/QX5uKalchwew1RS5fh4ztP+0dhs1xf0cAE3zLqHEYuBc9GkWXcsoQkKUiKzPGsdFkQBJ1HwS26b9QvN+gMRzucrZT+8iPLMzPRaY0cyevCufczerqHkTI2Ue02I8nyaKhbkpFkBUmWuLDlIX1wLwMuh8vP2+JdWG1Xv8l+DVezged2bENCx9qkSIbcECh8Pbpl8W4r+9cvwirmsDLLUaqC9cT3OeaHfna3KLh0TRV0OmozM6h5ejWiNY7nE2Jjp5t2VoKCoCpwZ8is3KIUFrz8YVLCwY8PPpLgNhermk8Oy3La9l2fIxtNYPJHUFU0nQ5Gwq0Y7Nfojl1IYGUBvl5elwVB0/ZYgnsJyflTdY4LRqPIKBrt6JLX0E2MkkTvm8men+njcujkGTUqOpq0k3WjWyPsldg+vdvFt/jPJ3hUnrjgX0+4qaWdyw3zAAAAAElFTkSuQmCC
 categories:
   - functional imaging


### PR DESCRIPTION
## Summary

Repair the Connectome Mapper 3 build on current `main` by moving it off the moving Miniconda `latest` installer, preserving the legacy Python 3.9/CMP3 stack, and reconciling the pip-side dependency pins that previously left the built image with `pip check` conflicts.

Changes:

- Use `miniconda` `py39_23.11.0-2` with `mamba: "true"` and an explicit `cmp3` env.
- Move `obspy=1.2.2` to conda so the build uses the compatible conda-forge binary instead of attempting a pip sdist build.
- Keep CMP3 on the expected historical stack while pinning transitive pip dependencies that pip had been overwriting incompatibly: `networkx==2.8.8`, `pydicom==2.3.1`, `pyparsing==2.4.7`, `pydot==1.4.2`, and `fsleyes-props==1.12.2`.
- Repair Ubuntu 24.04 bootstrap blockers for legacy AFNI/MATLAB MCR layers by installing `multiarch-support` from an explicit Ubuntu deb, pinning legacy `libxp6` to a Debian snapshot URL, and using `libncurses6` where `libncurses5` is unavailable.

## Evidence

- `python3 builder/validation.py recipes/connectomemapper3/build.yaml`: passed.
- YAML parse passed for `recipes/connectomemapper3/build.yaml`, `builder/templates/afni.yaml`, and `builder/templates/matlabmcr.yaml`.
- `git diff --check`: passed.
- `python3 -m builder generate connectomemapper3 --output-root /tmp/neurocontainers-connectomemapper3-20260626-clean-pip-generate --recreate --architecture x86_64 --ignore-architectures`: passed.
- Real x86_64 Docker build passed with `timeout 5400 sudo env PATH="$PATH" python3 -m builder test connectomemapper3 --output-root /tmp/neurocontainers-connectomemapper3-20260626-clean-pip-build --recreate --architecture x86_64 --ignore-architectures --build`, producing local image `connectomemapper3:3.2.0`.
- Runtime import smoke passed for `cmp`, `cmp.bidsappmanager`, `dipy`, `fsleyes`, `indexed_gzip`, `obspy`, `mne`, `mne_connectivity`, `datalad`, `datalad_container`, `datalad_neuroimaging`, `bids`, `statsmodels`, `networkx`, `pydicom`, `pycartool`, `pyface`, `nipype`, `traits`, `traitsui`, `nibabel`, `numpy`, `matplotlib`, `fsleyes_props`, `pydot`, and `pyparsing`.
- `python -m pip check`: `No broken requirements found.`
- Command smoke confirmed expected help/version output for `connectomemapper3 --help`, `connectomemapper3_docker --help`, `dwidenoise --version`, `bet`, `3dSkullStrip -help`, `antsRegistration --version`, and `QT_QPA_PLATFORM=offscreen cmpbidsappmanager --help`.

Notes:

- `bet` prints usage with exit 1 and `cmpbidsappmanager --help` prints its usage/banner with exit 2; both were treated as usage-smoke evidence rather than success-exit checks.
- No full CMP3 workflow/fulltest exists in this recipe, so validation is a real Docker build plus command/import/dependency smoke.
- Logs are preserved in `worklogs/connectomemapper3-build-repair-20260626/` in the maintenance tracker.

## Local validation

Pending CI. Locally checked patch application and YAML/schema consistency before opening this draft PR.
