### PR TITLE
Add release for svrtk 20260626

### DIFF
--- a/recipes/fetalsegmentation/fulltest.yaml
+++ b/recipes/fetalsegmentation/fulltest.yaml
@@ -10,4 +10,5 @@ tests:
     expected_output_contains: auto-brain-bounti-segmentation-fetal.sh
   - name: mirtk available
     description: Verify the MIRTK binary used by the pipelines is on PATH.
-    command: mirtk --version
+    command: mirtk --help
+    expected_output_contains: "Usage:"

--- a/recipes/svrtk/fulltest.yaml
+++ b/recipes/svrtk/fulltest.yaml
@@ -6,7 +6,8 @@ default_timeout: 120
 tests:
   - name: mirtk available
     description: Verify the MIRTK/SVRTK reconstruction binary is on PATH.
-    command: mirtk --version
+    command: mirtk --help
+    expected_output_contains: "Usage:"
   - name: auto brain reconstruction script available
     description: Verify the automated brain reconstruction launcher is deployed.
     command: command -v auto-brain-reconstruction.sh

--- a/releases/svrtk/20260626.json
+++ b/releases/svrtk/20260626.json
@@ -1,0 +1,14 @@
+{
+  "apps": {
+    "svrtk 20260626": {
+      "version": "20260716",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "image reconstruction",
+    "structural imaging",
+    "body"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **svrtk 20260626**.

## Changes

- Add `releases/svrtk/20260626.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh svrtk 20260626 20260716
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/svrtk_20260626_20260716.simg -O
singularity shell --overlay /tmp/apptainer_overlay svrtk_20260626_20260716.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @stebo85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the SVRTK 20260626 application release manifest.
  * Classified the release under image reconstruction, structural imaging, and body imaging.
* **Tests**
  * Updated the SVRTK and fetal segmentation availability checks to verify `mirtk` by validating its help/usage output (instead of relying on version output).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->