### PR TITLE
Fix sodiumgridding_ptpi OpenRecon label parameter cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ t1_dcm
 build/
 local/
 env/
+venv/
 sifs/
 output_dcm
 *.egg-info

--- a/recipes/sodiumgridding_ptpi/OpenReconLabel.json
+++ b/recipes/sodiumgridding_ptpi/OpenReconLabel.json
@@ -94,24 +94,6 @@
       "information": { "en": "Number of iterative Kaiser-Bessel density compensation updates. Use 0 for uniform weights." }
     },
     {
-      "id": "maxcoils",
-      "label": { "en": "Max coils" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 128,
-      "default": 0,
-      "information": { "en": "Limit physical coils before compression. Use 0 for all coils." }
-    },
-    {
-      "id": "maxworkers",
-      "label": { "en": "Max workers" },
-      "type": "int",
-      "minimum": 1,
-      "maximum": 64,
-      "default": 8,
-      "information": { "en": "Maximum number of parallel coil reconstructions." }
-    },
-    {
       "id": "coilcompression",
       "label": { "en": "Coil compression" },
       "type": "boolean",
@@ -197,17 +179,18 @@
         { "id": "zxy_fx", "name": { "en": "zxy, reverse columns" } },
         { "id": "zxy_fy", "name": { "en": "zxy, reverse rows" } },
         { "id": "zxy_fxy", "name": { "en": "zxy, reverse rows and columns" } },
+        { "id": "zyx_fz", "name": { "en": "zyx, reverse slices" } },
+        { "id": "zyx_fx_fz", "name": { "en": "zyx, reverse columns and slices" } },
+        { "id": "zyx_fy_fz", "name": { "en": "zyx, reverse rows and slices" } },
+        { "id": "zyx_fxy_fz", "name": { "en": "zyx, reverse rows, columns and slices" } },
+        { "id": "zxy_fz", "name": { "en": "zxy, reverse slices" } },
+        { "id": "zxy_fx_fz", "name": { "en": "zxy, reverse columns and slices" } },
+        { "id": "zxy_fy_fz", "name": { "en": "zxy, reverse rows and slices" } },
+        { "id": "zxy_fxy_fz", "name": { "en": "zxy, reverse rows, columns and slices" } },
         { "id": "debug", "name": { "en": "Debug sweep (all orientations)" } }
       ],
       "default": "zyx",
-      "information": { "en": "Map trajectory components into acquisition read/phase axes. Debug emits every mapping with slice kept/reversed." }
-    },
-    {
-      "id": "orientationflipslice",
-      "label": { "en": "Reverse slice axis" },
-      "type": "boolean",
-      "default": false,
-      "information": { "en": "Reverse trajectory component 2 before display-frame canonicalization." }
+      "information": { "en": "Map trajectory components into acquisition read/phase axes. The _fz variants also reverse the slice axis. Debug emits every mapping with slice kept/reversed." }
     }
   ]
 }

--- a/recipes/sodiumgridding_ptpi/OpenReconREADME.md
+++ b/recipes/sodiumgridding_ptpi/OpenReconREADME.md
@@ -59,8 +59,6 @@ for both echoes and infers sample timing from `sampling_time_us`.
 | Matrix size | `matrixsize` | int | `128` | Final isotropic reconstruction matrix. |
 | FOV cm | `fovcm` | string | `22.0` | Reconstruction field of view in centimetres. |
 | DCF iterations | `dcfiterations` | int | `5` | Kaiser-Bessel density compensation iterations. |
-| Max coils | `maxcoils` | int | `0` | Limit physical coils before compression; `0` uses all. |
-| Max workers | `maxworkers` | int | `8` | Parallel coil reconstruction workers. |
 | Coil compression | `coilcompression` | boolean | `true` | Use PCA variance-retention coil compression. |
 | Coil variance | `coilvarianceretention` | string | `0.9` | Variance retained by the compression basis. |
 | Coil combination | `coilcombinemode` | choice | `AC` | Adaptive combine or sum-of-squares. |
@@ -69,8 +67,20 @@ for both echoes and infers sample timing from `sampling_time_us`.
 | Phase correction | `runphasecorrection` | boolean | `true` | Run low-rank phase correction for both echoes. |
 | Low-rank rank | `phaselowrankrank` | int | `10` | Rank used for the low-rank phase table. |
 | N4 correction | `applyn4biascorrection` | boolean | `true` | Apply N4 bias correction to the final echoes. |
-| Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping. |
-| Reverse slice axis | `orientationflipslice` | boolean | `false` | Reverse trajectory component 2 before display canonicalization. |
+| Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping; `_fz` variants also reverse the slice axis. |
+
+The OpenRecon packaging schema allows at most 14 label parameters, so three
+settings are not exposed as parameters of their own:
+
+| Setting | Where it lives | Default |
+| --- | --- | --- |
+| Reverse slice axis | `_fz` suffix on the `orientation` choice | off |
+| Max coils | `SODIUMGRIDDING_PTPI_MAX_COILS` container env var | `0` (all coils) |
+| Max workers | `SODIUMGRIDDING_PTPI_MAX_WORKERS` container env var | `8` |
+
+All three are still read from `maxcoils`, `maxworkers`, and
+`orientationflipslice` when supplied in a manual JSON config, so the MRD
+contract is unchanged.
 
 ## Runtime Notes
 
@@ -82,8 +92,8 @@ for both echoes and infers sample timing from `sampling_time_us`.
   the supplied standalone script.
 - Geometry handling is delegated to `sodiumgridding.py`, so orientation changes
   should be validated the same way: use `orientation=debug` on an asymmetric
-  object or a known-side marker, then set `orientation` and
-  `orientationflipslice` to the matching result.
+  object or a known-side marker, then set `orientation` to the matching result,
+  adding the `_fz` suffix if the matching series had its slices reversed.
 
 ## Build
 

--- a/recipes/sodiumgridding_ptpi/build.yaml
+++ b/recipes/sodiumgridding_ptpi/build.yaml
@@ -41,6 +41,10 @@ build:
     - environment:
         DEBIAN_FRONTEND: noninteractive
         NUMBA_CACHE_DIR: /tmp/numba-sodiumgridding
+        # Machine-level reconstruction limits. The OpenRecon label is capped at
+        # 14 parameters, so these are set here instead of in the scanner UI.
+        SODIUMGRIDDING_PTPI_MAX_COILS: "0"
+        SODIUMGRIDDING_PTPI_MAX_WORKERS: "8"
     - install:
         - bzip2
         - ca-certificates

--- a/recipes/sodiumgridding_ptpi/fulltest.yaml
+++ b/recipes/sodiumgridding_ptpi/fulltest.yaml
@@ -55,18 +55,33 @@ tests:
       import json
       from pathlib import Path
       import sodiumgridding
+      import sodiumgridding_ptpi
 
       label = json.loads(
           Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json").read_text()
       )
       parameters = {item["id"]: item for item in label["parameters"]}
       offered = {value["id"] for value in parameters["orientation"]["values"]}
-      implemented = set(sodiumgridding.ORIENTATION_IN_PLANE_TRANSFORMS) | {
-          sodiumgridding.ORIENTATION_DEBUG_SELECTION
-      }
+      suffix = sodiumgridding_ptpi.ORIENTATION_FLIP_SLICE_SUFFIX
+      in_plane = set(sodiumgridding.ORIENTATION_IN_PLANE_TRANSFORMS)
+      implemented = (
+          in_plane
+          | {key + suffix for key in in_plane}
+          | {sodiumgridding.ORIENTATION_DEBUG_SELECTION}
+      )
       assert offered == implemented, offered ^ implemented
       assert parameters["orientation"]["default"] == sodiumgridding.DEFAULT_ORIENTATION
-      assert "orientationflipslice" in parameters
+
+      # Slice reversal is folded into the orientation choice rather than spending
+      # one of the 14 parameter slots the OpenRecon schema allows.
+      assert "orientationflipslice" not in parameters
+      for selection in sorted(offered):
+          resolved, flip_slice, _ = sodiumgridding_ptpi._resolve_orientation_with_slice_flip(
+              {"orientation": selection}
+          )
+          assert flip_slice == selection.endswith(suffix), selection
+          if selection != sodiumgridding.ORIENTATION_DEBUG_SELECTION:
+              assert resolved == selection.removesuffix(suffix), selection
       print("orientation choices:", sorted(offered))
       PY
 

--- a/recipes/sodiumgridding_ptpi/sodiumgridding_ptpi.py
+++ b/recipes/sodiumgridding_ptpi/sodiumgridding_ptpi.py
@@ -51,9 +51,42 @@ OPENRECON_DEFAULTS = {
     "orientationdebugseries": False,
 }
 
+# The OpenRecon packaging schema allows at most 14 label parameters, and the
+# dual-echo pTPI reconstruction needs more knobs than that. Three of them are
+# therefore not spent on a parameter slot of their own:
+#
+#   * slice reversal rides along in the ``orientation`` choice as an ``_fz``
+#     suffix, since it is part of the same trajectory-to-display mapping;
+#   * ``maxcoils`` and ``maxworkers`` are machine-level knobs rather than
+#     reconstruction parameters, so they are set on the container instead.
+#
+# All three stay readable from a manually supplied JSON config, so the MRD
+# contract itself is unchanged.
+ORIENTATION_FLIP_SLICE_SUFFIX = "_fz"
+MAX_COILS_ENV_VAR = "SODIUMGRIDDING_PTPI_MAX_COILS"
+MAX_WORKERS_ENV_VAR = "SODIUMGRIDDING_PTPI_MAX_WORKERS"
+
 
 def _ensure_debug_folder():
     os.makedirs(debugFolder, exist_ok=True)
+
+
+def _env_int_default(key, env_var):
+    """Resolve an int default from the environment, falling back to the label default."""
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return OPENRECON_DEFAULTS[key]
+    try:
+        return int(raw)
+    except ValueError:
+        logging.warning(
+            "Ignoring invalid %s=%r; using %s=%s",
+            env_var,
+            raw,
+            key,
+            OPENRECON_DEFAULTS[key],
+        )
+        return OPENRECON_DEFAULTS[key]
 
 
 def _config_bool(config, key):
@@ -70,6 +103,41 @@ def _config_float(config, key):
 
 def _config_str(config, key):
     return openrecon_base._config_str(config, key, OPENRECON_DEFAULTS[key])
+
+
+def _resolve_orientation_with_slice_flip(config):
+    """Split the UI orientation value into (orientation, flip_slice, debug_series).
+
+    An ``_fz`` suffix on the selection means "reverse the slice axis", which the
+    shared base module takes as a separate ``flip_slice`` argument.
+    """
+    selection = openrecon_base._config_str(
+        config,
+        "orientation",
+        OPENRECON_DEFAULTS["orientation"],
+    ).strip().lower()
+
+    flip_slice = selection.endswith(ORIENTATION_FLIP_SLICE_SUFFIX)
+    if flip_slice:
+        selection = selection[: -len(ORIENTATION_FLIP_SLICE_SUFFIX)]
+
+    orientation, emit_debug_series = openrecon_base._resolve_orientation_selection(
+        selection
+    )
+    if openrecon_base._config_bool(
+        config,
+        "orientationdebugseries",
+        OPENRECON_DEFAULTS["orientationdebugseries"],
+    ):
+        orientation, emit_debug_series = openrecon_base.DEFAULT_ORIENTATION, True
+    # Continue accepting the standalone boolean in manually supplied JSON configs.
+    if openrecon_base._config_bool(
+        config,
+        "orientationflipslice",
+        OPENRECON_DEFAULTS["orientationflipslice"],
+    ):
+        flip_slice = True
+    return orientation, flip_slice, emit_debug_series
 
 
 def _load_dual_trajectory(config):
@@ -186,7 +254,14 @@ def _configure_core(config, matrix_size, fov_cm):
     core.N = int(matrix_size)
     core.FOV_CM = float(fov_cm)
     core.DCF_ITER = max(0, _config_int(config, "dcfiterations"))
-    core.MAX_WORKERS = max(1, _config_int(config, "maxworkers"))
+    core.MAX_WORKERS = max(
+        1,
+        openrecon_base._config_int(
+            config,
+            "maxworkers",
+            _env_int_default("maxworkers", MAX_WORKERS_ENV_VAR),
+        ),
+    )
     core.COIL_COMPRESSION = _config_bool(config, "coilcompression")
     core.COIL_VARIANCE_RETENTION = float(
         np.clip(_config_float(config, "coilvarianceretention"), 0.0, 1.0)
@@ -301,12 +376,11 @@ def process_raw(group, connection, config, metadata):
         raise ValueError(f"fovcm must be positive, got {fov_cm}")
 
     _configure_core(config, matrix_size, fov_cm)
-    orientation, orientation_debug_series = openrecon_base._resolve_orientation_config(config)
-    orientation_flip_slice = openrecon_base._config_bool(
-        config,
-        "orientationflipslice",
-        OPENRECON_DEFAULTS["orientationflipslice"],
-    )
+    (
+        orientation,
+        orientation_flip_slice,
+        orientation_debug_series,
+    ) = _resolve_orientation_with_slice_flip(config)
 
     logging.info(
         "Resolved pTPI configuration: matrixsize=%d fovcm=%.3f dcfiterations=%d "
@@ -335,7 +409,14 @@ def process_raw(group, connection, config, metadata):
     )
 
     data_all = _build_interleaved_data_array(group)
-    max_coils = max(0, _config_int(config, "maxcoils"))
+    max_coils = max(
+        0,
+        openrecon_base._config_int(
+            config,
+            "maxcoils",
+            _env_int_default("maxcoils", MAX_COILS_ENV_VAR),
+        ),
+    )
     if 0 < max_coils < data_all.shape[0]:
         logging.warning("Limiting reconstruction to first %d of %d coils", max_coils, data_all.shape[0])
         data_all = data_all[:max_coils]

--- a/recipes/sodiumgridding_ptpi/test_sodiumgridding_ptpi.py
+++ b/recipes/sodiumgridding_ptpi/test_sodiumgridding_ptpi.py
@@ -64,6 +64,44 @@ def test_clip_to_common_shape_uses_shared_sample_and_readout_extent(monkeypatch)
     assert clipped[5].shape == (2, 4, 3)
 
 
+def test_resolve_orientation_with_slice_flip_folds_suffix_into_selection(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    resolve = sodiumgridding_ptpi._resolve_orientation_with_slice_flip
+
+    assert resolve({"orientation": "zxy_fxy"}) == ("zxy_fxy", False, False)
+    assert resolve({"orientation": "zxy_fxy_fz"}) == ("zxy_fxy", True, False)
+    assert resolve({"orientation": "zyx_fz"}) == ("zyx", True, False)
+    assert resolve({"orientation": "debug"}) == ("zyx", False, True)
+
+    # The retired boolean still works when supplied in a manual JSON config.
+    assert resolve({"orientation": "zyx", "orientationflipslice": True}) == (
+        "zyx",
+        True,
+        False,
+    )
+
+
+def test_machine_limits_fall_back_to_environment(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    monkeypatch.setenv(sodiumgridding_ptpi.MAX_WORKERS_ENV_VAR, "3")
+    assert sodiumgridding_ptpi._env_int_default("maxworkers", sodiumgridding_ptpi.MAX_WORKERS_ENV_VAR) == 3
+
+    monkeypatch.setenv(sodiumgridding_ptpi.MAX_WORKERS_ENV_VAR, "not-a-number")
+    assert sodiumgridding_ptpi._env_int_default("maxworkers", sodiumgridding_ptpi.MAX_WORKERS_ENV_VAR) == 8
+
+    monkeypatch.delenv(sodiumgridding_ptpi.MAX_COILS_ENV_VAR, raising=False)
+    assert sodiumgridding_ptpi._env_int_default("maxcoils", sodiumgridding_ptpi.MAX_COILS_ENV_VAR) == 0
+
+    # An explicit config value still wins over the environment default.
+    monkeypatch.setenv(sodiumgridding_ptpi.MAX_WORKERS_ENV_VAR, "3")
+    sodiumgridding_ptpi._configure_core({"maxworkers": 5}, matrix_size=64, fov_cm=20.0)
+    assert sodiumgridding_ptpi.core.MAX_WORKERS == 5
+
+    sodiumgridding_ptpi._configure_core({}, matrix_size=64, fov_cm=20.0)
+    assert sodiumgridding_ptpi.core.MAX_WORKERS == 3
+
+
 def test_configure_core_disables_standalone_outputs(monkeypatch):
     sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
 


### PR DESCRIPTION
The OpenRecon packaging schema (recipes/OpenReconSchema_1.1.0.json) caps
"parameters" at 14 items, but the recipe added in #2977 declared 17, so
builder/tests/test_openrecon_label_validation.py failed on main and the
label would have been rejected by OpenRecon packaging.

Bring the label back to 14 parameters without losing any behaviour:

- Fold slice reversal into the "orientation" choice as an "_fz" suffix and
  drop the separate "orientationflipslice" boolean. Parsing lives in
  _resolve_orientation_with_slice_flip() in the recipe module, so the shared
  sodiumgridding.py base and its two sibling recipes are untouched.
- Move "maxcoils" and "maxworkers" off the label. They are machine-level
  limits rather than reconstruction parameters, so they now default from the
  SODIUMGRIDDING_PTPI_MAX_COILS / SODIUMGRIDDING_PTPI_MAX_WORKERS container
  environment variables set in build.yaml.

All three keys are still read from a manually supplied JSON config, so the
MRD contract is unchanged. Updates the fulltest orientation assertions and
the OpenRecon README parameter table to match.