### PR TITLE
[codex] Fix bidsappmrtrix3connectome entrypoint

### DIFF
--- a/recipes/bidsappmrtrix3connectome/build.yaml
+++ b/recipes/bidsappmrtrix3connectome/build.yaml
@@ -19,7 +19,10 @@ build:
     - environment:
         DEBIAN_FRONTEND: noninteractive
         PATH: ${PATH}:/
-    - entrypoint: bash
+    - run:
+        - printf '%s\n' '#!/usr/bin/env bash' 'set -e' '' 'if [ "$#" -eq 0 ]; then' '  exec /usr/bin/env bash' 'fi' '' 'exec "$@"' > /usr/local/bin/bidsappmrtrix3connectome-entrypoint
+        - chmod +x /usr/local/bin/bidsappmrtrix3connectome-entrypoint
+    - entrypoint: /usr/local/bin/bidsappmrtrix3connectome-entrypoint
 
 deploy:
   path:


### PR DESCRIPTION
## Summary
- replace `bidsappmrtrix3connectome`'s `entrypoint: bash` with a small wrapper
- keep no-argument interactive bash behavior, but `exec "$@"` for explicit commands
- fixes the standard Docker/deploy smoke path where `/bin/sh -lc ...` must run as the command rather than being passed to bash as a script path

## Evidence
- `python3 -m builder generate bidsappmrtrix3connectome --recreate` passed
- `python3 -m builder stage bidsappmrtrix3connectome --recreate --architecture x86_64` passed
- `git diff --check` passed
- YAML parse passed for `recipes/bidsappmrtrix3connectome/build.yaml` and `recipes/bidsappmrtrix3connectome/fulltest.yaml`
- real Docker build passed with `sudo python3 -m builder test bidsappmrtrix3connectome --recreate --build`; image exported/loaded as `bidsappmrtrix3connectome:0.5.3` and builder deploy smoke ran `/bin/sh -lc test -n "$DEPLOY_BINS$DEPLOY_PATH"`
- direct runtime smoke passed against the built Docker image: explicit `/bin/sh -lc` command, `mrtrix3_connectome.py --version`, help text, `mrinfo --version`, and presence of `mrconvert`, `tckgen`, `recon-all`, and `fslmaths`

## Confidence
High for x86_64 Docker build/deploy-smoke and the core runtime surface. Full data-dependent MRtrix connectome analysis and Apptainer/SIF conversion were not run locally.

## Local validation

Pending CI. Locally checked path-filtered patch application and YAML/schema consistency before opening this draft PR.
