### PR TITLE
Fix LQT, MNE Extended, BrainLesion, and CIVET release builds

### DIFF
--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -19,7 +19,10 @@ build:
         name: miniconda
         version: py310_25.5.1-0
         install_path: /opt/miniconda
-        pip_install: loguru==0.7.3 panoptica deep_quality_estimation petu gliomoda brainles-aurora brats brainles-preprocessing
+        pip_install: loguru==0.7.3 panoptica==1.5.1 deep_quality_estimation==0.0.3 petu==0.0.5 gliomoda==0.0.3 brats==0.0.27 antspyx==0.6.3 auxiliary==0.3.1 brainles_hd_bet==0.0.11 ttictoc==0.5.6 typer==0.15.4 tqdm==4.67.1
+    - run:
+        - python -m pip install --no-cache-dir --no-deps brainles-aurora==0.2.7 brainles-preprocessing==0.6.10
+        - python {{ get_file("fix_aurora_import") }}
     - deploy:
         bins:
           - python
@@ -29,6 +32,9 @@ build:
           #!/bin/bash
           python --version
           exit 1
+files:
+  - name: fix_aurora_import
+    filename: fix_aurora_import.py
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAA4hJREFUSEvtlV1MW2UYx3+npYcOus51UMYcH6NlfpAZiSFFTYWwjWEzEnWhFAaYsU0YJXOZnQkxXphseMFmAtFCjGZtsl3Mqy3DLJELNQtW0UTC3A2ouAxBFmI/oF0K/TA9kyb9AOut8SQnOTnv/zy/5/k/z/seoWy8I0qGV65cicd/lsVgKMMvQPgf8E9e/YcsigTW8F69i9sxlVC1qN+Oqr6M7KfzEGZXmL80nuKKsGcvsmeqEKrrkD31LIjZcU3conXAYJ2N9vb2hCA+n4/W1la+ic5gKdmP3W5PWA+FQkxPT1PbYMJ9zIas6iWQyyWNcOpHU1SQ7+J7t4KfL48ztP8cZrOZ8vJyZDIZer2e0dFR/H4/j1fpOXbIIgGqq6tZXl6WgphMJgYGBhgbG+PlD528eLSByvxsOgPXEc7/oJU2WtbqDm45gpwwvkdTUxNKpTKe5eTkJDqdDo1uJyeOdEgAjUaD2+2Oa7xeLwsLC5w+XofdvEbh1sCjCtYBwUCU284Ax2tHJDscDgeCIEgVGI1GKejZi+/Q2dAiPRsMBjwej5SIxWKhr6+PwcFBvvvMRr9ZRKsWNga0tbWxtLQkCXJycqTb5XJxoOUwr5uaU3oQ0wWDQbRaLf2vBml5IQul4lFxaStItqi7u5vh4WEqKiqoqamJ9yBmiyiKdHV10dPTw9DQEH9+fQ7rQQW5fw9SRoDS0lJmZ2fp7e0lEonEe/B8iY/8rQLO2yFpCCYmJrh2vp53X1HwWO4mFjU3N9PY2CiVWFlZic1mk5qqVqulEY71oGhXHiNH/ZTkCbx1dRXnF3PMz8/T323gglmkaMcGgM6a4ZR9EBtHq9XKzdEJWix1EqCwoIBPOnyU75TRd22V96/cJVZpcUEOl08qMD4pRyak6cFXn/rTnl/btukoKm7gpzsfSeuiqOLjMwbqi118cGuNi5+vSe/z1QLOruxUQHgtyh8zYfyeSBywJWs7K65LeLxbUKv3EAx68K/8DkQRBDnagr3YDx7mt/uL/PogQjgCchk8UShjtybJonRph6YucP9b86Yn8r6SXzhZaNxQE5+iZEVk5k3ufdm7afD1xdf2XaE29+202rQA1cMD3Lsxgs+X2e9aqRQ4/dwpdoevp0BSAKJchf/mFHNz4YyyXxfFrHqj7AjRhw8SvksBZOL7RuR0ViUAVItnuHPD+q8yTxYnQ/4CysSosaI6GD0AAAAASUVORK5CYII=
 categories:
   - structural imaging

--- a/recipes/brainlesion/fix_aurora_import.py
+++ b/recipes/brainlesion/fix_aurora_import.py
@@ -1,0 +1,23 @@
+from importlib.util import find_spec
+from pathlib import Path
+
+
+package_spec = find_spec("brainles_aurora")
+if package_spec is None or package_spec.submodule_search_locations is None:
+    raise RuntimeError("brainles_aurora is not installed")
+
+weights_path = (
+    Path(next(iter(package_spec.submodule_search_locations))) / "utils" / "weights.py"
+)
+source = weights_path.read_text()
+old_import = (
+    "from brainles_aurora.inferer.constants import WEIGHTS_DIR_PATTERN"
+)
+replacement = 'WEIGHTS_DIR_PATTERN = "weights_v*.*.*"'
+
+if old_import not in source:
+    raise RuntimeError(
+        "brainles_aurora import layout changed; review the circular-import fix"
+    )
+
+weights_path.write_text(source.replace(old_import, replacement, 1))

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -17,28 +17,28 @@ tests:
     command: python -c 'import site; assert site.ENABLE_USER_SITE is False'
 
   - name: brainles_aurora distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_aurora"); assert d.version and len(tuple(d.files or ())) > 5'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_aurora"); assert d.version == "0.2.7" and len(tuple(d.files or ())) > 5'
 
   - name: brainles_preprocessing distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_preprocessing"); assert d.version and len(tuple(d.files or ())) > 20'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_preprocessing"); assert d.version == "0.6.10" and len(tuple(d.files or ())) > 20'
 
   - name: brats distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("brats"); assert d.version and len(tuple(d.files or ())) > 10'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("brats"); assert d.version == "0.0.27" and len(tuple(d.files or ())) > 10'
 
   - name: deep_quality_estimation distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("deep_quality_estimation"); assert d.version and len(tuple(d.files or ())) > 5'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("deep_quality_estimation"); assert d.version == "0.0.3" and len(tuple(d.files or ())) > 5'
 
   - name: gliomoda distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("gliomoda"); assert d.version and len(tuple(d.files or ())) > 5'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("gliomoda"); assert d.version == "0.0.3" and len(tuple(d.files or ())) > 5'
 
   - name: loguru distribution is pinned
     command: python -c 'from importlib.metadata import version; assert version("loguru") == "0.7.3"'
 
   - name: panoptica distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("panoptica"); assert d.version and len(tuple(d.files or ())) > 20'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("panoptica"); assert d.version == "1.5.1" and len(tuple(d.files or ())) > 20'
 
   - name: petu distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("petu"); assert d.version and len(tuple(d.files or ())) > 5'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("petu"); assert d.version == "0.0.5" and len(tuple(d.files or ())) > 5'
 
   - name: brainles_aurora imports
     command: python -c 'import brainles_aurora'

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -1,49 +1,282 @@
 name: brainlesion
 version: 1.0.0
 container: brainlesion_${version}_REFERENCE.simg
+default_timeout: 120
 
-test_data:
-  output_dir: test_output/brainlesion
-
-setup:
-  script: |
-    set -e
-    mkdir -p ${output_dir}
+env:
+  PYTHONNOUSERSITE: "1"
+  MPLCONFIGDIR: /tmp/brainlesion-matplotlib
 
 tests:
-  - name: Python runtime available
-    description: Verify the BrainLesion Suite runtime uses the expected Python series
-    command: python --version
-    expected_output_contains: "Python 3.10."
+  - name: Python runtime is 3.10
+    description: Verify the suite runs on its supported Python series.
+    command: python -c 'import sys; assert sys.version_info[:2] == (3, 10)'
 
-  - name: BrainLesion packages installed
-    description: Verify the BrainLesion Suite packages are present in package metadata
-    command: python -m pip list | grep -Ei "^(brainles_aurora|brainles-preprocessing|brats|gliomoda|petu|panoptica)"
-    expected_output_contains:
-      - "brainles_aurora"
-      - "brainles-preprocessing"
-      - "brats"
-      - "gliomoda"
-      - "petu"
-      - "panoptica"
+  - name: Python does not load user packages
+    description: Ensure results come from the container rather than a bound user site.
+    command: python -c 'import site; assert site.ENABLE_USER_SITE is False'
 
-  - name: BrainLesion Python modules import
-    description: Verify the installed suite modules import without loading model weights
+  - name: brainles_aurora distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_aurora"); assert d.version and len(tuple(d.files or ())) > 5'
+
+  - name: brainles_preprocessing distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_preprocessing"); assert d.version and len(tuple(d.files or ())) > 20'
+
+  - name: brats distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("brats"); assert d.version and len(tuple(d.files or ())) > 10'
+
+  - name: deep_quality_estimation distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("deep_quality_estimation"); assert d.version and len(tuple(d.files or ())) > 5'
+
+  - name: gliomoda distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("gliomoda"); assert d.version and len(tuple(d.files or ())) > 5'
+
+  - name: loguru distribution is pinned
+    command: python -c 'from importlib.metadata import version; assert version("loguru") == "0.7.3"'
+
+  - name: panoptica distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("panoptica"); assert d.version and len(tuple(d.files or ())) > 20'
+
+  - name: petu distribution is healthy
+    command: python -c 'from importlib.metadata import distribution; d=distribution("petu"); assert d.version and len(tuple(d.files or ())) > 5'
+
+  - name: brainles_aurora imports
+    command: python -c 'import brainles_aurora'
+
+  - name: brainles_preprocessing imports
+    command: python -c 'import brainles_preprocessing'
+
+  - name: brats imports
+    command: python -c 'import brats'
+
+  - name: deep_quality_estimation imports
+    command: python -c 'import deep_quality_estimation'
+
+  - name: gliomoda imports
+    command: python -c 'import gliomoda'
+
+  - name: loguru imports
+    command: python -c 'import loguru'
+
+  - name: panoptica imports
+    command: python -c 'import panoptica'
+
+  - name: petu imports
+    command: python -c 'import petu'
+
+  - name: NumPy numerical runtime works
+    command: python -c 'import numpy as np; a=np.arange(8).reshape(2,2,2); assert a.sum() == 28'
+
+  - name: SciPy image runtime works
+    command: python -c 'import numpy as np; from scipy import ndimage; a=np.zeros((5,5)); a[2,2]=1; assert ndimage.binary_dilation(a).sum() == 5'
+
+  - name: NiBabel runtime works
+    command: python -c 'import nibabel as nib, numpy as np; img=nib.Nifti1Image(np.zeros((2,3,4)), np.eye(4)); assert img.shape == (2,3,4)'
+
+  - name: PyTorch CPU runtime works
+    command: python -c 'import torch; x=torch.tensor([1.,2.,3.]); assert torch.dot(x,x).item() == 14'
+
+  - name: MONAI transform runtime works
+    command: python -c 'import numpy as np; from monai.transforms import ScaleIntensity; out=ScaleIntensity()(np.array([0.,2.])); assert np.allclose(out, [0.,1.])'
+
+  - name: SimpleITK image runtime works
+    command: python -c 'import SimpleITK as sitk; img=sitk.Image([3,4,5], sitk.sitkFloat32); assert img.GetSize() == (3,4,5)'
+
+  - name: Aurora inferer modules import
+    command: python -c 'import brainles_aurora.inferer.config, brainles_aurora.inferer.constants, brainles_aurora.inferer.data, brainles_aurora.inferer.model'
+
+  - name: Aurora utility modules import
+    command: python -c 'import brainles_aurora.utils.console_decorators, brainles_aurora.utils.utils, brainles_aurora.utils.weights'
+
+  - name: Preprocessing normalizer modules import
+    command: python -c 'import brainles_preprocessing.normalization.percentile_normalizer, brainles_preprocessing.normalization.windowing_normalizer'
+
+  - name: Preprocessing registration modules import
+    command: python -c 'import brainles_preprocessing.registration.ANTs.ANTs, brainles_preprocessing.registration.niftyreg.niftyreg'
+
+  - name: BraTS core modules import
+    command: python -c 'import brats.core.brats_algorithm, brats.core.inpainting_algorithms, brats.core.missing_mri_algorithms, brats.core.segmentation_algorithms'
+
+  - name: BraTS utility modules import
+    command: python -c 'import brats.utils.algorithm_config, brats.utils.data_handling, brats.utils.exceptions, brats.utils.zenodo'
+
+  - name: DQE processing modules import
+    command: python -c 'import deep_quality_estimation.center_of_mass, deep_quality_estimation.enums, deep_quality_estimation.transforms'
+
+  - name: PETU processing modules import
+    command: python -c 'import petu.constants, petu.data_handler, petu.model_handler, petu.weights'
+
+  - name: Gliomoda processing modules import
+    command: python -c 'import gliomoda.constants, gliomoda.data_handler, gliomoda.model_handler, gliomoda.weights'
+
+  - name: Panoptica evaluator modules import
+    command: python -c 'import panoptica.instance_approximator, panoptica.instance_matcher, panoptica.panoptica_evaluator, panoptica.panoptica_result'
+
+  - name: Panoptica Dice is one for identical masks
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([[1,1],[0,0]]); assert Metric.DSC(a,a) == 1.0'
+
+  - name: Panoptica Dice handles partial overlap
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([1,1,0]); b=np.array([1,0,0]); assert np.isclose(Metric.DSC(a,b), 2/3)'
+
+  - name: Panoptica IoU is one for identical masks
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([[1,0],[0,1]]); assert Metric.IOU(a,a) == 1.0'
+
+  - name: Panoptica IoU handles partial overlap
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([1,1,0]); b=np.array([1,0,0]); assert np.isclose(Metric.IOU(a,b), 0.5)'
+
+  - name: Panoptica relative volume difference detects oversegmentation
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([1,1,0,0]); b=np.array([1,1,1,0]); assert np.isclose(Metric.RVD(a,b), 0.5)'
+
+  - name: Panoptica relative volume difference detects undersegmentation
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([1,1,0,0]); b=np.array([1,0,0,0]); assert np.isclose(Metric.RVD(a,b), -0.5)'
+
+  - name: Panoptica absolute volume error is unsigned
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.array([1,1,0,0]); b=np.array([1,0,0,0]); assert np.isclose(Metric.RVAE(a,b), 0.5)'
+
+  - name: Panoptica center distance detects one voxel shift
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.zeros((4,4)); b=a.copy(); a[1,1]=1; b[2,1]=1; assert Metric.CEDI(a,b) == 1.0'
+
+  - name: Panoptica Hausdorff distance detects one voxel shift
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.zeros((4,4)); b=a.copy(); a[1,1]=1; b[2,1]=1; assert Metric.HD(a,b) == 1.0'
+
+  - name: Panoptica Hausdorff 95 detects one voxel shift
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.zeros((4,4)); b=a.copy(); a[1,1]=1; b[2,1]=1; assert Metric.HD95(a,b) == 1.0'
+
+  - name: Panoptica ASSD is zero for identical masks
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.zeros((5,5)); a[1:4,1:4]=1; assert Metric.ASSD(a,a) == 0.0'
+
+  - name: Panoptica centerline Dice is one for identical lines
+    command: python -c 'import numpy as np; from panoptica import Metric; a=np.zeros((5,5)); a[2,:]=1; assert Metric.clDSC(a,a) == 1.0'
+
+  - name: Panoptica metric threshold accepts good Dice
+    command: python -c 'from panoptica import Metric; assert Metric.DSC.score_beats_threshold(0.9, 0.8)'
+
+  - name: Panoptica metric threshold rejects poor Dice
+    command: python -c 'from panoptica import Metric; assert not Metric.DSC.score_beats_threshold(0.7, 0.8)'
+
+  - name: Panoptica connected components find separate lesions
     command: |
       python - <<'PY'
-      import importlib
-      modules = [
-          "brainles_aurora",
-          "brainles_preprocessing",
-          "brats",
-          "deep_quality_estimation",
-          "gliomoda",
-          "loguru",
-          "panoptica",
-          "petu",
-      ]
-      for module in modules:
-          importlib.import_module(module)
-      print("brainlesion imports ok")
+      import numpy as np
+      from panoptica import CCABackend
+      from panoptica._functionals import _connected_components
+      mask = np.zeros((7, 7), dtype=np.uint8)
+      mask[1:3, 1:3] = 1
+      mask[5, 5] = 1
+      labels, count = _connected_components(mask, CCABackend.scipy)
+      assert count == 2
+      assert set(np.unique(labels)) == {0, 1, 2}
       PY
-    expected_output_contains: "brainlesion imports ok"
+
+  - name: Panoptica connected component approximator constructs
+    command: python -c 'from panoptica import ConnectedComponentsInstanceApproximator; assert ConnectedComponentsInstanceApproximator() is not None'
+
+  - name: Panoptica naive matcher constructs
+    command: python -c 'from panoptica import NaiveThresholdMatching, Metric; assert NaiveThresholdMatching(matching_metric=Metric.IOU, matching_threshold=0.5) is not None'
+
+  - name: Panoptica evaluator constructs
+    command: python -c 'from panoptica import Panoptica_Evaluator; assert Panoptica_Evaluator() is not None'
+
+  - name: Percentile normalizer maps endpoints
+    command: python -c 'import numpy as np; from brainles_preprocessing.normalization import PercentileNormalizer; out=PercentileNormalizer().normalize(np.array([0.,5.,10.])); assert np.allclose(out, [0.,0.5,1.])'
+
+  - name: Percentile normalizer clips outliers
+    command: python -c 'import numpy as np; from brainles_preprocessing.normalization import PercentileNormalizer; out=PercentileNormalizer(25,75).normalize(np.array([0.,1.,2.,3.,100.])); assert out.min() == 0 and out.max() == 1'
+
+  - name: Percentile normalizer supports custom output range
+    command: python -c 'import numpy as np; from brainles_preprocessing.normalization import PercentileNormalizer; out=PercentileNormalizer(lower_limit=-1,upper_limit=1).normalize(np.array([0.,1.,2.])); assert np.allclose(out, [-1.,0.,1.])'
+
+  - name: Windowing normalizer clips below its window
+    command: python -c 'import numpy as np; from brainles_preprocessing.normalization import WindowingNormalizer; out=WindowingNormalizer(50,100).normalize(np.array([-10.,25.,100.])); assert np.array_equal(out, [0.,25.,100.])'
+
+  - name: Windowing normalizer clips above its window
+    command: python -c 'import numpy as np; from brainles_preprocessing.normalization import WindowingNormalizer; out=WindowingNormalizer(0,20).normalize(np.array([-20.,0.,20.])); assert np.array_equal(out, [-10.,0.,10.])'
+
+  - name: DQE finds tumor-core center of mass
+    command: python -c 'import numpy as np; from deep_quality_estimation.center_of_mass import compute_center_of_mass; a=np.zeros((5,5,5)); a[2,3,4]=1; assert compute_center_of_mass(a) == [2,3,4]'
+
+  - name: DQE falls back to edema center of mass
+    command: python -c 'import numpy as np; from deep_quality_estimation.center_of_mass import compute_center_of_mass; a=np.zeros((5,5,5)); a[1,2,3]=2; assert compute_center_of_mass(a) == [1,2,3]'
+
+  - name: DQE extracts three orthogonal slices
+    command: python -c 'import numpy as np; from deep_quality_estimation.center_of_mass import get_center_of_mass_slices; from deep_quality_estimation.enums import View; out=get_center_of_mass_slices(np.zeros((3,4,5)),[1,2,3]); assert out[View.AXIAL].shape==(3,4) and out[View.CORONAL].shape==(3,5) and out[View.SAGITTAL].shape==(4,5)'
+
+  - name: DQE converts BraTS labels to three channels
+    command: python -c 'import numpy as np; from deep_quality_estimation.transforms import CustomConvertToMultiChannelBasedOnBratsClasses; out=CustomConvertToMultiChannelBasedOnBratsClasses()(np.array([[0,1,2,3]])); assert out.shape == (3,1,4)'
+
+  - name: DQE whole-tumor channel includes all lesion labels
+    command: python -c 'import numpy as np; from deep_quality_estimation.transforms import CustomConvertToMultiChannelBasedOnBratsClasses; out=CustomConvertToMultiChannelBasedOnBratsClasses()(np.array([[0,1,2,3]])); assert np.array_equal(out[1], [[False,True,True,True]])'
+
+  - name: DQE packaged model weights are nonempty
+    command: python -c 'from importlib.resources import files; p=files("deep_quality_estimation").joinpath("weights/dqe_weights.pth"); assert p.is_file() and p.stat().st_size > 1000000'
+
+  - name: BraTS metadata catalog loads
+    command: |
+      python - <<'PY'
+      from importlib.resources import files
+      from brats.utils.algorithm_config import load_algorithms
+      path = files("brats").joinpath("data/meta/adult_glioma_pre_treatment.yml")
+      algorithms = load_algorithms(path)
+      assert algorithms
+      assert all(item.meta.authors and item.run_args.docker_image for item in algorithms.values())
+      PY
+
+  - name: BraTS algorithm parameters are valid YAML
+    command: python -c 'from importlib.resources import files; import yaml; data=yaml.safe_load(files("brats").joinpath("data/parameters/brats24_adult_glioma_mist.yml").read_text()); assert isinstance(data, dict) and data'
+
+  - name: BraTS metadata includes multiple challenge families
+    command: python -c 'from importlib.resources import files; names={p.name for p in files("brats").joinpath("data/meta").iterdir() if p.suffix==".yml"}; assert {"africa.yml","inpainting.yml","meningioma.yml","pediatric.yml"}.issubset(names)'
+
+  - name: BraTS algorithm classes are exposed
+    command: python -c 'from brats import AdultGliomaPreTreatmentSegmenter, AfricaSegmenter, Inpainter, MissingMRI; assert all(callable(x) for x in (AdultGliomaPreTreatmentSegmenter,AfricaSegmenter,Inpainter,MissingMRI))'
+
+  - name: Aurora default configuration is safe for CPU discovery
+    command: python -c 'from brainles_aurora.inferer.config import AuroraInfererConfig; c=AuroraInfererConfig(); assert c.workers == 0 and c.sliding_window_batch_size == 1 and 0 < c.threshold < 1'
+
+  - name: Aurora modality enum is complete
+    command: python -c 'from brainles_aurora.inferer.constants import MODALITIES; assert set(MODALITIES) == {"t1","t2","t1c","fla"}'
+
+  - name: PETU modality mapping covers single and multimodal input
+    command: python -c 'from petu.constants import IMGS_TO_MODE_DICT; assert len(IMGS_TO_MODE_DICT) >= 12 and (True,True,True,True) in IMGS_TO_MODE_DICT'
+
+  - name: Gliomoda modality mapping covers single and multimodal input
+    command: python -c 'from gliomoda.constants import IMGS_TO_MODE_DICT; assert len(IMGS_TO_MODE_DICT) >= 12 and (True,True,True,True) in IMGS_TO_MODE_DICT'
+
+  - name: PETU configures all nnUNet runtime variables
+    command: python -c 'import os, petu; from petu.constants import NNUNET_ENV_VARS; assert len(NNUNET_ENV_VARS)==3 and all(name in os.environ for name in NNUNET_ENV_VARS)'
+
+  - name: Gliomoda configures all nnUNet runtime variables
+    command: python -c 'import os, gliomoda; from gliomoda.constants import NNUNET_ENV_VARS; assert len(NNUNET_ENV_VARS)==3 and all(name in os.environ for name in NNUNET_ENV_VARS)'
+
+  - name: Preprocessor CLI is installed
+    command: command -v preprocessor
+    expected_output_contains: preprocessor
+
+  - name: Preprocessor CLI renders help
+    command: preprocessor --help
+    expected_output_contains: Usage
+
+  - name: Loguru writes structured records
+    command: |
+      python -c 'from loguru import logger; out=[]; token=logger.add(lambda m: out.append(m.record["message"])); logger.info("brainlesion-ready"); logger.remove(token); assert out == ["brainlesion-ready"]'
+
+  - name: Loguru catches contextual fields
+    command: |
+      python -c 'from loguru import logger; out=[]; token=logger.add(lambda m: out.append(m.record["extra"]["case"])); logger.bind(case="smoke").info("ok"); logger.remove(token); assert out == ["smoke"]'
+
+  - name: NIfTI file round trip preserves data and affine
+    command: |
+      python - <<'PY'
+      import tempfile
+      from pathlib import Path
+      import nibabel as nib
+      import numpy as np
+      with tempfile.TemporaryDirectory(dir="/tmp") as tmp:
+          path = Path(tmp) / "image.nii.gz"
+          data = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+          affine = np.diag([2.0, 2.0, 3.0, 1.0])
+          nib.save(nib.Nifti1Image(data, affine), path)
+          loaded = nib.load(path)
+          assert np.array_equal(loaded.get_fdata(), data)
+          assert np.array_equal(loaded.affine, affine)
+      PY

--- a/recipes/civet/build.yaml
+++ b/recipes/civet/build.yaml
@@ -25,6 +25,7 @@ build:
 
         - install:
               - perl
+              - tcsh
               - imagemagick
               - gnuplot-nox
               - locales

--- a/recipes/lesionquantificationtoolkit/build.yaml
+++ b/recipes/lesionquantificationtoolkit/build.yaml
@@ -70,11 +70,7 @@ build:
         - echo "d48c2a0b766206be0bec0a1b1613c3a0eff8bc2485bb315f3707b72624ad8589  {{ get_file("aws_methods_tar_gz") }}" | sha256sum -c -
         - echo "9ab2c58290be25dbe00e5edc32406f92cc1663745ea5f12224c33a32678f392c  {{ get_file("aws_tar_gz") }}" | sha256sum -c -
         - echo "fc343b31b9c113817f70c5c93d4a20d5ae194988c6d40ad00718fac1dd4975c3  {{ get_file("lqt_tar_gz") }}" | sha256sum -c -
-        - |-
-          R --slave -e 'options(repos = c(CRAN = "https://packagemanager.posit.co/cran/2026-07-15"));
-            install.packages(c("neurobase", "R.matlab", "igraph", "ggplot2", "network",
-              "patchwork", "reshape2", "pbmcapply", "purrr", "dplyr", "RNiftyReg"),
-              dependencies = c("Depends", "Imports", "LinkingTo"))'
+        - R --slave -e 'options(repos = c(CRAN = "https://packagemanager.posit.co/cran/2026-07-15")); install.packages(c("neurobase", "R.matlab", "igraph", "ggplot2", "network", "patchwork", "reshape2", "pbmcapply", "purrr", "dplyr", "RNiftyReg"), dependencies = c("Depends", "Imports", "LinkingTo"))'
         - R CMD INSTALL {{ get_file("gsl_tar_gz") }}
         - R CMD INSTALL {{ get_file("aws_methods_tar_gz") }}
         - R CMD INSTALL {{ get_file("aws_tar_gz") }}

--- a/recipes/mneextended/README.md
+++ b/recipes/mneextended/README.md
@@ -7,7 +7,7 @@ This environment contains MNE Python and some additional tools with dependencies
 
 Example:
 ```
-source /opt/miniconda-4.7.12/etc/profile.d/conda.sh
+source /opt/miniconda/etc/profile.d/conda.sh
 conda activate mne-extended 
 ```
 

--- a/recipes/mneextended/build.yaml
+++ b/recipes/mneextended/build.yaml
@@ -38,12 +38,13 @@ build:
     - copy: mne-extended.yml /opt/mne-extended.yml
     - template:
         name: miniconda
-        version: 4.7.12
-        env_name: base
+        version: py310_25.5.1-0
+        install_path: /opt/miniconda
+        env_name: mne-extended
+        mamba: "true"
+        yaml_file: /opt/mne-extended.yml
     - run:
-        - conda install -c conda-forge -n base mamba=0.24.0
-        - mamba env create --file /opt/mne-extended.yml
-        - /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c "import autoreject; import mne; import mne_bids; import mnelab"
+        - /opt/miniconda/envs/mne-extended/bin/python -c "import autoreject; import mne; import mne_bids; import mnelab"
         - cp {{ get_file("vscode_deb") }} vscode.deb
         - apt install ./vscode.deb
         - rm -rf ./vscode.deb
@@ -79,7 +80,7 @@ readme: |-
   
   Example:
   ```
-  source /opt/miniconda-4.7.12/etc/profile.d/conda.sh
+  source /opt/miniconda/etc/profile.d/conda.sh
   conda activate mne-extended 
   ```
   

--- a/recipes/mneextended/fulltest.yaml
+++ b/recipes/mneextended/fulltest.yaml
@@ -4,220 +4,220 @@ container: mneextended_${version}_REFERENCE.simg
 default_timeout: 60
 tests:
   - name: Python imports mne
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import mne'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import mne'
     expected_exit_code: 0
   - name: Python locates mne
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("mne") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("mne") is not None'
     expected_exit_code: 0
   - name: Python imports jupyter
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import jupyter'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import jupyter'
     expected_exit_code: 0
   - name: Python locates jupyter
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("jupyter") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("jupyter") is not None'
     expected_exit_code: 0
   - name: Python imports mne_bids
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import mne_bids'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import mne_bids'
     expected_exit_code: 0
   - name: Python locates mne_bids
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("mne_bids") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("mne_bids") is not None'
     expected_exit_code: 0
   - name: Python imports mnelab
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import mnelab'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import mnelab'
     expected_exit_code: 0
   - name: Python locates mnelab
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("mnelab") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("mnelab") is not None'
     expected_exit_code: 0
   - name: Python imports nb_conda_kernels
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import nb_conda_kernels'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import nb_conda_kernels'
     expected_exit_code: 0
   - name: Python locates nb_conda_kernels
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("nb_conda_kernels") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("nb_conda_kernels") is not None'
     expected_exit_code: 0
   - name: Python imports tables
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import tables'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import tables'
     expected_exit_code: 0
   - name: Python locates tables
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("tables") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("tables") is not None'
     expected_exit_code: 0
   - name: Python imports h5py
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import h5py'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import h5py'
     expected_exit_code: 0
   - name: Python locates h5py
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("h5py") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("h5py") is not None'
     expected_exit_code: 0
   - name: Python imports h5io
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import h5io'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import h5io'
     expected_exit_code: 0
   - name: Python locates h5io
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("h5io") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("h5io") is not None'
     expected_exit_code: 0
   - name: Python imports pymatreader
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pymatreader'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pymatreader'
     expected_exit_code: 0
   - name: Python locates pymatreader
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pymatreader") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pymatreader") is not None'
     expected_exit_code: 0
   - name: Python imports seaborn
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import seaborn'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import seaborn'
     expected_exit_code: 0
   - name: Python locates seaborn
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("seaborn") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("seaborn") is not None'
     expected_exit_code: 0
   - name: Python imports statsmodels
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import statsmodels'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import statsmodels'
     expected_exit_code: 0
   - name: Python locates statsmodels
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("statsmodels") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("statsmodels") is not None'
     expected_exit_code: 0
   - name: Python imports pybv
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pybv'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pybv'
     expected_exit_code: 0
   - name: Python locates pybv
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pybv") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pybv") is not None'
     expected_exit_code: 0
   - name: Python imports sklearn
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import sklearn'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import sklearn'
     expected_exit_code: 0
   - name: Python locates sklearn
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("sklearn") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("sklearn") is not None'
     expected_exit_code: 0
   - name: Python imports pyxdf
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pyxdf'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pyxdf'
     expected_exit_code: 0
   - name: Python locates pyxdf
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyxdf") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyxdf") is not None'
     expected_exit_code: 0
   - name: Python imports pyedflib
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pyedflib'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pyedflib'
     expected_exit_code: 0
   - name: Python locates pyedflib
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyedflib") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyedflib") is not None'
     expected_exit_code: 0
   - name: Python imports neurokit2
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import neurokit2'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import neurokit2'
     expected_exit_code: 0
   - name: Python locates neurokit2
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("neurokit2") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("neurokit2") is not None'
     expected_exit_code: 0
   - name: Python imports autoreject
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import autoreject'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import autoreject'
     expected_exit_code: 0
   - name: Python locates autoreject
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("autoreject") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("autoreject") is not None'
     expected_exit_code: 0
   - name: Python imports coloredlogs
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import coloredlogs'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import coloredlogs'
     expected_exit_code: 0
   - name: Python locates coloredlogs
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("coloredlogs") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("coloredlogs") is not None'
     expected_exit_code: 0
   - name: Python imports pandas
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pandas'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pandas'
     expected_exit_code: 0
   - name: Python locates pandas
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pandas") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pandas") is not None'
     expected_exit_code: 0
   - name: Python imports openpyxl
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import openpyxl'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import openpyxl'
     expected_exit_code: 0
   - name: Python locates openpyxl
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("openpyxl") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("openpyxl") is not None'
     expected_exit_code: 0
   - name: Python imports json_tricks
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import json_tricks'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import json_tricks'
     expected_exit_code: 0
   - name: Python locates json_tricks
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("json_tricks") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("json_tricks") is not None'
     expected_exit_code: 0
   - name: Python imports fire
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import fire'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import fire'
     expected_exit_code: 0
   - name: Python locates fire
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("fire") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("fire") is not None'
     expected_exit_code: 0
   - name: Python imports typing_extensions
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import typing_extensions'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import typing_extensions'
     expected_exit_code: 0
   - name: Python locates typing_extensions
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("typing_extensions") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("typing_extensions") is not None'
     expected_exit_code: 0
   - name: Python imports picard
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import picard'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import picard'
     expected_exit_code: 0
   - name: Python locates picard
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("picard") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("picard") is not None'
     expected_exit_code: 0
   - name: Python imports dask
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import dask'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import dask'
     expected_exit_code: 0
   - name: Python locates dask
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("dask") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("dask") is not None'
     expected_exit_code: 0
   - name: Python imports distributed
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import distributed'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import distributed'
     expected_exit_code: 0
   - name: Python locates distributed
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("distributed") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("distributed") is not None'
     expected_exit_code: 0
   - name: Python imports psutil
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import psutil'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import psutil'
     expected_exit_code: 0
   - name: Python locates psutil
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("psutil") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("psutil") is not None'
     expected_exit_code: 0
   - name: Python imports joblib
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import joblib'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import joblib'
     expected_exit_code: 0
   - name: Python locates joblib
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("joblib") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("joblib") is not None'
     expected_exit_code: 0
   - name: Python imports jupyter_server_proxy
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import jupyter_server_proxy'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import jupyter_server_proxy'
     expected_exit_code: 0
   - name: Python locates jupyter_server_proxy
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("jupyter_server_proxy") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("jupyter_server_proxy") is not None'
     expected_exit_code: 0
   - name: Python imports PyQt5
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import PyQt5'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import PyQt5'
     expected_exit_code: 0
   - name: Python locates PyQt5
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("PyQt5") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("PyQt5") is not None'
     expected_exit_code: 0
   - name: Python imports pyvista
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pyvista'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pyvista'
     expected_exit_code: 0
   - name: Python locates pyvista
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyvista") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyvista") is not None'
     expected_exit_code: 0
   - name: Python imports pyvistaqt
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import pyvistaqt'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import pyvistaqt'
     expected_exit_code: 0
   - name: Python locates pyvistaqt
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyvistaqt") is not None'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.util; assert importlib.util.find_spec("pyvistaqt") is not None'
     expected_exit_code: 0
   - name: MNE Extended environment exists
-    command: test -d /opt/miniconda-4.7.12/envs/mne-extended
+    command: test -d /opt/miniconda/envs/mne-extended
     expected_exit_code: 0
   - name: MNE Extended Python is executable
-    command: test -x /opt/miniconda-4.7.12/envs/mne-extended/bin/python
+    command: test -x /opt/miniconda/envs/mne-extended/bin/python
     expected_exit_code: 0
   - name: MNE Extended pip is executable
-    command: test -x /opt/miniconda-4.7.12/envs/mne-extended/bin/pip
+    command: test -x /opt/miniconda/envs/mne-extended/bin/pip
     expected_exit_code: 0
   - name: MNE Extended Jupyter is executable
-    command: test -x /opt/miniconda-4.7.12/envs/mne-extended/bin/jupyter
+    command: test -x /opt/miniconda/envs/mne-extended/bin/jupyter
     expected_exit_code: 0
   - name: MNE Extended IPython is executable
-    command: test -x /opt/miniconda-4.7.12/envs/mne-extended/bin/ipython
+    command: test -x /opt/miniconda/envs/mne-extended/bin/ipython
     expected_exit_code: 0
   - name: MNE Extended conda metadata exists
-    command: test -d /opt/miniconda-4.7.12/envs/mne-extended/conda-meta
+    command: test -d /opt/miniconda/envs/mne-extended/conda-meta
     expected_exit_code: 0
   - name: MNE Extended required package metadata exists
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import importlib.metadata as m; [m.version(name) for name in ("mne", "mne-bids", "autoreject", "mnelab")]'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import importlib.metadata as m; [m.version(name) for name in ("mne", "mne-bids", "autoreject", "mnelab")]'
     expected_exit_code: 0
   - name: MNE version is pinned
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import mne; assert mne.__version__ == "${version}"'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import mne; assert mne.__version__ == "${version}"'
     expected_exit_code: 0
   - name: Code wrapper resolves
     command: command -v code
@@ -256,10 +256,10 @@ tests:
     command: test -z "$(find /opt/mne-bids-pipeline -type f ! -readable -print -quit)"
     expected_exit_code: 0
   - name: Base Conda is executable
-    command: test -x /opt/miniconda-4.7.12/bin/conda
+    command: test -x /opt/miniconda/bin/conda
     expected_exit_code: 0
-  - name: Base Mamba is executable
-    command: test -x /opt/miniconda-4.7.12/bin/mamba
+  - name: Libmamba solver is configured
+    command: test "$(/opt/miniconda/bin/conda config --show solver | awk '{print $2}')" = libmamba
     expected_exit_code: 0
   - name: Wget resolves
     command: command -v wget
@@ -277,7 +277,7 @@ tests:
     command: command -v xdg-open
     expected_exit_code: 0
   - name: Qt5 runtime is linked
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import ctypes; ctypes.CDLL("/opt/miniconda-4.7.12/envs/mne-extended/lib/libQt5Core.so.5")'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import ctypes; ctypes.CDLL("/opt/miniconda/envs/mne-extended/lib/libQt5Core.so.5")'
     expected_exit_code: 0
   - name: GTK3 runtime is linked
     command: ldconfig -p | grep -q libgtk-3
@@ -286,7 +286,7 @@ tests:
     command: ldconfig -p | grep -q libGL.so
     expected_exit_code: 0
   - name: MNE BIDS pipeline runner compiles
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python -c 'import ast, pathlib; ast.parse(pathlib.Path("/opt/mne-bids-pipeline/run.py").read_text())'
+    command: /opt/miniconda/envs/mne-extended/bin/python -c 'import ast, pathlib; ast.parse(pathlib.Path("/opt/mne-bids-pipeline/run.py").read_text())'
     expected_exit_code: 0
   - name: XDG runtime directory is configured
     command: test "$XDG_RUNTIME_DIR" = /neurodesktop-storage
@@ -301,5 +301,5 @@ tests:
     command: test -d /opt/vscode-data
     expected_exit_code: 0
   - name: MNE environment Python reports a version
-    command: /opt/miniconda-4.7.12/envs/mne-extended/bin/python --version
+    command: /opt/miniconda/envs/mne-extended/bin/python --version
     expected_exit_code: 0


### PR DESCRIPTION
## Summary

- fix the Lesion Quantification Toolkit build by keeping the CRAN install expression on one physical recipe line, preventing the builder from injecting `&&` inside the quoted R program
- replace MNE Extended's legacy Miniconda 4.7.12 / Mamba 0.24 bootstrap with the current pinned Miniconda installer and libmamba solver, and update runtime paths and documentation
- expand BrainLesion release coverage from 3 tests to 78 focused checks, pin its tested package set, restore the current preprocessing API and CLI, and patch the Aurora 0.2.7 circular import during the build
- install CIVET's missing `tcsh` runtime dependency so the `#!/bin/csh`-based `mincview` launcher can execute

## Root causes and impact

LQT's multiline R expression was rendered as separate shell fragments, producing an R parse error around an injected `&&`.

MNE Extended's two-hour rebuild terminated in the old libsolv stack. The recipe now creates the environment directly through the maintained Miniconda template with libmamba enabled, while preserving Python 3.10 and MNE 1.1.0.

BrainLesion's unpinned dependency set now backtracks to obsolete BrainLesion packages because current preprocessing metadata conflicts with PETU/Gliomoda's NumPy requirement and Aurora's `path` constraint conflicts with Auxiliary. The recipe pins the runtime versions covered by the suite, installs Aurora and preprocessing without dependency backtracking after their runtime dependencies are resolved, and applies a guarded one-line patch to remove Aurora's import cycle. The expanded tests cover package integrity, imports, numerical dependencies, Panoptica segmentation metrics and connected components, preprocessing normalization, DQE center-of-mass and label transforms, BraTS metadata/configs, Aurora/PETU/Gliomoda contracts, packaged weights, CLI help, logging, and a NIfTI round trip.

CIVET's `mincview` exists in the image but uses `/bin/csh`, which was absent. Adding `tcsh` supplies that interpreter and fixes the launcher rather than weakening its fulltest.

## Validation

- validated all four recipes with `builder/validation.py`
- generated x86_64 Dockerfiles for LQT, MNE Extended, BrainLesion, and CIVET
- verified the pinned BrainLesion dependency set resolves for Python 3.10/x86_64 before the two intentional no-dependency installs
- tested the guarded Aurora patch against the published 0.2.7 wheel and confirmed `brainles_aurora.utils` imports without the cycle
- ran 14 focused builder template tests
- ran codespell and `git diff --check` on the changed files
- parsed the 78-test BrainLesion suite and retained version assertions for all pinned top-level packages

Full Linux container builds were not run locally because this host is arm64 and has no Docker or Apptainer runtime. Once merged, the four release builds can be launched together.
