### PR TITLE
Add release for clinicadl 1.6.1

### DIFF
--- a/recipes/clinicadl/fulltest.yaml
+++ b/recipes/clinicadl/fulltest.yaml
@@ -1,0 +1,327 @@
+name: clinicadl
+version: 1.6.1
+container: clinicadl_${version}_REFERENCE.simg
+default_timeout: 60
+clinica_version: 0.7.7
+env_setup: |
+  assert_linked() {
+    local target payload output interpreter
+    local -a interpreter_args
+    target="$(readlink -f "$1")" || return 1
+    if output="$(ldd "$target" 2>&1)"; then
+      payload="$target"
+    else
+      IFS= read -r interpreter < "$target" || return 1
+      interpreter="${interpreter#\#!}"
+      read -r -a interpreter_args <<< "$interpreter"
+      if [ "${interpreter_args[0]}" = /usr/bin/env ]; then
+        payload="$(command -v "${interpreter_args[1]}")" || return 1
+      else
+        payload="${interpreter_args[0]}"
+      fi
+      payload="$(readlink -f "$payload")" || return 1
+      output="$(ldd "$payload" 2>&1)" || return 1
+    fi
+    ! grep -q "not found" <<< "$output"
+  }
+tests:
+  - name: clinicadl resolves on PATH
+    command: command -v clinicadl
+    expected_exit_code: 0
+  - name: clinicadl is executable
+    command: test -x "$(command -v clinicadl)"
+    expected_exit_code: 0
+  - name: clinicadl help runs
+    command: clinicadl --help >/dev/null
+    expected_exit_code: 0
+  - name: clinicadl package version
+    command: /opt/miniconda/envs/clinicadlEnv/bin/python -c 'from importlib.metadata import version; assert version("clinicadl") == "${version}"'
+    expected_exit_code: 0
+  - name: clinica resolves on PATH
+    command: command -v clinica
+    expected_exit_code: 0
+  - name: clinica is executable
+    command: test -x "$(command -v clinica)"
+    expected_exit_code: 0
+  - name: clinica reports its version
+    command: clinica --version
+    expected_exit_code: 0
+  - name: clinica package version
+    command: /opt/miniconda/envs/clinicadlEnv/bin/python -c 'from importlib.metadata import version; assert version("clinica") == "${clinica_version}"'
+    expected_exit_code: 0
+  - name: python resolves on PATH
+    command: command -v python
+    expected_exit_code: 0
+  - name: python is executable
+    command: test -x "$(command -v python)"
+    expected_exit_code: 0
+  - name: python has no missing shared libraries
+    command: assert_linked "$(command -v python)"
+    expected_exit_code: 0
+  - name: Traits package version
+    command: python -c 'from importlib.metadata import version; assert version("traits") == "6.4.3"'
+    expected_exit_code: 0
+  - name: conda resolves on PATH
+    command: command -v conda
+    expected_exit_code: 0
+  - name: conda is executable
+    command: test -x "$(command -v conda)"
+    expected_exit_code: 0
+  - name: conda has no missing shared libraries
+    command: assert_linked "$(command -v conda)"
+    expected_exit_code: 0
+  - name: setuptools package version
+    command: python -c 'from importlib.metadata import version; assert version("setuptools") == "80.9.0"'
+    expected_exit_code: 0
+  - name: fslmaths resolves on PATH
+    command: command -v fslmaths
+    expected_exit_code: 0
+  - name: fslmaths is executable
+    command: test -x "$(command -v fslmaths)"
+    expected_exit_code: 0
+  - name: fslmaths has no missing shared libraries
+    command: assert_linked "$(command -v fslmaths)"
+    expected_exit_code: 0
+  - name: fslmaths target exists
+    command: test -e "$(readlink -f "$(command -v fslmaths)")"
+    expected_exit_code: 0
+  - name: bet resolves on PATH
+    command: command -v bet
+    expected_exit_code: 0
+  - name: bet is executable
+    command: test -x "$(command -v bet)"
+    expected_exit_code: 0
+  - name: bet has no missing shared libraries
+    command: assert_linked "$(command -v bet)"
+    expected_exit_code: 0
+  - name: bet target exists
+    command: test -e "$(readlink -f "$(command -v bet)")"
+    expected_exit_code: 0
+  - name: flirt resolves on PATH
+    command: command -v flirt
+    expected_exit_code: 0
+  - name: flirt is executable
+    command: test -x "$(command -v flirt)"
+    expected_exit_code: 0
+  - name: flirt has no missing shared libraries
+    command: assert_linked "$(command -v flirt)"
+    expected_exit_code: 0
+  - name: flirt target exists
+    command: test -e "$(readlink -f "$(command -v flirt)")"
+    expected_exit_code: 0
+  - name: fast resolves on PATH
+    command: command -v fast
+    expected_exit_code: 0
+  - name: fast is executable
+    command: test -x "$(command -v fast)"
+    expected_exit_code: 0
+  - name: fast has no missing shared libraries
+    command: assert_linked "$(command -v fast)"
+    expected_exit_code: 0
+  - name: fast target exists
+    command: test -e "$(readlink -f "$(command -v fast)")"
+    expected_exit_code: 0
+  - name: fnirt resolves on PATH
+    command: command -v fnirt
+    expected_exit_code: 0
+  - name: fnirt is executable
+    command: test -x "$(command -v fnirt)"
+    expected_exit_code: 0
+  - name: fnirt has no missing shared libraries
+    command: assert_linked "$(command -v fnirt)"
+    expected_exit_code: 0
+  - name: fnirt target exists
+    command: test -e "$(readlink -f "$(command -v fnirt)")"
+    expected_exit_code: 0
+  - name: applywarp resolves on PATH
+    command: command -v applywarp
+    expected_exit_code: 0
+  - name: applywarp is executable
+    command: test -x "$(command -v applywarp)"
+    expected_exit_code: 0
+  - name: applywarp has no missing shared libraries
+    command: assert_linked "$(command -v applywarp)"
+    expected_exit_code: 0
+  - name: applywarp target exists
+    command: test -e "$(readlink -f "$(command -v applywarp)")"
+    expected_exit_code: 0
+  - name: fslstats resolves on PATH
+    command: command -v fslstats
+    expected_exit_code: 0
+  - name: fslstats is executable
+    command: test -x "$(command -v fslstats)"
+    expected_exit_code: 0
+  - name: fslstats has no missing shared libraries
+    command: assert_linked "$(command -v fslstats)"
+    expected_exit_code: 0
+  - name: fslstats target exists
+    command: test -e "$(readlink -f "$(command -v fslstats)")"
+    expected_exit_code: 0
+  - name: recon-all resolves on PATH
+    command: command -v recon-all
+    expected_exit_code: 0
+  - name: recon-all is executable
+    command: test -x "$(command -v recon-all)"
+    expected_exit_code: 0
+  - name: recon-all has no missing shared libraries
+    command: assert_linked "$(command -v recon-all)"
+    expected_exit_code: 0
+  - name: recon-all target exists
+    command: test -e "$(readlink -f "$(command -v recon-all)")"
+    expected_exit_code: 0
+  - name: mri_convert resolves on PATH
+    command: command -v mri_convert
+    expected_exit_code: 0
+  - name: mri_convert is executable
+    command: test -x "$(command -v mri_convert)"
+    expected_exit_code: 0
+  - name: mri_convert has no missing shared libraries
+    command: assert_linked "$(command -v mri_convert)"
+    expected_exit_code: 0
+  - name: mri_convert target exists
+    command: test -e "$(readlink -f "$(command -v mri_convert)")"
+    expected_exit_code: 0
+  - name: mri_info resolves on PATH
+    command: command -v mri_info
+    expected_exit_code: 0
+  - name: mri_info is executable
+    command: test -x "$(command -v mri_info)"
+    expected_exit_code: 0
+  - name: mri_info has no missing shared libraries
+    command: assert_linked "$(command -v mri_info)"
+    expected_exit_code: 0
+  - name: mri_info target exists
+    command: test -e "$(readlink -f "$(command -v mri_info)")"
+    expected_exit_code: 0
+  - name: mri_vol2vol resolves on PATH
+    command: command -v mri_vol2vol
+    expected_exit_code: 0
+  - name: mri_vol2vol is executable
+    command: test -x "$(command -v mri_vol2vol)"
+    expected_exit_code: 0
+  - name: mri_vol2vol has no missing shared libraries
+    command: assert_linked "$(command -v mri_vol2vol)"
+    expected_exit_code: 0
+  - name: mri_vol2vol target exists
+    command: test -e "$(readlink -f "$(command -v mri_vol2vol)")"
+    expected_exit_code: 0
+  - name: antsRegistration resolves on PATH
+    command: command -v antsRegistration
+    expected_exit_code: 0
+  - name: antsRegistration is executable
+    command: test -x "$(command -v antsRegistration)"
+    expected_exit_code: 0
+  - name: antsRegistration has no missing shared libraries
+    command: assert_linked "$(command -v antsRegistration)"
+    expected_exit_code: 0
+  - name: antsRegistration target exists
+    command: test -e "$(readlink -f "$(command -v antsRegistration)")"
+    expected_exit_code: 0
+  - name: antsApplyTransforms resolves on PATH
+    command: command -v antsApplyTransforms
+    expected_exit_code: 0
+  - name: antsApplyTransforms is executable
+    command: test -x "$(command -v antsApplyTransforms)"
+    expected_exit_code: 0
+  - name: antsApplyTransforms has no missing shared libraries
+    command: assert_linked "$(command -v antsApplyTransforms)"
+    expected_exit_code: 0
+  - name: antsApplyTransforms target exists
+    command: test -e "$(readlink -f "$(command -v antsApplyTransforms)")"
+    expected_exit_code: 0
+  - name: N4BiasFieldCorrection resolves on PATH
+    command: command -v N4BiasFieldCorrection
+    expected_exit_code: 0
+  - name: N4BiasFieldCorrection is executable
+    command: test -x "$(command -v N4BiasFieldCorrection)"
+    expected_exit_code: 0
+  - name: N4BiasFieldCorrection has no missing shared libraries
+    command: assert_linked "$(command -v N4BiasFieldCorrection)"
+    expected_exit_code: 0
+  - name: N4BiasFieldCorrection target exists
+    command: test -e "$(readlink -f "$(command -v N4BiasFieldCorrection)")"
+    expected_exit_code: 0
+  - name: mrconvert resolves on PATH
+    command: command -v mrconvert
+    expected_exit_code: 0
+  - name: mrconvert is executable
+    command: test -x "$(command -v mrconvert)"
+    expected_exit_code: 0
+  - name: mrconvert has no missing shared libraries
+    command: assert_linked "$(command -v mrconvert)"
+    expected_exit_code: 0
+  - name: mrconvert target exists
+    command: test -e "$(readlink -f "$(command -v mrconvert)")"
+    expected_exit_code: 0
+  - name: mrinfo resolves on PATH
+    command: command -v mrinfo
+    expected_exit_code: 0
+  - name: mrinfo is executable
+    command: test -x "$(command -v mrinfo)"
+    expected_exit_code: 0
+  - name: mrinfo has no missing shared libraries
+    command: assert_linked "$(command -v mrinfo)"
+    expected_exit_code: 0
+  - name: mrinfo target exists
+    command: test -e "$(readlink -f "$(command -v mrinfo)")"
+    expected_exit_code: 0
+  - name: dwidenoise resolves on PATH
+    command: command -v dwidenoise
+    expected_exit_code: 0
+  - name: dwidenoise is executable
+    command: test -x "$(command -v dwidenoise)"
+    expected_exit_code: 0
+  - name: dwidenoise has no missing shared libraries
+    command: assert_linked "$(command -v dwidenoise)"
+    expected_exit_code: 0
+  - name: dwidenoise target exists
+    command: test -e "$(readlink -f "$(command -v dwidenoise)")"
+    expected_exit_code: 0
+  - name: dwi2tensor resolves on PATH
+    command: command -v dwi2tensor
+    expected_exit_code: 0
+  - name: dwi2tensor is executable
+    command: test -x "$(command -v dwi2tensor)"
+    expected_exit_code: 0
+  - name: dwi2tensor has no missing shared libraries
+    command: assert_linked "$(command -v dwi2tensor)"
+    expected_exit_code: 0
+  - name: dwi2tensor target exists
+    command: test -e "$(readlink -f "$(command -v dwi2tensor)")"
+    expected_exit_code: 0
+  - name: tckgen resolves on PATH
+    command: command -v tckgen
+    expected_exit_code: 0
+  - name: tckgen is executable
+    command: test -x "$(command -v tckgen)"
+    expected_exit_code: 0
+  - name: tckgen has no missing shared libraries
+    command: assert_linked "$(command -v tckgen)"
+    expected_exit_code: 0
+  - name: tckgen target exists
+    command: test -e "$(readlink -f "$(command -v tckgen)")"
+    expected_exit_code: 0
+  - name: dcm2niix resolves on PATH
+    command: command -v dcm2niix
+    expected_exit_code: 0
+  - name: dcm2niix is executable
+    command: test -x "$(command -v dcm2niix)"
+    expected_exit_code: 0
+  - name: dcm2niix has no missing shared libraries
+    command: assert_linked "$(command -v dcm2niix)"
+    expected_exit_code: 0
+  - name: dcm2niix target exists
+    command: test -e "$(readlink -f "$(command -v dcm2niix)")"
+    expected_exit_code: 0
+  - name: mris_convert resolves on PATH
+    command: command -v mris_convert
+    expected_exit_code: 0
+  - name: mris_convert is executable
+    command: test -x "$(command -v mris_convert)"
+    expected_exit_code: 0
+  - name: mris_convert has no missing shared libraries
+    command: assert_linked "$(command -v mris_convert)"
+    expected_exit_code: 0
+  - name: mris_convert target exists
+    command: test -e "$(readlink -f "$(command -v mris_convert)")"
+    expected_exit_code: 0

--- a/releases/clinicadl/1.6.1.json
+++ b/releases/clinicadl/1.6.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "clinicadl 1.6.1": {
+      "version": "20260715",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "workflows"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **clinicadl 1.6.1**.

## Changes

- Add `releases/clinicadl/1.6.1.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh clinicadl 1.6.1 20260715
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/clinicadl_1.6.1_20260715.simg -O
singularity shell --overlay /tmp/apptainer_overlay clinicadl_1.6.1_20260715.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ClinicADL 1.6.1 release in the workflows catalog.
  * Added a dedicated container test suite covering ClinicADL, Clinica, Python, and related neuroimaging tools.
* **Bug Fixes**
  * Added checks to detect missing executables, unresolved shared libraries, invalid binary targets, and incorrect installed package versions.
  * Improved confidence that the ClinicADL environment is ready for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->