### PR TITLE
Fix Panoptica optional image imports

### DIFF
--- a/recipes/panoptica/build.yaml
+++ b/recipes/panoptica/build.yaml
@@ -23,9 +23,9 @@ build:
         env_exists: "false"
 
     - run:
-        - /opt/miniconda-latest/envs/panoptica/bin/python -m pip install --no-cache-dir SimpleITK==2.5.5 panoptica=={{ context.version }}
+        - /opt/miniconda-latest/envs/panoptica/bin/python -m pip install --no-cache-dir nibabel==5.4.2 SimpleITK==2.5.5 panoptica=={{ context.version }}
         # sanity import at build time so a broken solve fails the build, not the user
-        - /opt/miniconda-latest/envs/panoptica/bin/python -c "import SimpleITK, panoptica; print('panoptica', panoptica.__version__)"
+        - /opt/miniconda-latest/envs/panoptica/bin/python -c "from importlib.metadata import version; import nibabel, SimpleITK, panoptica; print('panoptica', version('panoptica'))"
 
     - environment:
         PATH: /opt/miniconda-latest/envs/panoptica/bin:$PATH
@@ -37,7 +37,7 @@ deploy:
 tests:
   - name: "import panoptica"
     script: |
-      python -c "import panoptica; print(panoptica.__version__)"
+      python -c "from importlib.metadata import version; import panoptica; print(version('panoptica'))"
 
 categories:
   - quality control
@@ -55,7 +55,7 @@ readme: |
 
   ```
   ml panoptica/{{ context.version }}
-  python -c "import panoptica; print(panoptica.__version__)"
+  python -c "from importlib.metadata import version; import panoptica; print(version('panoptica'))"
   ```
 
   Docs: https://github.com/BrainLesion/panoptica


### PR DESCRIPTION
## Summary

- install pinned `nibabel==5.4.2` alongside the existing SimpleITK dependency
- exercise both optional image libraries in the build-time import check
- use distribution metadata for the Panoptica version check and README example

## Root cause

Panoptica 2.1.3 conditionally imports NiBabel but eagerly evaluates annotations such as `nib.Nifti1Image`. Because NiBabel is not declared as a package dependency, the image build reached `import panoptica` with `nib` undefined and failed with a `NameError`.

After supplying NiBabel, the existing sanity command would have failed again because Panoptica 2.1.3 does not expose `panoptica.__version__`. The recipe now reads the installed version through `importlib.metadata`.

Closes #2963.

## Validation

- `uv run python builder/validation.py recipes/panoptica/build.yaml`
- `uv run python -m builder generate panoptica --recreate --architecture x86_64`
- imported Panoptica 2.1.3 together with NiBabel 5.4.2 and SimpleITK 2.5.5 in an isolated environment
