### PR TITLE
[codex] Fix quickshear version metadata and entrypoint

### DIFF
--- a/recipes/quickshear/build.yaml
+++ b/recipes/quickshear/build.yaml
@@ -1,5 +1,5 @@
 name: quickshear
-version: 1.1.0
+version: 1.2.0
 
 copyright:
   - license: BSD-3-Clause
@@ -86,7 +86,11 @@ build:
         - run:
               - cp {{ get_file("invertcontrast.py") }} /opt/code/python-ismrmrd-server/invertcontrast.py
 
-        - entrypoint: bash
+        - run:
+              - printf '%s\n' '#!/usr/bin/env bash' 'set -e' '' 'if [ "$#" -eq 0 ]; then' '  exec /usr/bin/env bash' 'fi' '' 'exec "$@"' > /usr/local/bin/quickshear-entrypoint
+              - chmod +x /usr/local/bin/quickshear-entrypoint
+
+        - entrypoint: /usr/local/bin/quickshear-entrypoint
 
 deploy:
     bins:

--- a/recipes/quickshear/fulltest.yaml
+++ b/recipes/quickshear/fulltest.yaml
@@ -14,8 +14,8 @@
 #   USENIX Association, 2011.
 
 name: quickshear
-version: 1.1.0
-container: quickshear_1.1.0_20240606.simg
+version: 1.2.0
+container: quickshear_1.2.0_20260612.simg
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
## Summary
- bump quickshear recipe/fulltest metadata to 1.2.0 to match the package installed during the build and the existing fulltest expectations
- replace the bash entrypoint with a wrapper that preserves interactive no-arg behavior while allowing explicit Docker commands to run normally

## Evidence
- python3 -m builder generate quickshear --recreate
- python3 -m builder stage quickshear --recreate --architecture x86_64
- git diff --check
- YAML parse for recipes/quickshear/build.yaml and recipes/quickshear/fulltest.yaml
- sudo python3 -m builder test quickshear --recreate --build passed; built/exported/loaded quickshear:1.2.0 and builder deploy smoke ran explicit /bin/sh command
- direct Docker runtime smoke passed for explicit /bin/sh command, quickshear --help, Python quickshear.__version__ == 1.2.0, mri_synthstrip --help, and ISMRMRD tool presence

Confidence: high for x86_64 Docker build/entrypoint/runtime surface. Full data-dependent defacing suite and Apptainer/SIF conversion were not run locally before window cutoff.

## Local validation

Pending CI. Locally checked path-filtered patch application and YAML/schema consistency before opening this draft PR.
