### PR TITLE
Fix builds for issue 2693 containers

### DIFF
--- a/builder/templates/mrtrix3.yaml
+++ b/builder/templates/mrtrix3.yaml
@@ -8,13 +8,14 @@ binaries:
     optional:
       install_path: /opt/mrtrix3-{{ self.version }}
       build_processes: '1'
+      libtiff_package: libtiff6
   dependencies:
     apt:
     - bzip2
     - ca-certificates
     - curl
     - libpng16-16
-    - libtiff6
+    - '{{ self.libtiff_package }}'
     yum:
     - bzip2
     - curl

--- a/builder/templates/spm12.yaml
+++ b/builder/templates/spm12.yaml
@@ -45,15 +45,15 @@ binaries:
 
       curl -fL --retry 5 -o "$TMPDIR/mcr.zip" {{ self.urls[self.version].mcr }}
 
-      unzip -q "$TMPDIR/mcr.zip" -d "$TMPDIR/mcr"
-
-      "$TMPDIR/mcr/install" -destinationFolder "{{ self.matlab_install_path }}" -agreeToLicense yes -mode silent
-
       echo "Downloading standalone SPM12 ..."
 
       curl -fL --retry 5 -o "$TMPDIR/spm12.zip" {{ self.urls[self.version].spm }}
 
+      unzip -q "$TMPDIR/mcr.zip" -d "$TMPDIR/mcr"
+
       unzip -q "$TMPDIR/spm12.zip" -d "$TMPDIR"
+
+      "$TMPDIR/mcr/install" -destinationFolder "{{ self.matlab_install_path }}" -agreeToLicense yes -mode silent
 
       mkdir -p {{ self.install_path }}
 

--- a/builder/templates/spm12.yaml
+++ b/builder/templates/spm12.yaml
@@ -22,7 +22,6 @@ binaries:
     - libxmu6
     - libxpm-dev
     - libxt6
-    - multiarch-support
     debs:
     - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
     yum:

--- a/builder/templates/spm12.yaml
+++ b/builder/templates/spm12.yaml
@@ -23,7 +23,7 @@ binaries:
     - libxpm-dev
     - libxt6
     debs:
-    - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
+    - https://archive.debian.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
     yum:
     - curl
     - unzip

--- a/builder/templates/spm12.yaml
+++ b/builder/templates/spm12.yaml
@@ -32,9 +32,6 @@ binaries:
       FORCE_SPMMCR: '1'
       SPM_HTML_BROWSER: '0'
       SPMMCRCMD: '{{ self.install_path }}/run_spm12.sh {{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }} script'
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }}/runtime/glnxa64:{{ self.matlab_install_path
-        }}/{{ self.urls[self.version]["mcr-version"] }}/bin/glnxa64:{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"]
-        }}/sys/os/glnxa64:{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }}/sys/opengl/lib/glnxa64
       MATLABCMD: '{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }}/toolbox/matlab'
       MCR_INHIBIT_CTF_LOCK: '1'
   - run: 'export TMPDIR="$(mktemp -d)"

--- a/builder/templates/spm12.yaml
+++ b/builder/templates/spm12.yaml
@@ -22,8 +22,6 @@ binaries:
     - libxmu6
     - libxpm-dev
     - libxt6
-    debs:
-    - https://archive.debian.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
     yum:
     - curl
     - unzip
@@ -43,6 +41,14 @@ binaries:
   - run: 'export TMPDIR="$(mktemp -d)"
 
       {{ self.install_dependencies() }}
+
+      echo "Installing archived libXp runtime ..."
+
+      curl -fsSL --retry 5 -o "$TMPDIR/libxp6.deb" https://archive.debian.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
+
+      dpkg-deb --extract "$TMPDIR/libxp6.deb" /
+
+      rm -f "$TMPDIR/libxp6.deb"
 
       echo "Downloading MATLAB Compiler Runtime ..."
 

--- a/builder/templates/spm12.yaml
+++ b/builder/templates/spm12.yaml
@@ -7,79 +7,62 @@ binaries:
     - version
     optional:
       install_path: /opt/spm12-{{ self.version }}
-      matlab_install_path: /opt/matlab-compiler-runtime-2010a
+      matlab_install_path: /opt/matlab-compiler-runtime
   urls:
-    r7771: https://www.fil.ion.ucl.ac.uk/spm/download/restricted/utopia/previous/spm12_r7771_R2010a.zip
-    r7487: https://www.fil.ion.ucl.ac.uk/spm/download/restricted/utopia/previous/spm12_r7487_R2010a.zip
+    r7771:
+      mcr: https://ssd.mathworks.com/supportfiles/downloads/R2019b/Release/9/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_R2019b_Update_9_glnxa64.zip
+      mcr-version: v97
+      spm: https://www.fil.ion.ucl.ac.uk/spm/download/restricted/bids/spm12_r7771_Linux_R2019b.zip
+    r7487:
+      mcr: https://ssd.mathworks.com/supportfiles/downloads/R2018b/deployment_files/R2018b/installers/glnxa64/MCR_R2018b_glnxa64_installer.zip
+      mcr-version: v95
+      spm: https://www.fil.ion.ucl.ac.uk/spm/download/restricted/bids/spm12_r7487_Linux_R2018b.zip
   dependencies:
     apt:
     - ca-certificates
     - curl
     - unzip
-    - bc
-    - libncurses5
-    - libxext6
-    - libxmu6
-    - libxpm-dev
-    - libxt6
+    - xorg
     yum:
     - curl
     - unzip
-    - bc
-    - libXext
-    - libXmu
-    - libXpm
-    - libXt
+    - xorg-x11-server-Xorg
   directives:
   - environment:
       FORCE_SPMMCR: '1'
       SPM_HTML_BROWSER: '0'
-      SPMMCRCMD: '{{ self.install_path }}/run_spm12.sh {{ self.matlab_install_path }}/v713 script'
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:{{ self.matlab_install_path }}/v713/runtime/glnxa64:{{ self.matlab_install_path
-        }}/v713/bin/glnxa64:{{ self.matlab_install_path }}/v713/sys/os/glnxa64:{{ self.matlab_install_path }}/v713/extern/bin/glnxa64
-      MATLABCMD: '{{ self.matlab_install_path }}/v713/toolbox/matlab'
+      SPMMCRCMD: '{{ self.install_path }}/run_spm12.sh {{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }} script'
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }}/runtime/glnxa64:{{ self.matlab_install_path
+        }}/{{ self.urls[self.version]["mcr-version"] }}/bin/glnxa64:{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"]
+        }}/sys/os/glnxa64:{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }}/sys/opengl/lib/glnxa64
+      MATLABCMD: '{{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }}/toolbox/matlab'
+      MCR_INHIBIT_CTF_LOCK: '1'
   - run: 'export TMPDIR="$(mktemp -d)"
 
       {{ self.install_dependencies() }}
 
-      echo "Installing archived libXp runtime ..."
-
-      curl -fsSL --retry 5 -o "$TMPDIR/libxp6.deb" https://archive.debian.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
-
-      dpkg-deb --extract "$TMPDIR/libxp6.deb" /
-
-      rm -f "$TMPDIR/libxp6.deb"
-
       echo "Downloading MATLAB Compiler Runtime ..."
 
-      curl -fL -o "$TMPDIR/MCRInstaller.bin" https://dl.dropbox.com/s/zz6me0c3v4yq5fd/MCR_R2010a_glnxa64_installer.bin
+      curl -fL --retry 5 -o "$TMPDIR/mcr.zip" {{ self.urls[self.version].mcr }}
 
-      chmod +x "$TMPDIR/MCRInstaller.bin"
+      unzip -q "$TMPDIR/mcr.zip" -d "$TMPDIR/mcr"
 
-      "$TMPDIR/MCRInstaller.bin" -silent -P installLocation="{{ self.matlab_install_path }}"
-
-      rm -rf "$TMPDIR"
-
-      unset TMPDIR
-
-      # Install spm12
+      "$TMPDIR/mcr/install" -destinationFolder "{{ self.matlab_install_path }}" -agreeToLicense yes -mode silent
 
       echo "Downloading standalone SPM12 ..."
 
-      curl -fL -o /tmp/spm12.zip {{ self.urls[self.version] }}
+      curl -fL --retry 5 -o "$TMPDIR/spm12.zip" {{ self.urls[self.version].spm }}
 
-      unzip -q /tmp/spm12.zip -d /tmp
+      unzip -q "$TMPDIR/spm12.zip" -d "$TMPDIR"
 
       mkdir -p {{ self.install_path }}
 
-      mv /tmp/spm12/* {{ self.install_path }}/
+      mv "$TMPDIR/spm12"/* {{ self.install_path }}/
 
       chmod -R 777 {{ self.install_path }}
 
-      rm -rf /tmp/spm*
+      rm -rf "$TMPDIR"
 
-      # Test
-
-      {{ self.install_path }}/run_spm12.sh {{ self.matlab_install_path }}/v713 quit
+      {{ self.install_path }}/run_spm12.sh {{ self.matlab_install_path }}/{{ self.urls[self.version]["mcr-version"] }} quit
 
       '

--- a/recipes/clinica/build.yaml
+++ b/recipes/clinica/build.yaml
@@ -37,6 +37,7 @@ build:
     - template:
         name: mrtrix3
         version: 3.0.4
+        libtiff_package: libtiff5
     - template:
         name: dcm2niix
         version: latest

--- a/recipes/clinicadl/build.yaml
+++ b/recipes/clinicadl/build.yaml
@@ -22,7 +22,7 @@ build:
         install_path: /opt/miniconda
         conda_install: python=3.10 pip
     - run:
-        - source /opt/miniconda/bin/activate && conda create -y -n clinicadlEnv python=3.10 pip
+        - conda create -y -n clinicadlEnv python=3.10 pip
         - conda run -n clinicadlEnv pip install clinicadl clinica
     - template:
         name: fsl

--- a/recipes/clinicadl/build.yaml
+++ b/recipes/clinicadl/build.yaml
@@ -20,9 +20,7 @@ build:
         name: miniconda
         version: py310_25.5.1-0
         install_path: /opt/miniconda
-        conda_install:
-          - python=3.10
-          - pip
+        conda_install: python=3.10 pip
     - run:
         - source /opt/miniconda/bin/activate && conda create -y -n clinicadlEnv python=3.10 pip
         - conda run -n clinicadlEnv pip install clinicadl clinica

--- a/recipes/clinicadl/build.yaml
+++ b/recipes/clinicadl/build.yaml
@@ -39,6 +39,7 @@ build:
     - template:
         name: mrtrix3
         version: 3.0.4
+        libtiff_package: libtiff5
     - template:
         name: dcm2niix
         version: latest

--- a/recipes/clinicadl/build.yaml
+++ b/recipes/clinicadl/build.yaml
@@ -13,7 +13,7 @@ structured_readme:
     Routier, A., Burgos, N., Díaz, M., Bacci, M., Bottani, S., El-Rifai O., Fontanella, S., Gori, P., Guillon, J., Guyot, A., Hassanaly, R., Jacquemont, T., Lu, P., Marcoux, A., Moreau, T., Samper-González, J., Teichmann, M., Thibeau-Sutre, E., Vaillant G., Wen, J., Wild, A., Habert, M.-O., Durrleman, S., and Colliot, O.: ‘Clinica: An Open Source Software Platform for Reproducible Clinical Neuroscience Studies’, 2021. doi:10.3389/fninf.2021.689675
 build:
   kind: neurodocker
-  base-image: ubuntu:24.04
+  base-image: ubuntu:22.04
   pkg-manager: apt
   directives:
     - template:

--- a/recipes/deeplabcut/build.yaml
+++ b/recipes/deeplabcut/build.yaml
@@ -60,6 +60,7 @@ build:
           dependencies:
             - python=3.10
             - pip
+            - setuptools<81
             - ipython
             - jupyter
             - nb_conda

--- a/recipes/lesionquantificationtoolkit/build.yaml
+++ b/recipes/lesionquantificationtoolkit/build.yaml
@@ -67,10 +67,10 @@ build:
     - install: r-base r-base-dev libgsl-dev
     - run:
         - |-
-          R --slave -e "options(repos = c(CRAN = 'https://cloud.r-project.org')); \
-            if (!requireNamespace('remotes', quietly = TRUE)) install.packages('remotes'); \
-            remotes::install_github('jdwor/LQT', dependencies = NA, upgrade = 'never', build_vignettes = FALSE); \
-            cat('Installed LQT from GitHub (', 'jdwor/LQT', ")\n")"
+          R --slave -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); \
+            if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes"); \
+            remotes::install_github("jdwor/LQT", dependencies = NA, upgrade = "never", build_vignettes = FALSE); \
+            cat("Installed LQT from GitHub (jdwor/LQT)\n")'
     - test:
         name: verify_r_installation
         script: |-

--- a/recipes/voreen/build.yaml
+++ b/recipes/voreen/build.yaml
@@ -29,7 +29,7 @@ build:
         - tar -xf voreen-src-{{ context.version }}-unix.tar.gz
 
     - run:
-        - cd /root/voreen-src-unix-nightly && mkdir build && cd build && cmake .. && make -j8 && export VRN_DEPLOYMENT=ON && export VRN_ADD_INSTALL_TARGET=ON && export CMAKE_INSTALL_PREFIX=/usr/share/voreen/ && make install && rm -rf /root/*
+        - cd /root/voreen-src-unix-nightly && mkdir build && cd build && cmake -DVRN_DEPLOYMENT=ON -DVRN_ADD_INSTALL_TARGET=ON -DCMAKE_INSTALL_PREFIX=/usr/share/voreen .. && make -j8 && make install && rm -rf /root/*
 
 deploy:
   bins:


### PR DESCRIPTION
## Summary

Fix the five build failures found while rebuilding seven recipes from #2693. The other selected recipes, BrainLesion and GOUHFI, built without recipe changes.

- use supported MathWorks runtimes and matching official compiled SPM12 distributions for Clinica and Clinicadl
- keep MATLAB runtime libraries scoped to the SPM launcher
- allow the shared MRtrix template to select the TIFF runtime package required by older Ubuntu bases
- render Clinicadl Conda packages as valid specs and avoid shell activation during the build
- restore the `pkg_resources` compatibility needed by the DeepLabCut `nb_conda` post-link hook
- fix shell/R quoting for the Lesion Quantification Toolkit installation
- configure Voreen install options during CMake generation

## Validation

- schema validation and Dockerfile generation passed for all five changed recipes
- final Clinica and Clinicadl image builds passed: https://github.com/neurodesk/neurocontainers/actions/runs/29318996941
- DeepLabCut, Lesion Quantification Toolkit, and Voreen image builds passed: https://github.com/neurodesk/neurocontainers/actions/runs/29309573883
- PR recipe validation and CodeQL checks passed
- `builder/tests/test_template_rendering.py`: 13 passed; one existing x86-only fixture cannot compile on the aarch64 development host

Addresses part of #2693.