### PR TITLE
ci: auto-publish new Quay repos as public in push-quay

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1115,6 +1115,32 @@ jobs:
           docker push "${QUAY_REPO}:${VERSION}"
           docker push "${QUAY_REPO}:latest"
 
+      # New Quay repos are created PRIVATE on first push, which breaks anonymous
+      # pulls. Flip to public via the API so publishing stays hands-off. Needs an
+      # OAuth token (repo:admin) in secrets.QUAY_API_TOKEN — the robot registry
+      # token used above cannot call the REST API. Idempotent (already-public is a
+      # no-op) and non-fatal: a missing token or API error only warns.
+      - name: Make Quay repo public
+        env:
+          QUAY_API_TOKEN: ${{ secrets.QUAY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ -z "${QUAY_API_TOKEN:-}" ]; then
+            echo "QUAY_API_TOKEN not set; skipping visibility change for neurodesk/${APPLICATION}."
+            exit 0
+          fi
+          code=$(curl -sS -o /tmp/quay_vis.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${QUAY_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"visibility":"public"}' \
+            "https://quay.io/api/v1/repository/neurodesk/${APPLICATION}/changevisibility") || true
+          if [ "${code}" = "200" ]; then
+            echo "neurodesk/${APPLICATION} is public (HTTP ${code})."
+          else
+            echo "::warning::Could not set neurodesk/${APPLICATION} public (HTTP ${code})."
+            cat /tmp/quay_vis.json 2>/dev/null || true
+          fi
+
       - name: Download SIF (.simg) artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:


### PR DESCRIPTION
## What
Adds a `Make Quay repo public` step to the `push-quay` job in `build-app.yml`. New `quay.io/neurodesk/<tool>` repos are created **private** on first push, which breaks anonymous `apptainer`/`oras` pulls. This flips them to public automatically via the Quay REST API (`changevisibility`).

## How
- Uses a new secret `QUAY_API_TOKEN` (Quay OAuth, **repo:admin** scope) — the existing robot registry token can't call the REST API.
- **Idempotent** (already-public is a no-op) and **non-fatal**: skips cleanly when the secret is absent, only warns on API errors. `push-quay` remains `continue-on-error`, so it can never block a release.
- Caller workflows already use `secrets: inherit`, so no caller-side change is needed.

## Notes
- The token owner must hold **Admin** on the `neurodesk` namespace (the scope alone isn't sufficient); minted from an account already proven to have it.
- Fixes Quay only. GHCR has a separate private-by-default gap being handled in a follow-up.

cc @aswinnarayanan (this extends your `build-app.yml` v2 publish, commit a2a050c3)