### PR TITLE
Add release for civet 2.1.1

### DIFF
--- a/recipes/civet/fulltest.yaml
+++ b/recipes/civet/fulltest.yaml
@@ -210,8 +210,8 @@ tests:
   - name: mincview is executable
     command: test -x "$(command -v mincview)"
     expected_exit_code: 0
-  - name: mincview launcher help starts
-    command: mincview -help 2>&1 | grep -q 'Usage:'
+  - name: mincview help reports usage
+    command: output="$(mincview -help 2>&1 || true)" && grep -q 'Usage:' <<< "$output"
     expected_exit_code: 0
   - name: minctracc resolves on PATH
     command: command -v minctracc

--- a/releases/civet/2.1.1.json
+++ b/releases/civet/2.1.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "civet 2.1.1": {
+      "version": "20260722",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "structural imaging"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **civet 2.1.1**.

## Changes

- Add `releases/civet/2.1.1.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh civet 2.1.1 20260722
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/civet_2.1.1_20260722.simg -O
singularity shell --overlay /tmp/apptainer_overlay civet_2.1.1_20260722.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a release manifest for Civet 2.1.1.
  - Classified the release under structural imaging.
  - Included version metadata for the 20260722 build.
- **Tests**
  - Updated the `mincview` help-related test to validate the presence of the `Usage:` text in captured output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->