### PR TITLE
Fix BrainLesion preprocessor CLI help

### DIFF
--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -23,6 +23,7 @@ build:
     - run:
         - python -m pip install --no-cache-dir --no-deps brainles-aurora==0.2.7 brainles-preprocessing==0.6.10
         - python {{ get_file("fix_aurora_import") }}
+        - python {{ get_file("fix_preprocessor_cli") }}
     - deploy:
         bins:
           - python
@@ -35,6 +36,8 @@ build:
 files:
   - name: fix_aurora_import
     filename: fix_aurora_import.py
+  - name: fix_preprocessor_cli
+    filename: fix_preprocessor_cli.py
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAA4hJREFUSEvtlV1MW2UYx3+npYcOus51UMYcH6NlfpAZiSFFTYWwjWEzEnWhFAaYsU0YJXOZnQkxXphseMFmAtFCjGZtsl3Mqy3DLJELNQtW0UTC3A2ouAxBFmI/oF0K/TA9kyb9AOut8SQnOTnv/zy/5/k/z/seoWy8I0qGV65cicd/lsVgKMMvQPgf8E9e/YcsigTW8F69i9sxlVC1qN+Oqr6M7KfzEGZXmL80nuKKsGcvsmeqEKrrkD31LIjZcU3conXAYJ2N9vb2hCA+n4/W1la+ic5gKdmP3W5PWA+FQkxPT1PbYMJ9zIas6iWQyyWNcOpHU1SQ7+J7t4KfL48ztP8cZrOZ8vJyZDIZer2e0dFR/H4/j1fpOXbIIgGqq6tZXl6WgphMJgYGBhgbG+PlD528eLSByvxsOgPXEc7/oJU2WtbqDm45gpwwvkdTUxNKpTKe5eTkJDqdDo1uJyeOdEgAjUaD2+2Oa7xeLwsLC5w+XofdvEbh1sCjCtYBwUCU284Ax2tHJDscDgeCIEgVGI1GKejZi+/Q2dAiPRsMBjwej5SIxWKhr6+PwcFBvvvMRr9ZRKsWNga0tbWxtLQkCXJycqTb5XJxoOUwr5uaU3oQ0wWDQbRaLf2vBml5IQul4lFxaStItqi7u5vh4WEqKiqoqamJ9yBmiyiKdHV10dPTw9DQEH9+fQ7rQQW5fw9SRoDS0lJmZ2fp7e0lEonEe/B8iY/8rQLO2yFpCCYmJrh2vp53X1HwWO4mFjU3N9PY2CiVWFlZic1mk5qqVqulEY71oGhXHiNH/ZTkCbx1dRXnF3PMz8/T323gglmkaMcGgM6a4ZR9EBtHq9XKzdEJWix1EqCwoIBPOnyU75TRd22V96/cJVZpcUEOl08qMD4pRyak6cFXn/rTnl/btukoKm7gpzsfSeuiqOLjMwbqi118cGuNi5+vSe/z1QLOruxUQHgtyh8zYfyeSBywJWs7K65LeLxbUKv3EAx68K/8DkQRBDnagr3YDx7mt/uL/PogQjgCchk8UShjtybJonRph6YucP9b86Yn8r6SXzhZaNxQE5+iZEVk5k3ufdm7afD1xdf2XaE29+202rQA1cMD3Lsxgs+X2e9aqRQ4/dwpdoevp0BSAKJchf/mFHNz4YyyXxfFrHqj7AjRhw8SvksBZOL7RuR0ViUAVItnuHPD+q8yTxYnQ/4CysSosaI6GD0AAAAASUVORK5CYII=
 categories:
   - structural imaging

--- a/recipes/brainlesion/fix_preprocessor_cli.py
+++ b/recipes/brainlesion/fix_preprocessor_cli.py
@@ -1,0 +1,23 @@
+from importlib.util import find_spec
+from pathlib import Path
+
+
+package_spec = find_spec("brainles_preprocessing")
+if package_spec is None or package_spec.submodule_search_locations is None:
+    raise RuntimeError("brainles_preprocessing is not installed")
+
+cli_path = Path(next(iter(package_spec.submodule_search_locations))) / "cli.py"
+source = cli_path.read_text()
+old_annotation = """output_dir: Annotated[
+        str | Path,
+"""
+replacement = """output_dir: Annotated[
+        Path,
+"""
+
+if old_annotation not in source:
+    raise RuntimeError(
+        "brainles_preprocessing CLI layout changed; review the Typer fix"
+    )
+
+cli_path.write_text(source.replace(old_annotation, replacement, 1))


### PR DESCRIPTION
## Summary

- patch the installed `brainles_preprocessing` 0.6.10 CLI annotation from `str | Path` to `Path`
- apply the compatibility fix through a guarded build script that fails loudly if the upstream source layout changes
- keep the existing `preprocessor --help` fulltest unchanged so the user-facing CLI contract remains enforced

## Root cause

The BrainLesion 20260727 release candidate passed 77 of 78 fulltests, but `preprocessor --help` crashed while Typer constructed the command. `brainles_preprocessing` 0.6.10 annotates `output_dir` as `str | Path`; Typer does not support union-typed CLI parameters and raises `AssertionError: Typer Currently doesn't support Union types`.

The optional `itk-elastix` and `picsl_greedy` warnings in the same output are unrelated.

PR #2954 was closed because its release metadata points to the affected image. After this recipe fix merges, BrainLesion must be rebuilt and its replacement release PR tested before merge.

## Validation

- applied the guarded patch to the published `brainles_preprocessing==0.6.10` wheel
- parsed the patched module and confirmed `output_dir` is annotated as `Path`
- confirmed Typer 0.15.4 accepts the patched `Path` annotation
- validated the BrainLesion recipe with `builder/validation.py`
- generated the x86_64 Dockerfile and confirmed the patch runs during the image build
- ran codespell and `git diff --check`
- ran 14 focused builder template tests
- parsed the 78-test BrainLesion fulltest suite

A full x86_64 container rebuild was not run locally because this host is arm64 and has no Docker or Apptainer runtime.
