### PR TITLE
Add first-class named container variants

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -16,6 +16,9 @@ on:
       variant:
         required: false
         type: string
+      architecture:
+        required: true
+        type: string
       runner:
         required: true
         type: string
@@ -149,11 +152,10 @@ jobs:
             echo "Recipe version not found for $APPLICATION"
             exit 1
           fi
-          ARCHITECTURE="x86_64"
+          ARCHITECTURE="${{ inputs.architecture }}"
           IMAGE_SUFFIX=""
           RELEASE_VERSION="$VERSION"
-          if [[ "${{ inputs.runner }}" == *"arm"* ]]; then
-            ARCHITECTURE="aarch64"
+          if [ "$ARCHITECTURE" = "aarch64" ]; then
             IMAGE_SUFFIX="_arm64"
             RELEASE_VERSION="${VERSION}-arm64"
           fi

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -13,6 +13,9 @@ on:
       application:
         required: true
         type: string
+      variant:
+        required: false
+        type: string
       runner:
         required: true
         type: string
@@ -68,6 +71,9 @@ jobs:
       VERSION: ${{ steps.envars.outputs.VERSION }}
       ARCHITECTURE: ${{ steps.envars.outputs.ARCHITECTURE }}
       IMAGE_SUFFIX: ${{ steps.envars.outputs.IMAGE_SUFFIX }}
+      CONTAINER_NAME: ${{ steps.envars.outputs.CONTAINER_NAME }}
+      VARIANT: ${{ steps.envars.outputs.VARIANT }}
+      IMAGENAME: ${{ steps.envars.outputs.IMAGENAME }}
       RELEASE_VERSION: ${{ steps.envars.outputs.RELEASE_VERSION }}
       IMAGE_FINGERPRINT_CACHE: ${{ steps.getfingerprint.outputs.IMAGE_FINGERPRINT_CACHE }}
     steps:
@@ -132,6 +138,11 @@ jobs:
         id: envars
         run: |
           APPLICATION=${{ inputs.application }}
+          VARIANT=${{ inputs.variant }}
+          CONTAINER_NAME="$APPLICATION"
+          if [ -n "$VARIANT" ]; then
+            CONTAINER_NAME="${APPLICATION}_${VARIANT}"
+          fi
           SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)
           VERSION=$(sed -n 's/^version:[[:space:]]*//p' "recipes/${APPLICATION}/build.yaml" | head -1 | sed 's/[[:space:]]#.*$//' | tr -d "\"'")
           if [ -z "$VERSION" ]; then
@@ -146,6 +157,11 @@ jobs:
             IMAGE_SUFFIX="_arm64"
             RELEASE_VERSION="${VERSION}-arm64"
           fi
+          if [ -n "$VARIANT" ]; then
+            IMAGE_SUFFIX=""
+            RELEASE_VERSION="$VERSION"
+          fi
+          IMAGENAME="${CONTAINER_NAME}_${VERSION}${IMAGE_SUFFIX}"
           # Get the commit date of the recipe's build.yaml file
           # This ensures consistent build dates based on when the recipe was last modified
           BUILDDATE=$(git log -1 --format=%ad --date=format:%Y%m%d -- recipes/${APPLICATION}/build.yaml)
@@ -154,6 +170,12 @@ jobs:
             BUILDDATE=`date +%Y%m%d`
           fi
           echo "APPLICATION=$APPLICATION" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_OUTPUT
+          echo "VARIANT=$VARIANT" >> $GITHUB_ENV
+          echo "VARIANT=$VARIANT" >> $GITHUB_OUTPUT
+          echo "IMAGENAME=$IMAGENAME" >> $GITHUB_ENV
+          echo "IMAGENAME=$IMAGENAME" >> $GITHUB_OUTPUT
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -184,22 +206,24 @@ jobs:
         id: generate
         run: |
           echo "APPLICATION: $APPLICATION"
-          python3 -m builder stage "$APPLICATION" --recreate --architecture "$ARCHITECTURE"
+          VARIANT_ARGS=()
+          if [ -n "$VARIANT" ]; then
+            VARIANT_ARGS=(--variant "$VARIANT")
+          fi
+          python3 -m builder stage "$APPLICATION" --recreate --architecture "$ARCHITECTURE" "${VARIANT_ARGS[@]}"
 
       - name: Set image variables
         id: imgvars
         env:
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
         run: |
-          DOCKERFILE_PATH=$(find "./build/$APPLICATION/" -type f -iname "*.dockerfile" | head -1)
+          DOCKERFILE_PATH=$(find "./build/$CONTAINER_NAME/" -type f -iname "*.dockerfile" | head -1)
           # if the dockerfile is not found, exit with error
           if [ -z "$DOCKERFILE_PATH" ]; then
             echo "Dockerfile not found for $APPLICATION"
             exit 1
           fi
           DOCKERFILE=$(basename "$DOCKERFILE_PATH")
-          BASE_IMAGENAME=$(echo "${DOCKERFILE%.*}" | tr '[:upper:]' '[:lower:]')
-          IMAGENAME="${BASE_IMAGENAME}${IMAGE_SUFFIX}"
           echo "DOCKERFILE: $DOCKERFILE"
           echo "IMAGENAME: $IMAGENAME"
           echo "DOCKERFILE=$DOCKERFILE" >> "$GITHUB_ENV"
@@ -250,6 +274,10 @@ jobs:
       SHORT_SHA: ${{ needs.config.outputs.SHORT_SHA }}
       ARCHITECTURE: ${{ needs.config.outputs.ARCHITECTURE }}
       IMAGE_SUFFIX: ${{ needs.config.outputs.IMAGE_SUFFIX }}
+      CONTAINER_NAME: ${{ needs.config.outputs.CONTAINER_NAME }}
+      VERSION: ${{ needs.config.outputs.VERSION }}
+      VARIANT: ${{ needs.config.outputs.VARIANT }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
     steps:
       - name: Set runner base path
         run: |
@@ -339,22 +367,24 @@ jobs:
         id: generate
         run: |
           echo "APPLICATION: $APPLICATION"
-          python3 -m builder stage "$APPLICATION" --recreate --download --architecture "$ARCHITECTURE"
+          VARIANT_ARGS=()
+          if [ -n "$VARIANT" ]; then
+            VARIANT_ARGS=(--variant "$VARIANT")
+          fi
+          python3 -m builder stage "$APPLICATION" --recreate --download --architecture "$ARCHITECTURE" "${VARIANT_ARGS[@]}"
 
       - name: Set image variables
         id: imgvars
         env:
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
         run: |
-          DOCKERFILE_PATH=$(find "./build/$APPLICATION/" -type f -iname "*.dockerfile" | head -1)
+          DOCKERFILE_PATH=$(find "./build/$CONTAINER_NAME/" -type f -iname "*.dockerfile" | head -1)
           # if the dockerfile is not found, exit with error
           if [ -z "$DOCKERFILE_PATH" ]; then
             echo "Dockerfile not found for $APPLICATION"
             exit 1
           fi
           DOCKERFILE=$(basename "$DOCKERFILE_PATH")
-          BASE_IMAGENAME=$(echo "${DOCKERFILE%.*}" | tr '[:upper:]' '[:lower:]')
-          IMAGENAME="${BASE_IMAGENAME}${IMAGE_SUFFIX}"
           echo "DOCKERFILE: $DOCKERFILE"
           echo "IMAGENAME: $IMAGENAME"
           echo "DOCKERFILE=$DOCKERFILE" >> $GITHUB_ENV
@@ -378,7 +408,7 @@ jobs:
         uses: useblacksmith/setup-docker-builder@v1
 
       - name: Debug Dockerfile
-        run: cat ./build/${APPLICATION}/${DOCKERFILE}
+        run: cat ./build/${CONTAINER_NAME}/${DOCKERFILE}
 
       - name: Debug storage
         run: |
@@ -392,8 +422,8 @@ jobs:
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
           IS_BLACKSMITH_RUNNER: ${{ contains(inputs.runner, 'blacksmith') }}
         run: |
-          cd "./build/${APPLICATION}"
-          CACHE_REF=ghcr.io/${GH_REGISTRY}/${APPLICATION}${IMAGE_SUFFIX}:buildcache
+          cd "./build/${CONTAINER_NAME}"
+          CACHE_REF=ghcr.io/${GH_REGISTRY}/${CONTAINER_NAME}:buildcache
           CACHE_FROM_ARGS=()
           CACHE_TO_ARGS=()
           if [ "${IS_BLACKSMITH_RUNNER}" = "true" ]; then
@@ -557,7 +587,7 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
 
     steps:
       - name: Configure GitHub-hosted runner
@@ -628,7 +658,7 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
       NECTAR_REGISTRY: registry.rc.nectar.org.au
       NECTAR_REGISTRY_NAMESPACE: ssdsorg
 
@@ -685,7 +715,7 @@ jobs:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
       IMAGETAG: ${{ needs.config.outputs.IMAGETAG }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
 
     steps:
       - name: Set runner base path
@@ -838,7 +868,7 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
 
     steps:
       - name: Bootstrap build tooling
@@ -924,7 +954,7 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
       AWSCLI_ARCH: x86_64
     steps:
       - name: Configure runner
@@ -971,11 +1001,11 @@ jobs:
     permissions:
       packages: write
     env:
-      APPLICATION: ${{ inputs.application }}
+      APPLICATION: ${{ needs.config.outputs.CONTAINER_NAME }}
       VERSION: ${{ needs.config.outputs.VERSION }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      LEGACY_IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
-      QUAY_REPO: quay.io/neurodesk/${{ inputs.application }}
+      LEGACY_IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
+      QUAY_REPO: quay.io/neurodesk/${{ needs.config.outputs.CONTAINER_NAME }}
       SIF_MEDIATYPE: application/vnd.sylabs.sif.layer.v1.sif
     steps:
       - name: Configure GitHub-hosted runner
@@ -1074,10 +1104,10 @@ jobs:
     permissions:
       packages: write
     env:
-      APPLICATION: ${{ inputs.application }}
+      APPLICATION: ${{ needs.config.outputs.CONTAINER_NAME }}
       VERSION: ${{ needs.config.outputs.VERSION }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      LEGACY_IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}
+      LEGACY_IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
       SIF_MEDIATYPE: application/vnd.sylabs.sif.layer.v1.sif
     steps:
       - name: Configure GitHub-hosted runner
@@ -1149,8 +1179,11 @@ jobs:
     env:
       APPLICATION: ${{ inputs.application }}
       BUILDDATE: ${{ needs.config.outputs.BUILDDATE }}
-      IMAGENAME: ${{ inputs.application }}_${{ needs.config.outputs.VERSION }}${{ needs.config.outputs.IMAGE_SUFFIX }}
+      IMAGENAME: ${{ needs.config.outputs.IMAGENAME }}
       ARCHITECTURE: ${{ needs.config.outputs.ARCHITECTURE }}
+      VARIANT: ${{ needs.config.outputs.VARIANT }}
+      CONTAINER_NAME: ${{ needs.config.outputs.CONTAINER_NAME }}
+      VERSION: ${{ needs.config.outputs.VERSION }}
       SHORT_SHA: ${{ needs.config.outputs.SHORT_SHA }}
     steps:
     - uses: actions/checkout@v5
@@ -1163,7 +1196,11 @@ jobs:
       id: generate
       run: |
         echo "APPLICATION: $APPLICATION"
-        python3 -m builder release "$APPLICATION" --write --architecture "$ARCHITECTURE"
+        VARIANT_ARGS=()
+        if [ -n "$VARIANT" ]; then
+          VARIANT_ARGS=(--variant "$VARIANT")
+        fi
+        python3 -m builder release "$APPLICATION" --write --architecture "$ARCHITECTURE" "${VARIANT_ARGS[@]}"
 
     - name: Create Release File Pull Request
       if: steps.generate.outputs.container_name
@@ -1242,7 +1279,7 @@ jobs:
 
         To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
         \`\`\`bash
-        bash /neurocommand/local/fetch_and_run.sh ${IMAGENAME//_/ } ${BUILDDATE}
+        bash /neurocommand/local/fetch_and_run.sh "${CONTAINER_NAME}" "${{ needs.config.outputs.VERSION }}" "${BUILDDATE}"
         \`\`\`
 
         Or, for testing directly with Apptainer/Singularity:
@@ -1279,7 +1316,7 @@ jobs:
         echo "✅ Pull request created for ${CONTAINER_NAME} ${CONTAINER_VERSION}: ${PR_URL}"
     - name: Detect OpenReconLabel.json
       id: detect_openrecon
-      if: steps.generate.outputs.container_name && env.ARCHITECTURE == 'x86_64'
+      if: steps.generate.outputs.container_name && env.ARCHITECTURE == 'x86_64' && env.VARIANT == ''
       env:
         CONTAINER_NAME: ${{ steps.generate.outputs.container_name }}
       run: |
@@ -1419,7 +1456,7 @@ jobs:
       run: |
         echo "The container has been successfully build. To test the container, run this:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
-        echo "bash /neurocommand/local/fetch_and_run.sh ${IMAGENAME//_/ } $BUILDDATE" >> $GITHUB_STEP_SUMMARY
+        echo "bash /neurocommand/local/fetch_and_run.sh ${CONTAINER_NAME} $VERSION $BUILDDATE" >> $GITHUB_STEP_SUMMARY
 
   report-auto-build-failure:
     needs: [config, build-image, push-dockerhub, build-simg, upload-s3, create-pr]

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -128,7 +128,7 @@ jobs:
         ARM64_RUNNER: ${{ steps.select_runner.outputs.arm64_runner }}
       run: |
         python3 -m pip install pyyaml
-        build_matrix=$(python3 tools/variant_matrix.py \
+        build_matrix=$(python3 -m tools.variant_matrix \
           --applications "$APPLICATIONS" \
           --default-runner "$DEFAULT_RUNNER" \
           --arm64-runner "$ARM64_RUNNER")
@@ -144,6 +144,7 @@ jobs:
     with:
       application: ${{ matrix.application }}
       variant: ${{ matrix.variant }}
+      architecture: ${{ matrix.architecture }}
       runner: ${{ matrix.runner }}
       disable_auto_upload: ${{ github.event.inputs.disable_auto_upload }}
       force_push_ghcr: ${{ github.event.inputs.force_push_ghcr }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -77,9 +77,9 @@ jobs:
   list-apps:
     runs-on: ubuntu-22.04
     outputs:
-      app_list: ${{ steps.process_app_list.outputs.app_list }}
-      runner: ${{ steps.select_runner.outputs.runner }}
+      build_matrix: ${{ steps.expand_variants.outputs.build_matrix }}
     steps:
+    - uses: actions/checkout@v5
     - name: Process input list of applications
       id: process_app_list
       run: |
@@ -113,17 +113,38 @@ jobs:
         esac
         echo "runner=${runner}"
         echo "runner=${runner}" >> "$GITHUB_OUTPUT"
+        if [[ "$CHOICE" == *"arm"* ]]; then
+          echo 'default_runner="blacksmith-8vcpu-ubuntu-2404"' >> "$GITHUB_OUTPUT"
+          echo "arm64_runner=${runner}" >> "$GITHUB_OUTPUT"
+        else
+          echo "default_runner=${runner}" >> "$GITHUB_OUTPUT"
+          echo 'arm64_runner="blacksmith-8vcpu-ubuntu-2404-arm"' >> "$GITHUB_OUTPUT"
+        fi
+    - name: Expand named variants
+      id: expand_variants
+      env:
+        APPLICATIONS: ${{ steps.process_app_list.outputs.app_list }}
+        DEFAULT_RUNNER: ${{ steps.select_runner.outputs.default_runner }}
+        ARM64_RUNNER: ${{ steps.select_runner.outputs.arm64_runner }}
+      run: |
+        python3 -m pip install pyyaml
+        build_matrix=$(python3 tools/variant_matrix.py \
+          --applications "$APPLICATIONS" \
+          --default-runner "$DEFAULT_RUNNER" \
+          --arm64-runner "$ARM64_RUNNER")
+        echo "build_matrix=${build_matrix}" >> "$GITHUB_OUTPUT"
 
   build-app:
     needs: list-apps
     strategy:
       fail-fast: false
       matrix:
-        application: ${{ fromJSON(needs.list-apps.outputs.app_list) }}
+        include: ${{ fromJSON(needs.list-apps.outputs.build_matrix) }}
     uses: ./.github/workflows/build-app.yml
     with:
       application: ${{ matrix.application }}
-      runner: ${{ needs.list-apps.outputs.runner }}
+      variant: ${{ matrix.variant }}
+      runner: ${{ matrix.runner }}
       disable_auto_upload: ${{ github.event.inputs.disable_auto_upload }}
       force_push_ghcr: ${{ github.event.inputs.force_push_ghcr }}
       force_push_dockerhub: ${{ github.event.inputs.force_push_dockerhub }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -113,12 +113,23 @@ jobs:
         esac
         echo "runner=${runner}"
         echo "runner=${runner}" >> "$GITHUB_OUTPUT"
+        # A dispatch picks one runner, but a recipe can declare both
+        # architectures. The architecture the choice does not cover falls back
+        # to a pool this repository can actually schedule: forks have no access
+        # to the ARC or Blacksmith runner groups.
+        if [ "${GITHUB_REPOSITORY}" = "neurodesk/neurocontainers" ]; then
+          fallback_x86='"blacksmith-8vcpu-ubuntu-2404"'
+          fallback_arm64='"blacksmith-8vcpu-ubuntu-2404-arm"'
+        else
+          fallback_x86='"ubuntu-22.04"'
+          fallback_arm64='"ubuntu-24.04-arm"'
+        fi
         if [[ "$CHOICE" == *"arm"* ]]; then
-          echo 'default_runner="blacksmith-8vcpu-ubuntu-2404"' >> "$GITHUB_OUTPUT"
+          echo "default_runner=${fallback_x86}" >> "$GITHUB_OUTPUT"
           echo "arm64_runner=${runner}" >> "$GITHUB_OUTPUT"
         else
           echo "default_runner=${runner}" >> "$GITHUB_OUTPUT"
-          echo 'arm64_runner="blacksmith-8vcpu-ubuntu-2404-arm"' >> "$GITHUB_OUTPUT"
+          echo "arm64_runner=${fallback_arm64}" >> "$GITHUB_OUTPUT"
         fi
     - name: Expand named variants
       id: expand_variants

--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       recipes: ${{ steps.detect.outputs.recipes }}
+      targets: ${{ steps.detect.outputs.targets }}
     steps:
       # Run detection from the trusted base revision. A fork cannot change the
       # policy script before it decides that the PR is recipe-only.
@@ -56,15 +57,16 @@ jobs:
             --base "${BASE_SHA}" --head "${HEAD_SHA}"
 
   candidate:
-    name: candidate (${{ matrix.recipe }})
+    name: candidate (${{ matrix.container }})
     needs: detect
     # ARC pods are ephemeral; untrusted recipe build commands never run on a
-    # persistent self-hosted machine.
-    runs-on: neurodesk-syd-arcrunner-neurocontainers
+    # persistent self-hosted machine. The ARM64 pool must satisfy the same
+    # property: Blacksmith runners are ephemeral cloud VMs, not persistent hosts.
+    runs-on: ${{ matrix.architecture == 'aarch64' && 'blacksmith-8vcpu-ubuntu-2404-arm' || 'neurodesk-syd-arcrunner-neurocontainers' }}
     strategy:
       fail-fast: false
       matrix:
-        recipe: ${{ fromJSON(needs.detect.outputs.recipes) }}
+        include: ${{ fromJSON(needs.detect.outputs.targets) }}
     steps:
       - name: Checkout candidate source
         uses: actions/checkout@v5
@@ -89,50 +91,56 @@ jobs:
         id: info
         env:
           RECIPE: ${{ matrix.recipe }}
+          VARIANT: ${{ matrix.variant }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           python tools/one_pr_release.py inspect \
-            --recipe "${RECIPE}" --head-sha "${HEAD_SHA}"
+            --recipe "${RECIPE}" --variant "${VARIANT}" --head-sha "${HEAD_SHA}"
       - name: Stage and build candidate
         env:
           RECIPE: ${{ matrix.recipe }}
+          VARIANT: ${{ matrix.variant }}
+          ARCHITECTURE: ${{ matrix.architecture }}
+          CONTAINER: ${{ matrix.container }}
           CANDIDATE_TAG: ${{ steps.info.outputs.candidate_tag }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          python -m builder stage "${RECIPE}" --recreate --download --architecture x86_64
-          dockerfile="$(find "build/${RECIPE}" -maxdepth 1 -iname '*.Dockerfile' -print -quit)"
+          python -m builder stage "${RECIPE}" --recreate --download \
+            --architecture "${ARCHITECTURE}" --variant "${VARIANT}"
+          dockerfile="$(find "build/${CONTAINER}" -maxdepth 1 -iname '*.Dockerfile' -print -quit)"
           test -n "${dockerfile}"
-          docker buildx build "build/${RECIPE}" --load \
+          docker buildx build "build/${CONTAINER}" --load \
             --file "${dockerfile}" --tag "${CANDIDATE_TAG}" \
-            --build-context "neurocontainer-cache=build/${RECIPE}/cache" \
+            --build-context "neurocontainer-cache=build/${CONTAINER}/cache" \
             --label "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
             --label "GITHUB_SHA=${HEAD_SHA}"
       - name: Create immutable candidate files
         env:
-          RECIPE: ${{ matrix.recipe }}
+          CONTAINER: ${{ matrix.container }}
           CANDIDATE_TAG: ${{ steps.info.outputs.candidate_tag }}
           DOCKER_ARCHIVE: ${{ steps.info.outputs.docker_archive }}
           SIF: ${{ steps.info.outputs.sif }}
         run: |
-          mkdir -p "candidate/${RECIPE}"
-          docker save "${CANDIDATE_TAG}" --output "candidate/${RECIPE}/${DOCKER_ARCHIVE}"
-          apptainer build "candidate/${RECIPE}/${SIF}" "docker-archive://candidate/${RECIPE}/${DOCKER_ARCHIVE}"
+          mkdir -p "candidate/${CONTAINER}"
+          docker save "${CANDIDATE_TAG}" --output "candidate/${CONTAINER}/${DOCKER_ARCHIVE}"
+          apptainer build "candidate/${CONTAINER}/${SIF}" "docker-archive://candidate/${CONTAINER}/${DOCKER_ARCHIVE}"
       - name: Run deploy and fulltest checks
         id: fulltest
         continue-on-error: true
         env:
           RECIPE: ${{ matrix.recipe }}
+          CONTAINER: ${{ matrix.container }}
           VERSION: ${{ steps.info.outputs.version }}
           SIF: ${{ steps.info.outputs.sif }}
         run: |
           python -m workflows.release_test_runner \
             --recipe "${RECIPE}" \
             --version "${VERSION}" \
-            --release-file "candidate/${RECIPE}/${VERSION}.json" \
-            --candidate-container "candidate/${RECIPE}/${SIF}" \
+            --release-file "candidate/${CONTAINER}/${VERSION}.json" \
+            --candidate-container "candidate/${CONTAINER}/${SIF}" \
             --test-config "recipes/${RECIPE}/fulltest.yaml" \
-            --results-path "candidate/${RECIPE}/test-results.json" \
-            --output-dir "candidate/${RECIPE}/test-output" \
+            --results-path "candidate/${CONTAINER}/test-results.json" \
+            --output-dir "candidate/${CONTAINER}/test-output" \
             --repo-root . --verbose
       - name: Run Dive policy check
         id: dive
@@ -146,17 +154,19 @@ jobs:
       - name: Generate manifest and release preview
         env:
           RECIPE: ${{ matrix.recipe }}
+          VARIANT: ${{ matrix.variant }}
+          CONTAINER: ${{ matrix.container }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           python tools/one_pr_release.py manifest \
-            --recipe "${RECIPE}" --head-sha "${HEAD_SHA}" \
-            --pr-number "${PR_NUMBER}" --candidate-dir "candidate/${RECIPE}"
+            --recipe "${RECIPE}" --variant "${VARIANT}" --head-sha "${HEAD_SHA}" \
+            --pr-number "${PR_NUMBER}" --candidate-dir "candidate/${CONTAINER}"
       - name: Upload candidate bundle
         uses: actions/upload-artifact@v4
         with:
-          name: candidate-${{ matrix.recipe }}-${{ github.event.pull_request.head.sha }}
-          path: candidate/${{ matrix.recipe }}/
+          name: candidate-${{ matrix.container }}-${{ github.event.pull_request.head.sha }}
+          path: candidate/${{ matrix.container }}/
           compression-level: 0
           retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -93,11 +93,11 @@ jobs:
           echo "${ARTIFACTS}" | jq -c '.[]' | while read -r artifact; do
             id="$(echo "${artifact}" | jq -r '.id')"
             name="$(echo "${artifact}" | jq -r '.name')"
-            recipe="${name#candidate-}"
-            recipe="${recipe%-${HEAD_SHA}}"
-            mkdir -p "promotion-bundle/${recipe}"
+            container="${name#candidate-}"
+            container="${container%-${HEAD_SHA}}"
+            mkdir -p "promotion-bundle/${container}"
             gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" > artifact.zip
-            unzip -q artifact.zip -d "promotion-bundle/${recipe}"
+            unzip -q artifact.zip -d "promotion-bundle/${container}"
             rm artifact.zip
           done
       - name: Verify provenance, merged recipes, and checksums
@@ -142,21 +142,21 @@ jobs:
           DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_ORG }}
         run: |
           jq -c '.[]' verified-manifests.json | while read -r manifest; do
-            recipe="$(echo "${manifest}" | jq -r '.recipe')"
+            container="$(echo "${manifest}" | jq -r '.container')"
             version="$(echo "${manifest}" | jq -r '.version')"
             build_date="$(echo "${manifest}" | jq -r '.build_date')"
             archive="$(echo "${manifest}" | jq -r '.docker_archive')"
             source="$(echo "${manifest}" | jq -r '.candidate_tag')"
-            docker load --input "promotion-bundle/${recipe}/${archive}"
+            docker load --input "promotion-bundle/${container}/${archive}"
 
-            legacy="${recipe}_${version}"
+            legacy="${container}_${version}"
             legacy_ghcr="ghcr.io/${GH_REGISTRY}/${legacy}"
             docker tag "${source}" "${legacy_ghcr}:${build_date}"
             docker tag "${source}" "${legacy_ghcr}:latest"
             docker push "${legacy_ghcr}:${build_date}"
             docker push "${legacy_ghcr}:latest"
 
-            ghcr="ghcr.io/${GH_REGISTRY}/${recipe}"
+            ghcr="ghcr.io/${GH_REGISTRY}/${container}"
             for tag in "${version}_${build_date}" "${version}" latest; do
               docker tag "${source}" "${ghcr}:${tag}"
               docker push "${ghcr}:${tag}"
@@ -173,7 +173,7 @@ jobs:
               fi
             done
 
-            quay="quay.io/neurodesk/${recipe}"
+            quay="quay.io/neurodesk/${container}"
             for tag in "${version}_${build_date}" "${version}" latest; do
               docker tag "${source}" "${quay}:${tag}"
               docker push "${quay}:${tag}" || \
@@ -194,9 +194,9 @@ jobs:
           OS_IDENTITY_API_VERSION: "3"
         run: |
           jq -c '.[]' verified-manifests.json | while read -r manifest; do
-            recipe="$(echo "${manifest}" | jq -r '.recipe')"
+            container="$(echo "${manifest}" | jq -r '.container')"
             sif="$(echo "${manifest}" | jq -r '.sif')"
-            path="promotion-bundle/${recipe}/${sif}"
+            path="promotion-bundle/${container}/${sif}"
             aws s3 cp "${path}" "s3://neurocontainers/${sif}"
             aws s3api head-object --bucket neurocontainers --key "${sif}" >/dev/null
             swift upload neurodesk "${path}" --object-name "${sif}" \
@@ -216,19 +216,19 @@ jobs:
           sudo tar -xzf "${oras_archive}" -C /usr/local/bin oras
           rm "${oras_archive}"
           jq -c '.[]' verified-manifests.json | while read -r manifest; do
-            recipe="$(echo "${manifest}" | jq -r '.recipe')"
+            container="$(echo "${manifest}" | jq -r '.container')"
             version="$(echo "${manifest}" | jq -r '.version')"
             build_date="$(echo "${manifest}" | jq -r '.build_date')"
             sif="$(echo "${manifest}" | jq -r '.sif')"
-            cp "promotion-bundle/${recipe}/${sif}" "${RUNNER_TEMP}/${sif}"
+            cp "promotion-bundle/${container}/${sif}" "${RUNNER_TEMP}/${sif}"
             cd "${RUNNER_TEMP}"
             oras attach --artifact-type application/vnd.sylabs.sif.layer.v1.sif \
-              "ghcr.io/${GH_REGISTRY}/${recipe}:${version}_${build_date}" \
+              "ghcr.io/${GH_REGISTRY}/${container}:${version}_${build_date}" \
               "${sif}:application/vnd.sylabs.sif.layer.v1.sif"
             oras attach --artifact-type application/vnd.sylabs.sif.layer.v1.sif \
-              "quay.io/neurodesk/${recipe}:${version}_${build_date}" \
+              "quay.io/neurodesk/${container}:${version}_${build_date}" \
               "${sif}:application/vnd.sylabs.sif.layer.v1.sif" || \
-              echo "::warning::Optional Quay SIF attach failed for ${recipe}"
+              echo "::warning::Optional Quay SIF attach failed for ${container}"
             cd "${GITHUB_WORKSPACE}"
           done
       - name: Commit generated release metadata directly to main

--- a/builder/README.md
+++ b/builder/README.md
@@ -27,7 +27,7 @@ A common workflow involves building the container and running a command inside i
 All build commands (`sf-build`, `sf-login`, `sf-test`, `sf-make`) support architecture options:
 
 - `--architecture <arch>`: Specify the target architecture (e.g., `x86_64`, `aarch64`, `arm64`). Defaults to the current machine's architecture.
-- `--variant <name>`: Build a named container variant declared by the recipe. The variant selects its architecture and gets a distinct container name such as `myrecipe_arm64`.
+- `--variant <name>`: Build an arbitrary named alternative declared by the recipe, such as `gpu` or `cuda12`.
 - `--ignore-architectures`: Ignore architecture compatibility checks in the recipe.
 - `--generate-release`: Generate release files after successful build (for `sf-build` and `sf-login`).
 
@@ -36,8 +36,11 @@ Example usage:
 # Build for ARM64 architecture
 sf-build myrecipe --architecture aarch64
 
-# Build the independently published myrecipe_arm64 container
+# Equivalent: build the automatically named myrecipe_arm64 container
 sf-build myrecipe --variant arm64
+
+# Build a declared GPU alternative
+sf-build myrecipe --variant gpu
 
 # Build ignoring architecture restrictions
 sf-build myrecipe --architecture x86_64 --ignore-architectures
@@ -74,13 +77,28 @@ architectures:
   - aarch64
 
 variants:
-  arm64:
-    architecture: aarch64
-    description: Native ARM64 build
+  gpu:
+    architectures:
+      - x86_64
+      - aarch64
+    description: CUDA-enabled build
+    options:
+      gpu: true
+
+options:
+  gpu:
+    description: Install GPU dependencies
+    default: false
 
 readme: |
     This is a recipe for {{ context.name }}/{{ context.version }}
 ```
+
+Architectures are concrete variants automatically: `aarch64` produces
+`qsmxt_arm64`. Declared alternatives are independent of architecture, so the
+example above produces `qsmxt_gpu` and `qsmxt_gpu_arm64`. Variant `options`
+preset the same boolean recipe options used by `context.options.<name>`
+conditions.
 
 If your readme is externally hosted you can include it using `readme_url`.
 

--- a/builder/README.md
+++ b/builder/README.md
@@ -27,6 +27,7 @@ A common workflow involves building the container and running a command inside i
 All build commands (`sf-build`, `sf-login`, `sf-test`, `sf-make`) support architecture options:
 
 - `--architecture <arch>`: Specify the target architecture (e.g., `x86_64`, `aarch64`, `arm64`). Defaults to the current machine's architecture.
+- `--variant <name>`: Build a named container variant declared by the recipe. The variant selects its architecture and gets a distinct container name such as `myrecipe_arm64`.
 - `--ignore-architectures`: Ignore architecture compatibility checks in the recipe.
 - `--generate-release`: Generate release files after successful build (for `sf-build` and `sf-login`).
 
@@ -34,6 +35,9 @@ Example usage:
 ```sh
 # Build for ARM64 architecture
 sf-build myrecipe --architecture aarch64
+
+# Build the independently published myrecipe_arm64 container
+sf-build myrecipe --variant arm64
 
 # Build ignoring architecture restrictions
 sf-build myrecipe --architecture x86_64 --ignore-architectures
@@ -68,6 +72,11 @@ copyright:
 architectures:
   - x86_64
   - aarch64
+
+variants:
+  arm64:
+    architecture: aarch64
+    description: Native ARM64 build
 
 readme: |
     This is a recipe for {{ context.name }}/{{ context.version }}

--- a/builder/README.md
+++ b/builder/README.md
@@ -100,6 +100,12 @@ example above produces `qsmxt_gpu` and `qsmxt_gpu_arm64`. Variant `options`
 preset the same boolean recipe options used by `context.options.<name>`
 conditions.
 
+Each concrete identity is a container in its own right: it builds as its own PR
+candidate, publishes to its own `ghcr.io`/`quay.io` repository, and gets its own
+`releases/<container>/<version>.json`. Adding `aarch64` to a recipe therefore
+adds an ARM64 build to every PR that touches it, so declare it only once the
+recipe actually builds on ARM64.
+
 If your readme is externally hosted you can include it using `readme_url`.
 
 ```yaml

--- a/builder/cli.py
+++ b/builder/cli.py
@@ -15,7 +15,7 @@ from .adapters import (
 )
 from .config import default_config, resolve_recipe
 from .dockerfile import render_dockerfile
-from .recipe import compile_recipe
+from .recipe import compile_recipe, load_recipe, variant_specs
 from .release import build_date_for_recipe, release_data, release_version, write_github_release_outputs, write_release_file
 from .staging import materialize_plan
 from .tester import ContainerTesterAdapter, TestRequest
@@ -62,6 +62,7 @@ def write_build_files(
 def add_common_recipe_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("recipe", nargs="?", help="Recipe name or recipe directory")
     parser.add_argument("--architecture", default=None, help="Target architecture")
+    parser.add_argument("--variant", default=None, help="Named container variant")
     parser.add_argument("--ignore-architectures", action="store_true")
     parser.add_argument("--output-root", type=Path, default=None)
     parser.add_argument("--recreate", action="store_true")
@@ -106,6 +107,7 @@ def compile_from_args(args: argparse.Namespace):
     return config, compile_recipe(
         recipe_dir,
         architecture=args.architecture,
+        variant=args.variant,
         ignore_architecture=args.ignore_architectures,
         local_keys=local_keys(args.local),
         include_dirs=config.include_dirs,
@@ -137,6 +139,7 @@ def cmd_stage(args: argparse.Namespace) -> int:
         "name": compiled.name,
         "version": compiled.version,
         "architecture": compiled.architecture,
+        "variant": compiled.variant,
         "build_dir": str(build_dir),
         "dockerfile": str(dockerfile_path),
         "declared_files": sorted(compiled.staging_plan.files),
@@ -148,8 +151,15 @@ def cmd_stage(args: argparse.Namespace) -> int:
 def cmd_release(args: argparse.Namespace) -> int:
     config, compiled = compile_from_args(args)
     date = build_date_for_recipe(config.repo_root, compiled.recipe_dir)
-    data = release_data(compiled.name, compiled.version, compiled.recipe, date, compiled.architecture)
-    version = release_version(compiled.version, compiled.architecture)
+    data = release_data(
+        compiled.name,
+        compiled.version,
+        compiled.recipe,
+        date,
+        compiled.architecture,
+        compiled.variant,
+    )
+    version = release_version(compiled.version, compiled.architecture, compiled.variant)
     if args.write:
         path = write_release_file(config.repo_root, compiled.name, version, data)
         write_github_release_outputs(compiled.name, version, data)
@@ -199,8 +209,15 @@ def cmd_build(args: argparse.Namespace) -> int:
     print(" ".join(str(part) for part in command))
     if getattr(args, "generate_release", False) and not args.dry_run:
         date = build_date_for_recipe(config.repo_root, compiled.recipe_dir)
-        version = release_version(compiled.version, compiled.architecture)
-        data = release_data(compiled.name, compiled.version, compiled.recipe, date, compiled.architecture)
+        version = release_version(compiled.version, compiled.architecture, compiled.variant)
+        data = release_data(
+            compiled.name,
+            compiled.version,
+            compiled.recipe,
+            date,
+            compiled.architecture,
+            compiled.variant,
+        )
         path = write_release_file(
             config.repo_root,
             compiled.name,
@@ -310,6 +327,13 @@ def cmd_cache(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_variants(args: argparse.Namespace) -> int:
+    config = default_config()
+    recipe_dir = resolve_recipe(config, args.recipe or str(Path.cwd()))
+    print(json.dumps(variant_specs(load_recipe(recipe_dir))))
+    return 0
+
+
 def cmd_login(args: argparse.Namespace) -> int:
     cmd_build(args)
     if args.dry_run:
@@ -350,6 +374,10 @@ def build_parser() -> argparse.ArgumentParser:
     add_common_recipe_args(release)
     release.add_argument("--write", action="store_true", help="Write into releases/")
     release.set_defaults(func=cmd_release)
+
+    variants = subparsers.add_parser("variants", help="List concrete containers for a recipe")
+    variants.add_argument("recipe", nargs="?", help="Recipe name or recipe directory")
+    variants.set_defaults(func=cmd_variants)
 
     build = subparsers.add_parser("build", help="Stage and build a recipe")
     add_common_recipe_args(build)

--- a/builder/recipe.py
+++ b/builder/recipe.py
@@ -19,6 +19,7 @@ from .template import RenderContext, TemplateRenderer
 from .template_backend import apply_builtin_template
 from .validation import validate_recipe_dict
 from .cache import DEFAULT_TIMEOUT_SECONDS, DEFAULT_USER_AGENT, sha256_text
+from .variants import concrete_variant_specs, variant_specs
 
 
 ARCHITECTURE_ALIASES = {
@@ -213,30 +214,6 @@ def normalize_architecture(value: str | None) -> str:
         raise ValueError(f"unsupported architecture: {arch}") from exc
 
 
-def variant_specs(recipe: dict[str, Any]) -> list[dict[str, str]]:
-    """Return the concrete containers declared by a logical recipe."""
-    architectures = [normalize_architecture(str(item)) for item in recipe.get("architectures", [])]
-    if not architectures:
-        raise ValueError(f"recipe {recipe.get('name', '<unknown>')} has no architectures")
-
-    specs = [
-        {
-            "variant": "",
-            "name": str(recipe["name"]),
-            "architecture": architectures[0],
-        }
-    ]
-    for variant_name, config in (recipe.get("variants") or {}).items():
-        specs.append(
-            {
-                "variant": str(variant_name),
-                "name": f"{recipe['name']}_{variant_name}",
-                "architecture": normalize_architecture(str(config["architecture"])),
-            }
-        )
-    return specs
-
-
 def _split_install(value: Any) -> list[str]:
     if isinstance(value, str):
         return shlex.split(value)
@@ -371,20 +348,36 @@ def compile_recipe(
 ) -> CompiledRecipe:
     recipe_file = load_recipe_file(recipe_dir)
     recipe = recipe_file.data
-    variant_name = variant or ""
-    variants = recipe.get("variants") or {}
-    if variant_name and variant_name not in variants:
-        available = ", ".join(sorted(variants)) or "none"
-        raise ValueError(f"unknown variant '{variant_name}' for {recipe['name']}; available: {available}")
-    variant_arch = variants.get(variant_name, {}).get("architecture") if variant_name else None
-    if architecture is not None and variant_arch is not None:
-        requested_arch = normalize_architecture(architecture)
-        declared_arch = normalize_architecture(str(variant_arch))
-        if requested_arch != declared_arch:
-            raise ValueError(
-                f"variant '{variant_name}' requires architecture {declared_arch}, got {requested_arch}"
-            )
-    arch = normalize_architecture(str(variant_arch) if variant_arch is not None else architecture)
+    specs = concrete_variant_specs(recipe)
+    requested_arch = normalize_architecture(architecture) if architecture is not None else None
+    requested_variant = variant or ""
+    selection_arch = requested_arch
+    if not requested_variant or requested_variant in (recipe.get("variants") or {}):
+        selection_arch = requested_arch or normalize_architecture(None)
+    candidates = [spec for spec in specs if spec["variant"] == requested_variant]
+    if not requested_variant:
+        candidates = [
+            spec
+            for spec in specs
+            if not spec["recipe_variant"] and spec["architecture"] == selection_arch
+        ]
+    elif requested_variant in (recipe.get("variants") or {}):
+        candidates = [
+            spec
+            for spec in specs
+            if spec["recipe_variant"] == requested_variant and spec["architecture"] == selection_arch
+        ]
+    if requested_arch is not None:
+        candidates = [spec for spec in candidates if spec["architecture"] == requested_arch]
+    if not candidates:
+        available = ", ".join(str(spec["variant"]) or "default" for spec in specs)
+        raise ValueError(
+            f"unknown variant/architecture '{requested_variant or 'default'}'/{selection_arch or 'default'} "
+            f"for {recipe['name']}; available: {available}"
+        )
+    selected_variant = candidates[0]
+    variant_name = str(selected_variant["variant"])
+    arch = str(selected_variant["architecture"])
     allowed = [str(item) for item in recipe.get("architectures", [])]
     if arch not in allowed and not ignore_architecture:
         raise ValueError(f"architecture {arch} not supported by {recipe['name']}")
@@ -395,13 +388,14 @@ def compile_recipe(
         for key, value in (recipe.get("options") or {}).items()
         if isinstance(value, dict)
     }
+    option_values.update(selected_variant["options"])
     option_values.update(option_overrides or {})
     version = str(recipe["version"])
     for key, value in (recipe.get("options") or {}).items():
         if option_values.get(str(key)) and isinstance(value, dict):
             version += str(value.get("version_suffix") or "")
     context = RenderContext(
-        name=f"{recipe['name']}_{variant_name}" if variant_name else recipe["name"],
+        name=str(selected_variant["name"]),
         version=version,
         original_version=recipe["version"],
         arch=arch,

--- a/builder/recipe.py
+++ b/builder/recipe.py
@@ -173,6 +173,8 @@ class CompiledRecipe:
     recipe: dict[str, Any]
     recipe_dir: Path
     name: str
+    base_name: str
+    variant: str
     version: str
     architecture: str
     readme: str
@@ -209,6 +211,30 @@ def normalize_architecture(value: str | None) -> str:
         return ARCHITECTURE_ALIASES[arch]
     except KeyError as exc:
         raise ValueError(f"unsupported architecture: {arch}") from exc
+
+
+def variant_specs(recipe: dict[str, Any]) -> list[dict[str, str]]:
+    """Return the concrete containers declared by a logical recipe."""
+    architectures = [normalize_architecture(str(item)) for item in recipe.get("architectures", [])]
+    if not architectures:
+        raise ValueError(f"recipe {recipe.get('name', '<unknown>')} has no architectures")
+
+    specs = [
+        {
+            "variant": "",
+            "name": str(recipe["name"]),
+            "architecture": architectures[0],
+        }
+    ]
+    for variant_name, config in (recipe.get("variants") or {}).items():
+        specs.append(
+            {
+                "variant": str(variant_name),
+                "name": f"{recipe['name']}_{variant_name}",
+                "architecture": normalize_architecture(str(config["architecture"])),
+            }
+        )
+    return specs
 
 
 def _split_install(value: Any) -> list[str]:
@@ -336,6 +362,7 @@ def compile_recipe(
     recipe_dir: Path,
     *,
     architecture: str | None = None,
+    variant: str | None = None,
     ignore_architecture: bool = False,
     local_keys: set[str] | None = None,
     include_dirs: tuple[Path, ...] = (),
@@ -344,7 +371,20 @@ def compile_recipe(
 ) -> CompiledRecipe:
     recipe_file = load_recipe_file(recipe_dir)
     recipe = recipe_file.data
-    arch = normalize_architecture(architecture)
+    variant_name = variant or ""
+    variants = recipe.get("variants") or {}
+    if variant_name and variant_name not in variants:
+        available = ", ".join(sorted(variants)) or "none"
+        raise ValueError(f"unknown variant '{variant_name}' for {recipe['name']}; available: {available}")
+    variant_arch = variants.get(variant_name, {}).get("architecture") if variant_name else None
+    if architecture is not None and variant_arch is not None:
+        requested_arch = normalize_architecture(architecture)
+        declared_arch = normalize_architecture(str(variant_arch))
+        if requested_arch != declared_arch:
+            raise ValueError(
+                f"variant '{variant_name}' requires architecture {declared_arch}, got {requested_arch}"
+            )
+    arch = normalize_architecture(str(variant_arch) if variant_arch is not None else architecture)
     allowed = [str(item) for item in recipe.get("architectures", [])]
     if arch not in allowed and not ignore_architecture:
         raise ValueError(f"architecture {arch} not supported by {recipe['name']}")
@@ -361,10 +401,11 @@ def compile_recipe(
         if option_values.get(str(key)) and isinstance(value, dict):
             version += str(value.get("version_suffix") or "")
     context = RenderContext(
-        name=recipe["name"],
+        name=f"{recipe['name']}_{variant_name}" if variant_name else recipe["name"],
         version=version,
         original_version=recipe["version"],
         arch=arch,
+        variant=variant_name,
         parallel_jobs=parallel_jobs or (os.cpu_count() or 1),
         local_keys=local_keys or set(),
         options=SimpleNamespace(**option_values),
@@ -600,7 +641,9 @@ def compile_recipe(
     return CompiledRecipe(
         recipe=_render_release_recipe(recipe, renderer, context),
         recipe_dir=recipe_dir,
-        name=recipe["name"],
+        name=context.name,
+        base_name=recipe["name"],
+        variant=variant_name,
         version=version,
         architecture=arch,
         readme=readme,

--- a/builder/recipe.py
+++ b/builder/recipe.py
@@ -19,7 +19,7 @@ from .template import RenderContext, TemplateRenderer
 from .template_backend import apply_builtin_template
 from .validation import validate_recipe_dict
 from .cache import DEFAULT_TIMEOUT_SECONDS, DEFAULT_USER_AGENT, sha256_text
-from .variants import concrete_variant_specs, variant_specs
+from .variants import concrete_variant_specs, forced_variant_spec, variant_specs
 
 
 ARCHITECTURE_ALIASES = {
@@ -369,6 +369,15 @@ def compile_recipe(
         ]
     if requested_arch is not None:
         candidates = [spec for spec in candidates if spec["architecture"] == requested_arch]
+    if not candidates and ignore_architecture:
+        forced_arch = requested_arch
+        if forced_arch is None:
+            forced_arch = (
+                "aarch64"
+                if requested_variant == "arm64" or requested_variant.endswith("_arm64")
+                else normalize_architecture(None)
+            )
+        candidates = [forced_variant_spec(recipe, requested_variant, forced_arch)]
     if not candidates:
         available = ", ".join(str(spec["variant"]) or "default" for spec in specs)
         raise ValueError(

--- a/builder/release.py
+++ b/builder/release.py
@@ -41,7 +41,9 @@ def normalize_architecture(architecture: str | None) -> str:
     return ARCHITECTURE_ALIASES.get(architecture or "x86_64", architecture or "x86_64")
 
 
-def release_version(version: str, architecture: str | None) -> str:
+def release_version(version: str, architecture: str | None, variant: str | None = None) -> str:
+    if variant:
+        return version
     return f"{version}-arm64" if normalize_architecture(architecture) == "aarch64" else version
 
 
@@ -51,10 +53,12 @@ def release_data(
     recipe: dict[str, Any],
     build_date: str,
     architecture: str | None = None,
+    variant: str | None = None,
 ) -> dict[str, Any]:
     apptainer_args = recipe.get("apptainer_args", [])
     normalized_architecture = normalize_architecture(architecture)
-    is_arm64 = normalized_architecture == "aarch64"
+    is_named_variant = bool(variant)
+    is_arm64 = normalized_architecture == "aarch64" and not is_named_variant
     app_version = f"{version} arm64" if is_arm64 else version
     image_suffix = "_arm64" if is_arm64 else ""
     image = f"{name}_{version}{image_suffix}"
@@ -71,6 +75,9 @@ def release_data(
         },
         "categories": recipe.get("categories", ["other"]),
     }
+    if is_named_variant:
+        data["variant"] = variant
+        data["architecture"] = normalized_architecture
     for visibility_field in ("show_in_menu", "show_in_applist"):
         if recipe.get(visibility_field) is not None:
             data[visibility_field] = recipe[visibility_field]

--- a/builder/template.py
+++ b/builder/template.py
@@ -23,6 +23,7 @@ class RenderContext:
     name: str
     version: str
     arch: str
+    variant: str = ""
     original_version: str | None = None
     parallel_jobs: int = 1
     values: dict[str, Any] = field(default_factory=dict)

--- a/builder/tests/test_cli.py
+++ b/builder/tests/test_cli.py
@@ -65,6 +65,7 @@ def test_cmd_stage_can_download_declared_url_files(
         name="tool",
         version="1.0",
         architecture="x86_64",
+        variant="",
         staging_plan=SimpleNamespace(files={"archive": object()}),
     )
     config = SimpleNamespace(repo_root=object(), output_root=object())

--- a/builder/tests/test_generate_apps_json.py
+++ b/builder/tests/test_generate_apps_json.py
@@ -64,3 +64,27 @@ def test_generate_apps_json_rejects_duplicate_app_identity(tmp_path) -> None:
         ),
     ):
         generate_apps_json(str(releases_dir), str(tmp_path / "apps.json"))
+
+
+def test_merge_includes_named_arm64_variant(tmp_path) -> None:
+    release_path = tmp_path / "1.0.0.json"
+    release_path.write_text(
+        json.dumps(
+            {
+                "variant": "arm64",
+                "architecture": "aarch64",
+                "apps": {
+                    "tool_arm64 1.0.0": {
+                        "version": "20260102",
+                        "exec": "",
+                        "apptainer_args": [],
+                    }
+                },
+                "categories": ["workflows"],
+            }
+        )
+    )
+
+    merged = merge_container_releases("tool_arm64", [("1.0.0", str(release_path))])
+
+    assert merged["apps"]["tool_arm64 1.0.0"]["version"] == "20260102"

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -189,6 +189,9 @@ def test_verify_candidate_binds_artifacts_to_pr_and_recipe(
     (candidate_dir / "1.2.3.json").write_text(json.dumps(release), encoding="utf-8")
     manifest = {
         "recipe": "demo",
+        "container": "demo",
+        "variant": "",
+        "architecture": "x86_64",
         "version": "1.2.3",
         "build_date": "20260721",
         "image_name": "demo_1.2.3",
@@ -274,6 +277,69 @@ def test_verify_candidate_binds_artifacts_to_pr_and_recipe(
         raise AssertionError("changed recipe matched stale candidate")
 
 
+def test_verify_candidate_rejects_a_variant_the_recipe_does_not_declare(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A candidate cannot invent a container identity to promote itself into."""
+    write_recipe(tmp_path)
+    monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        one_pr_release, "build_date", lambda recipe, revision="HEAD": "20260721"
+    )
+    candidate_dir = tmp_path / "bundle" / "demo_gpu"
+    candidate_dir.mkdir(parents=True)
+    manifest = {
+        "recipe": "demo",
+        "container": "demo_gpu",
+        "variant": "gpu",
+        "architecture": "x86_64",
+        "version": "1.2.3",
+        "build_date": "20260721",
+        "image_name": "demo_gpu_1.2.3",
+        "candidate_tag": "nd-candidate-demo_gpu:abc123",
+        "docker_archive": "demo_gpu_1.2.3_20260721.docker.tar",
+        "docker_sha256": "0" * 64,
+        "sif": "demo_gpu_1.2.3_20260721.simg",
+        "sif_sha256": "0" * 64,
+        "release_json": "1.2.3.json",
+        "pr_number": 42,
+        "head_sha": "abc123",
+        "recipe_fingerprint": one_pr_release.recipe_fingerprint("demo"),
+    }
+    (candidate_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    try:
+        one_pr_release.verify_candidate(candidate_dir, "abc123", 42)
+    except RuntimeError as error:
+        assert "does not declare variant" in str(error)
+    else:
+        raise AssertionError("undeclared variant identity was accepted")
+
+
+def test_detect_targets_expands_declared_architectures(tmp_path: Path, monkeypatch) -> None:
+    """Every architecture a recipe declares becomes its own build target."""
+    recipe_dir = write_recipe(tmp_path)
+    recipe = yaml.safe_load((recipe_dir / "build.yaml").read_text(encoding="utf-8"))
+    recipe["architectures"] = ["x86_64", "aarch64"]
+    (recipe_dir / "build.yaml").write_text(yaml.safe_dump(recipe), encoding="utf-8")
+    monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
+
+    assert one_pr_release.detect_targets(["demo"]) == [
+        {
+            "recipe": "demo",
+            "variant": "",
+            "architecture": "x86_64",
+            "container": "demo",
+        },
+        {
+            "recipe": "demo",
+            "variant": "arm64",
+            "architecture": "aarch64",
+            "container": "demo_arm64",
+        },
+    ]
+
+
 def test_materialize_rejects_unverified_release_path(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -286,6 +352,7 @@ def test_materialize_rejects_unverified_release_path(
             [
                 {
                     "recipe": "demo",
+                    "container": "demo",
                     "version": "1.2.3",
                     "release_json": "../outside.json",
                 }
@@ -313,6 +380,7 @@ def test_materialize_rejects_unverified_release_path(
             [
                 {
                     "recipe": "demo",
+                    "container": "demo",
                     "version": "1.2.3",
                     "release_json": "1.2.3.json",
                 }

--- a/builder/tests/test_recipe_loading.py
+++ b/builder/tests/test_recipe_loading.py
@@ -129,3 +129,29 @@ def test_compile_rejects_empty_readme(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="README.*cannot be empty"):
         compile_recipe(recipe_dir, architecture="x86_64")
+
+
+def test_compile_named_variant_uses_concrete_container_identity() -> None:
+    config = default_config()
+    compiled = compile_recipe(
+        resolve_recipe(config, "workshopdemo"),
+        variant="arm64",
+        include_dirs=config.include_dirs,
+    )
+
+    assert compiled.base_name == "workshopdemo"
+    assert compiled.name == "workshopdemo_arm64"
+    assert compiled.variant == "arm64"
+    assert compiled.architecture == "aarch64"
+    assert compiled.tag == "workshopdemo_arm64:1.0.0"
+
+
+def test_compile_named_variant_rejects_wrong_architecture() -> None:
+    config = default_config()
+    with pytest.raises(ValueError, match="requires architecture aarch64"):
+        compile_recipe(
+            resolve_recipe(config, "workshopdemo"),
+            variant="arm64",
+            architecture="x86_64",
+            include_dirs=config.include_dirs,
+        )

--- a/builder/tests/test_recipe_loading.py
+++ b/builder/tests/test_recipe_loading.py
@@ -166,6 +166,7 @@ def test_arbitrary_variant_can_span_architectures_and_enable_options(tmp_path) -
         """name: gpu-tool
 version: 1.0
 architectures: [x86_64, aarch64]
+readme: gpu-tool {{ context.version }}
 options:
   gpu:
     default: false
@@ -217,3 +218,85 @@ categories: [workflows]
 
     with pytest.raises(ValueError, match="unknown variant/architecture"):
         compile_recipe(recipe_dir, variant="gpu", architecture="aarch64")
+
+
+def write_single_architecture_recipe(recipe_dir: Path) -> None:
+    recipe_dir.mkdir()
+    (recipe_dir / "build.yaml").write_text(
+        """name: x86only
+version: 1.0
+architectures: [x86_64]
+readme: x86only {{ context.version }}
+build:
+  kind: neurodocker
+  base-image: ubuntu:24.04
+  pkg-manager: apt
+  directives: []
+deploy:
+  bins: [x86only]
+categories: [workflows]
+"""
+    )
+
+
+def test_ignore_architectures_still_builds_an_undeclared_architecture(tmp_path) -> None:
+    recipe_dir = tmp_path / "x86only"
+    write_single_architecture_recipe(recipe_dir)
+
+    compiled = compile_recipe(
+        recipe_dir,
+        architecture="aarch64",
+        ignore_architecture=True,
+    )
+
+    assert compiled.architecture == "aarch64"
+    assert compiled.name == "x86only_arm64"
+    assert compiled.variant == "arm64"
+
+
+def test_undeclared_architecture_without_the_escape_hatch_is_rejected(tmp_path) -> None:
+    recipe_dir = tmp_path / "x86only"
+    write_single_architecture_recipe(recipe_dir)
+
+    with pytest.raises(ValueError, match="unknown variant/architecture"):
+        compile_recipe(recipe_dir, architecture="aarch64")
+
+
+def test_ignore_architectures_preserves_variant_options(tmp_path) -> None:
+    recipe_dir = tmp_path / "gpu-tool"
+    recipe_dir.mkdir()
+    (recipe_dir / "build.yaml").write_text(
+        """name: gpu-tool
+version: 1.0
+architectures: [x86_64]
+readme: gpu-tool {{ context.version }}
+options:
+  gpu:
+    default: false
+variants:
+  gpu:
+    architecture: x86_64
+    options:
+      gpu: true
+build:
+  kind: neurodocker
+  base-image: ubuntu:24.04
+  pkg-manager: apt
+  directives:
+    - condition: context.options.gpu
+      run: echo gpu-enabled
+deploy:
+  bins: [gpu-tool]
+categories: [workflows]
+"""
+    )
+
+    compiled = compile_recipe(
+        recipe_dir,
+        variant="gpu",
+        architecture="aarch64",
+        ignore_architecture=True,
+    )
+
+    assert compiled.name == "gpu-tool_gpu_arm64"
+    assert "gpu-enabled" in render_dockerfile(compiled.definition)

--- a/builder/tests/test_recipe_loading.py
+++ b/builder/tests/test_recipe_loading.py
@@ -7,6 +7,7 @@ import yaml
 
 from builder.config import default_config, resolve_recipe
 from builder.recipe import RecipeFile, compile_recipe, load_recipe, load_recipe_file
+from builder.dockerfile import render_dockerfile
 
 
 def write_minimal_recipe(recipe_dir: Path, **metadata: object) -> None:
@@ -146,12 +147,73 @@ def test_compile_named_variant_uses_concrete_container_identity() -> None:
     assert compiled.tag == "workshopdemo_arm64:1.0.0"
 
 
-def test_compile_named_variant_rejects_wrong_architecture() -> None:
+def test_compile_architecture_automatically_selects_arm64_variant() -> None:
     config = default_config()
-    with pytest.raises(ValueError, match="requires architecture aarch64"):
-        compile_recipe(
-            resolve_recipe(config, "workshopdemo"),
-            variant="arm64",
-            architecture="x86_64",
-            include_dirs=config.include_dirs,
-        )
+    compiled = compile_recipe(
+        resolve_recipe(config, "workshopdemo"),
+        architecture="aarch64",
+        include_dirs=config.include_dirs,
+    )
+
+    assert compiled.name == "workshopdemo_arm64"
+    assert compiled.variant == "arm64"
+
+
+def test_arbitrary_variant_can_span_architectures_and_enable_options(tmp_path) -> None:
+    recipe_dir = tmp_path / "gpu-tool"
+    recipe_dir.mkdir()
+    (recipe_dir / "build.yaml").write_text(
+        """name: gpu-tool
+version: 1.0
+architectures: [x86_64, aarch64]
+options:
+  gpu:
+    default: false
+variants:
+  gpu:
+    architectures: [x86_64, aarch64]
+    options:
+      gpu: true
+build:
+  kind: neurodocker
+  base-image: ubuntu:24.04
+  pkg-manager: apt
+  directives:
+    - condition: context.options.gpu
+      run: echo gpu-enabled
+deploy:
+  bins: [gpu-tool]
+categories: [workflows]
+"""
+    )
+
+    compiled = compile_recipe(recipe_dir, variant="gpu", architecture="aarch64")
+
+    assert compiled.name == "gpu-tool_gpu_arm64"
+    assert compiled.variant == "gpu_arm64"
+    assert "gpu-enabled" in render_dockerfile(compiled.definition)
+
+
+def test_compile_rejects_variant_on_an_undeclared_architecture(tmp_path) -> None:
+    recipe_dir = tmp_path / "gpu-tool"
+    recipe_dir.mkdir()
+    (recipe_dir / "build.yaml").write_text(
+        """name: gpu-tool
+version: 1.0
+architectures: [x86_64, aarch64]
+variants:
+  gpu:
+    architecture: x86_64
+build:
+  kind: neurodocker
+  base-image: ubuntu:24.04
+  pkg-manager: apt
+  directives: []
+deploy:
+  bins: [gpu-tool]
+categories: [workflows]
+"""
+    )
+
+    with pytest.raises(ValueError, match="unknown variant/architecture"):
+        compile_recipe(recipe_dir, variant="gpu", architecture="aarch64")

--- a/builder/tests/test_release.py
+++ b/builder/tests/test_release.py
@@ -60,3 +60,25 @@ def test_arm64_release_shape_matches_current_contract() -> None:
     assert data["architecture"] == "aarch64"
     assert data["apps"]["tool 1.2.3 arm64"]["architecture"] == "aarch64"
     assert data["apps"]["tool 1.2.3 arm64"]["image"] == "tool_1.2.3_arm64"
+
+
+def test_named_arm64_variant_is_a_normal_container_release() -> None:
+    data = release_data(
+        "tool_arm64",
+        "1.2.3",
+        {"categories": ["workflows"], "apptainer_args": ["--cleanenv"]},
+        "20260102",
+        "aarch64",
+        "arm64",
+    )
+
+    assert release_version("1.2.3", "aarch64", "arm64") == "1.2.3"
+    assert data["variant"] == "arm64"
+    assert data["architecture"] == "aarch64"
+    assert data["apps"] == {
+        "tool_arm64 1.2.3": {
+            "version": "20260102",
+            "exec": "",
+            "apptainer_args": ["--cleanenv"],
+        }
+    }

--- a/builder/tests/test_variant_matrix.py
+++ b/builder/tests/test_variant_matrix.py
@@ -14,9 +14,9 @@ architectures:
   - aarch64
 variants:
   gpu:
-    architecture: x86_64
-  arm64:
-    architecture: aarch64
+    architectures:
+      - x86_64
+      - aarch64
 """
     )
 
@@ -29,13 +29,19 @@ variants:
         },
         {
             "application": "tool",
+            "variant": "arm64",
+            "architecture": "aarch64",
+            "runner": '"arm-runner"',
+        },
+        {
+            "application": "tool",
             "variant": "gpu",
             "architecture": "x86_64",
             "runner": '"x86-runner"',
         },
         {
             "application": "tool",
-            "variant": "arm64",
+            "variant": "gpu_arm64",
             "architecture": "aarch64",
             "runner": '"arm-runner"',
         },

--- a/builder/tests/test_variant_matrix.py
+++ b/builder/tests/test_variant_matrix.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from tools.variant_matrix import build_matrix
+
+
+def test_build_matrix_expands_named_variants(tmp_path) -> None:
+    recipe_dir = tmp_path / "recipes" / "tool"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "build.yaml").write_text(
+        """name: tool
+version: 1.0
+architectures:
+  - x86_64
+  - aarch64
+variants:
+  gpu:
+    architecture: x86_64
+  arm64:
+    architecture: aarch64
+"""
+    )
+
+    assert build_matrix(tmp_path, ["tool"], '"x86-runner"', '"arm-runner"') == [
+        {
+            "application": "tool",
+            "variant": "",
+            "architecture": "x86_64",
+            "runner": '"x86-runner"',
+        },
+        {
+            "application": "tool",
+            "variant": "gpu",
+            "architecture": "x86_64",
+            "runner": '"x86-runner"',
+        },
+        {
+            "application": "tool",
+            "variant": "arm64",
+            "architecture": "aarch64",
+            "runner": '"arm-runner"',
+        },
+    ]

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -24,9 +24,12 @@ def test_workflows_expand_named_variants_and_pass_identity_to_builder() -> None:
 
     assert 'variant: ${{ matrix.variant }}' in manual_workflow
     assert 'variant: ${{ matrix.variant }}' in auto_workflow
-    assert "tools/variant_matrix.py" in manual_workflow
-    assert "tools/variant_matrix.py" in auto_workflow
+    assert 'architecture: ${{ matrix.architecture }}' in manual_workflow
+    assert 'architecture: ${{ matrix.architecture }}' in auto_workflow
+    assert "-m tools.variant_matrix" in manual_workflow
+    assert "-m tools.variant_matrix" in auto_workflow
     assert 'VARIANT_ARGS=(--variant "$VARIANT")' in build_workflow
+    assert 'ARCHITECTURE="${{ inputs.architecture }}"' in build_workflow
     assert 'CONTAINER_NAME="${APPLICATION}_${VARIANT}"' in build_workflow
 
 

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -13,8 +13,21 @@ def test_build_app_workflow_uses_staged_cache_context() -> None:
 def test_build_app_workflow_uses_version_stable_build_cache_ref() -> None:
     workflow = Path(".github/workflows/build-app.yml").read_text()
 
-    assert "CACHE_REF=ghcr.io/${GH_REGISTRY}/${APPLICATION}${IMAGE_SUFFIX}:buildcache" in workflow
+    assert "CACHE_REF=ghcr.io/${GH_REGISTRY}/${CONTAINER_NAME}:buildcache" in workflow
     assert "CACHE_REF=ghcr.io/${GH_REGISTRY}/${IMAGENAME}:buildcache" not in workflow
+
+
+def test_workflows_expand_named_variants_and_pass_identity_to_builder() -> None:
+    build_workflow = Path(".github/workflows/build-app.yml").read_text()
+    manual_workflow = Path(".github/workflows/manual-build.yml").read_text()
+    auto_workflow = Path(".github/workflows/auto-build.yml").read_text()
+
+    assert 'variant: ${{ matrix.variant }}' in manual_workflow
+    assert 'variant: ${{ matrix.variant }}' in auto_workflow
+    assert "tools/variant_matrix.py" in manual_workflow
+    assert "tools/variant_matrix.py" in auto_workflow
+    assert 'VARIANT_ARGS=(--variant "$VARIANT")' in build_workflow
+    assert 'CONTAINER_NAME="${APPLICATION}_${VARIANT}"' in build_workflow
 
 
 def test_build_app_workflow_strips_version_inline_comments() -> None:

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -17,20 +17,41 @@ def test_build_app_workflow_uses_version_stable_build_cache_ref() -> None:
     assert "CACHE_REF=ghcr.io/${GH_REGISTRY}/${IMAGENAME}:buildcache" not in workflow
 
 
-def test_workflows_expand_named_variants_and_pass_identity_to_builder() -> None:
+def test_manual_workflow_expands_named_variants_and_passes_identity_to_builder() -> None:
     build_workflow = Path(".github/workflows/build-app.yml").read_text()
     manual_workflow = Path(".github/workflows/manual-build.yml").read_text()
-    auto_workflow = Path(".github/workflows/auto-build.yml").read_text()
 
-    assert 'variant: ${{ matrix.variant }}' in manual_workflow
-    assert 'variant: ${{ matrix.variant }}' in auto_workflow
-    assert 'architecture: ${{ matrix.architecture }}' in manual_workflow
-    assert 'architecture: ${{ matrix.architecture }}' in auto_workflow
+    assert "variant: ${{ matrix.variant }}" in manual_workflow
+    assert "architecture: ${{ matrix.architecture }}" in manual_workflow
     assert "-m tools.variant_matrix" in manual_workflow
-    assert "-m tools.variant_matrix" in auto_workflow
     assert 'VARIANT_ARGS=(--variant "$VARIANT")' in build_workflow
     assert 'ARCHITECTURE="${{ inputs.architecture }}"' in build_workflow
     assert 'CONTAINER_NAME="${APPLICATION}_${VARIANT}"' in build_workflow
+
+
+def test_candidate_workflow_builds_every_declared_variant() -> None:
+    candidate_workflow = Path(".github/workflows/pr-container-candidate.yml").read_text()
+
+    assert "include: ${{ fromJSON(needs.detect.outputs.targets) }}" in candidate_workflow
+    assert '--architecture "${ARCHITECTURE}" --variant "${VARIANT}"' in candidate_workflow
+    # aarch64 candidates must not land on the x86 ARC pool.
+    assert "matrix.architecture == 'aarch64'" in candidate_workflow
+    assert "--architecture x86_64" not in candidate_workflow
+
+
+def test_candidate_artifacts_and_promotion_key_off_container_identity() -> None:
+    candidate_workflow = Path(".github/workflows/pr-container-candidate.yml").read_text()
+    promote_workflow = Path(".github/workflows/promote-container-candidate.yml").read_text()
+
+    assert (
+        "name: candidate-${{ matrix.container }}-${{ github.event.pull_request.head.sha }}"
+        in candidate_workflow
+    )
+    assert "path: candidate/${{ matrix.container }}/" in candidate_workflow
+    # Two variants of one recipe publish to different registry repositories.
+    assert 'ghcr="ghcr.io/${GH_REGISTRY}/${container}"' in promote_workflow
+    assert 'quay="quay.io/neurodesk/${container}"' in promote_workflow
+    assert "${recipe}" not in promote_workflow
 
 
 def test_build_app_workflow_strips_version_inline_comments() -> None:

--- a/builder/validation.py
+++ b/builder/validation.py
@@ -636,6 +636,12 @@ class NeuroDockerBuildRecipe:
     fix_locale_def: Optional[bool] = attrs.field(default=None)
 
 
+@attrs.define
+class VariantConfig:
+    architecture: str = attrs.field(validator=validate_architecture)
+    description: Optional[str] = attrs.field(default=None)
+
+
 # ============================================================================
 # Main Container Recipe Schema
 # ============================================================================
@@ -647,6 +653,7 @@ class ContainerRecipe:
     version: str = attrs.field(validator=validate_non_empty_string)
     architectures: List[str] = attrs.field(validator=attrs.validators.min_len(1))
     build: NeuroDockerBuildRecipe = attrs.field()
+    variants: Optional[Dict[str, VariantConfig]] = attrs.field(default=None)
     auto_update: Optional[AutoUpdate] = attrs.field(default=None)
     icon: Optional[str] = attrs.field(default=None)
     copyright: Optional[List[Union[CustomCopyrightInfo, SPDXCopyrightInfo]]] = (
@@ -677,6 +684,21 @@ class ContainerRecipe:
             if arch not in ARCHITECTURES:
                 raise ValueError(
                     f"Architecture '{arch}' not supported. Must be one of: {ARCHITECTURES}"
+                )
+
+    @variants.validator
+    def _validate_variants(self, attribute, value):
+        if not value:
+            return
+        for name, variant in value.items():
+            if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", name):
+                raise ValueError(
+                    f"Variant name '{name}' must contain only lowercase letters, numbers, underscores, or hyphens"
+                )
+            if variant.architecture not in self.architectures:
+                raise ValueError(
+                    f"Variant '{name}' uses architecture '{variant.architecture}', "
+                    "which is not listed in architectures"
                 )
 
     @categories.validator
@@ -885,6 +907,12 @@ def validate_recipe_dict(
 
         build_recipe = NeuroDockerBuildRecipe(**build_dict)
         recipe_copy["build"] = build_recipe
+
+        if "variants" in recipe_copy and recipe_copy["variants"]:
+            recipe_copy["variants"] = {
+                str(name): VariantConfig(**config)
+                for name, config in recipe_copy["variants"].items()
+            }
 
         # Parse files if present
         if "files" in recipe_copy and recipe_copy["files"]:

--- a/builder/validation.py
+++ b/builder/validation.py
@@ -638,8 +638,25 @@ class NeuroDockerBuildRecipe:
 
 @attrs.define
 class VariantConfig:
-    architecture: str = attrs.field(validator=validate_architecture)
+    architecture: Optional[str] = attrs.field(
+        default=None, validator=attrs.validators.optional(validate_architecture)
+    )
+    architectures: Optional[List[str]] = attrs.field(default=None)
     description: Optional[str] = attrs.field(default=None)
+    options: Optional[Dict[str, bool]] = attrs.field(default=None)
+
+    @architectures.validator
+    def _validate_architectures(self, attribute, value):
+        if value is None:
+            return
+        if not value:
+            raise ValueError("Variant architectures must not be empty")
+        for architecture in value:
+            validate_architecture(None, attribute, architecture)
+
+    def __attrs_post_init__(self):
+        if self.architecture is not None and self.architectures is not None:
+            raise ValueError("Variant must use architecture or architectures, not both")
 
 
 # ============================================================================
@@ -695,11 +712,28 @@ class ContainerRecipe:
                 raise ValueError(
                     f"Variant name '{name}' must contain only lowercase letters, numbers, underscores, or hyphens"
                 )
-            if variant.architecture not in self.architectures:
+            if name == "arm64" or name.endswith("_arm64"):
                 raise ValueError(
-                    f"Variant '{name}' uses architecture '{variant.architecture}', "
-                    "which is not listed in architectures"
+                    f"Variant name '{name}' conflicts with the automatic ARM64 suffix"
                 )
+            variant_architectures = variant.architectures or (
+                [variant.architecture] if variant.architecture else []
+            )
+            for architecture in variant_architectures:
+                if architecture not in self.architectures:
+                    raise ValueError(
+                        f"Variant '{name}' uses architecture '{architecture}', "
+                        "which is not listed in architectures"
+                    )
+            for option, enabled in (variant.options or {}).items():
+                if option not in (self.options or {}):
+                    raise ValueError(
+                        f"Variant '{name}' sets unknown recipe option '{option}'"
+                    )
+                if not isinstance(enabled, bool):
+                    raise ValueError(
+                        f"Variant '{name}' option '{option}' must be true or false"
+                    )
 
     @categories.validator
     def _validate_categories(self, attribute, value):

--- a/builder/variants.py
+++ b/builder/variants.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+ARCHITECTURE_ALIASES = {
+    "x86_64": "x86_64",
+    "AMD64": "x86_64",
+    "amd64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+    "ARM64": "aarch64",
+}
+
+
+def normalize_declared_architecture(value: str) -> str:
+    try:
+        return ARCHITECTURE_ALIASES[value]
+    except KeyError as exc:
+        raise ValueError(f"unsupported architecture: {value}") from exc
+
+
+def concrete_variant_specs(recipe: dict[str, Any]) -> list[dict[str, Any]]:
+    """Expand architectures and alternatives into concrete container identities."""
+    architectures = [
+        normalize_declared_architecture(str(item))
+        for item in recipe.get("architectures", [])
+    ]
+    if not architectures:
+        raise ValueError(f"recipe {recipe.get('name', '<unknown>')} has no architectures")
+    default_architecture = "x86_64" if "x86_64" in architectures else architectures[0]
+
+    specs: list[dict[str, Any]] = []
+    ordered_architectures = [
+        default_architecture,
+        *[arch for arch in architectures if arch != default_architecture],
+    ]
+    for architecture in ordered_architectures:
+        architecture_variant = "arm64" if architecture == "aarch64" else ""
+        specs.append(
+            {
+                "variant": architecture_variant,
+                "recipe_variant": "",
+                "name": (
+                    f"{recipe['name']}_{architecture_variant}"
+                    if architecture_variant
+                    else str(recipe["name"])
+                ),
+                "architecture": architecture,
+                "options": {},
+            }
+        )
+
+    for variant_name, config in (recipe.get("variants") or {}).items():
+        configured_architectures = config.get("architectures") or (
+            [config["architecture"]]
+            if config.get("architecture")
+            else [default_architecture]
+        )
+        for configured_architecture in configured_architectures:
+            architecture = normalize_declared_architecture(str(configured_architecture))
+            suffix = (
+                f"{variant_name}_arm64"
+                if architecture == "aarch64"
+                else str(variant_name)
+            )
+            specs.append(
+                {
+                    "variant": suffix,
+                    "recipe_variant": str(variant_name),
+                    "name": f"{recipe['name']}_{suffix}",
+                    "architecture": architecture,
+                    "options": dict(config.get("options") or {}),
+                }
+            )
+
+    selectors = [str(spec["variant"]) for spec in specs]
+    if len(selectors) != len(set(selectors)):
+        raise ValueError(f"recipe {recipe['name']} declares duplicate concrete variants")
+    return specs
+
+
+def variant_specs(recipe: dict[str, Any]) -> list[dict[str, str]]:
+    """Return the public workflow representation of concrete containers."""
+    return [
+        {key: str(spec[key]) for key in ("variant", "name", "architecture")}
+        for spec in concrete_variant_specs(recipe)
+    ]

--- a/builder/variants.py
+++ b/builder/variants.py
@@ -20,6 +20,54 @@ def normalize_declared_architecture(value: str) -> str:
         raise ValueError(f"unsupported architecture: {value}") from exc
 
 
+def make_variant_spec(
+    recipe_name: str,
+    recipe_variant: str,
+    architecture: str,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one concrete container identity from its parts."""
+    suffix = "_arm64" if architecture == "aarch64" else ""
+    selector = f"{recipe_variant}{suffix}" if recipe_variant else suffix.lstrip("_")
+    return {
+        "variant": selector,
+        "recipe_variant": recipe_variant,
+        "name": f"{recipe_name}_{selector}" if selector else recipe_name,
+        "architecture": architecture,
+        "options": dict(options or {}),
+    }
+
+
+def forced_variant_spec(
+    recipe: dict[str, Any],
+    variant: str,
+    architecture: str,
+) -> dict[str, Any]:
+    """Build an identity for an architecture the recipe does not declare.
+
+    Only reachable via --ignore-architectures, which exists so a recipe can be
+    built (usually under emulation) on a machine it does not advertise support
+    for. Naming still follows the normal rules so the escape hatch cannot
+    produce an identity that collides with a declared one.
+    """
+    recipe_variant = variant
+    if recipe_variant.endswith("_arm64"):
+        recipe_variant = recipe_variant[: -len("_arm64")]
+    elif recipe_variant == "arm64":
+        recipe_variant = ""
+    config = (recipe.get("variants") or {}).get(recipe_variant) or {}
+    if recipe_variant and not config:
+        raise ValueError(
+            f"recipe {recipe['name']} does not declare variant '{recipe_variant}'"
+        )
+    return make_variant_spec(
+        str(recipe["name"]),
+        recipe_variant,
+        architecture,
+        config.get("options"),
+    )
+
+
 def concrete_variant_specs(recipe: dict[str, Any]) -> list[dict[str, Any]]:
     """Expand architectures and alternatives into concrete container identities."""
     architectures = [
@@ -36,20 +84,7 @@ def concrete_variant_specs(recipe: dict[str, Any]) -> list[dict[str, Any]]:
         *[arch for arch in architectures if arch != default_architecture],
     ]
     for architecture in ordered_architectures:
-        architecture_variant = "arm64" if architecture == "aarch64" else ""
-        specs.append(
-            {
-                "variant": architecture_variant,
-                "recipe_variant": "",
-                "name": (
-                    f"{recipe['name']}_{architecture_variant}"
-                    if architecture_variant
-                    else str(recipe["name"])
-                ),
-                "architecture": architecture,
-                "options": {},
-            }
-        )
+        specs.append(make_variant_spec(str(recipe["name"]), "", architecture))
 
     for variant_name, config in (recipe.get("variants") or {}).items():
         configured_architectures = config.get("architectures") or (
@@ -59,19 +94,13 @@ def concrete_variant_specs(recipe: dict[str, Any]) -> list[dict[str, Any]]:
         )
         for configured_architecture in configured_architectures:
             architecture = normalize_declared_architecture(str(configured_architecture))
-            suffix = (
-                f"{variant_name}_arm64"
-                if architecture == "aarch64"
-                else str(variant_name)
-            )
             specs.append(
-                {
-                    "variant": suffix,
-                    "recipe_variant": str(variant_name),
-                    "name": f"{recipe['name']}_{suffix}",
-                    "architecture": architecture,
-                    "options": dict(config.get("options") or {}),
-                }
+                make_variant_spec(
+                    str(recipe["name"]),
+                    str(variant_name),
+                    architecture,
+                    config.get("options"),
+                )
             )
 
     selectors = [str(spec["variant"]) for spec in specs]

--- a/recipes/workshopdemo/build.yaml
+++ b/recipes/workshopdemo/build.yaml
@@ -3,10 +3,6 @@ version: 1.0.0
 architectures:
   - x86_64
   - aarch64
-variants:
-  arm64:
-    architecture: aarch64
-    description: Native ARM64 build
 structured_readme:
   description: This tool was commited for the workshop.
   example: hello

--- a/recipes/workshopdemo/build.yaml
+++ b/recipes/workshopdemo/build.yaml
@@ -3,6 +3,10 @@ version: 1.0.0
 architectures:
   - x86_64
   - aarch64
+variants:
+  arm64:
+    architecture: aarch64
+    description: Native ARM64 build
 structured_readme:
   description: This tool was commited for the workshop.
   example: hello
@@ -14,6 +18,9 @@ build:
   pkg-manager: apt
   directives:
     - install: hello
+deploy:
+  bins:
+    - hello
 categories:
   - functional imaging
   - workflows

--- a/recipes/workshopdemo/build.yaml
+++ b/recipes/workshopdemo/build.yaml
@@ -14,9 +14,6 @@ build:
   pkg-manager: apt
   directives:
     - install: hello
-deploy:
-  bins:
-    - hello
 categories:
   - functional imaging
   - workflows

--- a/tools/generate_apps_json.py
+++ b/tools/generate_apps_json.py
@@ -58,8 +58,10 @@ def load_release_file(file_path: str) -> Dict[str, Any]:
         return {"apps": {}, "categories": []}
 
 
-def is_arm64_release(release_data: Dict[str, Any]) -> bool:
-    """Return whether a release targets arm64/aarch64."""
+def is_legacy_arm64_release(release_data: Dict[str, Any]) -> bool:
+    """Return whether this uses the old version-suffixed arm64 contract."""
+    if release_data.get("variant"):
+        return False
     architecture = release_data.get('architecture')
     if architecture in {'aarch64', 'arm64'}:
         return True
@@ -91,8 +93,8 @@ def merge_container_releases(container_name: str, release_files: list) -> Dict[s
         print(f"  Processing {container_name} {version}")
         
         release_data = load_release_file(file_path)
-        if is_arm64_release(release_data):
-            print(f"    Skipping {container_name} {version}: arm64 releases are not included in apps.json yet")
+        if is_legacy_arm64_release(release_data):
+            print(f"    Skipping {container_name} {version}: legacy arm64 releases are not included in apps.json")
             continue
         
         # Merge apps

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -22,12 +22,16 @@ if str(SCRIPT_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPT_REPO_ROOT))
 
 from builder.release import release_data
+from builder.variants import concrete_variant_specs
 
 REPO_ROOT = SCRIPT_REPO_ROOT
 VERSION_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 RECIPE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 CANDIDATE_MANIFEST_FIELDS = (
     "recipe",
+    "container",
+    "variant",
+    "architecture",
     "version",
     "build_date",
     "image_name",
@@ -151,8 +155,24 @@ def load_recipe(recipe: str) -> dict[str, Any]:
     return data
 
 
-def inspect_recipe(recipe: str, head_sha: str) -> dict[str, str]:
-    """Derive safe candidate names and release identifiers for a recipe."""
+def resolve_variant(recipe: str, variant: str) -> dict[str, Any]:
+    """Return the declared concrete identity for a recipe variant selector.
+
+    The selector reaches promotion inside an untrusted candidate manifest, so it
+    is always resolved against the merged recipe rather than trusted as a name.
+    """
+    data = load_recipe(recipe)
+    for spec in concrete_variant_specs(data):
+        if str(spec["variant"]) == variant:
+            return spec
+    declared = ", ".join(str(spec["variant"]) or "default" for spec in concrete_variant_specs(data))
+    raise RuntimeError(
+        f"Recipe {recipe} does not declare variant {variant or 'default'!r}; declared: {declared}"
+    )
+
+
+def inspect_recipe(recipe: str, head_sha: str, variant: str = "") -> dict[str, str]:
+    """Derive safe candidate names and release identifiers for a recipe variant."""
     data = load_recipe(recipe)
     if "version" not in data:
         raise RuntimeError(f"Recipe {recipe} build.yaml is missing a version field")
@@ -162,14 +182,19 @@ def inspect_recipe(recipe: str, head_sha: str) -> dict[str, str]:
             f"Recipe {recipe} has an invalid version {version!r}; "
             "use only letters, numbers, dots, underscores, and hyphens"
         )
+    spec = resolve_variant(recipe, variant)
+    container = validate_recipe_identifier(str(spec["name"]))
     date = build_date(recipe, head_sha)
-    image_name = f"{recipe}_{version}"
+    image_name = f"{container}_{version}"
     return {
         "recipe": recipe,
+        "container": container,
+        "variant": variant,
+        "architecture": str(spec["architecture"]),
         "version": version,
         "build_date": date,
         "image_name": image_name,
-        "candidate_tag": f"nd-candidate-{recipe}:{head_sha[:12]}",
+        "candidate_tag": f"nd-candidate-{container}:{head_sha[:12]}",
         "docker_archive": f"{image_name}_{date}.docker.tar",
         "sif": f"{image_name}_{date}.simg",
     }
@@ -187,19 +212,43 @@ def write_output(values: dict[str, str]) -> None:
             handle.write(f"{key}={value}\n")
 
 
+def detect_targets(recipes: list[str]) -> list[dict[str, str]]:
+    """Expand changed recipes into the concrete containers they now declare."""
+    targets = []
+    for recipe in recipes:
+        for spec in concrete_variant_specs(load_recipe(recipe)):
+            targets.append(
+                {
+                    "recipe": recipe,
+                    "variant": str(spec["variant"]),
+                    "architecture": str(spec["architecture"]),
+                    # The identity becomes an artifact name and a build path, so
+                    # it is checked here rather than only at promotion time.
+                    "container": validate_recipe_identifier(str(spec["name"])),
+                }
+            )
+    return targets
+
+
 def command_detect(args: argparse.Namespace) -> None:
     """Implement the detect CLI command."""
-    write_output({"recipes": json.dumps(detect_recipes(args.base, args.head))})
+    recipes = detect_recipes(args.base, args.head)
+    write_output(
+        {
+            "recipes": json.dumps(recipes),
+            "targets": json.dumps(detect_targets(recipes)),
+        }
+    )
 
 
 def command_inspect(args: argparse.Namespace) -> None:
     """Implement the inspect CLI command."""
-    write_output(inspect_recipe(args.recipe, args.head_sha))
+    write_output(inspect_recipe(args.recipe, args.head_sha, args.variant))
 
 
 def command_manifest(args: argparse.Namespace) -> None:
     """Create the release preview and provenance manifest for a candidate."""
-    info = inspect_recipe(args.recipe, args.head_sha)
+    info = inspect_recipe(args.recipe, args.head_sha, args.variant)
     candidate_dir = Path(args.candidate_dir)
     docker_archive = candidate_dir / info["docker_archive"]
     sif = candidate_dir / info["sif"]
@@ -208,7 +257,12 @@ def command_manifest(args: argparse.Namespace) -> None:
 
     recipe = load_recipe(args.recipe)
     metadata = release_data(
-        args.recipe, info["version"], recipe, info["build_date"], "x86_64"
+        info["container"],
+        info["version"],
+        recipe,
+        info["build_date"],
+        info["architecture"],
+        info["variant"],
     )
     release_path = candidate_dir / f"{info['version']}.json"
     release_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
@@ -270,16 +324,25 @@ def verify_candidate(
     """Verify a candidate against its PR identity and the merged recipe."""
     manifest = load_candidate_manifest(candidate_dir)
     recipe = validate_recipe_identifier(manifest.get("recipe"))
-    if candidate_dir.name != recipe:
-        raise RuntimeError(f"Candidate directory does not match recipe {recipe}")
+    variant = manifest.get("variant")
+    if not isinstance(variant, str):
+        raise RuntimeError(f"Invalid candidate variant for {recipe}: {variant!r}")
+    # Resolving the selector against the merged recipe is what stops a candidate
+    # from inventing a container identity and promoting itself into an
+    # unrelated releases/ directory.
+    expected_info = inspect_recipe(recipe, expected_head_sha, variant)
+    container = expected_info["container"]
+    if candidate_dir.name != container:
+        raise RuntimeError(f"Candidate directory does not match container {container}")
+    if manifest.get("container") != container:
+        raise RuntimeError(f"Candidate container mismatch for {recipe}")
     if manifest["head_sha"] != expected_head_sha:
-        raise RuntimeError(f"Candidate head SHA mismatch for {recipe}")
+        raise RuntimeError(f"Candidate head SHA mismatch for {container}")
     if expected_pr_number is not None and manifest["pr_number"] != expected_pr_number:
-        raise RuntimeError(f"Candidate PR number mismatch for {recipe}")
+        raise RuntimeError(f"Candidate PR number mismatch for {container}")
     if manifest["recipe_fingerprint"] != recipe_fingerprint(recipe):
-        raise RuntimeError(f"Merged recipe differs from tested candidate: {recipe}")
+        raise RuntimeError(f"Merged recipe differs from tested candidate: {container}")
 
-    expected_info = inspect_recipe(recipe, expected_head_sha)
     expected_release_json = f"{expected_info['version']}.json"
     paths = {
         "docker_archive": candidate_file(
@@ -291,6 +354,9 @@ def verify_candidate(
         ),
     }
     expected_values = {
+        "container": container,
+        "variant": variant,
+        "architecture": expected_info["architecture"],
         "version": expected_info["version"],
         "build_date": expected_info["build_date"],
         "image_name": expected_info["image_name"],
@@ -302,7 +368,7 @@ def verify_candidate(
     for field, expected in expected_values.items():
         if manifest.get(field) != expected:
             raise RuntimeError(
-                f"Candidate {field} mismatch for {recipe}: "
+                f"Candidate {field} mismatch for {container}: "
                 f"expected {expected!r}, got {manifest.get(field)!r}"
             )
     for filename_key, digest_key in (
@@ -314,15 +380,16 @@ def verify_candidate(
             raise RuntimeError(f"Checksum mismatch: {path}")
 
     expected_release = release_data(
-        recipe,
+        container,
         expected_info["version"],
         load_recipe(recipe),
         expected_info["build_date"],
-        "x86_64",
+        expected_info["architecture"],
+        variant,
     )
     actual_release = json.loads(paths["release_json"].read_text(encoding="utf-8"))
     if actual_release != expected_release:
-        raise RuntimeError(f"Release JSON mismatch for {recipe}")
+        raise RuntimeError(f"Release JSON mismatch for {container}")
     return {**manifest, **expected_values, "recipe": recipe}
 
 
@@ -345,16 +412,17 @@ def command_materialize(args: argparse.Namespace) -> None:
     manifests = json.loads(Path(args.manifests).read_text(encoding="utf-8"))
     for manifest in manifests:
         recipe = validate_recipe_identifier(manifest.get("recipe"))
+        container = validate_recipe_identifier(manifest.get("container"))
         version = manifest.get("version")
         if not isinstance(version, str) or not VERSION_PATTERN.fullmatch(version):
-            raise RuntimeError(f"Invalid verified version for {recipe}: {version!r}")
+            raise RuntimeError(f"Invalid verified version for {container}: {version!r}")
         expected_release_json = f"{version}.json"
         if manifest.get("release_json") != expected_release_json:
-            raise RuntimeError(f"Invalid verified release JSON for {recipe}")
+            raise RuntimeError(f"Invalid verified release JSON for {container}")
         source = candidate_file(
-            bundle / recipe, manifest["release_json"], "release JSON"
+            bundle / container, manifest["release_json"], "release JSON"
         )
-        destination = REPO_ROOT / "releases" / recipe / expected_release_json
+        destination = REPO_ROOT / "releases" / container / expected_release_json
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, destination)
 
@@ -373,11 +441,13 @@ def parser() -> argparse.ArgumentParser:
     inspect = subparsers.add_parser("inspect")
     inspect.add_argument("--recipe", required=True)
     inspect.add_argument("--head-sha", required=True)
+    inspect.add_argument("--variant", default="")
     inspect.set_defaults(func=command_inspect)
 
     manifest = subparsers.add_parser("manifest")
     manifest.add_argument("--recipe", required=True)
     manifest.add_argument("--head-sha", required=True)
+    manifest.add_argument("--variant", default="")
     manifest.add_argument("--pr-number", required=True, type=int)
     manifest.add_argument("--candidate-dir", required=True)
     manifest.set_defaults(func=command_manifest)

--- a/tools/variant_matrix.py
+++ b/tools/variant_matrix.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import yaml
 
+from builder.variants import variant_specs
+
 
 def build_matrix(
     repo_root: Path,
@@ -20,24 +22,12 @@ def build_matrix(
     for application in applications:
         recipe_path = repo_root / "recipes" / application / "build.yaml"
         recipe = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
-        architectures = recipe.get("architectures") or []
-        if not architectures:
-            raise ValueError(f"{recipe_path} does not declare architectures")
-
-        matrix.append(
-            {
-                "application": application,
-                "variant": "",
-                "architecture": str(architectures[0]),
-                "runner": default_runner,
-            }
-        )
-        for variant, config in (recipe.get("variants") or {}).items():
-            architecture = str(config["architecture"])
+        for spec in variant_specs(recipe):
+            architecture = spec["architecture"]
             matrix.append(
                 {
                     "application": application,
-                    "variant": str(variant),
+                    "variant": spec["variant"],
                     "architecture": architecture,
                     "runner": arm64_runner if architecture == "aarch64" else default_runner,
                 }

--- a/tools/variant_matrix.py
+++ b/tools/variant_matrix.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Expand logical recipe names into concrete workflow build jobs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+
+def build_matrix(
+    repo_root: Path,
+    applications: list[str],
+    default_runner: str,
+    arm64_runner: str,
+) -> list[dict[str, str]]:
+    matrix: list[dict[str, str]] = []
+    for application in applications:
+        recipe_path = repo_root / "recipes" / application / "build.yaml"
+        recipe = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
+        architectures = recipe.get("architectures") or []
+        if not architectures:
+            raise ValueError(f"{recipe_path} does not declare architectures")
+
+        matrix.append(
+            {
+                "application": application,
+                "variant": "",
+                "architecture": str(architectures[0]),
+                "runner": default_runner,
+            }
+        )
+        for variant, config in (recipe.get("variants") or {}).items():
+            architecture = str(config["architecture"])
+            matrix.append(
+                {
+                    "application": application,
+                    "variant": str(variant),
+                    "architecture": architecture,
+                    "runner": arm64_runner if architecture == "aarch64" else default_runner,
+                }
+            )
+    return matrix
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--applications", required=True, help="JSON array of recipe names")
+    parser.add_argument("--default-runner", required=True, help="JSON-encoded runner payload")
+    parser.add_argument("--arm64-runner", required=True, help="JSON-encoded ARM64 runner payload")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    applications = json.loads(args.applications)
+    if not isinstance(applications, list) or not all(isinstance(item, str) for item in applications):
+        raise ValueError("--applications must be a JSON array of strings")
+    print(
+        json.dumps(
+            build_matrix(
+                args.repo_root,
+                applications,
+                args.default_runner,
+                args.arm64_runner,
+            ),
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/variant_matrix.py
+++ b/tools/variant_matrix.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import yaml
@@ -21,6 +22,12 @@ def build_matrix(
     matrix: list[dict[str, str]] = []
     for application in applications:
         recipe_path = repo_root / "recipes" / application / "build.yaml"
+        if not recipe_path.is_file():
+            # A deleted recipe still shows up in the changed-paths list. Skipping
+            # it keeps the rest of the batch buildable; failing here would expand
+            # one missing recipe into zero builds for every other application.
+            print(f"skipping {application}: no build.yaml", file=sys.stderr)
+            continue
         recipe = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
         for spec in variant_specs(recipe):
             architecture = spec["architecture"]

--- a/workflows/ONE_PR_RELEASES.md
+++ b/workflows/ONE_PR_RELEASES.md
@@ -6,15 +6,21 @@ artifacts after merge. They no longer create a second release-metadata PR.
 ## Flow
 
 1. A recipe-only PR runs `PR container candidate` with `contents: read` and no
-   secrets on an ephemeral ARC runner.
-2. It builds a Docker archive and SIF, runs the deploy/fulltest and Dive checks,
-   generates the release JSON preview, and stores everything for 30 days.
+   secrets on an ephemeral ARC runner. Each recipe fans out into one candidate
+   per concrete container it declares, so a recipe listing both architectures
+   builds `<name>` on the ARC pool and `<name>_arm64` on an ephemeral ARM64
+   runner.
+2. Each candidate builds a Docker archive and SIF, runs the deploy/fulltest and
+   Dive checks, generates the release JSON preview, and stores everything for
+   30 days under its own container identity.
 3. A trusted `workflow_run` posts download/testing instructions on the PR but
    never opens or executes its artifacts.
 4. `Container release gate` is the stable required check for branch rules.
 5. After merge, `Promote merged container candidate` selects the successful run
    for the exact PR head SHA. It verifies the PR number, recipe fingerprint,
    artifact hashes, and release metadata before publishing the tested files.
+   The variant a candidate claims is re-resolved against the merged recipe, so a
+   candidate cannot promote itself into an identity the recipe never declared.
 6. The promoter commits the generated JSON to `releases/` on `main`. That push
    triggers the existing apps/webapps update workflows.
 


### PR DESCRIPTION
## Summary

- automatically expand recipe architectures into concrete identities: x86_64 keeps the base name and aarch64 becomes `{base}_arm64`
- support arbitrary named alternatives such as `gpu` or `cuda12`, optionally across multiple architectures
- allow alternatives to preset existing boolean recipe options, producing identities such as `{base}_gpu` and `{base}_gpu_arm64`
- fan out automatic and manual workflows onto architecture-appropriate runners and pass architecture explicitly
- publish every concrete identity through normal release/apps metadata while leaving legacy `*-arm64` releases excluded

## Validation

- 33 affected builder and workflow contract tests pass
- workflow YAML parses successfully
- native amd64 Docker build: `workshopdemo:1.0.0`, `hello` passes
- native arm64 Docker/buildx build on astra-pi5 using only `--architecture aarch64`: automatically named `workshopdemo_arm64:1.0.0`, architecture is `arm64`, `hello` passes

Related to neurodesk/neurocommand#733.