### PR TITLE
Allow manual runs of the apps.json update workflow

### DIFF
--- a/.github/workflows/update-apps-json.yml
+++ b/.github/workflows/update-apps-json.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   update-apps-json:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The workflow has a `workflow_dispatch` trigger, but the job's `if: github.event.pull_request.merged == true` condition is always false for manual runs, so dispatching it silently did nothing. Manual runs are the recovery path if an apps.json update needs to be re-pushed to the `update-apps-json` queue branch (follow-up to #2848).

🤖 Generated with [Claude Code](https://claude.com/claude-code)