### PR TITLE
Return original SCT images when analysis fails

### DIFF
--- a/recipes/spinalcordtoolbox/build.yaml
+++ b/recipes/spinalcordtoolbox/build.yaml
@@ -1,5 +1,5 @@
 name: spinalcordtoolbox
-version: "7.3.1"
+version: "7.3.2"
 copyright:
   - license: LGPL-3.0
     url: https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/LICENSE

--- a/recipes/spinalcordtoolbox/spinalcordtoolbox.py
+++ b/recipes/spinalcordtoolbox/spinalcordtoolbox.py
@@ -177,7 +177,6 @@ SCT_SEGMENT_POSTPROCESSING_META_KEY = "SegmentPostProcessing"
 SCT_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY = "SegmentPostProcessingChildRole"
 SCT_SEGMENT_SOURCE_GEOMETRY_META_KEY = "SegmentSourceGeometry"
 SCT_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY = "SegmentSourceImageHeader"
-
 SOURCE_PARENT_REFERENCE_META_KEYS = {
     "DicomEngineDimString",
     "MFInstanceNumber",
@@ -238,6 +237,18 @@ SCT_BATCH_PROCESSING_OPENRECON_CASES = (
         "source_command": 'sct_deepseg spinalcord -i dmri_moco_dwi_mean.nii.gz -qc "$SCT_BP_QC_FOLDER"',
     },
 )
+
+
+def _get_boolean_config_param(config, parameter_id, default=False):
+    option = mrdhelper.get_json_config_param(
+        config,
+        parameter_id,
+        default,
+        type="bool",
+    )
+    if isinstance(option, str):
+        return option.strip().lower() in ("1", "true", "yes", "on")
+    return bool(option)
 
 
 def process(connection, config, metadata):
@@ -342,13 +353,38 @@ def process(connection, config, metadata):
                 series_index,
                 len(imgGroup),
             )
-            image = process_image(
-                imgGroup,
-                connection,
-                config,
-                metadata,
-                derived_series_allocator=derived_series_allocator,
-            )
+            try:
+                image = process_image(
+                    imgGroup,
+                    connection,
+                    config,
+                    metadata,
+                    derived_series_allocator=derived_series_allocator,
+                )
+            except subprocess.CalledProcessError:
+                if not _get_boolean_config_param(
+                    config,
+                    "sendoriginal",
+                    default=OPENRECON_DEFAULTS["sendoriginal"],
+                ):
+                    raise
+
+                failure_traceback = traceback.format_exc()
+                logging.error(failure_traceback)
+                connection.send_logging(constants.MRD_LOGGING_ERROR, failure_traceback)
+                original_series_index = derived_series_allocator.allocate("ORIGINAL")
+                image = _restamp_passthrough_images(
+                    imgGroup,
+                    "ORIGINAL",
+                    original_series_index,
+                )
+                logging.warning(
+                    "SCT analysis failed for image_series_index=%d; returning %d "
+                    "original images as series_index=%d",
+                    series_index,
+                    len(image),
+                    original_series_index,
+                )
             output_images.extend(_as_image_list(image))
 
         if output_images:
@@ -4283,23 +4319,20 @@ def process_image(imgGroup, connection, config, metadata, derived_series_allocat
 
     os.makedirs(debugFolder, exist_ok=True)
 
-    def boolean_checker(id: str, default_val: bool = False):
-        option = mrdhelper.get_json_config_param(config, id, default_val, type="bool")
-        if isinstance(option, str):
-            return option.strip().lower() in ("1", "true", "yes", "on")
-        return bool(option)
-
-    send_original = boolean_checker(
+    send_original = _get_boolean_config_param(
+        config,
         "sendoriginal",
-        default_val=OPENRECON_DEFAULTS["sendoriginal"],
+        default=OPENRECON_DEFAULTS["sendoriginal"],
     )
-    segmentation_colormap = boolean_checker(
+    segmentation_colormap = _get_boolean_config_param(
+        config,
         "segmentationcolormap",
-        default_val=OPENRECON_DEFAULTS["segmentationcolormap"],
+        default=OPENRECON_DEFAULTS["segmentationcolormap"],
     )
-    debug_threshold_segment = boolean_checker(
+    debug_threshold_segment = _get_boolean_config_param(
+        config,
         "sctdebugthresholdsegment",
-        default_val=OPENRECON_DEFAULTS["sctdebugthresholdsegment"],
+        default=OPENRECON_DEFAULTS["sctdebugthresholdsegment"],
     )
     called_from_raw = traceback.extract_stack()[-2].name == "process_raw"
     original_images = []

--- a/recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py
+++ b/recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py
@@ -426,6 +426,97 @@ def test_openrecon_exposes_debug_threshold_segment_toggle():
     assert defaults["sctdebugthresholdsegment"] is False
 
 
+def test_process_returns_original_images_when_sct_analysis_fails():
+    helpers = _load_runtime_helpers_for_test(
+        ["_get_boolean_config_param", "process"],
+        assignments=["OPENRECON_DEFAULTS"],
+    )
+    image = helpers["FakeImage"](np.ones((1, 2, 2), dtype=np.int16))
+    image.image_type = helpers["ismrmrd"].IMTYPE_MAGNITUDE
+    image.getHead().image_series_index = 1
+    fallback_image = object()
+
+    class FakeConnection:
+        def __init__(self):
+            self.sent_images = []
+            self.logged_errors = []
+            self.closed = False
+
+        def __iter__(self):
+            return iter([image])
+
+        def send_logging(self, severity, message):
+            self.logged_errors.append((severity, message))
+
+        def send_close(self):
+            self.closed = True
+
+    class FakeAllocator:
+        def allocate(self, role):
+            assert role == "ORIGINAL"
+            return 2
+
+    class FakeLogging:
+        @staticmethod
+        def info(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def warning(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def error(*args, **kwargs):
+            pass
+
+    class FakeMrdHelper:
+        @staticmethod
+        def get_json_config_param(config, parameter_id, default, type=None):
+            return config.get(parameter_id, default)
+
+    helpers["ismrmrd"].Acquisition = type("FakeAcquisition", (), {})
+    helpers["ismrmrd"].Waveform = type("FakeWaveform", (), {})
+    helpers["logging"] = FakeLogging
+    helpers["mrdhelper"] = FakeMrdHelper
+    helpers["traceback"] = __import__("traceback")
+    helpers["constants"] = type("FakeConstants", (), {"MRD_LOGGING_ERROR": 2})
+    helpers["_get_image_series_index"] = lambda source_image: 1
+    helpers["_build_connection_series_allocator"] = (
+        lambda source_images: FakeAllocator()
+    )
+    helpers["_as_image_list"] = (
+        lambda value: list(value) if isinstance(value, list) else [value]
+    )
+
+    def fail_sct(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["sct_deepseg", "spine"])
+
+    helpers["process_image"] = fail_sct
+
+    def restamp_originals(images, role, series_index):
+        assert images == [image]
+        assert role == "ORIGINAL"
+        assert series_index == 2
+        return [fallback_image]
+
+    helpers["_restamp_passthrough_images"] = restamp_originals
+    helpers["_log_and_validate_output_series_contract"] = (
+        lambda *args, **kwargs: None
+    )
+    helpers["_send_images_by_series"] = (
+        lambda connection, images, label: connection.sent_images.extend(images)
+    )
+
+    connection = FakeConnection()
+    metadata = type("Metadata", (), {"encoding": []})()
+    helpers["process"](connection, {"sendoriginal": True}, metadata)
+
+    assert connection.sent_images == [fallback_image]
+    assert len(connection.logged_errors) == 1
+    assert "CalledProcessError" in connection.logged_errors[0][1]
+    assert connection.closed is True
+
+
 def test_repeated_slice_positions_are_split_into_sct_input_volumes():
     helpers = _load_runtime_helpers_for_test(
         [


### PR DESCRIPTION
## Summary

- Return a restamped `ORIGINAL` series when an SCT subprocess fails and `sendoriginal` is enabled.
- Preserve the SCT traceback in OpenRecon logging while allowing the original images to pass through the normal validation and send path.
- Add a process-level regression test covering image return, error reporting, and connection closure.
- Bump the spinalcordtoolbox recipe version from 7.3.1 to 7.3.2.

## Root cause

The wrapper buffered all output until `process_image()` completed. When `sct_deepseg` exited non-zero, the exception escaped before the already-prepared original images could be returned, so the connection closed without sending any images.

## Impact

Scanner users still receive the original image series when SCT analysis fails, while the analysis error remains visible for diagnosis. Behavior is unchanged when `sendoriginal` is disabled.

## Validation

- `env/bin/python -m pytest -q recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py` — 57 passed
- `env/bin/python builder/validation.py recipes/spinalcordtoolbox/build.yaml` — valid recipe v7.3.2
- `env/bin/python -m builder generate spinalcordtoolbox --recreate --architecture x86_64`
- `codespell` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated SpineCordToolbox to version 7.3.2.
  - Added clearer handling for boolean processing settings.

- **Bug Fixes**
  - If image analysis fails and “send original” is enabled, the original images are now returned instead of derived results.
  - Processing failures are logged with an error while ensuring the connection closes cleanly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->