### PR TITLE
Fix Panoptica Python 3.11 import

### DIFF
--- a/recipes/panoptica/build.yaml
+++ b/recipes/panoptica/build.yaml
@@ -23,9 +23,9 @@ build:
         env_exists: "false"
 
     - run:
-        - /opt/miniconda-latest/envs/panoptica/bin/python -m pip install --no-cache-dir panoptica=={{ context.version }}
+        - /opt/miniconda-latest/envs/panoptica/bin/python -m pip install --no-cache-dir SimpleITK==2.5.5 panoptica=={{ context.version }}
         # sanity import at build time so a broken solve fails the build, not the user
-        - /opt/miniconda-latest/envs/panoptica/bin/python -c "import panoptica; print('panoptica', panoptica.__version__)"
+        - /opt/miniconda-latest/envs/panoptica/bin/python -c "import SimpleITK, panoptica; print('panoptica', panoptica.__version__)"
 
     - environment:
         PATH: /opt/miniconda-latest/envs/panoptica/bin:$PATH

--- a/recipes/panoptica/fulltest.yaml
+++ b/recipes/panoptica/fulltest.yaml
@@ -18,6 +18,7 @@ tests:
     description: Verify Panoptica and the libraries used by its evaluation pipeline import together.
     command: |
       python - <<'PY'
+      import SimpleITK
       import cc3d
       import numpy
       import pandas
@@ -26,8 +27,11 @@ tests:
       import skimage
 
       print(panoptica.__file__)
+      print("SimpleITK", SimpleITK.__version__)
       PY
-    expected_output_contains: "/site-packages/panoptica/__init__.py"
+    expected_output_contains:
+      - "/site-packages/panoptica/__init__.py"
+      - "SimpleITK 2.5.5"
 
   - name: Matched instance evaluation
     description: Exercise a perfect instance match and verify the resulting detection and quality metrics.


### PR DESCRIPTION
## Summary

- install pinned SimpleITK 2.5.5 alongside Panoptica 2.1.3
- make the build-time sanity check import both packages
- extend the runtime fulltest to verify the exact SimpleITK version

## Root cause

Panoptica 2.1.3 treats SimpleITK as optional but evaluates a type annotation containing sitk.Image during import on Python 3.11. When SimpleITK is absent, sitk is undefined and the container build fails with NameError before Panoptica can start. The earlier local verification used Python 3.14, whose annotation behavior masked this Python 3.11-specific failure.

Installing the supported dependency fixes the import without modifying upstream source.

## Validation

- reproduced the environment with Python 3.11.14
- installed SimpleITK 2.5.5 and Panoptica 2.1.3 together
- verified both packages import
- executed matched-instance and semantic connected-component evaluation paths successfully
- validated the recipe and regenerated the Dockerfile
- uv run bash ./workflows/test_all.sh passed for all recipes
- codespell and git diff --check passed

Fixes #2960