### PR TITLE
Add release for deeplabcut 2.3.11

### DIFF
--- a/recipes/deeplabcut/fulltest.yaml
+++ b/recipes/deeplabcut/fulltest.yaml
@@ -1,0 +1,305 @@
+name: deeplabcut
+version: 2.3.11
+container: deeplabcut_${version}_REFERENCE.simg
+default_timeout: 60
+tests:
+  - name: deeplabcut imports
+    command: python -c 'import deeplabcut'
+    expected_exit_code: 0
+  - name: deeplabcut is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("deeplabcut") is not None'
+    expected_exit_code: 0
+  - name: deeplabcut reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("deeplabcut") == "${version}"'
+    expected_exit_code: 0
+  - name: deeplabcut records installed files
+    command: python -c 'from importlib.metadata import files; assert files("deeplabcut")'
+    expected_exit_code: 0
+  - name: torch imports
+    command: python -c 'import torch'
+    expected_exit_code: 0
+  - name: torch is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("torch") is not None'
+    expected_exit_code: 0
+  - name: torch reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("torch")'
+    expected_exit_code: 0
+  - name: torch records installed files
+    command: python -c 'from importlib.metadata import files; assert files("torch")'
+    expected_exit_code: 0
+  - name: torchvision imports
+    command: python -c 'import torchvision'
+    expected_exit_code: 0
+  - name: torchvision is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("torchvision") is not None'
+    expected_exit_code: 0
+  - name: torchvision reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("torchvision")'
+    expected_exit_code: 0
+  - name: torchvision records installed files
+    command: python -c 'from importlib.metadata import files; assert files("torchvision")'
+    expected_exit_code: 0
+  - name: numpy imports
+    command: python -c 'import numpy'
+    expected_exit_code: 0
+  - name: numpy is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("numpy") is not None'
+    expected_exit_code: 0
+  - name: numpy reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("numpy")'
+    expected_exit_code: 0
+  - name: numpy records installed files
+    command: python -c 'from importlib.metadata import files; assert files("numpy")'
+    expected_exit_code: 0
+  - name: pandas imports
+    command: python -c 'import pandas'
+    expected_exit_code: 0
+  - name: pandas is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("pandas") is not None'
+    expected_exit_code: 0
+  - name: pandas reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("pandas")'
+    expected_exit_code: 0
+  - name: pandas records installed files
+    command: python -c 'from importlib.metadata import files; assert files("pandas")'
+    expected_exit_code: 0
+  - name: scipy imports
+    command: python -c 'import scipy'
+    expected_exit_code: 0
+  - name: scipy is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("scipy") is not None'
+    expected_exit_code: 0
+  - name: scipy reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("scipy")'
+    expected_exit_code: 0
+  - name: scipy records installed files
+    command: python -c 'from importlib.metadata import files; assert files("scipy")'
+    expected_exit_code: 0
+  - name: sklearn imports
+    command: python -c 'import sklearn'
+    expected_exit_code: 0
+  - name: sklearn is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("sklearn") is not None'
+    expected_exit_code: 0
+  - name: scikit-learn reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("scikit-learn")'
+    expected_exit_code: 0
+  - name: scikit-learn records installed files
+    command: python -c 'from importlib.metadata import files; assert files("scikit-learn")'
+    expected_exit_code: 0
+  - name: skimage imports
+    command: python -c 'import skimage'
+    expected_exit_code: 0
+  - name: skimage is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("skimage") is not None'
+    expected_exit_code: 0
+  - name: scikit-image reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("scikit-image")'
+    expected_exit_code: 0
+  - name: scikit-image records installed files
+    command: python -c 'from importlib.metadata import files; assert files("scikit-image")'
+    expected_exit_code: 0
+  - name: matplotlib imports
+    command: python -c 'import matplotlib'
+    expected_exit_code: 0
+  - name: matplotlib is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("matplotlib") is not None'
+    expected_exit_code: 0
+  - name: matplotlib reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("matplotlib")'
+    expected_exit_code: 0
+  - name: matplotlib records installed files
+    command: python -c 'from importlib.metadata import files; assert files("matplotlib")'
+    expected_exit_code: 0
+  - name: statsmodels imports
+    command: python -c 'import statsmodels'
+    expected_exit_code: 0
+  - name: statsmodels is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("statsmodels") is not None'
+    expected_exit_code: 0
+  - name: statsmodels reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("statsmodels")'
+    expected_exit_code: 0
+  - name: statsmodels records installed files
+    command: python -c 'from importlib.metadata import files; assert files("statsmodels")'
+    expected_exit_code: 0
+  - name: tables imports
+    command: python -c 'import tables'
+    expected_exit_code: 0
+  - name: tables is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("tables") is not None'
+    expected_exit_code: 0
+  - name: tables reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("tables")'
+    expected_exit_code: 0
+  - name: tables records installed files
+    command: python -c 'from importlib.metadata import files; assert files("tables")'
+    expected_exit_code: 0
+  - name: tqdm imports
+    command: python -c 'import tqdm'
+    expected_exit_code: 0
+  - name: tqdm is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("tqdm") is not None'
+    expected_exit_code: 0
+  - name: tqdm reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("tqdm")'
+    expected_exit_code: 0
+  - name: tqdm records installed files
+    command: python -c 'from importlib.metadata import files; assert files("tqdm")'
+    expected_exit_code: 0
+  - name: PIL imports
+    command: python -c 'import PIL'
+    expected_exit_code: 0
+  - name: PIL is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("PIL") is not None'
+    expected_exit_code: 0
+  - name: Pillow reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("Pillow")'
+    expected_exit_code: 0
+  - name: Pillow records installed files
+    command: python -c 'from importlib.metadata import files; assert files("Pillow")'
+    expected_exit_code: 0
+  - name: networkx imports
+    command: python -c 'import networkx'
+    expected_exit_code: 0
+  - name: networkx is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("networkx") is not None'
+    expected_exit_code: 0
+  - name: networkx reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("networkx")'
+    expected_exit_code: 0
+  - name: networkx records installed files
+    command: python -c 'from importlib.metadata import files; assert files("networkx")'
+    expected_exit_code: 0
+  - name: numba imports
+    command: python -c 'import numba'
+    expected_exit_code: 0
+  - name: numba is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("numba") is not None'
+    expected_exit_code: 0
+  - name: numba reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("numba")'
+    expected_exit_code: 0
+  - name: numba records installed files
+    command: python -c 'from importlib.metadata import files; assert files("numba")'
+    expected_exit_code: 0
+  - name: dlclibrary imports
+    command: python -c 'import dlclibrary'
+    expected_exit_code: 0
+  - name: dlclibrary is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("dlclibrary") is not None'
+    expected_exit_code: 0
+  - name: dlclibrary reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("dlclibrary")'
+    expected_exit_code: 0
+  - name: dlclibrary records installed files
+    command: python -c 'from importlib.metadata import files; assert files("dlclibrary")'
+    expected_exit_code: 0
+  - name: filterpy imports
+    command: python -c 'import filterpy'
+    expected_exit_code: 0
+  - name: filterpy is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("filterpy") is not None'
+    expected_exit_code: 0
+  - name: filterpy reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("filterpy")'
+    expected_exit_code: 0
+  - name: filterpy records installed files
+    command: python -c 'from importlib.metadata import files; assert files("filterpy")'
+    expected_exit_code: 0
+  - name: ruamel.yaml imports
+    command: python -c 'import ruamel.yaml'
+    expected_exit_code: 0
+  - name: ruamel.yaml is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("ruamel.yaml") is not None'
+    expected_exit_code: 0
+  - name: ruamel.yaml reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("ruamel.yaml")'
+    expected_exit_code: 0
+  - name: ruamel.yaml records installed files
+    command: python -c 'from importlib.metadata import files; assert files("ruamel.yaml")'
+    expected_exit_code: 0
+  - name: imgaug imports
+    command: python -c 'import imgaug'
+    expected_exit_code: 0
+  - name: imgaug is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("imgaug") is not None'
+    expected_exit_code: 0
+  - name: imgaug reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("imgaug")'
+    expected_exit_code: 0
+  - name: imgaug records installed files
+    command: python -c 'from importlib.metadata import files; assert files("imgaug")'
+    expected_exit_code: 0
+  - name: imageio_ffmpeg imports
+    command: python -c 'import imageio_ffmpeg'
+    expected_exit_code: 0
+  - name: imageio_ffmpeg is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("imageio_ffmpeg") is not None'
+    expected_exit_code: 0
+  - name: imageio-ffmpeg reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("imageio-ffmpeg")'
+    expected_exit_code: 0
+  - name: imageio-ffmpeg records installed files
+    command: python -c 'from importlib.metadata import files; assert files("imageio-ffmpeg")'
+    expected_exit_code: 0
+  - name: yaml imports
+    command: python -c 'import yaml'
+    expected_exit_code: 0
+  - name: yaml is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("yaml") is not None'
+    expected_exit_code: 0
+  - name: PyYAML reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("PyYAML")'
+    expected_exit_code: 0
+  - name: PyYAML records installed files
+    command: python -c 'from importlib.metadata import files; assert files("PyYAML")'
+    expected_exit_code: 0
+  - name: IPython imports
+    command: python -c 'import IPython'
+    expected_exit_code: 0
+  - name: IPython is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("IPython") is not None'
+    expected_exit_code: 0
+  - name: ipython reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("ipython")'
+    expected_exit_code: 0
+  - name: ipython records installed files
+    command: python -c 'from importlib.metadata import files; assert files("ipython")'
+    expected_exit_code: 0
+  - name: jupyter imports
+    command: python -c 'import jupyter'
+    expected_exit_code: 0
+  - name: jupyter is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("jupyter") is not None'
+    expected_exit_code: 0
+  - name: jupyter reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("jupyter")'
+    expected_exit_code: 0
+  - name: jupyter records installed files
+    command: python -c 'from importlib.metadata import files; assert files("jupyter")'
+    expected_exit_code: 0
+  - name: notebook imports
+    command: python -c 'import notebook'
+    expected_exit_code: 0
+  - name: notebook is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("notebook") is not None'
+    expected_exit_code: 0
+  - name: notebook reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("notebook")'
+    expected_exit_code: 0
+  - name: notebook records installed files
+    command: python -c 'from importlib.metadata import files; assert files("notebook")'
+    expected_exit_code: 0
+  - name: wandb imports
+    command: python -c 'import wandb'
+    expected_exit_code: 0
+  - name: wandb is discoverable
+    command: python -c 'import importlib.util; assert importlib.util.find_spec("wandb") is not None'
+    expected_exit_code: 0
+  - name: wandb reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("wandb") == "0.17.9"; assert version("tensorflow") == "2.12.0"'
+    expected_exit_code: 0
+  - name: wandb records installed files
+    command: python -c 'from importlib.metadata import files; assert files("wandb")'
+    expected_exit_code: 0

--- a/recipes/deeplabcut/fulltest.yaml
+++ b/recipes/deeplabcut/fulltest.yaml
@@ -21,7 +21,7 @@ tests:
   - name: torch is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("torch") is not None'
     expected_exit_code: 0
-  - name: torch reports the expected version
+  - name: torch has package metadata
     command: python -c 'from importlib.metadata import version; assert version("torch")'
     expected_exit_code: 0
   - name: torch records installed files
@@ -33,7 +33,7 @@ tests:
   - name: torchvision is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("torchvision") is not None'
     expected_exit_code: 0
-  - name: torchvision reports the expected version
+  - name: torchvision has package metadata
     command: python -c 'from importlib.metadata import version; assert version("torchvision")'
     expected_exit_code: 0
   - name: torchvision records installed files
@@ -45,7 +45,7 @@ tests:
   - name: numpy is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("numpy") is not None'
     expected_exit_code: 0
-  - name: numpy reports the expected version
+  - name: numpy has package metadata
     command: python -c 'from importlib.metadata import version; assert version("numpy")'
     expected_exit_code: 0
   - name: numpy records installed files
@@ -57,7 +57,7 @@ tests:
   - name: pandas is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("pandas") is not None'
     expected_exit_code: 0
-  - name: pandas reports the expected version
+  - name: pandas has package metadata
     command: python -c 'from importlib.metadata import version; assert version("pandas")'
     expected_exit_code: 0
   - name: pandas records installed files
@@ -69,7 +69,7 @@ tests:
   - name: scipy is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("scipy") is not None'
     expected_exit_code: 0
-  - name: scipy reports the expected version
+  - name: scipy has package metadata
     command: python -c 'from importlib.metadata import version; assert version("scipy")'
     expected_exit_code: 0
   - name: scipy records installed files
@@ -81,7 +81,7 @@ tests:
   - name: sklearn is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("sklearn") is not None'
     expected_exit_code: 0
-  - name: scikit-learn reports the expected version
+  - name: scikit-learn has package metadata
     command: python -c 'from importlib.metadata import version; assert version("scikit-learn")'
     expected_exit_code: 0
   - name: scikit-learn records installed files
@@ -93,7 +93,7 @@ tests:
   - name: skimage is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("skimage") is not None'
     expected_exit_code: 0
-  - name: scikit-image reports the expected version
+  - name: scikit-image has package metadata
     command: python -c 'from importlib.metadata import version; assert version("scikit-image")'
     expected_exit_code: 0
   - name: scikit-image records installed files
@@ -105,7 +105,7 @@ tests:
   - name: matplotlib is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("matplotlib") is not None'
     expected_exit_code: 0
-  - name: matplotlib reports the expected version
+  - name: matplotlib has package metadata
     command: python -c 'from importlib.metadata import version; assert version("matplotlib")'
     expected_exit_code: 0
   - name: matplotlib records installed files
@@ -117,7 +117,7 @@ tests:
   - name: statsmodels is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("statsmodels") is not None'
     expected_exit_code: 0
-  - name: statsmodels reports the expected version
+  - name: statsmodels has package metadata
     command: python -c 'from importlib.metadata import version; assert version("statsmodels")'
     expected_exit_code: 0
   - name: statsmodels records installed files
@@ -129,7 +129,7 @@ tests:
   - name: tables is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("tables") is not None'
     expected_exit_code: 0
-  - name: tables reports the expected version
+  - name: tables has package metadata
     command: python -c 'from importlib.metadata import version; assert version("tables")'
     expected_exit_code: 0
   - name: tables records installed files
@@ -141,7 +141,7 @@ tests:
   - name: tqdm is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("tqdm") is not None'
     expected_exit_code: 0
-  - name: tqdm reports the expected version
+  - name: tqdm has package metadata
     command: python -c 'from importlib.metadata import version; assert version("tqdm")'
     expected_exit_code: 0
   - name: tqdm records installed files
@@ -153,7 +153,7 @@ tests:
   - name: PIL is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("PIL") is not None'
     expected_exit_code: 0
-  - name: Pillow reports the expected version
+  - name: Pillow has package metadata
     command: python -c 'from importlib.metadata import version; assert version("Pillow")'
     expected_exit_code: 0
   - name: Pillow records installed files
@@ -165,7 +165,7 @@ tests:
   - name: networkx is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("networkx") is not None'
     expected_exit_code: 0
-  - name: networkx reports the expected version
+  - name: networkx has package metadata
     command: python -c 'from importlib.metadata import version; assert version("networkx")'
     expected_exit_code: 0
   - name: networkx records installed files
@@ -177,7 +177,7 @@ tests:
   - name: numba is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("numba") is not None'
     expected_exit_code: 0
-  - name: numba reports the expected version
+  - name: numba has package metadata
     command: python -c 'from importlib.metadata import version; assert version("numba")'
     expected_exit_code: 0
   - name: numba records installed files
@@ -189,7 +189,7 @@ tests:
   - name: dlclibrary is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("dlclibrary") is not None'
     expected_exit_code: 0
-  - name: dlclibrary reports the expected version
+  - name: dlclibrary has package metadata
     command: python -c 'from importlib.metadata import version; assert version("dlclibrary")'
     expected_exit_code: 0
   - name: dlclibrary records installed files
@@ -201,7 +201,7 @@ tests:
   - name: filterpy is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("filterpy") is not None'
     expected_exit_code: 0
-  - name: filterpy reports the expected version
+  - name: filterpy has package metadata
     command: python -c 'from importlib.metadata import version; assert version("filterpy")'
     expected_exit_code: 0
   - name: filterpy records installed files
@@ -213,7 +213,7 @@ tests:
   - name: ruamel.yaml is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("ruamel.yaml") is not None'
     expected_exit_code: 0
-  - name: ruamel.yaml reports the expected version
+  - name: ruamel.yaml has package metadata
     command: python -c 'from importlib.metadata import version; assert version("ruamel.yaml")'
     expected_exit_code: 0
   - name: ruamel.yaml records installed files
@@ -225,7 +225,7 @@ tests:
   - name: imgaug is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("imgaug") is not None'
     expected_exit_code: 0
-  - name: imgaug reports the expected version
+  - name: imgaug has package metadata
     command: python -c 'from importlib.metadata import version; assert version("imgaug")'
     expected_exit_code: 0
   - name: imgaug records installed files
@@ -237,7 +237,7 @@ tests:
   - name: imageio_ffmpeg is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("imageio_ffmpeg") is not None'
     expected_exit_code: 0
-  - name: imageio-ffmpeg reports the expected version
+  - name: imageio-ffmpeg has package metadata
     command: python -c 'from importlib.metadata import version; assert version("imageio-ffmpeg")'
     expected_exit_code: 0
   - name: imageio-ffmpeg records installed files
@@ -249,7 +249,7 @@ tests:
   - name: yaml is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("yaml") is not None'
     expected_exit_code: 0
-  - name: PyYAML reports the expected version
+  - name: PyYAML has package metadata
     command: python -c 'from importlib.metadata import version; assert version("PyYAML")'
     expected_exit_code: 0
   - name: PyYAML records installed files
@@ -261,7 +261,7 @@ tests:
   - name: IPython is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("IPython") is not None'
     expected_exit_code: 0
-  - name: ipython reports the expected version
+  - name: ipython has package metadata
     command: python -c 'from importlib.metadata import version; assert version("ipython")'
     expected_exit_code: 0
   - name: ipython records installed files
@@ -273,7 +273,7 @@ tests:
   - name: jupyter is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("jupyter") is not None'
     expected_exit_code: 0
-  - name: jupyter reports the expected version
+  - name: jupyter has package metadata
     command: python -c 'from importlib.metadata import version; assert version("jupyter")'
     expected_exit_code: 0
   - name: jupyter records installed files
@@ -285,7 +285,7 @@ tests:
   - name: notebook is discoverable
     command: python -c 'import importlib.util; assert importlib.util.find_spec("notebook") is not None'
     expected_exit_code: 0
-  - name: notebook reports the expected version
+  - name: notebook has package metadata
     command: python -c 'from importlib.metadata import version; assert version("notebook")'
     expected_exit_code: 0
   - name: notebook records installed files
@@ -294,12 +294,12 @@ tests:
   - name: wandb imports
     command: python -c 'import wandb'
     expected_exit_code: 0
-  - name: wandb is discoverable
-    command: python -c 'import importlib.util; assert importlib.util.find_spec("wandb") is not None'
+  - name: TensorFlow imports
+    command: python -c 'import tensorflow'
     expected_exit_code: 0
   - name: wandb reports the expected version
-    command: python -c 'from importlib.metadata import version; assert version("wandb") == "0.17.9"; assert version("tensorflow") == "2.12.0"'
+    command: python -c 'from importlib.metadata import version; assert version("wandb") == "0.17.9"'
     expected_exit_code: 0
-  - name: wandb records installed files
-    command: python -c 'from importlib.metadata import files; assert files("wandb")'
+  - name: TensorFlow reports the expected version
+    command: python -c 'from importlib.metadata import version; assert version("tensorflow") == "2.12.0"'
     expected_exit_code: 0

--- a/releases/deeplabcut/2.3.11.json
+++ b/releases/deeplabcut/2.3.11.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "deeplabcut 2.3.11": {
+      "version": "20260715",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "machine learning"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **deeplabcut 2.3.11**.

## Changes

- Add `releases/deeplabcut/2.3.11.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh deeplabcut 2.3.11 20260715
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/deeplabcut_2.3.11_20260715.simg -O
singularity shell --overlay /tmp/apptainer_overlay deeplabcut_2.3.11_20260715.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepLabCut version 2.3.11 to the available application catalog.
  * Added a comprehensive validation suite covering DeepLabCut and its key dependencies, including imports, versions, discoverability, and installed files.
  * Classified DeepLabCut under the machine learning category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->