### PR TITLE
Fix HCP Pipelines Tcl deploy metadata

### DIFF
--- a/recipes/bidsapphcppipelines/build.yaml
+++ b/recipes/bidsapphcppipelines/build.yaml
@@ -34,10 +34,14 @@ build:
 
     - install:
         - qt4-dev-tools
+        - tcl
         - libxss1
         - libxext6
         - libxft2
         - libjpeg62-dev
+    - run:
+        - test -x /usr/bin/tclsh
+        - if [ ! -e /bin/tclsh ]; then ln -s /usr/bin/tclsh /bin/tclsh; fi
 
     - entrypoint: /usr/local/bin/bidsapphcppipelines-entrypoint
 


### PR DESCRIPTION
## Summary

- install Tcl in the HCP Pipelines image
- ensure /bin/tclsh resolves to /usr/bin/tclsh for deployed FSL executables

## Testing

- env/bin/python builder/validation.py recipes/bidsapphcppipelines/build.yaml
- env/bin/python -m builder generate bidsapphcppipelines --recreate --architecture x86_64

This addresses the #2842 release-test deploy failure where the rebuilt image reports missing /bin/tclsh and /usr/bin/tclsh.