### PR TITLE
Create build.yaml for brainles-preprocessing

### DIFF
--- a/brainles-preprocessing/build.yaml
+++ b/brainles-preprocessing/build.yaml
@@ -1,0 +1,57 @@
+name: brainles-preprocessing
+version: 0.6.10
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAABOUlEQVR42u3dsRHCMAwF0CxBywhUDMQajMIATMQSrAAVC3CHogQnsp9OdYp39p2U4nualFK7rMPxVKiJbOrVE83KTL3SrMM0gk7eaBydjNFoOvOMxtSZYQSIzgIjQHQWGKEBBAjQZkBcfhglvnK5v6t0U6BCLmmpPFBpnbhREqgDnaARIEDtgbrRiRg5Qa4YoD0CmYNM0naxlkC2eUCAAAECBAgQIEBf+/y4VemmQIVc0lJ5oNI6caMkUAc6QSNAgNoDdaMTMXKCXDFAewQyB5mk7WK2eb87AAECBAgQIECANgd6Xl9VuilQIZe0VB6otE7cKAnUgU7QCBCg9kDd6ESMnCBXDNAegcxBJmm7mPAF2R2AAAESYyYFDxAjSZx/AhJ2y2ixjsBtRmvoCP33bIRnNlqKKKXm1wc7XnMcuYuNogAAAABJRU5ErkJggg==
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+  base-image: ubuntu:22.04
+  pkg-manager: apt
+
+  directives:
+    - install:
+        - git
+        - wget
+        - ca-certificates
+        - unzip
+
+    - template:
+        name: miniconda
+        version: latest
+        conda_install: "python=3.11 pip"
+        env_name: brainles
+        env_exists: "false"
+
+    - run:
+        # Core library. antspyx (registration) + SimpleITK ship self-contained
+        # manylinux wheels, so no extra system libraries are needed on x86_64.
+        - /opt/miniconda-latest/envs/brainles/bin/python -m pip install --no-cache-dir brainles-preprocessing=={{ context.version }}
+        - /opt/miniconda-latest/envs/brainles/bin/python -c "import brainles_preprocessing; print('brainles-preprocessing OK')"
+
+    - environment:
+        PATH: /opt/miniconda-latest/envs/brainles/bin:$PATH
+
+deploy:
+  path:
+    - /opt/miniconda-latest/envs/brainles/bin
+
+tests:
+  - name: "import brainles_preprocessing"
+    script: |
+      python -c "import brainles_preprocessing; from brainles_preprocessing.preprocessor import Preprocessor; print('ok')"
+
+categories:
+  - image registration
+  - structural imaging
+
+readme: |
+  ----------------------------------
+  ## brainles-preprocessing/{{ context.version }} ##
+  brainles-preprocessing (BrainLesion Suite) provides a preprocessing pipeline
+  for brain MRI: co-registration, atlas alignment, skull-stripping, defacing
+  and intensity normalization.
+
+  This is a Python library (no command-line tool). It is configured in code via
+  Modality / Preprocessor classes:

--- a/brainles-preprocessing/build.yaml
+++ b/brainles-preprocessing/build.yaml
@@ -19,23 +19,23 @@ build:
 
     - template:
         name: miniconda
-        version: latest
-        conda_install: "python=3.11 pip"
+        version: py311_24.9.2-0
+        conda_install: "python=3.11.10 pip=24.2"
         env_name: brainles
         env_exists: "false"
 
     - run:
         # Core library. antspyx (registration) + SimpleITK ship self-contained
         # manylinux wheels, so no extra system libraries are needed on x86_64.
-        - /opt/miniconda-latest/envs/brainles/bin/python -m pip install --no-cache-dir brainles-preprocessing=={{ context.version }}
-        - /opt/miniconda-latest/envs/brainles/bin/python -c "import brainles_preprocessing; print('brainles-preprocessing OK')"
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -m pip install --no-cache-dir brainles-preprocessing=={{ context.version }}
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import brainles_preprocessing; print('brainles-preprocessing OK')"
 
     - environment:
-        PATH: /opt/miniconda-latest/envs/brainles/bin:$PATH
+        PATH: /opt/miniconda-py311_24.9.2-0/envs/brainles/bin:$PATH
 
 deploy:
   path:
-    - /opt/miniconda-latest/envs/brainles/bin
+    - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin
 
 tests:
   - name: "import brainles_preprocessing"
@@ -55,3 +55,23 @@ readme: |
 
   This is a Python library (no command-line tool). It is configured in code via
   Modality / Preprocessor classes:
+
+  ```
+  ml brainles-preprocessing/{{ context.version }}
+  python -c "from brainles_preprocessing.preprocessor import Preprocessor; print('ok')"
+  ```
+
+  Registration uses the bundled antspyx backend (CPU) out of the box.
+  Brain extraction backends (HD-BET, SynthStrip) and extra registration
+  backends (greedy, elastix) are optional extras and are NOT installed here to
+  keep the image lean. HD-BET is available as its own Neurodesk module
+  (`ml hdbet`) and can be used alongside this one.
+
+  Docs: https://github.com/BrainLesion/preprocessing
+
+  To run container outside of this environment: ml brainles-preprocessing/{{ context.version }}
+  ----------------------------------
+
+copyright:
+  - license: Apache-2.0
+    url: https://github.com/BrainLesion/preprocessing/blob/main/LICENSE


### PR DESCRIPTION
Add build configuration for brainles-preprocessing with dependencies and testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the containerized BrainLes Preprocessing build to target **x86_64** on **Ubuntu 22.04** with a **fresh Python 3.11** environment.
  * Installs required system tools and the **brainles-preprocessing** package pinned to the specified version.
  * Sets up runtime paths and exports the environment binaries for use.

* **Tests**
  * Added automated import validation, including verification of `Preprocessor`, to confirm preprocessing is available.

* **Documentation**
  * Added/updated embedded usage documentation describing the preprocessing pipeline and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->