### PR TITLE
Avoid exporting HCP conda internals

### DIFF
--- a/recipes/bidsapphcppipelines/build.yaml
+++ b/recipes/bidsapphcppipelines/build.yaml
@@ -45,7 +45,6 @@ deploy:
   path:
     - /usr/local/fsl/bin
     - /opt/workbench/bin_linux64
-    - /usr/local/miniconda/bin
     - /opt/freesurfer/bin
     - /opt/freesurfer/fsfast/bin
     - /opt/freesurfer/tktools


### PR DESCRIPTION
Removes /usr/local/miniconda/bin from bidsapphcppipelines deploy.path. The release deploy check was exposing conda helper scripts with missing tclsh interpreter paths. The actual HCP, Workbench, FSL, and FreeSurfer command directories remain exported.