### PR TITLE
[codex] Fix spm25 entrypoint

### DIFF
--- a/recipes/spm25/build.yaml
+++ b/recipes/spm25/build.yaml
@@ -51,7 +51,10 @@ build:
   base-image: ghcr.io/spm/spm-docker:docker-matlab-{{ context.version }}
   pkg-manager: apt
   directives:
-    - entrypoint: bash
+    - run:
+        - printf '%s\n' '#!/usr/bin/env bash' 'set -e' '' 'if [ "$#" -eq 0 ]; then' '  exec /usr/bin/env bash' 'fi' '' 'exec "$@"' > /usr/local/bin/spm25-entrypoint
+        - chmod +x /usr/local/bin/spm25-entrypoint
+    - entrypoint: /usr/local/bin/spm25-entrypoint
     - environment:
           PATH: ${PATH}:/opt/spm
     - deploy:


### PR DESCRIPTION
## Summary
- replace `spm25`'s `entrypoint: bash` with a small wrapper
- keep no-argument interactive bash behavior, but `exec "$@"` for explicit Docker commands
- preserves deploy bins/path while fixing standard command execution under Docker

## Evidence
- `python3 -m builder generate spm25 --recreate` passed
- `python3 -m builder stage spm25 --recreate --architecture x86_64` passed
- `git diff --check` passed
- YAML parse passed for `recipes/spm25/build.yaml` and `recipes/spm25/fulltest.yaml`
- real Docker build passed with `sudo python3 -m builder test spm25 --recreate --build`; image exported/loaded as `spm25:25.01.02` and builder deploy smoke ran `/bin/sh -lc test -n "$DEPLOY_BINS$DEPLOY_PATH"`
- direct runtime smoke passed against the built Docker image: explicit `/bin/sh -lc`, `spm25` and `run_spm25.sh` on PATH, compiled SPM files present, and `/opt/spm/run_spm25.sh /usr/local/MATLAB/MATLAB_Runtime/R2024b help` printed `Usage: spm`

## Confidence
High for x86_64 Docker build/deploy-smoke and the core SPM help/runtime surface. Full data-dependent SPM25 processing and Apptainer/SIF conversion were not run locally.

## Local validation

Pending CI. Locally checked path-filtered patch application and YAML/schema consistency before opening this draft PR.
