### PR TITLE
Fix rapidtide deploy bin: resamp1tc -> resampletc

### DIFF
--- a/recipes/rapidtide/build.yaml
+++ b/recipes/rapidtide/build.yaml
@@ -65,7 +65,7 @@ build:
           - showtc
           - showxy
           - showhist
-          - resamp1tc
+          - resampletc
           - resamplenifti
           - python
 categories:
@@ -84,7 +84,7 @@ readme: |-
   The suite includes the core `rapidtide` program (RIPTiDe delay mapping), `happy`
   (cardiac waveform extraction from fMRI), registration helpers (`rapidtide2std`,
   `happy2std`), the `tidepool` GUI viewer, and a number of time course/NIfTI
-  utilities (`showtc`, `showxcorrx`, `showxy`, `showhist`, `resamp1tc`,
+  utilities (`showtc`, `showxcorrx`, `showxy`, `showhist`, `resampletc`,
   `resamplenifti`).
 
   Example:


### PR DESCRIPTION
## Summary

The rapidtide 3.1.11 recipe listed `resamp1tc` as a deploy bin, but that console script does not exist in rapidtide. The actual entry point (see rapidtide's `pyproject.toml` `[project.scripts]`) is `resampletc`.

This caused the auto-generated **"Simple Deploy Bins/Path Test"** to fail during release testing (PR #2868) because the binary was not on `PATH` in the built container — 4/5 tests passed, with only the deploy-bins check failing.

## Changes

- `recipes/rapidtide/build.yaml`: correct the deploy bin `resamp1tc` → `resampletc`, and the matching reference in the readme utility list.

## Validation

- `python3 builder/validation.py recipes/rapidtide/build.yaml` → valid
- `python3 -m builder generate rapidtide --recreate` → Dockerfile regenerates cleanly
- `codespell recipes/rapidtide/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1ZTdVftBpuW2AxTaf39F5)_