### PR TITLE
Prepare FLAMeS and Panoptica for release

### DIFF
--- a/recipes/flames/fulltest.yaml
+++ b/recipes/flames/fulltest.yaml
@@ -1,0 +1,112 @@
+name: flames
+version: 1.0.0
+container: flames_${version}_REFERENCE.simg
+default_timeout: 120
+
+tests:
+  - name: FLAMeS runtime entrypoints
+    description: Verify the user-facing wrapper and its two inference entrypoints are executable.
+    command: |
+      set -e
+      for entrypoint in flames nnUNetv2_predict hd-bet; do
+        path="$(command -v "$entrypoint")"
+        test -x "$path"
+        echo "$entrypoint=$path"
+      done
+    expected_output_contains:
+      - "flames=/opt/flames/bin/flames"
+      - "nnUNetv2_predict=/opt/miniforge3/envs/flames/bin/nnUNetv2_predict"
+      - "hd-bet=/opt/miniforge3/envs/flames/bin/hd-bet"
+
+  - name: FLAMeS command help
+    description: Verify the wrapper documents its required input, output, skull-stripping, and device options.
+    command: flames --help
+    expected_exit_code: 1
+    expected_output_contains:
+      - "Usage: flames -i FLAIR.nii.gz -o OUTPUT_DIR"
+      - "--skull-strip"
+      - "--device"
+
+  - name: Inference Python stack
+    description: Verify the primary inference and medical-image libraries import in the deployed environment.
+    command: |
+      python - <<'PY'
+      import SimpleITK
+      import nibabel
+      import nnunetv2
+      import numpy
+      import scipy
+      import torch
+
+      print("torch", torch.__version__)
+      print("nnunetv2", nnunetv2.__path__[0])
+      print("SimpleITK", SimpleITK.__version__)
+      PY
+    expected_output_contains:
+      - "torch"
+      - "nnunetv2"
+      - "SimpleITK"
+
+  - name: CPU tensor execution
+    description: Verify the CPU PyTorch runtime can perform a small inference-style tensor operation.
+    command: |
+      python - <<'PY'
+      import torch
+
+      tensor = torch.arange(8, dtype=torch.float32).reshape(1, 1, 2, 2, 2)
+      result = torch.nn.functional.avg_pool3d(tensor, kernel_size=2)
+      assert result.device.type == "cpu"
+      assert result.item() == 3.5
+      print("cpu-average", result.item())
+      PY
+    expected_output_contains: "cpu-average 3.5"
+
+  - name: NIfTI image round trip
+    description: Verify the image I/O stack can write and reload a small three-dimensional FLAIR-like image.
+    command: |
+      python - <<'PY'
+      from pathlib import Path
+
+      import nibabel as nib
+      import numpy as np
+
+      path = Path("/tmp/flames-fulltest.nii.gz")
+      data = np.arange(64, dtype=np.float32).reshape(4, 4, 4)
+      nib.save(nib.Nifti1Image(data, np.eye(4)), path)
+      loaded = nib.load(path)
+      np.testing.assert_array_equal(loaded.get_fdata(), data)
+      print("nifti-shape", loaded.shape)
+      PY
+    expected_output_contains: "nifti-shape (4, 4, 4)"
+
+  - name: FLAMeS model assets
+    description: Verify the packaged nnU-Net model contains configuration, plans, and checkpoint data.
+    command: |
+      set -e
+      model=/opt/flames/model
+      test -d "$model"
+      find "$model" -type f | grep -E '/dataset\\.json$'
+      find "$model" -type f | grep -E '/plans\\.json$'
+      find "$model" -type f | grep -E '/checkpoint_final\\.pth$'
+      echo "model-assets-ok"
+    expected_output_contains: "model-assets-ok"
+
+  - name: HD-BET parameter assets
+    description: Verify all five packaged skull-stripping parameter files are present and non-empty.
+    command: |
+      set -e
+      for index in 0 1 2 3 4; do
+        test -s "/opt/hd-bet_params/${index}.model"
+      done
+      test "$(find /opt/hd-bet_params -maxdepth 1 -name '*.model' | wc -l)" -eq 5
+      echo "hd-bet-parameters-ok"
+    expected_output_contains: "hd-bet-parameters-ok"
+
+  - name: Runtime paths avoid the home directory
+    description: Verify model and nnU-Net runtime state use container or temporary paths available at runtime.
+    command: |
+      test "$nnUNet_results" = "/opt/flames/model"
+      test "$nnUNet_raw" = "/tmp/nnunet_raw"
+      test "$nnUNet_preprocessed" = "/tmp/nnunet_preprocessed"
+      echo "runtime-paths-ok"
+    expected_output_contains: "runtime-paths-ok"

--- a/recipes/panoptica/build.yaml
+++ b/recipes/panoptica/build.yaml
@@ -1,5 +1,5 @@
 name: panoptica
-version: 1.4.0
+version: 2.1.3
 
 architectures:
   - x86_64

--- a/recipes/panoptica/fulltest.yaml
+++ b/recipes/panoptica/fulltest.yaml
@@ -1,0 +1,90 @@
+name: panoptica
+version: 2.1.3
+container: panoptica_${version}_REFERENCE.simg
+default_timeout: 60
+
+tests:
+  - name: Panoptica package metadata
+    description: Verify the installed distribution matches the recipe version.
+    command: |
+      python - <<'PY'
+      from importlib.metadata import version
+
+      print(version("panoptica"))
+      PY
+    expected_output_contains: "2.1.3"
+
+  - name: Panoptica runtime imports
+    description: Verify Panoptica and the libraries used by its evaluation pipeline import together.
+    command: |
+      python - <<'PY'
+      import cc3d
+      import numpy
+      import pandas
+      import panoptica
+      import scipy
+      import skimage
+
+      print(panoptica.__file__)
+      PY
+    expected_output_contains: "/site-packages/panoptica/__init__.py"
+
+  - name: Matched instance evaluation
+    description: Exercise a perfect instance match and verify the resulting detection and quality metrics.
+    command: |
+      python - <<'PY'
+      import numpy as np
+      from panoptica import InputType, Panoptica_Evaluator
+      from panoptica.metrics import Metric
+
+      reference = np.zeros((8, 8, 8), dtype=np.uint8)
+      prediction = np.zeros_like(reference)
+      reference[1:4, 1:4, 1:4] = 1
+      prediction[1:4, 1:4, 1:4] = 1
+
+      evaluator = Panoptica_Evaluator(
+          expected_input=InputType.MATCHED_INSTANCE,
+          decision_metric=Metric.IOU,
+          decision_threshold=0.5,
+      )
+      result = evaluator.evaluate(prediction, reference)["ungrouped"]
+
+      assert result.tp == 1
+      assert result.fp == 0
+      assert result.fn == 0
+      assert result.sq == 1.0
+      assert result.pq == 1.0
+      print("perfect-match", result.tp, result.sq, result.pq)
+      PY
+    expected_output_contains: "perfect-match 1 1.0 1.0"
+
+  - name: Semantic instance approximation
+    description: Exercise connected-component approximation, matching, and evaluation from semantic masks.
+    command: |
+      python - <<'PY'
+      import numpy as np
+      from panoptica import InputType, Panoptica_Evaluator
+      from panoptica.instance_approximator import ConnectedComponentsInstanceApproximator
+      from panoptica.instance_matcher import NaiveThresholdMatching
+
+      reference = np.zeros((12, 12, 12), dtype=np.uint8)
+      prediction = np.zeros_like(reference)
+      reference[1:4, 1:4, 1:4] = 1
+      reference[7:10, 7:10, 7:10] = 1
+      prediction[1:4, 1:4, 1:4] = 1
+      prediction[7:10, 7:10, 7:10] = 1
+
+      evaluator = Panoptica_Evaluator(
+          expected_input=InputType.SEMANTIC,
+          instance_approximator=ConnectedComponentsInstanceApproximator(),
+          instance_matcher=NaiveThresholdMatching(),
+      )
+      result = evaluator.evaluate(prediction, reference)["ungrouped"]
+
+      assert result.tp == 2
+      assert result.fp == 0
+      assert result.fn == 0
+      assert result.pq == 1.0
+      print("semantic-match", result.tp, result.pq)
+      PY
+    expected_output_contains: "semantic-match 2 1.0"


### PR DESCRIPTION
## Summary

- Add a focused eight-test FLAMeS runtime suite covering deployed entrypoints, command help, Python dependencies, CPU tensor execution, NIfTI I/O, bundled nnU-Net model files, HD-BET parameters, and runtime-safe paths.
- Update Panoptica from 1.4.0 to 2.1.3, avoiding the upstream 1.4.0 import failure caused by an unresolved optional SimpleITK name.
- Add Panoptica fulltests that verify package metadata, runtime imports, matched-instance metrics, and the complete semantic approximation/matching/evaluation pipeline.

## Root cause

Panoptica 1.4.0 imports a helper whose evaluated type annotation references sitk even when SimpleITK is unavailable. The package therefore fails at import time with NameError: name sitk is not defined. Current Panoptica 2.1.3 imports and runs both evaluation paths successfully without patching upstream.

The existing FLAMeS release image was built, but its release PR predates the current fulltest coverage and failed artifact retrieval rather than a recipe build. Adding runtime coverage allows a fresh build/release to prove the packaged model and user-facing commands.

## Validation

- uv run bash ./workflows/test_all.sh — all repository recipe validation and Dockerfile generation checks passed.
- Panoptica 2.1.3 installed in an isolated environment and executed perfect matched-instance and semantic connected-component evaluations successfully.
- codespell and git diff --check passed.

A local container build was not available because this host does not have the Docker CLI; the PR and post-merge build workflows will provide container-level verification.