### PR TITLE
[codex] Fix MATLAB MCR ncurses package on xenial

### DIFF
--- a/builder/template_backend.py
+++ b/builder/template_backend.py
@@ -66,7 +66,7 @@ class TemplateMethod:
         values = deps.get(pkg_manager, [])
         if not isinstance(values, list):
             return []
-        return [str(item) for item in values]
+        return [_render_string(str(item), self) for item in values]
 
     def install(self, pkgs: list[str], opts: str | None = None) -> str:
         return _install_command(self.pkg_manager, tuple(str(item) for item in pkgs), opts)

--- a/builder/templates/matlabmcr.yaml
+++ b/builder/templates/matlabmcr.yaml
@@ -8,6 +8,7 @@ binaries:
     optional:
       curl_opts: ''
       install_path: /opt/MCR-{{ self.version }}
+      ncurses_package: libncurses6
   urls:
     2023b: https://ssd.mathworks.com/supportfiles/downloads/R2023b/Release/9/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_R2023b_Update_9_glnxa64.zip
     2023a: https://ssd.mathworks.com/supportfiles/downloads/R2023a/Release/5/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_R2023a_Update_5_glnxa64.zip
@@ -22,7 +23,7 @@ binaries:
     apt:
     - bc
     - curl
-    - libncurses6
+    - '{{ self.ncurses_package }}'
     - libxext6
     - libxmu6
     - libxpm-dev

--- a/builder/tests/test_template_rendering.py
+++ b/builder/tests/test_template_rendering.py
@@ -206,3 +206,16 @@ def test_matlabmcr_template_uses_release_named_runtime_dirs_for_r2023b() -> None
     assert env["MATLABCMD"].strip() == "/opt/mcr/R2023b/toolbox/matlab"
     assert env["MCRROOT"].strip() == "/opt/mcr/R2023b"
     assert env["XAPPLRESDIR"].strip() == "/opt/mcr/R2023b/x11/app-defaults"
+
+
+def test_matlabmcr_template_allows_legacy_ncurses_package() -> None:
+    directives = []
+    apply_builtin_template(
+        "matlabmcr",
+        {"version": "2019b", "install_path": "/opt/mcr", "ncurses_package": "libncurses5"},
+        "apt",
+        directives.append,
+    )
+    command = "\n".join(item.command for item in directives if isinstance(item, Run))
+    assert "libncurses5" in command
+    assert "libncurses6" not in command

--- a/recipes/physio/build.yaml
+++ b/recipes/physio/build.yaml
@@ -30,6 +30,7 @@ build:
         name: matlabmcr
         install_path: /opt/mcr
         version: 2020b
+        ncurses_package: libncurses5
 
     - environment:
         MCR_INHIBIT_CTF_LOCK: "1"

--- a/recipes/spm12/build.yaml
+++ b/recipes/spm12/build.yaml
@@ -31,6 +31,7 @@ build:
         name: matlabmcr
         install_path: /opt/mcr
         version: 2019b
+        ncurses_package: libncurses5
 
     - environment:
         MCR_INHIBIT_CTF_LOCK: "1"

--- a/recipes/spm12bi/build.yaml
+++ b/recipes/spm12bi/build.yaml
@@ -27,6 +27,7 @@ build:
         name: matlabmcr
         version: 2019b
         install_path: /opt/mcr
+        ncurses_package: libncurses5
     - environment:
         SPM_VERSION: "12"
         SPM_REVISION: "{{ context.version }}"


### PR DESCRIPTION
## Summary
- make the local matlabmcr template render Jinja in dependency entries
- add an ncurses package override, defaulting to libncurses6
- use libncurses5 for Ubuntu 16.04 MATLAB MCR recipes: spm12bi, spm12, physio

## Why
The spm12bi auto-build failed on Ubuntu 16.04 because the generated MATLAB MCR install step requested libncurses6, which is not available in xenial. The override keeps newer recipes on libncurses6 while allowing xenial recipes to build with libncurses5.

## Validation
- env/bin/python builder/validation.py recipes/spm12bi/build.yaml
- env/bin/python builder/validation.py recipes/spm12/build.yaml
- env/bin/python builder/validation.py recipes/physio/build.yaml
- env/bin/python -m pytest builder/tests/test_template_rendering.py -q -k 'matlabmcr'
- env/bin/python -m builder generate spm12bi --recreate --architecture x86_64
- rg -n 'libncurses[56]' build/spm12bi/spm12bi_latest.Dockerfile
