### PR TITLE
[codex] Fix bidsappbrainsuite entrypoint

### DIFF
--- a/recipes/bidsappbrainsuite/build.yaml
+++ b/recipes/bidsappbrainsuite/build.yaml
@@ -15,7 +15,11 @@ build:
         DEBIAN_FRONTEND: noninteractive
         PATH: $PATH:/BrainSuite/
 
-    - entrypoint: bash
+    - run:
+        - printf '%s\n' '#!/usr/bin/env bash' 'set -e' '' 'if [ "$#" -eq 0 ]; then' '  exec /usr/bin/env bash' 'fi' '' 'exec "$@"' > /usr/local/bin/bidsappbrainsuite-entrypoint
+        - chmod +x /usr/local/bin/bidsappbrainsuite-entrypoint
+
+    - entrypoint: /usr/local/bin/bidsappbrainsuite-entrypoint
 
 deploy:
   path:


### PR DESCRIPTION
## Summary
- replace `bidsappbrainsuite`'s `ENTRYPOINT bash` with a tiny wrapper that preserves interactive no-arg bash but execs explicit commands normally

## Evidence
- Triggered by the BACKLOG fulltest failure for `bidsappbrainsuite` and the same entrypoint failure class reproduced in `brainsuite` during this window.
- Fresh generation: `python3 -m builder generate bidsappbrainsuite --recreate`
- Fresh staging: `python3 -m builder stage bidsappbrainsuite --recreate --architecture x86_64`
- Static checks: `git diff --check`; YAML parsed for `recipes/bidsappbrainsuite/build.yaml` and `recipes/bidsappbrainsuite/fulltest.yaml`
- Real Docker build passed: `sudo python3 -m builder test bidsappbrainsuite --recreate --build`; image exported/loaded and builder deploy smoke ran `/bin/sh -lc test -n "$DEPLOY_BINS$DEPLOY_PATH"` successfully.
- Direct runtime/fulltest subset passed against `bidsappbrainsuite:21a`: `/BrainSuite/run.py --help`, `/BrainSuite/run.py --version`, `bse` presence/help, and `bfc` help.

Confidence: high for the entrypoint/build-smoke fix and basic BrainSuite runtime surface. Full data-dependent BIDS-App pipeline tests were not run locally.

## Local validation

Pending CI. Locally checked path-filtered patch application and YAML/schema consistency before opening this draft PR.
