### PR TITLE
Fix HCP Pipelines deploy path metadata

### DIFF
--- a/recipes/bidsapphcppipelines/build.yaml
+++ b/recipes/bidsapphcppipelines/build.yaml
@@ -50,7 +50,6 @@ deploy:
     - /opt/freesurfer/fsfast/bin
     - /opt/freesurfer/tktools
     - /opt/freesurfer/mni/bin
-    - /
 
 categories:
   - bids apps


### PR DESCRIPTION
Removes the root directory from bidsapphcppipelines deploy.path. The release fulltest deploy check was traversing / and expecting runtime paths such as /bin/tclsh and /usr/bin/tclsh that are not present in the release container. The actual tool directories remain exported.