### PR TITLE
build-app: always push GHCR :BUILDDATE so build-simg can pull it

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -587,13 +587,21 @@ jobs:
       #     retention-days: 7
 
       - name: Push to GHCR
-        if: steps.imgcompare.outputs.IMGDIFFERS == 'true'
+        if: inputs.skip_docker_build != 'true'
         env:
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
         run: |
-          docker tag ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE} ghcr.io/${GH_REGISTRY}/${IMAGENAME}:latest
+          # Always push :BUILDDATE so build-simg (and the downstream simg/OCI
+          # jobs) can pull it. GHCR dedupes identical manifests, so re-pushing
+          # an unchanged image is essentially free. Without this, manual
+          # no-change rebuilds and disable_auto_upload runs leave :BUILDDATE
+          # missing and build-simg fails with MANIFEST_UNKNOWN.
           docker push ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE}
-          docker push ghcr.io/${GH_REGISTRY}/${IMAGENAME}:latest
+          # Only advance :latest when the image actually changed (or forced).
+          if [ "${{ steps.imgcompare.outputs.IMGDIFFERS }}" = "true" ] || [ "${{ inputs.force_push_ghcr }}" = "true" ]; then
+            docker tag ghcr.io/${GH_REGISTRY}/${IMAGENAME}:${BUILDDATE} ghcr.io/${GH_REGISTRY}/${IMAGENAME}:latest
+            docker push ghcr.io/${GH_REGISTRY}/${IMAGENAME}:latest
+          fi
 
   # push-ghcr:
   #   needs: [config, build-image]


### PR DESCRIPTION
## Problem
The "Push to GHCR" step pushed the :BUILDDATE image tag only when
`IMGDIFFERS == 'true'`. But on MANUAL builds, build-simg runs by default
(its gate includes `skip_simg_build == 'false'`) and pulls that same
:BUILDDATE tag. When the tag was never pushed, build-simg failed with
MANIFEST_UNKNOWN — and the docker-archive fallback re-pulls the same
missing ref, so it couldn't recover.

Two real triggers (manual builds only; auto-build is structurally immune):
- `disable_auto_upload=true` on a first build, or
- a metadata-only recipe edit that mints a new BUILDDATE without changing
  the image fingerprint.

Observed: manual-build run 29384589387 (deepisles, 2026-07-15) failed
exactly this way under disable_auto_upload=true.

## Fix
Always push :BUILDDATE (gate the step on `skip_docker_build != 'true'`);
only push/advance :latest when `IMGDIFFERS` or `force_push_ghcr`. GHCR
dedupes identical manifests, so re-pushing an unchanged image is ~free.
Reapplies the previously-reviewed arc-runner commit 8a2013c8.

## Why it's safe
- The local :BUILDDATE image is guaranteed to exist whenever this step runs
  (same gate as "Build new image"; imgcompare hard-fails if it's missing).
- :latest and every consumer-facing registry (DockerHub, Nectar, S3,
  Quay-v2, GHCR-v2) stay gated on IMGDIFFERS/force — nothing new is published.
- Tradeoff (intended): under disable_auto_upload=true the internal :BUILDDATE
  *staging* tag now lands on the (private) GHCR package. A tag push doesn't
  change visibility, so nothing becomes public.

## Validation
Live-tested: a manual dispatch with disable_auto_upload=true and a fresh
BUILDDATE (run 29465435898) → "Push to GHCR" ran, build-simg went GREEN,
all publishers correctly skipped. Before/after vs the deepisles failure.
