### PR TITLE
Add fetal/neonatal super-resolution reconstruction and segmentation recipes

### DIFF
--- a/recipes/dhcpstructuralpipeline/build.yaml
+++ b/recipes/dhcpstructuralpipeline/build.yaml
@@ -1,0 +1,54 @@
+name: dhcpstructuralpipeline
+version: "1.1"
+
+copyright:
+  - license: Apache-2.0
+    url: https://github.com/BioMedIA/dhcp-structural-pipeline/blob/master/LICENSE.txt
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: biomedia/dhcp-structural-pipeline:latest
+  pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
+
+  directives:
+    - environment:
+        FSLDIR: /usr/local/fsl
+        FSLOUTPUTTYPE: NIFTI_GZ
+        PATH: /usr/src/structural-pipeline:/usr/local/fsl/bin:$PATH
+
+    - deploy:
+        path:
+          - /usr/src/structural-pipeline
+        bins:
+          - dhcp-pipeline.sh
+
+structured_readme:
+  description: >-
+    The dHCP (developing Human Connectome Project) structural pipeline performs
+    automated structural analysis of neonatal brain MRI (T1w and T2w),
+    including tissue and structural segmentation, cortical surface extraction,
+    inflation and spherical projection. It is designed for neonatal data with a
+    post-menstrual age of 28-44 weeks.
+  example: |-
+    # Run the structural pipeline for one neonatal subject/session
+    dhcp-pipeline.sh subject1 session1 -a 40 \
+      -T2 /data/sub-subject1_T2w.nii.gz \
+      -t 8
+  documentation: https://github.com/BioMedIA/dhcp-structural-pipeline
+  citation: >-
+    Makropoulos, A., Robinson, E. C., Schuh, A., Wright, R., Fitzgibbon, S.,
+    Bozek, J., ... Rueckert, D. (2018). The developing human connectome
+    project: A minimal processing pipeline for neonatal cortical surface
+    reconstruction. NeuroImage, 173, 88-112.
+    https://doi.org/10.1016/j.neuroimage.2018.01.054
+
+categories:
+  - structural imaging
+  - image segmentation
+  - workflows
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAE5UlEQVR4nO2cbVBUVRjH/+vCLrAssLiskSQMiExgxZvyorRr6pAvpFMaRQNKDWNqEtEHGMVhKnNiqplqasxmdCa1sQ9RWqPMCNWIWkEUZUnRusACNuM4uLwI5LLM7YOz6x735ZzLXmvYPb9vz9lzz3nOj+fevXv3LACH4wuymRyUvaZMkDqR/4KOpiOi18t8wGyV4glWWXNYOvmbHIB9TV4t+qMYd3irJo8VFChyAO9rdSsokOTY8bRmpmtQIOMiKBCrx467tc+hdQg07nTATzEKXBAFhyB+et3G2QWvIApcEAUuiAIXRIELosAFUeCCKHBBFLggClwQBS6IAhdEgQuiECTlYGGhITjbeJBoe2r7HpjMg474yHuv4P6FCY74+59+Q+Xet9yOV19dgfWrljvia0MWrC2t8prDkvRUGPKy8FBqMmLmahARrsKUzYYhywgu9w2grfMSWlrbMTw6xrQmSQX9nyQnLsDequcI+XaCguSIi9UhLlYHQ14WXqoowaMluzA2PkEd1y8E6XMz8XrtdigVCqb+iuAgyOVypr6zXlBKUjz21ZByBEHAqZbz+LzpW5jMVyAIAu6dF4OCnHQUP7Ya2ugo5vFnvaCXtz2DECVZOfvePYwvz7QSbSbzIEzmQRw/cQZVFU9DANsDVNGCIsJVKC8ugiE/CzptNMYnJvFr11841tgEY++A2OF8Ii0lERmLU4i25tY2FznO3LRa0fDBx8xziBI0/54YHHijFrE6raNNEamGIS8L+txMfHTsCzHD+Ux+9oMubZ+ebJZ0DmZBcrkcDXt2EXKckclk2Fb6uOgE8rIewI+n2f+iziQn3EfE1ikbuow9MxrLE8yCVhcsRUpSPNH2VfM5HDp+EmM3JlCQk46anVsQGqKUNEFvREWqiXhkdAw227SkczALWrEsm4h7+6/gtXcOQRBuXexOfX0BMXM12Ll1s6QJisGei5QwC1qYEEfE59p/cUmota1TtCAxd9J3MjxC3g1HRUZALpdjelq6KmL+LKYKCyViy7Drrfp1y6jvGYnA2Ee+ayqCg5C2KFHSOZgFjU9MErEmSu3SJ1oT4XtGIviu46JL25NFqySdg1mQqW+QiJcvSYdMRu5cezgnQ5qsGLnU3YPO37uJtkJDLtatXObxGKVCgZodZYiMCGeag1nQNxc6iDgxfj52V5Yjdp4WalUY1jySj/LiItbhJOPtg5/gn5tWoq2+ugJ1Lz6LxSlJCA1RIkSpQFJ8HLZsXocTh9/EpvUrIWPc4Mt8kW45346yTWuRnLjA0baxUI+NhXrWIe4K3SYz6hoOYH/tDigUwQBu3ZNtKNRjgwS5MVeQzTaNmv3v4+q1625fFwQBHx5t9DmhmXD2h5+xtfpV/Hm5j6m/dcrG/E4n6qPGwN9XUfJCHcqLi7AiPxs6rQY3xidx8Q8jjn52GsbeATxf+oSYISXD2NOP0sp6LM1IgyEvE+mpixCj1UCtCsOUbRpDlhEYe/vR3tmF5tY2pmdBgNM+ab4/iMS+d5o/k6bABVHggihwQRS4IApcEAUuiAIXRIELosAFUeCCKHBBFLggCg5BM/nRvb/i7IJXEAUuiAIhiJ9mrg5cKiiQJblbOz/FKLgVFIhV5GnNHisokCR5WyuTBH/9xoOlCJiuQf5YTaxr4v+ii8O5q/wLd01vRoeBwgEAAAAASUVORK5CYII=

--- a/recipes/dhcpstructuralpipeline/fulltest.yaml
+++ b/recipes/dhcpstructuralpipeline/fulltest.yaml
@@ -1,0 +1,13 @@
+name: dhcpstructuralpipeline
+version: "1.1"
+container: dhcpstructuralpipeline_1.1_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: dhcp pipeline launcher available
+    description: Verify the dHCP structural pipeline entrypoint is deployed on PATH.
+    command: command -v dhcp-pipeline.sh
+    expected_output_contains: dhcp-pipeline.sh
+  - name: dhcp pipeline help
+    description: Verify the pipeline launcher runs and prints its usage.
+    command: dhcp-pipeline.sh -help || true

--- a/recipes/fetalsegmentation/build.yaml
+++ b/recipes/fetalsegmentation/build.yaml
@@ -1,0 +1,61 @@
+name: fetalsegmentation
+version: "20241116"
+
+copyright:
+  - license: Apache-2.0
+    url: https://github.com/SVRTK/SVRTK/blob/master/LICENSE
+  - license: GPL-3.0-only
+    url: https://github.com/SVRTK/auto-proc-svrtk/blob/main/LICENSE
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: fetalsvrtk/segmentation:general_auto_amd
+  pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
+
+  directives:
+    - run:
+        # The MONAI segmentation pipelines, atlases and trained models ship
+        # under /home in the upstream image, but /home is masked at runtime in
+        # Neurodesk. Relocate them to /opt and repoint the hard-coded paths.
+        - if [ -d /home/auto-proc-svrtk ]; then mv /home/auto-proc-svrtk /opt/auto-proc-svrtk; fi
+        - sed -i -e 's#^software_path=/home#software_path=/opt#' -e 's#/home/auto-proc-svrtk#/opt/auto-proc-svrtk#g' -e 's#^default_run_dir=/home/tmp_proc#default_run_dir=/tmp/svrtk_proc#' /opt/auto-proc-svrtk/scripts/*.sh
+
+    - environment:
+        PATH: /opt/auto-proc-svrtk/scripts:/bin/MIRTK/build/bin:/bin/MIRTK/build/lib/tools:$PATH
+
+    - deploy:
+        path:
+          - /opt/auto-proc-svrtk/scripts
+          - /bin/MIRTK/build/bin
+        bins:
+          - mirtk
+          - auto-brain-bounti-segmentation-fetal.sh
+          - auto-body-reconstruction.sh
+
+structured_readme:
+  description: >-
+    Automated 3D deep-learning (MONAI) segmentation pipelines for fetal MRI from
+    the SVRTK group at King's College London. The image provides BOUNTI (Brain
+    vOlumetry and aUtomated parcellatioN for 3D feTal MRI) fetal brain tissue
+    segmentation into 19 regions, along with fetal body organ, head/face and
+    whole-body BTFE segmentation pipelines. Inputs are typically 3D
+    super-resolution reconstructed fetal MRI volumes.
+  example: |-
+    # BOUNTI automated fetal brain tissue segmentation (19 ROIs)
+    auto-brain-bounti-segmentation-fetal.sh /data/svr_volumes /data/segmentations
+  documentation: https://hub.docker.com/r/fetalsvrtk/segmentation
+  citation: >-
+    Uus, A. U., Kyriakopoulou, V., Makropoulos, A., Fukami-Gartner, A.,
+    Cromb, D., Davidson, A., ... Deprez, M. (2023). BOUNTI: Brain vOlumetry and
+    aUtomated parcellatioN for 3D feTal MRI. bioRxiv 2023.04.18.537347.
+    https://doi.org/10.1101/2023.04.18.537347
+
+categories:
+  - image segmentation
+  - structural imaging
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAEF0lEQVR4nO2ca2gUVxTH/7uTzcbV1fisxYivoIkSE02l+II+JPWD8YNIUIiIL8RSRL+oCK1YsBjRUqEmWD9URKq0lNJShYAvxKjR1WyMRhQ1anRbY3xmH0lmN/aDZpLZR86dnTst3T2/T5k79x7O+XHuzGR2E4BhzGBLalXlzjeS8/h3+HyL4XrFF/xfpSRCUJZdKFiqyQGEa+rbYiqKiUcf3ZS4g9JFDtBnrfEFpZOcbhLULHYNSmNiBaVj93QTp3Y7NSHtiHLAW4yABRH0COLt1UMvF9xBBCyIgAURsCACFkTAgghYEAELImBBBCyIgAURsCACFkSQYWSyZ/FyFA8fGfec2tUFv9qJ+22v4Gn5G0fuNOL044fCcb721GDb5XMxc1fnF+LAR/O148eBNuQcqgQA3C9fhzHugUZK0PHx70dwxhc/x26kdZDDbsdgZxamDXsPayYX4tTCpTj06QLYbWKfTW4snIGhWf1kpSMNS7fYsolTsCp/qtBctyMTm4o+tDKdpDC0xaKpbm7C/D9/BgC4MhxYODYXh+eVQunVNUty83GgsV4o3hcF0/Ft/WU8CQWE5o89XBUzlu104sXKDbqxjTUn8d01j1DMaKR1UDCs4uidm6huvqcbH+MeJBzDleHA1uKZslKSguV3sRcd7eScjkhE+3nt5CLkDHBbmZIhpAlyZThQNiEPJTnjdOPHHtwl1x681aBJcioKviyeJSst05i6Bn02ehzerNuc8PwZ30Psqqsl4zzyt2F/oxfrC4oBACvypqKirhb3Xr80k54ULNtifwX92HrxLIJhVWj+N1cuaHMddju++mC2VakZwjJB77sGoGZRufBt/kkogO8brmrH5ROnYFL2EKvSE8aUoOrmJtiqKmCrqkDWD7sx7ZcfcdbXrJ23Adg3twQjXf2F4u3y1qJN7QQAKDYbts+YYyY9KUjroI5IBN7WFiw98Ydu3KkoKJuQJxTjWXtI97xSlpuPgqHDZaWYFNK3mC/g17qgm/EDs4XX7/Fe0h4NbHh72/8vkS5oVH833I5M3Zja1SW8/lVnB3Z7L2nHTkWRllsySBOUaVdQNGwEfppXGnOu/lmLoVh7Gzx4GgrKSs0Ulj4HAW9fT/zWdNtQ3ICqYmfdReyZ9YmZ9KRg6a8avoAfpcd/RUAVexbqTeX1OvgCfguyMoapDoomFA6jtT2IG89bcezBXRy8dR3+qAu2KO2RMHZcPY99c0tkpmiYnvcS/P0gPe++O83vpAlYEAELImBBBCyIgAURsCACFkTAgghYEAELImBBBCyIoEdQEn90n7L0csEdRMCCCPSCeJvFOIjtoHSWFKd23mIE8QWlYxclqDlxB6WTpD5qFZOQqp94CDSB2DUoFbtJsCb+F10MYyn/AOq+JyL5h+2mAAAAAElFTkSuQmCC

--- a/recipes/fetalsegmentation/fulltest.yaml
+++ b/recipes/fetalsegmentation/fulltest.yaml
@@ -1,0 +1,13 @@
+name: fetalsegmentation
+version: "20241116"
+container: fetalsegmentation_20241116_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: BOUNTI segmentation script available
+    description: Verify the automated BOUNTI brain tissue segmentation launcher is deployed.
+    command: command -v auto-brain-bounti-segmentation-fetal.sh
+    expected_output_contains: auto-brain-bounti-segmentation-fetal.sh
+  - name: mirtk available
+    description: Verify the MIRTK binary used by the pipelines is on PATH.
+    command: mirtk --version

--- a/recipes/fetalsynthseg/build.yaml
+++ b/recipes/fetalsynthseg/build.yaml
@@ -1,0 +1,85 @@
+name: fetalsynthseg
+version: 1.0.0
+
+copyright:
+  - name: FetalSynthSeg Academic Non-Commercial Research License (UNIL)
+    url: https://github.com/Medical-Image-Analysis-Laboratory/FetalSynthSeg/blob/main/LICENSE
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: vzalevskyi/fetalsynthseg:latest
+  pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
+
+  directives:
+    - run:
+        # Locate the bundled inference script at build time and expose it as a
+        # stable `fetalsynthseg` launcher (see files: below for the logic). If
+        # the code lives under /home (masked at runtime in Neurodesk) it is
+        # copied into /opt first.
+        - bash {{ get_file("setup_fetalsynthseg.sh") }}
+
+    - environment:
+        PATH: /opt/fetalsynthseg:$PATH
+
+    - deploy:
+        path:
+          - /opt/fetalsynthseg
+        bins:
+          - fetalsynthseg
+
+files:
+  - name: setup_fetalsynthseg.sh
+    contents: |
+      #!/usr/bin/env bash
+      # Expose the FetalSynthSeg inference script (predict.py) as a stable
+      # `fetalsynthseg` launcher, relocating it out of /home if necessary.
+      set -e
+      mkdir -p /opt/fetalsynthseg
+      PREDICT="$(find / -maxdepth 6 -name predict.py 2>/dev/null | head -n1)"
+      if [ -z "$PREDICT" ]; then
+        echo "ERROR: predict.py not found in image" >&2
+        exit 1
+      fi
+      WD="$(dirname "$PREDICT")"
+      case "$WD" in
+        /home/*)
+          cp -a "$WD" /opt/fetalsynthseg/app
+          WD=/opt/fetalsynthseg/app
+          ;;
+      esac
+      cat > /opt/fetalsynthseg/fetalsynthseg <<EOF
+      #!/usr/bin/env bash
+      cd "$WD"
+      exec python3 predict.py "\$@"
+      EOF
+      chmod +x /opt/fetalsynthseg/fetalsynthseg
+
+structured_readme:
+  description: >-
+    FetalSynthSeg is a deep-learning fetal brain MRI tissue segmentation tool
+    from the Medical Image Analysis Laboratory (CHUV/UNIL). It uses a domain
+    randomization (SynthSeg-style) training strategy so that a single model
+    generalises across acquisition protocols and field strengths. It is
+    optimised for super-resolution reconstructed fetal brain volumes
+    (gestational age 18-36 weeks), preferably skull-stripped. A CUDA-capable GPU
+    is recommended (run with `--nv` under Singularity/Apptainer); CPU inference
+    is possible but slow. Licensed for academic non-commercial research only.
+  example: |-
+    # Segment a reconstructed fetal brain volume
+    fetalsynthseg --model MODEL --input /data/recon.nii.gz --output /data --gpu
+  documentation: https://github.com/Medical-Image-Analysis-Laboratory/FetalSynthSeg
+  citation: >-
+    Zalevskyi, V., Sanchez, T., Roulet, M., Aviles Verdera, J., Hutter, J.,
+    Kebiri, H., & Bach Cuadra, M. (2024). Improving cross-domain brain tissue
+    segmentation in fetal MRI with synthetic data. MICCAI 2024, LNCS 15003.
+    https://doi.org/10.1007/978-3-031-72384-1_41
+
+categories:
+  - image segmentation
+  - machine learning
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAD1UlEQVR4nO2cS2gTURSG/5lJJjWN1tagJVIftSA+CkoEqdCKCIKCS18rUUQRXejGpYi4cV0R1wouBEEXXbgRqRvxgSi1BRW1VWuK1qa1ddqZ5I4LbZo0k5ybdDKtmfPtZubck5yPc++dSdICDDMXlHIGDV5stt1+I14Qu/yh5HqlB/yvUgohK0uVCao2OYB8TUUtVqMYJ4p1U8EO8oscoHitjoL8JGeaQjVLrUF+Jk+QH7tnGqfaVSrAb8x2wFOMgAURZATx9Joh2wV3EAELImBBBCyIgAURsCACFkTAgghYEAELImBBBCyIgAURBMoZFD11H8HYZun45L0LMF7ezTuvr9mO8NYDCDZtgbZ4BRRNh5gcgzCSEL+GYCX6YCV6MfWuG2Ji2DG3GzmKUZagOaOoqNt/BeH4obxLam0D1NoGINoMfW0bgAKC3cghwbxMscjOM46FeZ1DBlc6aOp9N37eOiYXrAUQ2XEi55TR04WJ7utIjQwAiopAdB1q1u9GOH4IaiRamRySeD7FgsvXQwlFMsfCGEXy7nlApDPnrK+vYH19hfHua6htOw7bNFzPIYvngtRFdTnHtmXkFJZzLWVi/PGNiuSQxfM1KD1rJ9GWNGLJ3ot/F1UPc8iS+dK+lA/tS9nmxe8khq7Gs15RxfJzj6AtXTkrMA0r0QvrWy+swdcwPz1F6seHAu/ahRwE0z9o8H6btwVGuy6h4cgNQNVmzqsagrFWBGOtwL/dyUr0YfxRJyb7HrifQ5J52ean3j7E8M2jSH1/XzQu2LgB9YevY/GucxXJIYMrU6ykbT7n1RXoq7Yh1NIBfVUcwVgrFD2cH2cLfO/cg9Twx8rkcGD+plg2tg2z/xnM/md/j1UNelMckY7TCLV0zMQpKkIt7c7FuZGjCAvrYVWkYfY/xcjtkxC/kzmX1Npl3uXIHlPyiDmi1cVQf7ATgWhzwRhbpABb5JwTxqirOWTxfoopKmo27UPNxr0wPz2B0dMFc+A50qODgEhDa1iNSPvpvHsa8/NLd3NIMn9rkKJAX9uWedouhjnwAtYXh+LcyEHg/RokLCCdkg63Er0YuXPW/RySeN5B6bEhJK7GEVrXDn31NgQbN0Crb4IarocSCMG2JiEmhmF9e4PJvgcwerrynrPcyCFLWfdBfmD6PmhhbfMLEBZEwIIIWBABCyJgQQQsiIAFEbAgAhZEwIIIWBABCyLICCrnj+6rlWwX3EEELIggRxBPs3wHeR3kZ0lOtfMUI3AU5McuKlRzwQ7yk6RitUpJqNZvPGSaQGoNqsZukq2J/0UXw1SUP6mv/y9sw82fAAAAAElFTkSuQmCC

--- a/recipes/fetalsynthseg/fulltest.yaml
+++ b/recipes/fetalsynthseg/fulltest.yaml
@@ -1,0 +1,13 @@
+name: fetalsynthseg
+version: 1.0.0
+container: fetalsynthseg_1.0.0_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: fetalsynthseg launcher available
+    description: Verify the fetalsynthseg inference launcher is deployed on PATH.
+    command: command -v fetalsynthseg
+    expected_output_contains: fetalsynthseg
+  - name: fetalsynthseg help
+    description: Verify the inference entrypoint runs and prints its usage.
+    command: fetalsynthseg --help

--- a/recipes/nesvor/build.yaml
+++ b/recipes/nesvor/build.yaml
@@ -1,0 +1,48 @@
+name: nesvor
+version: 0.5.0
+
+copyright:
+  - license: MIT
+    url: https://github.com/daviddmc/NeSVoR/blob/master/LICENSE
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: junshenxu/nesvor:v0.5.0
+  pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
+
+  directives:
+    - deploy:
+        bins:
+          - nesvor
+
+structured_readme:
+  description: >-
+    NeSVoR is a GPU-accelerated package for slice-to-volume reconstruction of
+    fetal and neonatal brain MRI. It uses an implicit neural representation to
+    reconstruct a high-resolution isotropic 3D volume from multiple stacks of
+    motion-corrupted 2D slices, supporting both rigid and deformable motion. A
+    CUDA-capable GPU is required (run the container with `--nv` under
+    Singularity/Apptainer).
+  example: |-
+    # 3D reconstruction from multiple stacks (requires a GPU)
+    nesvor reconstruct \
+      --input-stacks stack1.nii.gz stack2.nii.gz stack3.nii.gz \
+      --thicknesses 3.0 3.0 3.0 \
+      --output-volume /data/volume.nii.gz
+  documentation: https://nesvor.readthedocs.io
+  citation: >-
+    Xu, J., Moyer, D., Gagoski, B., Iglesias, J. E., Grant, P. E., Golland, P.,
+    & Adalsteinsson, E. (2023). NeSVoR: Implicit Neural Representation for
+    Slice-to-Volume Reconstruction in MRI. IEEE Transactions on Medical
+    Imaging, 42(6), 1707-1719. https://doi.org/10.1109/TMI.2023.3236216
+
+categories:
+  - image reconstruction
+  - structural imaging
+  - machine learning
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAGQ0lEQVR4nO2ce1BUVRzHv/fucmHRDXZ5CQoLwoIvIA1Mk4fPwTREppykGk0qR3uMTjXNMFRTOU01TpNT/sGUoyNqZVam4gss/9BCCRUfKCyvUDeUx67Lw32wj/4AF9Zd9tzLbs3Ens9/Z/d37jm/z/7OOfu4AFAonsCMptOa9EM2b0/kv6D0zzzB+fLu8H+VMhJ8ZbF8gsaaHIB/Tm4tjkUxrnBXTSNWkK/IAdzn6lKQL8l5wEg589qDfBknQb5YPQ9wlTtLCvA1HnZAlxgBKoiAXRBdXkMMd0EriAAVRIAKIkAFEaCCCFBBBKggAlQQASqIABVEgAoiQAURoIIIiIUEf1iahdgpwQ6P/bKjHge/rneKzc5ToLA41d7WdhiweXn56GZJYMqsEGStiEH8DBmCQwPgx7G432NGb7cJ2g4Dbql0aFV142plO7q1RkHXFiTIFUufi0fF/hb06kyeXkowDMtgXVEKsvMUTs9JZRykMg6RivGYlhYKANjx0SWcKbslaAyPl1hAoBjL1iR4eplRkVeY6FKON/G4ggBgyao4nNzXBJ1GWPl6gkjMYunz8Q6Pna9Q48iuBrSr+8CyDCJjpZiZGYHslQoEyf1HNY5XBHEBIuSuU2Lv59e8cTleRCdIIRk3NP2+nn6UvHcRVuvQF6PNtVo012pxaKcKSwviYdRbBI/jkSCzyQoxN7BKF+TH4tieJmja9YKvo0yRI3NFDJQpMsjCJOD8WfTq+tFy4x7OnVTjfIXaIXEACJT6ObSNerNTzPB5lu1uEDwvwMM96EzZTZhNVgCAmGOR91KioP5cgAgbtszCuzsykL0iBlGxA1UhErMICvHHoxkR2LBlFoq/yUBwaIBD326t46EgD5fghbdmQCrjPEnJCY8EadoNOH3wL3s7MzcaYRMDefd/9ePHMDdnEjEuIVmGN794HH7c0HTVzT3obHOs1iXPTsaXx3Pwwe4sFBanYn6+ApGK8bzn4wqPT7EjuxpgMgysbZGYxcqXk3j1S1sQiZmZE+xtq9WGH766jk3LyvFK1lF8svEPtN/usz+vSArC4lVx9rbNasOerVeclhXLMoibGozsPAXWFaXi0wMLsWXffKQtiBxVfh4L0mmMqDjQYm8/8eQkXq/avGXRDu2K/S04uqcR9zoNMBksqLvQiW+31TrEZCx37FNz9i62vl4JdUuP27FilI/gjc/Skb+e34s3HK+cYsdKG7Ho6VgEBIrBsgzy1yehtqrTbZ/YKUEO7ZyCycgpmOy2z6SER+DHsegf3PcA4Hp1J4pXn0ZiagiS54ZDmSpH3NRg+EtETv3zChNReUKNOzd7eefmFUG9OhNOftds36RnL56IbsJ7oodPIb5Ig/2dTkqbDaiv6UJ9TRcAQCRikJAiR+6LSiTPDbfHMSyD5DlhggR57cPq8X1N6OvpH5gIM3Dsu+P+YKxQWBH51kKLxYb6S13Y9naV00cgqUzYG0avVBAA6Hv7cXxvI57ZOHXgwpx79631OsgjJPb24Z0q/FRSx3u8kAkSrN40HT+X1KGt1XVFWMxW2KyOj/UJfGG8JggAyr9vRs7qeF7vRc4eu4WZWUOn2PK1SljMNpwrV0NzVw9WxCAoxB+ysAAkpMgxPT0M186342hpIwCAYRjMXhSF9IVRuHGhE1Wn/oaqpgtdd/SwWmwIjx6H3LVKp7k0XtEIysmrgox6C8p2N6Bg83RibPVvbbj8+12kzosAMLBv5K9PcnvSqAb3mOEwDDAtLdT+id0dDZc1aLqmJcYNx+tfmP36YwvudRh4xW4vqkblidujGsditsJitpIDB7mp0mF7UbXgcbxaQQDQb7Li8C4V1ryTQow1GSwoef8iyve3IPOpaCSkyBEWKQEnEUPf249urRHadgMarmhQd6ELjVeHloe2w4DXlpzAjDnhSEyVIyYxCGFRgZAGc/DjWJiMVnRrjGit16H6dBuqTqlhsQi/w8d+JND7gxx5cO80/U6aABVEgAoiQAURoIIIUEEEqCACVBABKogAFUSACiJABRGgggjYBY3mj+7HKsNd0AoiQAURcBBEl5mzA6cK8mVJrnKnS4yAS0G+WEUj5TxiBfmSJHe58pIwVn/x4FMEvPagsVhNfHOi/6KLQvlX+Qegbgz23PpDlQAAAABJRU5ErkJggg==

--- a/recipes/nesvor/fulltest.yaml
+++ b/recipes/nesvor/fulltest.yaml
@@ -1,0 +1,10 @@
+name: nesvor
+version: 0.5.0
+container: nesvor_0.5.0_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: nesvor available
+    description: Verify the nesvor entrypoint is installed and reports its help.
+    command: nesvor --help
+    expected_output_contains: reconstruct

--- a/recipes/niftymic/build.yaml
+++ b/recipes/niftymic/build.yaml
@@ -1,0 +1,58 @@
+name: niftymic
+version: 0.9
+
+copyright:
+  - license: BSD-3-Clause
+    url: https://github.com/gift-surg/NiftyMIC/blob/master/LICENSE
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: renbem/niftymic:v0.9
+  pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
+
+  directives:
+    - deploy:
+        bins:
+          - niftymic_run_reconstruction_pipeline
+          - niftymic_reconstruct_volume
+          - niftymic_reconstruct_volume_from_slices
+          - niftymic_segment_fetal_brains
+          - niftymic_correct_bias_field
+          - niftymic_register_image
+
+structured_readme:
+  description: >-
+    NiftyMIC is a Python-based research toolkit developed within the GIFT-Surg
+    project for motion-corrected super-resolution reconstruction (SRR) of fetal
+    brain MRI. It reconstructs an isotropic, high-resolution volume from
+    multiple, possibly motion-corrupted, stacks of low-resolution 2D slices and
+    includes automatic fetal brain segmentation (MONAIfbs), bias-field
+    correction and volumetric registration.
+  example: |-
+    # Fully automated reconstruction pipeline from multiple stacks
+    niftymic_run_reconstruction_pipeline \
+      --filenames stack1.nii.gz stack2.nii.gz stack3.nii.gz \
+      --dir-output /data/output
+
+    # Automatic fetal brain masking
+    niftymic_segment_fetal_brains \
+      --filenames stack1.nii.gz \
+      --filenames-masks stack1_mask.nii.gz
+  documentation: https://github.com/gift-surg/NiftyMIC
+  citation: >-
+    Ebner, M., Wang, G., Li, W., Aertsen, M., Patel, P. A., Aughwane, R.,
+    Melbourne, A., Doel, T., Dymarkowski, S., De Coppi, P., David, A. L.,
+    Deprest, J., Ourselin, S., & Vercauteren, T. (2020). An automated framework
+    for localization, segmentation and super-resolution reconstruction of fetal
+    brain MRI. NeuroImage, 206, 116324.
+    https://doi.org/10.1016/j.neuroimage.2019.116324
+
+categories:
+  - image reconstruction
+  - structural imaging
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAE+0lEQVR4nO2cT2gTWRzHvzOZNG3Spk2zaZKNa7WVWqQWwV5MwRZBWhsriAoKoeJJ0EMFvSl4UfCgB4+KIPhfUVS0pVpatOJWDwt7WLB/dKG2qU0y2URN2pi00z1IJxnz500m48Im73PqezPzm9/75PdeeNNpAQolHxglF/3e3r6sdiL/Bc4XL3Ier+wL/q9SMiFXFivnpEKTA8gfU1aLhSgmHdmqKWMFFYscIPtY0woqJjkrZBqzrDWomEkRVIzVs0K6sbOkE4qNHx3QKUaACiIgCqLTK0GyC1pBBKggAlQQASqIABVEgAoiQAURoIIIUEEEqCACVBABKogAFUSAk3NS86VLMDQ0SPpmrl3D9NWrKefWuFyoP3FCbMd4Hn/s20eMBwB/9vRgYXo6bQ6Vmzdjw/nzKf2BkRFMnD4tZxiKUFxB9r17wRmNauYCa3e3omM/E8WCNHo9HAcOqJkLLB0dYLXalH6tyYTq1lZV7yWXvNYg2+7d0JpMauUCzmhE9datKf01XV1gOFmrgerkJYjV6eBwu9XKBQBg3bVL2sEwsLpcqt4jFxR9LEI8Lk4Fa3c3Zu/cQczvV5xEeHwc5evXAwCMzc0oW70aCx8/AgCqWlqgs9sT546NobyxUVZcQ309LDt2wLhxI3R2OzRlZYgHg4h6PAi8fAl+aAiLX79mjaGogvwDAxDi8e8BtFqs6ulREkYkODqKGM+LbevOnYmfkxbn8Pg4IpOTxHisVou648fRfOUK7Hv2wNDQAK6iAgzHocRigXHTJqzt7cWao0fJsXIcCwAg5vfD++SJ2K7p7ERp0qecM4IAX3+/2LR0doItKUGJ2QyT0yn2J98zG+tOnpRIzgfFK5/nxg1YXS6wOh0YjsOqgwfx/tw5xYl4+/rgcLvBsCy4igqY29qgs9nAaDQAgKX5efBDQ+JUzER1ayvMbW2SvoWpKUxdvozw2BiEaBSlDgeqWlqgMRiIeSkWFA8GMffwIX7dvx8A8Mv27fDcvKk0HGI+H0Jv38K0ZQuA74t1icUiHucHByFEo8Q4lo4OaZ6hEP7q7cXi589iX2RyUtZUBfL8FvPcvo2l+XkAAMOy+O3QoXzCSaZQRVMTdFZr2mPZMPxQYYHhYYmcXMlL0OKXL/h0/77YNre3Q19Xpzhe8M0bxHy+lP7wu3eIfPggKwZXXi5pR+fmFOcDqLBZnb13L/FVyTD5bQmWl+Ht60vplls9ALAYDkvapTab8nyggqClSASzd+8mAqbZKuSCr78fy4Igic8PD8u+PjIxIWmbt20DV1mpOB9VHnd8evAA8VBIjVCI8TyCo6Ni2//8OYRv32Rf7x8YkLS1VVVoungRJqcTWpMJGr0ehvp6ONxu1B4+TIynygZHiEbhuXULa44cUSMcxk+dUnztP69fIzAyAnPSnq6sthaNZ8+mnOt/9owYT7UHZt7HjxELBNQKlxfvz5yB9+lTVWKptkUWYjF4rl/H2mPH1AqpPJd4HH9fuADvo0ewdHUl9mKlpYiHQojOzCDw6hX4wUFiLPH9YPp+kJSVd6fpM2kCVBABKogAFUSACiJABRGggghQQQSoIAJUEAEqiAAVRIAKIiAKUvJH94VKsgtaQQSoIAISQXSapTpIqaBilpRu7HSKEUgrqBirKNOYM1ZQMUnKNlZZEgr1Nx5yikDWGlSI1SR3TPRfdFEoP5V/AUxsgrwFSABUAAAAAElFTkSuQmCC

--- a/recipes/niftymic/fulltest.yaml
+++ b/recipes/niftymic/fulltest.yaml
@@ -1,0 +1,13 @@
+name: niftymic
+version: 0.9
+container: niftymic_0.9_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: reconstruction pipeline available
+    description: Verify the main NiftyMIC reconstruction pipeline launcher is on PATH.
+    command: command -v niftymic_run_reconstruction_pipeline
+    expected_output_contains: niftymic_run_reconstruction_pipeline
+  - name: reconstruction help
+    description: Verify the volume reconstruction entrypoint runs and prints help.
+    command: niftymic_reconstruct_volume --help

--- a/recipes/svrtk/build.yaml
+++ b/recipes/svrtk/build.yaml
@@ -1,0 +1,71 @@
+name: svrtk
+version: "20260626"
+
+copyright:
+  - license: Apache-2.0
+    url: https://github.com/SVRTK/SVRTK/blob/master/LICENSE
+  - license: GPL-3.0-only
+    url: https://github.com/SVRTK/auto-proc-svrtk/blob/main/LICENSE
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: fetalsvrtk/svrtk:general_auto_amd
+  pkg-manager: apt
+  add-default-template: false
+  add-tzdata: false
+
+  directives:
+    - run:
+        # The automated processing scripts, atlases and trained models ship
+        # under /home in the upstream image, but /home is masked at runtime in
+        # Neurodesk. Relocate them to /opt and repoint the hard-coded paths.
+        - if [ -d /home/auto-proc-svrtk ]; then mv /home/auto-proc-svrtk /opt/auto-proc-svrtk; fi
+        - sed -i -e 's#^software_path=/home#software_path=/opt#' -e 's#/home/auto-proc-svrtk#/opt/auto-proc-svrtk#g' -e 's#^default_run_dir=/home/tmp_proc#default_run_dir=/tmp/svrtk_proc#' /opt/auto-proc-svrtk/scripts/*.sh
+
+    - environment:
+        PATH: /opt/auto-proc-svrtk/scripts:/bin/MIRTK/build/bin:/bin/MIRTK/build/lib/tools:$PATH
+
+    - deploy:
+        path:
+          - /opt/auto-proc-svrtk/scripts
+          - /bin/MIRTK/build/bin
+        bins:
+          - mirtk
+          - auto-brain-reconstruction.sh
+          - auto-body-reconstruction.sh
+          - auto-thorax-reconstruction.sh
+          - auto-brain-bounti-segmentation-fetal.sh
+
+structured_readme:
+  description: >-
+    SVRTK (Slice-to-Volume Reconstruction ToolKit) is a MIRTK-based C++ toolkit
+    from King's College London for motion-corrected super-resolution
+    reconstruction of fetal and neonatal MRI (brain, body, thorax, heart,
+    placenta and diffusion). This container bundles the compiled MIRTK/SVRTK
+    tools together with the automated deep-learning driven processing scripts
+    (auto-proc-svrtk), including the BOUNTI fetal brain tissue segmentation
+    pipeline.
+  example: |-
+    # Automated 3D fetal brain SVR reconstruction from stacks of 2D slices
+    auto-brain-reconstruction.sh /data/input_stacks /data/output_recon
+
+    # BOUNTI automated fetal brain tissue segmentation of a 3D SVR volume
+    auto-brain-bounti-segmentation-fetal.sh /data/svr_volumes /data/segmentations
+
+    # Manual reconstruction with MIRTK
+    mirtk reconstruct output.nii.gz 3 stack1.nii.gz stack2.nii.gz -thickness 2.5 2.5
+  documentation: https://github.com/SVRTK/SVRTK
+  citation: >-
+    Kuklisova-Murgasova, M., Quaghebeur, G., Rutherford, M. A., Hajnal, J. V., &
+    Schnabel, J. A. (2012). Reconstruction of fetal brain MRI with intensity
+    matching and complete outlier removal. Medical Image Analysis, 16(8),
+    1550-1564. https://doi.org/10.1016/j.media.2012.07.004
+
+categories:
+  - image reconstruction
+  - structural imaging
+  - body
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAG3klEQVR4nO2ce0xTVxzHv7ctFBDKGyrUgQ8eTnRM5bEoio8NHxh1mct0i4nTRWecMZnZ9sfcEk2WLJluLsZHtsVEs7lk04nvmSgkvlAYGpw8KoKjtCliwRZogba3+4O0cNp7e+5lbsngfP7r7zzu+X35nd85vz4AGIx/AjeSQRkbf/M874X8Fzz8YbVsfyUP+L+KIoZUsRRSOo02cQDpPgVVcTQKI0SwaBKNoLEiDhDcV0GBxpI4XsR8lpSDxjIBAo3F6PEi5LuC1mGs4a8B22IUmEAUfAKx7TXEcC1YBFFgAlFgAlFgAlFgAlFgAlFgAlFgAlFgAlFgAlFgAlFgAlFgAlFQjWRQflYC3piThtzJsUiKCUOoSgGb3QlrrxPtzxyoN9hQb3iGa/efwNLdDwA4sr0QC2ZofXM8NHVj+WdXgj6nMDsBx3bOJWwb9t3EjbonAIBTu4qRkxYjONbl5tHb74ahoxd3mzrx6/W/UG+wyvZVlkAKjsOe9blYU5QW0BYXpUZclBoTtZEozE4EAHxytAanbrQCAMpuGQiBMlKikKnTQN9mE31eab6OeN1h7UNlQ4ektaqUCkRHKBCdFoOctBi8s3AS9pfV4+C5RknjvcjaYltLswTFkcKVe2b0OFyEbUWBTqT3oIMls1II27nbbXDzI3vbiuOAHaumIi8zXtY4yRGkUirw7mtTCNuFKiMOnW9Ea0cvlAoOk7RRWPiSFm/OS0eCRk307Xe6cbnGhNfnvOCzlebpsPdkneDziqYlIXpcKGErqzQEXeO1B0+w8eubUHAckmLCsGnJFKxfNJnos7JwAqr0Fqq/XiRHUJZOg8jwIT2tdic+/K4ajW02OPrd6HG4UNvShW9O16P4o9+x92QdHP1uYg5/B1MTIjBzcpzg80r9oqvJ1I26Vmk5hPd4YO5y4Iuf/4S5y0G0vZAUKWkOL5IF0kSEEK8d/S7RcB9w8ThyUY+L1UbCfrvhKdq7+gibvxAAEB6qxOLc8YSNFj1C8B4PTBY7YesbcIn0FkayQN7TyIs2Nhyfrp2OuCi1yIhAeI8H5+60EbalealQKsiPxhfmjke4Wul77fEM5h+5KDgOqfHjCJve2C1rDsk5qMnYDaPFjtT4CJ9t/aLJeHvBJNS3WlFvsKK2pQt39E/RYu4Rnef0rVZsLBnKZfFRarwyNRHXHzzx2fxPr+qHFhj9IiEYw3NQcmyYzz7g4vFTebPkeQAZAvEeD3b/WIuD2wqIv7hSwSEnPQY56TG+E67BYMWBs424XGMKmKexzQZ9mw2ZOo3PtqJA5xNIExGCeTlJxBip26toWhL0368SbLPZndh++A5MnQ7BdjFkHfPltWZs2HcTTabgYZo9IRoHtuZj+8pswfYzt0mHX305BeqQwS1VMisFIaqhZQ24eFzyy2VyaTH3YOXuctysk3aHGo7sUqOyoQPLP7+CdV9ew+HzetxpfBpwWnnZWpqF9OTAU+NMZRt4z1CCjwxXYf70ZACB26ui1gyb3Sl3mQQTtZE48XGR4FpojKjU8HgG80L1w8H7hFLBYeaUOGxelol5Ocm+fgqOQ1FOEh63kznJ3OVAld6CgqwEn21FgQ53H3Uif5gNkHd6ee9BmogQLM/XYdfa6VApB2NAGxuOb7fkYfWeClmXzedSrLp5D6r0Frx/4Dae9QwQbWKn3Bk/x4tnJGNNURqR36x2Jypq22Wvx2Z34kRFC77yu4RmT4iWXQlIFiglLhz7t+RholY8TF1untg6AGDrHRDse6nahH7n0NZUhyixtTTLr48RThcvdYkBHL/aHHD6bV6WGXCtCIZkgTgFh6WzU3Fpz2Ic2zkHb81PR0ZKFMaFqRAWqkSmToO9780OiJi7j7oE5+t2OFHuFx2hKnI5ZbfkXw6H43TxOHr5EWFLjY8IWgP6IzsHcRxQmJ3oq9iDUdNkwb3mTtH2M7cMWOJXkHoxWuz4o0l6zSTGL9ceY9uKLMREDtV1m5ZkoKzSAI+EVCQ5glxuHi639HCvN1jxwaGqoH0q7rcH5CwvZyvbJDlAwzHgxvGr5OUwM1WD4ulakREkkiOovasP+TsuYO6LSZiVEY+pE6KhSxyH2MhQqEMU6B/g8dTWh7pWKy7XmHChykg9LVxuHheqjVhXPDGgbSS1lxjHrzZjU0kGUb5sXpaB8lozdawvW7HvB5F4vzvN3pOmwASiwASiwASiwASiwASiwASiwASiwASiwASiwASiwASiwASi4BNoJD+6H60M14JFEAUmEAVCILbNAjUIiKCxLJKQ72yLURAUaCxGkZjPohE0lkQK5qskEUbrJx5SgkBSDhqN0STVJ/YvuhiMf5W/AedqaTAEZv6SAAAAAElFTkSuQmCC

--- a/recipes/svrtk/fulltest.yaml
+++ b/recipes/svrtk/fulltest.yaml
@@ -1,0 +1,17 @@
+name: svrtk
+version: "20260626"
+container: svrtk_20260626_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: mirtk available
+    description: Verify the MIRTK/SVRTK reconstruction binary is on PATH.
+    command: mirtk --version
+  - name: auto brain reconstruction script available
+    description: Verify the automated brain reconstruction launcher is deployed.
+    command: command -v auto-brain-reconstruction.sh
+    expected_output_contains: auto-brain-reconstruction.sh
+  - name: BOUNTI segmentation script available
+    description: Verify the automated BOUNTI brain tissue segmentation launcher is deployed.
+    command: command -v auto-brain-bounti-segmentation-fetal.sh
+    expected_output_contains: auto-brain-bounti-segmentation-fetal.sh


### PR DESCRIPTION
## Summary

Adds container recipes for fetal MRI super-resolution reconstruction (SRR), fetal brain segmentation, and neonatal structural processing. Each wraps the upstream Docker image (the established pattern in this repo, as with `micapipe`/`fmriprep`/`xcpd`) and ships a `build.yaml` plus a focused `fulltest.yaml`.

### Super-resolution reconstruction
- **svrtk** — SVRTK/MIRTK slice-to-volume reconstruction plus the automated `auto-proc-svrtk` pipelines and BOUNTI brain tissue segmentation (`fetalsvrtk/svrtk:general_auto_amd`)
- **niftymic** — GIFT-Surg NiftyMIC motion-corrected SRR (`renbem/niftymic:v0.9`)
- **nesvor** — GPU-accelerated implicit-neural-representation SRR (`junshenxu/nesvor:v0.5.0`)

### Fetal brain segmentation
- **fetalsegmentation** — MONAI deep-learning fetal MRI segmentation incl. BOUNTI (`fetalsvrtk/segmentation:general_auto_amd`)
- **fetalsynthseg** — domain-randomized fetal brain tissue segmentation (`vzalevskyi/fetalsynthseg`)

### Neonatal
- **dhcpstructuralpipeline** — dHCP neonatal structural pipeline (`biomedia/dhcp-structural-pipeline`)

## Notes for reviewers

- **`/home` masking:** The SVRTK-based images (`svrtk`, `fetalsegmentation`) install scripts, atlases and trained models under `/home/auto-proc-svrtk`, which is masked at runtime in Neurodesk. Both recipes relocate that tree to `/opt` and repoint the hard-coded paths (`software_path`, `default_run_dir`) inside the scripts. MIRTK already lives at `/bin/MIRTK` in these images and is left in place.
- **FetalSynthSeg** has no console entrypoint — the image runs `python3 predict.py` from an image-specific working directory. A build-time helper locates `predict.py`, relocates it out of `/home` if necessary, and exposes a stable `fetalsynthseg` launcher.
- **License note:** FetalSynthSeg is released under a custom **academic non-commercial** research license (recorded in its recipe) rather than an SPDX identifier — flagging in case that affects distribution.

## Validation

All six recipes pass `builder/validation.py`, generate Dockerfiles cleanly via `python -m builder generate`, and are codespell-clean. The container builds themselves (5–15 GB GPU/CPU images) were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ac1TH5Jvr6ggLfShd5f3F

---
_Generated by [Claude Code](https://claude.ai/code/session_014ac1TH5Jvr6ggLfShd5f3F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container recipes for DHCP Structural Pipeline, Fetal Segmentation, Fetal SynthSeg, NeSVoR, NiftyMIC, and SVRTK.
  * Included packaged documentation, usage examples, citations, categories, and application icons.
  * Exposed the primary command-line tools and launchers for each application.

* **Tests**
  * Added automated checks confirming the tools are available and can display help or version information.
  * Added validation for key fetal imaging and reconstruction workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->