### PR TITLE
Push apps.json updates to a fixed branch instead of a PR per release

### DIFF
--- a/.github/workflows/update-apps-json.yml
+++ b/.github/workflows/update-apps-json.yml
@@ -12,6 +12,12 @@ on:
       - "releases/**/*.json"
   workflow_dispatch:
 
+# Serialize runs so quick release bursts force-push the branch in order; each
+# run regenerates the full apps.json, so the newest push supersedes the rest.
+concurrency:
+  group: update-apps-json
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -38,7 +44,12 @@ jobs:
         run: |
           python3 tools/generate_apps_json.py --output apps.json
 
-      - name: Create pull request
+      # Force-push a fixed PR-less branch instead of opening a PR per release.
+      # neurocommand's "Consolidate apps.json queue" workflow consumes this
+      # branch as a queue source, folds it into its consolidated PR, and
+      # merges on a schedule — so release bursts no longer create one
+      # notification-generating PR each.
+      - name: Push consolidated update branch
         env:
           GH_TOKEN: ${{ secrets.NEURODESK_GITHUB_TOKEN_ISSUE_AUTOMATION }}
         run: |
@@ -52,8 +63,8 @@ jobs:
           git config user.name "neurocontainers-bot"
           git config user.email "neurocontainers-bot@neurodesk.github.io"
 
-          # Create a new branch for the update
-          BRANCH_NAME="update-apps-json-$(date +%Y%m%d-%H%M%S)"
+          # Fixed branch consumed by neurocommand's consolidation queue
+          BRANCH_NAME="update-apps-json"
           git checkout -b "$BRANCH_NAME"
 
           # Copy the generated apps.json
@@ -66,45 +77,20 @@ jobs:
           # Check if there are any changes
           if ! git diff --quiet neurodesk/apps.json neurodesk/icons; then
             echo "Changes detected in apps.json"
-            
+
             # Add and commit changes
             git add neurodesk/apps.json neurodesk/icons
             git commit -m "Update apps.json from neurocontainers releases
-            
+
             Auto-generated from release files in neurocontainers repo.
-            
+
             🤖 Generated with neurocontainers automation"
-            
-            # Push the branch
-            git push origin "$BRANCH_NAME"
-            
-            # Create pull request
-            gh pr create \
-              --title "Update apps.json from neurocontainers releases" \
-              --body "$(cat <<'EOF'
-          ## Summary
 
-          This PR updates apps.json based on the latest release files from the neurocontainers repository.
+            # Each run regenerates the full apps.json from all release files,
+            # so force-pushing always supersedes older queue content.
+            git push --force origin "$BRANCH_NAME"
 
-          ## Changes
-
-          - Updated apps.json with latest container releases
-          - Synced any missing icons from neurocontainers recipe metadata
-          - Generated automatically from individual release files
-
-          ## Test Plan
-
-          - [ ] Verify apps.json format is correct
-          - [ ] Check that all expected containers are present
-          - [ ] Test container availability after merge
-
-          🤖 Generated with neurocontainers automation
-          EOF
-          )" \
-              --head "$BRANCH_NAME" \
-              --base main
-
-            echo "Pull request created successfully"
+            echo "Consolidated update branch pushed successfully"
           else
             echo "No changes detected in apps.json"
           fi

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -143,3 +143,15 @@ def test_update_apps_json_syncs_neurocommand_icons() -> None:
     assert "--neurocontainers-path .." in workflow
     assert "git diff --quiet neurodesk/apps.json neurodesk/icons" in workflow
     assert "git add neurodesk/apps.json neurodesk/icons" in workflow
+
+
+def test_update_apps_json_pushes_fixed_branch_without_per_release_pr() -> None:
+    # apps.json updates flow through the fixed update-apps-json branch that
+    # neurocommand's consolidation queue consumes; opening a PR per release
+    # floods subscribers with notifications.
+    workflow = Path(".github/workflows/update-apps-json.yml").read_text()
+
+    assert 'BRANCH_NAME="update-apps-json"' in workflow
+    assert 'git push --force origin "$BRANCH_NAME"' in workflow
+    assert "gh pr create" not in workflow
+    assert "group: update-apps-json" in workflow


### PR DESCRIPTION
## Problem

Every merged release regenerated the full apps.json and opened a **new timestamped PR** against neurocommand — 14 PRs on 2026-07-03 alone, each notifying every subscriber. Since each PR is a full regeneration, the newest one always supersedes the rest; the older PRs were pure noise. The consolidation queue in neurocommand was also unable to close them (fixed in neurodesk/neurocommand#755).

## Change

- Force-push the regenerated `apps.json` + icons to the fixed, PR-less branch `update-apps-json` in neurocommand instead of creating a PR per release.
- neurocommand's "Consolidate apps.json queue" workflow now consumes that branch as a queue source (triggered by the push), folds it into its consolidated PR, and squash-merges on a 6-hour schedule.
- Added a `concurrency` group so release bursts push in order; last push wins, which is correct because each run regenerates the complete file.
- Contract test added: the workflow must use the fixed branch and must not call `gh pr create`.

Result: release bursts produce zero PRs here and a single consolidated PR + scheduled merge in neurocommand — a handful of notifications per day instead of dozens.

Depends on neurodesk/neurocommand#755, which is already merged and live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)