### PR TITLE
Add release for mimosa 0.5.8

### DIFF
--- a/recipes/mimosa/fulltest.yaml
+++ b/recipes/mimosa/fulltest.yaml
@@ -52,11 +52,11 @@ tests:
       R --slave - <<'RS'
       library(mimosa)
       exports <- getNamespaceExports("mimosa")
-      needed <- c("mimosa_model", "mimosa_fit", "mimosa_formula", "weighted_slr", "get_weights")
+      needed <- c("count_stats", "get_weights", "mimosa_data", "mimosa_fit", "mimosa_formula", "mimosa_training")
       stopifnot(all(needed %in% exports))
       cat("exports", paste(needed, collapse = ","), "\n")
       RS
-    expected_output_contains: mimosa_model
+    expected_output_contains: mimosa_formula
 
   - name: Bundled mimosa model data loads
     description: Verify packaged model objects are present.
@@ -116,7 +116,7 @@ tests:
       x <- matrix(rnorm(n * p), ncol = p)
       y <- 2 + 3 * x + rnorm(n * p, sd = 0.05)
       wts <- rep(1, p)
-      fit <- weighted_slr(x, y, wts = wts)
+      fit <- mimosa:::weighted_slr(x, y, wts = wts)
       stopifnot(all(c("beta0", "beta1", "r2") %in% names(fit)))
       stopifnot(mean(fit$beta1, na.rm = TRUE) > 2.8)
       cat("mean beta", round(mean(fit$beta1), 2), "\n")
@@ -137,7 +137,7 @@ tests:
       wts <- expand.grid(wts, wts, wts)
       sigma <- 2
       wts <- exp(-rowSums(wts^2) / (2 * sigma^2))
-      slr <- weighted_slr(x, y, wts = wts)
+      slr <- mimosa:::weighted_slr(x, y, wts = wts)
       stopifnot(all(c("beta0", "beta1", "r2", "beta0_reverse", "beta1_reverse", "r2_reverse") %in% names(slr)))
       stopifnot(length(slr$beta0) == 27)
       cat("weighted_slr regression ok\n")
@@ -169,8 +169,8 @@ tests:
       truth <- nifti(truth_arr)
       pred <- nifti(pred_arr)
       stats <- count_stats(truth, pred, k = 1, verbose = FALSE)
-      stopifnot(is.matrix(stats), ncol(stats) == 5)
-      cat("count stats", paste(colnames(stats), collapse = ","), "\n")
+      stopifnot(length(stats) == 5)
+      cat("count stats", paste(names(stats), collapse = ","), "\n")
       RS
     expected_output_contains: count stats
 
@@ -207,7 +207,7 @@ tests:
       library(mimosa)
       library(ANTsRCore)
       ref <- as.antsImage(array(0, dim = c(3, 3, 3)))
-      img <- make_ants_image(1:3, mask_indices = c(1, 5, 9), reference = ref)
+      img <- mimosa:::make_ants_image(1:3, mask_indices = c(1, 5, 9), reference = ref)
       stopifnot(length(dim(img)) == 3)
       cat("mapped image\n")
       RS

--- a/recipes/mimosa/fulltest.yaml
+++ b/recipes/mimosa/fulltest.yaml
@@ -1,0 +1,267 @@
+name: mimosa
+version: 0.5.8
+container: mimosa_${version}_REFERENCE.simg
+default_timeout: 240
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: R and Rscript are deployed
+    description: Verify R commands exposed by the recipe are available.
+    command: |
+      set -e
+      which R
+      which Rscript
+      R --version | head -1
+    expected_output_contains:
+      - /usr/bin/R
+      - R version
+
+  - name: mimosa package loads
+    description: Verify the main R package is installed and loadable.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      cat("mimosa", as.character(packageVersion("mimosa")), "\n")
+      RS
+    expected_output_contains: mimosa
+
+  - name: Core R dependencies load
+    description: Verify major R dependencies from the recipe load.
+    command: |
+      R --slave - <<'RS'
+      pkgs <- c("ANTsRCore", "dplyr", "extrantsr", "fslr", "neurobase", "oasis", "rlist", "WhiteStripe")
+      for (pkg in pkgs) {
+        suppressPackageStartupMessages(library(pkg, character.only = TRUE))
+        cat(pkg, "ok\n")
+      }
+      RS
+    expected_output_contains:
+      - ANTsRCore ok
+      - WhiteStripe ok
+
+  - name: mimosa exports expected functions
+    description: Verify package namespace exposes documented modeling functions.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      exports <- getNamespaceExports("mimosa")
+      needed <- c("mimosa_model", "mimosa_fit", "mimosa_formula", "weighted_slr", "get_weights")
+      stopifnot(all(needed %in% exports))
+      cat("exports", paste(needed, collapse = ","), "\n")
+      RS
+    expected_output_contains: mimosa_model
+
+  - name: Bundled mimosa model data loads
+    description: Verify packaged model objects are present.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      data("mimosa_model", package = "mimosa")
+      data("mimosa_model_No_PD", package = "mimosa")
+      data("mimosa_model_No_T2", package = "mimosa")
+      stopifnot(exists("mimosa_model"))
+      cat("model data ok\n")
+      RS
+    expected_output_contains: model data ok
+
+  - name: mimosa formula includes expected terms
+    description: Exercise formula construction with all modalities.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      f <- mimosa_formula()
+      txt <- paste(deparse(f), collapse = " ")
+      stopifnot(grepl("FLAIR_10", txt), grepl("T2_10", txt), grepl("PD_10", txt))
+      cat(txt, "\n")
+      RS
+    expected_output_contains: FLAIR_10
+
+  - name: mimosa formula drops T2 terms
+    description: Verify modality exclusion logic for T2 works.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      txt <- paste(deparse(mimosa_formula(T2 = FALSE)), collapse = " ")
+      stopifnot(!grepl("T2", txt))
+      cat("no T2 terms\n")
+      RS
+    expected_output_contains: no T2 terms
+
+  - name: mimosa formula drops PD terms
+    description: Verify modality exclusion logic for PD works.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      txt <- paste(deparse(mimosa_formula(PD = FALSE)), collapse = " ")
+      stopifnot(!grepl("PD", txt))
+      cat("no PD terms\n")
+      RS
+    expected_output_contains: no PD terms
+
+  - name: weighted SLR synthetic regression works
+    description: Exercise the weighted simple linear regression helper.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      set.seed(5)
+      n <- 200
+      p <- 27
+      x <- matrix(rnorm(n * p), ncol = p)
+      y <- 2 + 3 * x + rnorm(n * p, sd = 0.05)
+      wts <- rep(1, p)
+      fit <- weighted_slr(x, y, wts = wts)
+      stopifnot(all(c("beta0", "beta1", "r2") %in% names(fit)))
+      stopifnot(mean(fit$beta1, na.rm = TRUE) > 2.8)
+      cat("mean beta", round(mean(fit$beta1), 2), "\n")
+      RS
+    expected_output_contains: mean beta
+
+  - name: package testthat regression passes
+    description: Run the upstream weighted_slr regression test logic.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      set.seed(5)
+      n <- 1000
+      p <- 27
+      x <- matrix(rnorm(n * p), ncol = p)
+      y <- x * 4 + 6 * x * (x > 0) + rnorm(n * p)
+      wts <- c(-1, 0, 1)
+      wts <- expand.grid(wts, wts, wts)
+      sigma <- 2
+      wts <- exp(-rowSums(wts^2) / (2 * sigma^2))
+      slr <- weighted_slr(x, y, wts = wts)
+      stopifnot(all(c("beta0", "beta1", "r2", "beta0_reverse", "beta1_reverse", "r2_reverse") %in% names(slr)))
+      stopifnot(length(slr$beta0) == 27)
+      cat("weighted_slr regression ok\n")
+      RS
+    expected_output_contains: weighted_slr regression ok
+
+  - name: get_weights returns numeric kernel
+    description: Verify neighborhood weight generation returns finite weights.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      offsets <- as.matrix(expand.grid(-1:1, -1:1, -1:1))
+      w <- get_weights(offsets = offsets, voxelDims = c(1, 1, 1), sigma = 2)
+      stopifnot(is.numeric(w), length(w) > 0, all(is.finite(w)))
+      cat("weights", length(w), "\n")
+      RS
+    expected_output_contains: weights
+
+  - name: count_stats handles synthetic predictions
+    description: Exercise classification count statistics helper on synthetic NIfTI masks.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      library(oro.nifti)
+      truth_arr <- array(0, dim = c(6, 6, 6))
+      pred_arr <- array(0, dim = c(6, 6, 6))
+      truth_arr[2:3, 2:3, 2:3] <- 1
+      pred_arr[2:3, 2:3, 2:3] <- 1
+      truth <- nifti(truth_arr)
+      pred <- nifti(pred_arr)
+      stats <- count_stats(truth, pred, k = 1, verbose = FALSE)
+      stopifnot(is.matrix(stats), ncol(stats) == 5)
+      cat("count stats", paste(colnames(stats), collapse = ","), "\n")
+      RS
+    expected_output_contains: count stats
+
+  - name: R NIfTI stack creates image
+    description: Verify neurobase/oro.nifti can create and write a small image.
+    command: |
+      R --slave - <<'RS'
+      library(neurobase)
+      library(oro.nifti)
+      img <- nifti(array(1, dim = c(4, 4, 4)))
+      writenii(img, filename = "${output_dir}/synthetic_mimosa")
+      stopifnot(file.exists("${output_dir}/synthetic_mimosa.nii.gz"))
+      cat("nifti written\n")
+      RS
+    expected_output_contains: nifti written
+    validate:
+      - output_exists: ${output_dir}/synthetic_mimosa.nii.gz
+
+  - name: ANTsRCore creates image
+    description: Verify ANTsRCore can create an ANTs image from an array.
+    command: |
+      R --slave - <<'RS'
+      library(ANTsRCore)
+      img <- as.antsImage(array(1, dim = c(4, 4, 4)))
+      stopifnot(length(dim(img)) == 3)
+      cat("ants image", paste(dim(img), collapse = "x"), "\n")
+      RS
+    expected_output_contains: ants image 4x4x4
+
+  - name: make_ants_image maps vector to image
+    description: Exercise mimosa image helper with a synthetic reference image.
+    command: |
+      R --slave - <<'RS'
+      library(mimosa)
+      library(ANTsRCore)
+      ref <- as.antsImage(array(0, dim = c(3, 3, 3)))
+      img <- make_ants_image(1:3, mask_indices = c(1, 5, 9), reference = ref)
+      stopifnot(length(dim(img)) == 3)
+      cat("mapped image\n")
+      RS
+    expected_output_contains: mapped image
+
+  - name: dplyr data manipulation works
+    description: Verify tidyverse dependency used by mimosa workflows works.
+    command: |
+      R --slave - <<'RS'
+      library(dplyr)
+      df <- tibble::tibble(x = 1:5, y = c(1, 1, 2, 2, 2))
+      out <- df %>% group_by(y) %>% summarise(mx = mean(x), .groups = "drop")
+      stopifnot(nrow(out) == 2)
+      cat("dplyr rows", nrow(out), "\n")
+      RS
+    expected_output_contains: dplyr rows 2
+
+  - name: WhiteStripe normalization function loads
+    description: Verify WhiteStripe dependency exposes normalization helpers.
+    command: |
+      R --slave - <<'RS'
+      library(WhiteStripe)
+      stopifnot("whitestripe" %in% getNamespaceExports("WhiteStripe"))
+      cat("WhiteStripe exports ok\n")
+      RS
+    expected_output_contains: WhiteStripe exports ok
+
+  - name: fslr sees FSL installation
+    description: Verify FSL-backed R package can locate FSL commands from the container.
+    command: |
+      R --slave - <<'RS'
+      library(fslr)
+      cat("fsl path", fslr::fsldir(), "\n")
+      stopifnot(nzchar(fslr::fsldir()))
+      RS
+    expected_output_contains: fsl path
+
+  - name: R Markdown stack loads
+    description: Verify reporting dependencies installed for mimosa documentation load.
+    command: |
+      R --slave - <<'RS'
+      library(knitr)
+      library(rmarkdown)
+      library(testthat)
+      cat("rmarkdown stack ok\n")
+      RS
+    expected_output_contains: rmarkdown stack ok
+
+  - name: Session info can be written
+    description: Verify runtime can write an R session artifact for debugging.
+    command: |
+      R --slave - <<'RS'
+      writeLines(capture.output(sessionInfo()), "${output_dir}/mimosa_session.txt")
+      cat("session written\n")
+      RS
+    validate:
+      - output_exists: ${output_dir}/mimosa_session.txt

--- a/releases/mimosa/0.5.8.json
+++ b/releases/mimosa/0.5.8.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "mimosa 0.5.8": {
+      "version": "20260629",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "image segmentation"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **mimosa 0.5.8**.

## Changes

- Add `releases/mimosa/0.5.8.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh mimosa 0.5.8 20260629
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/mimosa_0.5.8_20260629.simg -O
singularity shell --overlay /tmp/apptainer_overlay mimosa_0.5.8_20260629.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz