### PR TITLE
Fix BrainSuite deploy path metadata

### DIFF
--- a/recipes/bidsappbrainsuite/build.yaml
+++ b/recipes/bidsappbrainsuite/build.yaml
@@ -24,7 +24,6 @@ build:
 deploy:
   path:
     - /BrainSuite/QC
-    - /bfp
     - /opt/BrainSuite21a/bin
     - /opt/BrainSuite21a/svreg/bin
     - /opt/BrainSuite21a/bdp


### PR DESCRIPTION
Removes /bfp from bidsappbrainsuite deploy.path. The release deploy check was treating /bfp/bfp_version.txt as a runtime command path, but /bfp is not a command directory used by the module. The actual BrainSuite command paths remain exported.