### PR TITLE
Add a bootable Neurodesktop Glass variant

### DIFF
--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -11,6 +11,11 @@ architectures:
   - x86_64
   - aarch64
 
+options:
+  glass:
+    description: "Boot the LXDE desktop directly on a cc Glass display"
+    default: false
+
 show_in_menu: false
 show_in_applist: false
 
@@ -444,6 +449,42 @@ build:
         - ln -s /neurodesktop-storage/containers /neurocommand/local/containers
         - rm -rf /root/.cache /home/${NB_USER}/.cache
 
+    - condition: context.options.glass
+      install:
+        - build-essential
+        - fonts-dejavu-core
+        - libx11-6
+        - libx11-dev
+        - systemd
+        - systemd-sysv
+        - x11-xserver-utils
+        - xclip
+        - xserver-xorg-core
+        - xserver-xorg-input-evdev
+
+    - condition: context.options.glass
+      run:
+        - cc -x c -O2 -Wall -Wextra -o /usr/local/bin/glass-clipboard {{ get_file("glass_clipboard_source") }} -lX11
+        - cc -x c -O2 -Wall -Wextra -o /usr/local/bin/glass-resize {{ get_file("glass_resize_source") }}
+        - install -m 0755 {{ get_file("glass_session") }} /usr/local/sbin/neurodesktop-glass-session
+        - install -m 0755 {{ get_file("glass_cvmfs_mount") }} /usr/local/sbin/neurodesktop-glass-cvmfs
+        - install -m 0644 {{ get_file("glass_service") }} /etc/systemd/system/neurodesktop-glass.service
+        - install -m 0644 {{ get_file("glass_target") }} /etc/systemd/system/glass.target
+        - install -m 0644 {{ get_file("glass_xorg_config") }} /etc/X11/xorg.conf
+        - if [ -x /usr/bin/systemctl.orig ]; then mv -f /usr/bin/systemctl.orig /usr/bin/systemctl; fi
+        - mkdir -p /etc/systemd/system/glass.target.wants
+        - ln -sf /etc/systemd/system/neurodesktop-glass.service /etc/systemd/system/glass.target.wants/neurodesktop-glass.service
+        - ln -sf /etc/systemd/system/glass.target /etc/systemd/system/default.target
+        - ln -sf /dev/null /etc/systemd/system/apt-daily.timer
+        - ln -sf /dev/null /etc/systemd/system/apt-daily-upgrade.timer
+        - ln -sf /dev/null /etc/systemd/system/systemd-networkd-wait-online.service
+        - sed -i 's#^CVMFS_CACHE_BASE=.*#CVMFS_CACHE_BASE=/var/lib/cvmfs#' /etc/cvmfs/default.local
+        - install -d -o cvmfs -g cvmfs -m 0700 /var/lib/cvmfs /var/lib/cvmfs/shared
+        - truncate -s 0 /etc/machine-id
+        - DEBIAN_FRONTEND=noninteractive apt-get purge --yes build-essential libx11-dev
+        - apt-get clean
+        - rm -rf /var/lib/apt/lists/*
+
     - workdir: /home/${NB_USER}
 
 deploy:
@@ -589,6 +630,13 @@ files:
 
   - name: bashrc_append
     contents: |
+      # Desktop terminals start non-login shells, so /etc/profile.d/lmod.sh is
+      # not sourced. Initialise Lmod here as part of the system-wide Bash
+      # configuration so `module` and its `ml` shorthand work immediately.
+      if ! type module >/dev/null 2>&1 && [ -r /usr/share/lmod/lmod/init/bash ]; then
+          source /usr/share/lmod/lmod/init/bash
+      fi
+
       source /opt/neurodesktop/environment_variables.sh
 
       # Neurodesk persistent bash history
@@ -644,3 +692,139 @@ files:
           export NEURODESKTOP_TOMCAT_PORT="${NEURODESK_WEBAPP_PORT}"
       fi
       exec /opt/neurodesktop/guacamole.sh
+
+  - name: glass_clipboard_source
+    filename: glass-clipboard.c
+    condition: context.options.glass
+
+  - name: glass_resize_source
+    filename: glass-resize.c
+    condition: context.options.glass
+
+  - name: glass_xorg_config
+    filename: xorg.conf
+    condition: context.options.glass
+
+  - name: glass_session
+    condition: context.options.glass
+    executable: true
+    contents: |
+      #!/bin/sh
+      set -eu
+
+      install -d -o 1000 -g 100 -m 0700 /run/user/1000
+      install -d -m 0755 /run/dbus
+      install -d -o 1000 -g 100 -m 0755 /home/jovyan
+      /usr/local/sbin/neurodesktop-glass-cvmfs \
+          >/var/log/neurodesktop-glass-cvmfs.log 2>&1 &
+      if [ -d /opt/jovyan_defaults ]; then
+          cp -an /opt/jovyan_defaults/. /home/jovyan/
+          chown -R 1000:100 /home/jovyan
+      fi
+      rm -f /tmp/.X0-lock /tmp/.X11-unix/X0
+
+      /usr/bin/dbus-daemon --system --nofork --nopidfile &
+      dbus_pid=$!
+      /usr/lib/xorg/Xorg :0 \
+          -noreset \
+          -nolisten tcp \
+          -novtswitch \
+          -sharevts \
+          -logfile /var/log/neurodesktop-glass-Xorg.log &
+      xorg_pid=$!
+
+      cleanup() {
+          kill "$xorg_pid" 2>/dev/null || true
+          kill "$dbus_pid" 2>/dev/null || true
+      }
+      trap cleanup EXIT INT TERM
+
+      attempt=0
+      while [ ! -S /tmp/.X11-unix/X0 ]; do
+          attempt=$((attempt + 1))
+          if [ "$attempt" -ge 200 ]; then
+              echo "neurodesktop-glass: Xorg did not create display :0" >&2
+              exit 1
+          fi
+          sleep 0.05
+      done
+
+      attempt=0
+      while [ ! -S /run/dbus/system_bus_socket ]; do
+          attempt=$((attempt + 1))
+          if [ "$attempt" -ge 200 ]; then
+              echo "neurodesktop-glass: D-Bus did not create the system bus socket" >&2
+              exit 1
+          fi
+          sleep 0.05
+      done
+
+      exec setpriv --reuid=1000 --regid=100 --clear-groups env \
+          DISPLAY=:0 \
+          HOME=/home/jovyan \
+          USER=jovyan \
+          LOGNAME=jovyan \
+          XDG_RUNTIME_DIR=/run/user/1000 \
+          dbus-run-session -- sh -lc '
+              /usr/local/bin/glass-clipboard &
+              /usr/local/bin/glass-resize &
+              exec startlxde
+          '
+
+  - name: glass_service
+    condition: context.options.glass
+    contents: |
+      [Unit]
+      Description=Neurodesktop Glass LXDE session
+      DefaultDependencies=no
+      After=ccx3-stage2.service
+      Wants=ccx3-stage2.service
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/local/sbin/neurodesktop-glass-session
+      Restart=on-failure
+      RestartSec=1s
+      StandardOutput=append:/run/neurodesktop-glass.log
+      StandardError=inherit
+
+      [Install]
+      WantedBy=glass.target
+
+  - name: glass_cvmfs_mount
+    condition: context.options.glass
+    executable: true
+    contents: |
+      #!/bin/sh
+      set -eu
+
+      repository=neurodesk.ardc.edu.au
+      mountpoint=/cvmfs/$repository
+      selected=/etc/cvmfs/config.d/$repository.conf
+      default_config=/etc/cvmfs/config.d/$repository.conf.direct.asia
+
+      if mountpoint -q "$mountpoint"; then
+          exit 0
+      fi
+
+      install -d -o cvmfs -g cvmfs -m 0700 /var/lib/cvmfs /var/lib/cvmfs/shared
+      install -d -o cvmfs -g cvmfs -m 0755 "$mountpoint"
+
+      # The first endpoint in this configuration is Neurodesk's global
+      # geoproximity service. The regional endpoints remain fallbacks.
+      if [ ! -f "$selected" ]; then
+          cp "$default_config" "$selected"
+      fi
+
+      mount -t cvmfs "$repository" "$mountpoint"
+      test -d "$mountpoint/neurodesk-modules"
+
+  - name: glass_target
+    condition: context.options.glass
+    contents: |
+      [Unit]
+      Description=Neurodesktop Glass desktop
+      DefaultDependencies=no
+      Wants=ccx3-stage2.service neurodesktop-glass.service
+      After=ccx3-stage2.service
+      AllowIsolate=yes

--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -475,11 +475,9 @@ build:
         - mkdir -p /etc/systemd/system/glass.target.wants
         - ln -sf /etc/systemd/system/neurodesktop-glass.service /etc/systemd/system/glass.target.wants/neurodesktop-glass.service
         - ln -sf /etc/systemd/system/glass.target /etc/systemd/system/default.target
-        - ln -sf /dev/null /etc/systemd/system/apt-daily.timer
-        - ln -sf /dev/null /etc/systemd/system/apt-daily-upgrade.timer
-        - ln -sf /dev/null /etc/systemd/system/systemd-networkd-wait-online.service
-        - sed -i 's#^CVMFS_CACHE_BASE=.*#CVMFS_CACHE_BASE=/var/lib/cvmfs#' /etc/cvmfs/default.local
-        - install -d -o cvmfs -g cvmfs -m 0700 /var/lib/cvmfs /var/lib/cvmfs/shared
+        - sed -i 's#^CVMFS_CACHE_BASE=.*#CVMFS_CACHE_BASE=/home/jovyan/.cvmfs_cache#' /etc/cvmfs/default.local
+        - printf '\nCVMFS_USER=jovyan\n' >> /etc/cvmfs/default.local
+        - install -d -o ${NB_USER} -g users -m 0700 /home/${NB_USER}/.cvmfs_cache /home/${NB_USER}/.cvmfs_cache/shared
         - truncate -s 0 /etc/machine-id
         - DEBIAN_FRONTEND=noninteractive apt-get purge --yes build-essential libx11-dev
         - apt-get clean
@@ -714,30 +712,23 @@ files:
 
       install -d -o 1000 -g 100 -m 0700 /run/user/1000
       install -d -m 0755 /run/dbus
-      install -d -o 1000 -g 100 -m 0755 /home/jovyan
-      /usr/local/sbin/neurodesktop-glass-cvmfs \
-          >/var/log/neurodesktop-glass-cvmfs.log 2>&1 &
       if [ -d /opt/jovyan_defaults ]; then
-          cp -an /opt/jovyan_defaults/. /home/jovyan/
-          chown -R 1000:100 /home/jovyan
+          setpriv --reuid=1000 --regid=100 --clear-groups \
+              cp -a --update=none /opt/jovyan_defaults/. /home/jovyan/
+      fi
+      if ! /usr/local/sbin/neurodesktop-glass-cvmfs \
+          >/var/log/neurodesktop-glass-cvmfs.log 2>&1; then
+          echo "neurodesktop-glass: CVMFS mount failed; see /var/log/neurodesktop-glass-cvmfs.log" >&2
       fi
       rm -f /tmp/.X0-lock /tmp/.X11-unix/X0
 
       /usr/bin/dbus-daemon --system --nofork --nopidfile &
-      dbus_pid=$!
       /usr/lib/xorg/Xorg :0 \
           -noreset \
           -nolisten tcp \
           -novtswitch \
           -sharevts \
           -logfile /var/log/neurodesktop-glass-Xorg.log &
-      xorg_pid=$!
-
-      cleanup() {
-          kill "$xorg_pid" 2>/dev/null || true
-          kill "$dbus_pid" 2>/dev/null || true
-      }
-      trap cleanup EXIT INT TERM
 
       attempt=0
       while [ ! -S /tmp/.X11-unix/X0 ]; do
@@ -807,11 +798,12 @@ files:
           exit 0
       fi
 
-      install -d -o cvmfs -g cvmfs -m 0700 /var/lib/cvmfs /var/lib/cvmfs/shared
+      cache_base=/home/jovyan/.cvmfs_cache
+      install -d -o jovyan -g users -m 0700 "$cache_base" "$cache_base/shared"
       install -d -o cvmfs -g cvmfs -m 0755 "$mountpoint"
 
-      # The first endpoint in this configuration is Neurodesk's global
-      # geoproximity service. The regional endpoints remain fallbacks.
+      # The Asia configuration prefers the Brisbane endpoint selected by the
+      # regional probe. Other regional endpoints remain fallbacks.
       if [ ! -f "$selected" ]; then
           cp "$default_config" "$selected"
       fi
@@ -825,6 +817,5 @@ files:
       [Unit]
       Description=Neurodesktop Glass desktop
       DefaultDependencies=no
-      Wants=ccx3-stage2.service neurodesktop-glass.service
-      After=ccx3-stage2.service
+      Wants=neurodesktop-glass.service
       AllowIsolate=yes

--- a/recipes/neurodesktop-lite/config/README.md
+++ b/recipes/neurodesktop-lite/config/README.md
@@ -13,4 +13,4 @@ Error while waiting event for user namespace mappings: no event received
 
 This is a host security-policy limitation rather than a broken Neurodesk app container. Supported workarounds are to run on a host profile that permits the nested runtime, disable Ubuntu's AppArmor user-namespace restriction for the deployment, or bind a host setuid Singularity runtime and set `NEURODESKTOP_NESTED_CONTAINER_RUNTIME=host`.
 
-The default `neurodesk_singularity_opts` uses `/tmp/apptainer_overlay` for app containers. Some setuid Singularity installations reject directory overlays for non-root users; in those environments use a rootless/user-namespace launch mode, a writable overlay image, or the host-runtime path above.
+The default `neurodesk_singularity_opts` uses a private `apptainer_overlay` under `$XDG_RUNTIME_DIR` (falling back to `/tmp`) for app containers. Some setuid Singularity installations reject directory overlays for non-root users; in those environments use a rootless/user-namespace launch mode, a writable overlay image, or the host-runtime path above.

--- a/recipes/neurodesktop-lite/config/cvmfs/neurodesk.ardc.edu.au.conf.direct.asia
+++ b/recipes/neurodesktop-lite/config/cvmfs/neurodesk.ardc.edu.au.conf.direct.asia
@@ -1,3 +1,3 @@
 CVMFS_USE_GEOAPI=no
-CVMFS_SERVER_URL="http://cvmfs-geoproximity.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-melbourne.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-sydney.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-brisbane.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-perth.neurodesk.org/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://cvmfs-brisbane.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-sydney.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-melbourne.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-perth.neurodesk.org/cvmfs/@fqrn@;http://cvmfs-geoproximity.neurodesk.org/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR="/etc/cvmfs/keys/ardc.edu.au/"

--- a/recipes/neurodesktop-lite/config/jupyter/environment_variables.sh
+++ b/recipes/neurodesktop-lite/config/jupyter/environment_variables.sh
@@ -294,11 +294,16 @@ esac
 # This is needed to make app containers writable as a workaround for macos with Apple Silicon.
 # We need to do it here for the desktop and in the dockerfile for the jupyter notebook.
 #
-# Host note: some setuid Singularity installations reject directory overlays for
-# non-root users. If /tmp/apptainer_overlay fails on a host, use a rootless
-# launch mode, a writable overlay image, or the host-runtime nested container
-# path documented in /opt/neurodesktop/nested_container_runtime.sh.
-export neurodesk_singularity_opts=" --overlay /tmp/apptainer_overlay "
+# Keep each user's writable app-container overlay in their private runtime
+# directory when one is available. Desktop terminals source this file directly,
+# so create the directory here rather than relying on the Jupyter launcher.
+export NEURODESKTOP_APPTAINER_OVERLAY="${XDG_RUNTIME_DIR:-/tmp}/apptainer_overlay"
+if install -d -m 0700 "${NEURODESKTOP_APPTAINER_OVERLAY}" 2>/dev/null; then
+        export neurodesk_singularity_opts=" --overlay ${NEURODESKTOP_APPTAINER_OVERLAY} "
+else
+        echo "[WARN] Could not create writable Apptainer overlay at ${NEURODESKTOP_APPTAINER_OVERLAY}." >&2
+        export neurodesk_singularity_opts=""
+fi
 # export neurodesk_singularity_opts=" -w " THIS DOES NOT WORK FOR SIMG FILES IN OFFLINE MODE
 # There is a small delay in using --overlay in comparison to -w - maybe it would be faster to use a fixed size overlay file instead?
 

--- a/recipes/neurodesktop-lite/config/jupyter/jupyterlab_startup.sh
+++ b/recipes/neurodesktop-lite/config/jupyter/jupyterlab_startup.sh
@@ -237,8 +237,9 @@ if ! grep -iq 'cpu.*hz' /proc/cpuinfo; then
     fi
 fi
 
-# ensure overlay directory exists
-mkdir -p /tmp/apptainer_overlay
+# environment_variables.sh creates this for terminals too; retain the startup
+# check for callers that invoke this script without sourcing the environment.
+install -d -m 0700 "${NEURODESKTOP_APPTAINER_OVERLAY:-/tmp/apptainer_overlay}"
 
 # ensure goose config directory exists
 mkdir -p ${HOME}/.config/goose

--- a/recipes/neurodesktop-lite/fulltest.yaml
+++ b/recipes/neurodesktop-lite/fulltest.yaml
@@ -59,6 +59,38 @@ tests:
       - "code-server"
       - "apptainer"
 
+  - name: Desktop terminals initialize Lmod
+    description: Verify a non-login interactive Bash shell exposes module and ml
+    command: |
+      bash --noprofile --norc -ic '
+        set -eo pipefail
+        source /etc/bash.bashrc
+        type module
+        type ml
+        ml --help >/dev/null
+        echo lmod-terminal-ok
+      '
+    expected_output_contains: "lmod-terminal-ok"
+
+  - name: App container overlay is ready for terminal tools
+    description: Verify sourcing the desktop environment creates its private writable overlay
+    command: |
+      bash -c '
+        set -eo pipefail
+        runtime="$(mktemp -d)"
+        trap '"'"'rm -rf "$runtime"'"'"' EXIT
+        XDG_RUNTIME_DIR="$runtime"
+        source /opt/neurodesktop/environment_variables.sh
+        test -d "$NEURODESKTOP_APPTAINER_OVERLAY"
+        test "$(stat -c %a "$NEURODESKTOP_APPTAINER_OVERLAY")" = 700
+        case "$neurodesk_singularity_opts" in
+          *"$NEURODESKTOP_APPTAINER_OVERLAY"*) ;;
+          *) exit 1 ;;
+        esac
+        echo app-overlay-ready
+      '
+    expected_output_contains: "app-overlay-ready"
+
   - name: Neurodesktop version environment
     description: Verify the image exposes the recipe version
     command: bash -lc 'echo "NEURODESKTOP_VERSION=${NEURODESKTOP_VERSION:-missing}"'

--- a/recipes/neurodesktop-lite/glass-clipboard.c
+++ b/recipes/neurodesktop-lite/glass-clipboard.c
@@ -1,0 +1,241 @@
+#define _GNU_SOURCE
+
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/vm_sockets.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define CLIPBOARD_PORT 10778
+#define CLIPBOARD_MAX (64U << 20)
+
+static int read_full(int fd, void *buffer, size_t length) {
+    unsigned char *cursor = buffer;
+    while (length != 0) {
+        ssize_t count = read(fd, cursor, length);
+        if (count == 0) {
+            return -1;
+        }
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        cursor += count;
+        length -= (size_t)count;
+    }
+    return 0;
+}
+
+static int write_full(int fd, const void *buffer, size_t length) {
+    const unsigned char *cursor = buffer;
+    while (length != 0) {
+        ssize_t count = write(fd, cursor, length);
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        cursor += count;
+        length -= (size_t)count;
+    }
+    return 0;
+}
+
+static int send_text(int fd, const unsigned char *text, size_t length) {
+    if (length > CLIPBOARD_MAX) {
+        return -1;
+    }
+    uint32_t encoded = htonl((uint32_t)length);
+    return write_full(fd, &encoded, sizeof(encoded)) ||
+        write_full(fd, text, length);
+}
+
+static int connect_host(void) {
+    int fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    struct sockaddr_vm address;
+    memset(&address, 0, sizeof(address));
+    address.svm_family = AF_VSOCK;
+    address.svm_cid = VMADDR_CID_HOST;
+    address.svm_port = CLIPBOARD_PORT;
+    if (connect(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static void answer_selection(
+    Display *display,
+    XSelectionRequestEvent *request,
+    Atom targets,
+    Atom utf8,
+    const unsigned char *text,
+    size_t length) {
+    XSelectionEvent response;
+    memset(&response, 0, sizeof(response));
+    response.type = SelectionNotify;
+    response.display = request->display;
+    response.requestor = request->requestor;
+    response.selection = request->selection;
+    response.target = request->target;
+    response.time = request->time;
+    response.property = None;
+
+    Atom property = request->property == None ? request->target : request->property;
+    if (request->target == targets) {
+        Atom supported[] = {targets, utf8, XA_STRING};
+        XChangeProperty(
+            display, request->requestor, property, XA_ATOM, 32,
+            PropModeReplace, (unsigned char *)supported,
+            (int)(sizeof(supported) / sizeof(supported[0])));
+        response.property = property;
+    } else if (request->target == utf8 || request->target == XA_STRING) {
+        XChangeProperty(
+            display, request->requestor, property, request->target, 8,
+            PropModeReplace, text, (int)length);
+        response.property = property;
+    }
+    XSendEvent(display, request->requestor, False, 0, (XEvent *)&response);
+    XFlush(display);
+}
+
+static int run_bridge(Display *display, Window window, Atom clipboard, Atom targets, Atom utf8, Atom property, int fd) {
+    unsigned char *owned = NULL;
+    size_t owned_length = 0;
+    unsigned char *last_sent = NULL;
+    size_t last_sent_length = 0;
+    Window observed_owner = None;
+    int xfd = ConnectionNumber(display);
+
+    for (;;) {
+        struct pollfd pollfds[] = {
+            {.fd = xfd, .events = POLLIN},
+            {.fd = fd, .events = POLLIN},
+        };
+        int ready = poll(pollfds, 2, 200);
+        if (ready < 0 && errno != EINTR) {
+            break;
+        }
+        if (pollfds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            break;
+        }
+        if (pollfds[1].revents & POLLIN) {
+            uint32_t encoded = 0;
+            if (read_full(fd, &encoded, sizeof(encoded)) != 0) {
+                break;
+            }
+            uint32_t length = ntohl(encoded);
+            if (length > CLIPBOARD_MAX) {
+                break;
+            }
+            unsigned char *next = malloc((size_t)length + 1);
+            if (next == NULL || read_full(fd, next, length) != 0) {
+                free(next);
+                break;
+            }
+            next[length] = '\0';
+            free(owned);
+            owned = next;
+            owned_length = length;
+            XSetSelectionOwner(display, clipboard, window, CurrentTime);
+            observed_owner = window;
+            XFlush(display);
+        }
+
+        while (XPending(display) != 0) {
+            XEvent event;
+            XNextEvent(display, &event);
+            if (event.type == SelectionRequest) {
+                answer_selection(display, &event.xselectionrequest, targets, utf8, owned, owned_length);
+            } else if (event.type == SelectionClear) {
+                observed_owner = None;
+            } else if (event.type == SelectionNotify && event.xselection.property != None) {
+                Atom actual_type;
+                int actual_format;
+                unsigned long items;
+                unsigned long remaining;
+                unsigned char *value = NULL;
+                if (XGetWindowProperty(
+                        display, window, property, 0, CLIPBOARD_MAX / 4,
+                        True, AnyPropertyType, &actual_type, &actual_format,
+                        &items, &remaining, &value) == Success &&
+                    actual_format == 8 && remaining == 0 && items <= CLIPBOARD_MAX &&
+                    (items != last_sent_length ||
+                     (items != 0 && memcmp(value, last_sent, items) != 0))) {
+                    if (send_text(fd, value, items) != 0) {
+                        if (value != NULL) {
+                            XFree(value);
+                        }
+                        free(owned);
+                        free(last_sent);
+                        return -1;
+                    }
+                    unsigned char *copy = malloc(items == 0 ? 1 : items);
+                    if (copy != NULL) {
+                        if (items != 0) {
+                            memcpy(copy, value, items);
+                        }
+                        free(last_sent);
+                        last_sent = copy;
+                        last_sent_length = items;
+                    }
+                }
+                if (value != NULL) {
+                    XFree(value);
+                }
+            }
+        }
+
+        Window owner = XGetSelectionOwner(display, clipboard);
+        if (owner != None && owner != window && owner != observed_owner) {
+            observed_owner = owner;
+            XConvertSelection(display, clipboard, utf8, property, window, CurrentTime);
+            XFlush(display);
+        }
+    }
+    free(owned);
+    free(last_sent);
+    return -1;
+}
+
+int main(void) {
+    signal(SIGPIPE, SIG_IGN);
+    Display *display = NULL;
+    while (display == NULL) {
+        display = XOpenDisplay(NULL);
+        if (display == NULL) {
+            usleep(100000);
+        }
+    }
+    Window window = XCreateSimpleWindow(
+        display, DefaultRootWindow(display), -1, -1, 1, 1, 0, 0, 0);
+    Atom clipboard = XInternAtom(display, "CLIPBOARD", False);
+    Atom targets = XInternAtom(display, "TARGETS", False);
+    Atom utf8 = XInternAtom(display, "UTF8_STRING", False);
+    Atom property = XInternAtom(display, "GLASS_CLIPBOARD", False);
+
+    for (;;) {
+        int fd = connect_host();
+        if (fd < 0) {
+            usleep(250000);
+            continue;
+        }
+        run_bridge(display, window, clipboard, targets, utf8, property, fd);
+        close(fd);
+        usleep(250000);
+    }
+}

--- a/recipes/neurodesktop-lite/glass-resize.c
+++ b/recipes/neurodesktop-lite/glass-resize.c
@@ -1,0 +1,103 @@
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/vm_sockets.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define DISPLAY_PORT 10779
+
+static int read_full(int fd, void *buffer, size_t length) {
+    unsigned char *cursor = buffer;
+    while (length != 0) {
+        ssize_t count = read(fd, cursor, length);
+        if (count == 0) {
+            return -1;
+        }
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        cursor += count;
+        length -= (size_t)count;
+    }
+    return 0;
+}
+
+static int connect_host(void) {
+    int fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    struct sockaddr_vm address;
+    memset(&address, 0, sizeof(address));
+    address.svm_family = AF_VSOCK;
+    address.svm_cid = VMADDR_CID_HOST;
+    address.svm_port = DISPLAY_PORT;
+    if (connect(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static int apply_size(uint32_t width, uint32_t height) {
+    char mode[32];
+    if (snprintf(mode, sizeof(mode), "%ux%u", width, height) >= (int)sizeof(mode)) {
+        return -1;
+    }
+    pid_t child = fork();
+    if (child < 0) {
+        return -1;
+    }
+    if (child == 0) {
+        execl("/usr/bin/xrandr", "xrandr", "--screen", "0", "--size", mode, (char *)NULL);
+        _exit(127);
+    }
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0) {
+        if (errno != EINTR) {
+            return -1;
+        }
+    }
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0 : -1;
+}
+
+int main(void) {
+    signal(SIGPIPE, SIG_IGN);
+    for (;;) {
+        int fd = connect_host();
+        if (fd < 0) {
+            usleep(250000);
+            continue;
+        }
+        for (;;) {
+            uint32_t raw[2];
+            if (read_full(fd, raw, sizeof(raw)) != 0) {
+                break;
+            }
+            uint32_t width = ntohl(raw[0]);
+            uint32_t height = ntohl(raw[1]);
+            if (width == 0 || height == 0 || width > 8192 || height > 8192) {
+                break;
+            }
+            for (int attempt = 0; attempt < 40; attempt++) {
+                if (apply_size(width, height) == 0) {
+                    break;
+                }
+                usleep(50000);
+            }
+        }
+        close(fd);
+        usleep(250000);
+    }
+}

--- a/recipes/neurodesktop-lite/xorg.conf
+++ b/recipes/neurodesktop-lite/xorg.conf
@@ -1,0 +1,37 @@
+Section "ServerLayout"
+    Identifier  "Glass"
+    Screen      "Screen0"
+    InputDevice "GlassKeyboard" "CoreKeyboard"
+    InputDevice "GlassPointer" "CorePointer"
+EndSection
+
+Section "ServerFlags"
+    Option "AutoAddDevices" "false"
+EndSection
+
+Section "Device"
+    Identifier "GlassGPU"
+    Driver     "modesetting"
+EndSection
+
+Section "Monitor"
+    Identifier "GlassMonitor"
+EndSection
+
+Section "Screen"
+    Identifier "Screen0"
+    Device     "GlassGPU"
+    Monitor    "GlassMonitor"
+EndSection
+
+Section "InputDevice"
+    Identifier "GlassKeyboard"
+    Driver     "evdev"
+    Option     "Device" "/dev/input/event0"
+EndSection
+
+Section "InputDevice"
+    Identifier "GlassPointer"
+    Driver     "evdev"
+    Option     "Device" "/dev/input/event1"
+EndSection


### PR DESCRIPTION
## What changed

- add an opt-in `glass` variant to `neurodesktop-lite`
- install and configure Xorg, LXDE, systemd, virtio input, dynamic resize, and clipboard integration for direct cc Glass boots
- mount the Neurodesk CVMFS repository during desktop startup
- initialize Lmod in ordinary desktop terminals so `module` and `ml` work
- create a private per-user Apptainer overlay for terminal-launched applications
- add focused full-test coverage for terminal Lmod and overlay setup
- keep all Glass build assets inside the recipe so generation does not depend on an adjacent cc checkout

## Why

The existing recipe is oriented around its browser/Jupyter entrypoints. A cc Glass VM needs a real init system and local X11 session, plus guest bridges for framebuffer resize and clipboard traffic. It also exposed two terminal-specific gaps: non-login shells did not initialize Lmod and the shared `/tmp/apptainer_overlay` path was not prepared safely.

## User impact

Building `neurodesktop-lite` with `--option glass=true` produces an image that boots directly into the Neurodesktop LXDE environment under cc Glass, with CVMFS applications, resize, clipboard, `ml`, and writable app-container overlays available.

## Validation

- `python3 builder/validation.py recipes/neurodesktop-lite/build.yaml`
- `.venv/bin/python -m builder generate neurodesktop-lite --recreate --option glass=true`
- `.venv/bin/sf-test neurodesktop-lite --option glass=true`
- syntax-check both C guest bridges with the host compiler
- live 4-core/8 GiB cc boot of the locally built 7.6 GB image
- verified LXDE, CVMFS, `ml`, niimath/Apptainer, resize, clipboard, keyboard, pointer, and wheel input
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Glass desktop session with improved host clipboard integration and dynamic display resizing.
  - Enabled Lmod/module commands in non-login Bash sessions.
  - Added safer per-user Apptainer overlay storage with private permissions.

- **Bug Fixes**
  - Improved overlay setup behavior when the runtime directory is unavailable.
  - Updated CVMFS mirror ordering for improved access reliability.

- **Documentation**
  - Updated nested container guidance to reflect the new per-user overlay location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->