### PR TITLE
Add release for flames 1.0.0

### DIFF
--- a/recipes/flames/fulltest.yaml
+++ b/recipes/flames/fulltest.yaml
@@ -85,9 +85,9 @@ tests:
       set -e
       model=/opt/flames/model
       test -d "$model"
-      find "$model" -type f | grep -E '/dataset\\.json$'
-      find "$model" -type f | grep -E '/plans\\.json$'
-      find "$model" -type f | grep -E '/checkpoint_final\\.pth$'
+      find "$model" -type f | grep -E '/dataset\.json$'
+      find "$model" -type f | grep -E '/plans\.json$'
+      find "$model" -type f | grep -E '/checkpoint_final\.pth$'
       echo "model-assets-ok"
     expected_output_contains: "model-assets-ok"
 

--- a/releases/flames/1.0.0.json
+++ b/releases/flames/1.0.0.json
@@ -1,0 +1,13 @@
+{
+  "apps": {
+    "flames 1.0.0": {
+      "version": "20260612",
+      "exec": "",
+      "apptainer_args": []
+    }
+  },
+  "categories": [
+    "image segmentation",
+    "machine learning"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the release file for **flames 1.0.0**.

## Changes

- Add `releases/flames/1.0.0.json` with container metadata
- Generated automatically from successful container build
- Contains categories and GUI applications from build.yaml

## Testing Instructions

To test this container on Neurodesk (either a local installation or https://play.neurodesk.org/):
```bash
bash /neurocommand/local/fetch_and_run.sh flames 1.0.0 20260612
```

Or, for testing directly with Apptainer/Singularity:
```bash
curl -X GET https://neurocontainers.neurodesk.workers.dev/flames_1.0.0_20260612.simg -O
singularity shell --overlay /tmp/apptainer_overlay flames_1.0.0_20260612.simg
```

## Review Checklist

- [ ] Release file format is correct
- [ ] Categories are appropriate for this container
- [ ] GUI applications (if any) are correctly defined
- [ ] Version and build date are accurate
- [ ] Container has been tested using the commands above

## Next Steps

After merging this PR:
1. The apps.json update workflow will automatically regenerate apps.json from all release files
2. A PR will be created to the neurocommand repository
3. The container will become available in neurodesk

If additional releases are needed:
- Add to apps.json to release to Neurodesk: https://github.com/NeuroDesk/neurocommand/edit/main/neurodesk/apps.json
- Or add to the Open Recon recipes: https://github.com/NeuroDesk/openrecon/tree/main/recipes

🤖 Generated by neurocontainers CI | Created by @Vbitz