### PR TITLE
Add release for clinicadl 1.6.1

### DIFF
--- a/releases/clinicadl/1.6.1.json
+++ b/releases/clinicadl/1.6.1.json
@@ -1,0 +1,12 @@
+{
+  "apps": {
+    "clinicadl 1.6.1": {
+      "version": "20260722",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "workflows"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **clinicadl 1.6.1**.

## Changes

- Add `releases/clinicadl/1.6.1.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh clinicadl 1.6.1 20260722
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/clinicadl_1.6.1_20260722.simg -O
singularity shell --overlay /tmp/apptainer_overlay clinicadl_1.6.1_20260722.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ClinicADL 1.6.1 release.
  * Registered the release in the workflows catalog for availability through supported deployment options.

* **Chores**
  * Updated release metadata to identify the new version and its standard execution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->