### PR TITLE
Add OpenRecon SynthSeg container recipe

### DIFF
--- a/recipes/synthseg/OpenReconLabel.json
+++ b/recipes/synthseg/OpenReconLabel.json
@@ -1,0 +1,153 @@
+{
+  "general": {
+    "name": { "en": "synthseg" },
+    "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+    "vendor": "neurodesk",
+    "information": { "en": "SynthSeg contrast-agnostic brain segmentation." },
+    "id": "synthseg",
+    "regulatory_information": {
+      "device_trade_name": "synthseg",
+      "production_identifier": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "manufacturer_address": "Erlangen, Germany",
+      "made_in": "DE",
+      "manufacture_date": "2026/07/30",
+      "material_number": "synthseg_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "gtin": "00860000171212",
+      "udi": "(01)00860000171212(21)1.3.0",
+      "safety_advices": "",
+      "special_operating_instructions": "Open Recon SynthSeg brain segmentation pipeline",
+      "additional_relevant_information": ""
+    }
+  },
+  "reconstruction": {
+    "transfer_protocol": {
+      "protocol": "ISMRMRD",
+      "version": "1.4.1"
+    },
+    "port": 9002,
+    "emitter": "image",
+    "injector": "image",
+    "can_process_adjustment_data": false,
+    "can_use_gpu": true,
+    "min_count_required_gpus": 1,
+    "min_required_gpu_memory": 10048,
+    "min_required_memory": 40096,
+    "min_count_required_cpu_cores": 8,
+    "content_qualification_type": "RESEARCH"
+  },
+  "parameters": [
+    {
+      "id": "config",
+      "label": { "en": "config" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "synthseg",
+          "name": { "en": "synthseg" }
+        }
+      ],
+      "default": "synthseg",
+      "information": { "en": "Define the config to be executed by MRD server" }
+    },
+    {
+      "id": "sendoriginal",
+      "label": { "en": "Keep original images" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Return restamped original images first, before the SynthSeg label map." }
+    },
+    {
+      "id": "ssmodel",
+      "label": { "en": "SynthSeg model" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "synthseg",
+          "name": { "en": "SynthSeg 2.0" }
+        },
+        {
+          "id": "robust",
+          "name": { "en": "SynthSeg-robust 2.0" }
+        },
+        {
+          "id": "v1",
+          "name": { "en": "SynthSeg 1.0" }
+        }
+      ],
+      "default": "synthseg",
+      "information": { "en": "Trained network used for segmentation. SynthSeg 2.0 is the default. SynthSeg-robust is slower but more reliable on low-quality clinical scans and always runs in fast mode. SynthSeg 1.0 is the original 2021 model, kept for reproducing older results." }
+    },
+    {
+      "id": "ssparc",
+      "label": { "en": "Cortical parcellation" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Also run the cortical parcellation network so the label map contains the 2000/2035-series Desikan-Killiany cortical parcels. Adds roughly one further inference pass." }
+    },
+    {
+      "id": "ssfast",
+      "label": { "en": "Fast mode" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Bypass topological refinement and left/right flipping for a faster prediction. Recommended for inline scanner use; disable for the highest-quality offline-equivalent result." }
+    },
+    {
+      "id": "ssusegpu",
+      "label": { "en": "Use GPU" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Run inference on the reconstruction GPU. Disable to force CPU inference, which is several times slower." }
+    },
+    {
+      "id": "ssthreads",
+      "label": { "en": "CPU threads" },
+      "type": "int",
+      "minimum": 1,
+      "maximum": 64,
+      "default": 8,
+      "information": { "en": "Number of TensorFlow inter/intra-op threads. Only relevant for the CPU parts of the pipeline." }
+    },
+    {
+      "id": "ssvolumes",
+      "label": { "en": "Report region volumes" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Compute per-structure volumes in mm3 and write them to the reconstruction log as CSV." }
+    },
+    {
+      "id": "ssqc",
+      "label": { "en": "Report QC scores" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Run the automated quality-control network and write per-structure QC scores to the reconstruction log as CSV." }
+    },
+    {
+      "id": "sssegmentheader",
+      "label": { "en": "Segmentation header" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Send the label map in a source-geometry 2D segmentation-header format so scanner post-processing treats it as a segmentation stream. When disabled, the label map keeps the source image header identity and post-processing stays on the original stream." }
+    },
+    {
+      "id": "ssreslicesagittal",
+      "label": { "en": "Sagittal reformat" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Send an additional sagittal 3D reformat of the label map." }
+    },
+    {
+      "id": "ssreslicecoronal",
+      "label": { "en": "Coronal reformat" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Send an additional coronal 3D reformat of the label map." }
+    },
+    {
+      "id": "ssdebugthresholdsegment",
+      "label": { "en": "Debug threshold segmentation" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Skip SynthSeg inference and create a simple threshold-based segmentation for send-path debugging." }
+    }
+  ]
+}

--- a/recipes/synthseg/OpenReconREADME.md
+++ b/recipes/synthseg/OpenReconREADME.md
@@ -1,0 +1,155 @@
+# SynthSeg OpenRecon
+
+SynthSeg segments brain MRI scans of any contrast and resolution without
+retraining or preprocessing. It is trained purely on synthetic data generated
+with domain randomisation, which is what makes a single network usable on
+whatever contrast the scanner happens to produce. The OpenRecon configuration
+runs `mri_synthseg` inline on the reconstructed image stream and returns a
+derived label-map series named `<source>_synthseg`.
+
+The container packages `mri_synthseg` and the trained weights published with
+FreeSurfer 8.2.0. The scanner GUI exposes the three MRI networks (SynthSeg 2.0,
+SynthSeg-robust 2.0, SynthSeg 1.0), the cortical parcellation network and the
+automated QC network. Photo-SynthSeg is installed in the container but is not
+offered in the scanner GUI, because it segments 3D-reconstructed dissection
+photographs rather than MR images.
+
+## Input and Output
+
+Use this reconstruction pipeline on 3D brain image data. Any contrast works;
+no bias correction, skull stripping or intensity normalisation is required.
+
+SynthSeg always segments at 1 mm isotropic internally. The wrapper always runs
+`mri_synthseg --keepgeom`, so the returned label map is resampled with nearest
+neighbour interpolation back onto the incoming MRD slice grid and there is
+exactly one output image per source image.
+
+The main derived output is named `<source>_synthseg`, where `<source>` is the
+incoming source `SeriesDescription` or, when that is absent, the incoming
+`SequenceDescription`. If neither source name is available, the fallback name is
+`synthseg`. Most returned scanner series use `OR` as the short OpenRecon suffix.
+When `sssegmentheader` is enabled, the source-geometry segmentation stream uses
+the `openrecon` suffix to mirror `openreconi2iexample`.
+
+By default, OpenRecon returns restamped original images first as
+`<source>_original`, then sends one source-image-header 2D SynthSeg label image
+per source image.
+
+**Pixel values are FreeSurfer label indices, not intensities.** They are passed
+through unscaled so they can be looked up in
+`$FREESURFER_HOME/FreeSurferColorLUT.txt` (for example 2 = left cerebral white
+matter, 17 = left hippocampus, and the 1000/2000 series for cortical parcels).
+Only the returned display window is derived from the label range, so the
+segmentation is visible without manual windowing.
+
+## GUI Parameters
+
+| GUI label | Parameter id | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| config | `config` | choice | `synthseg` | Selects the MRD server configuration. The available GUI option is `synthseg`. |
+| Keep original images | `sendoriginal` | boolean | `true` | Return restamped original images first, before the `synthseg` label map. Disable this to return only the derived SynthSeg series. |
+| SynthSeg model | `ssmodel` | choice | `synthseg` | Trained network used for segmentation: `synthseg` (SynthSeg 2.0), `robust` (SynthSeg-robust 2.0) or `v1` (SynthSeg 1.0). |
+| Cortical parcellation | `ssparc` | boolean | `false` | Also run the cortical parcellation network, adding the Desikan-Killiany cortical parcels to the label map. |
+| Fast mode | `ssfast` | boolean | `true` | Bypass topological refinement and left/right flipping for a faster prediction. |
+| Use GPU | `ssusegpu` | boolean | `true` | Run inference on the reconstruction GPU. Disable to force CPU inference. |
+| CPU threads | `ssthreads` | integer | `8` | TensorFlow inter/intra-op thread count. Valid GUI range: 1 to 64. |
+| Report region volumes | `ssvolumes` | boolean | `false` | Compute per-structure volumes in mm3 and write them to the reconstruction log as CSV. |
+| Report QC scores | `ssqc` | boolean | `false` | Run the automated QC network and write per-structure QC scores to the reconstruction log as CSV. |
+| Segmentation header | `sssegmentheader` | boolean | `false` | Use the `openreconi2iexample` 2D segmentation-header delivery mode so scanner post-processing targets the segmentation stream. |
+| Sagittal reformat | `ssreslicesagittal` | boolean | `false` | Send an additional sagittal 3D reformat of the label map. |
+| Coronal reformat | `ssreslicecoronal` | boolean | `false` | Send an additional coronal 3D reformat of the label map. |
+| Debug threshold segmentation | `ssdebugthresholdsegment` | boolean | `false` | Skip SynthSeg inference and use the simple threshold segmentation from `openreconi2iexample` to exercise the send path quickly. |
+
+## Model Combinations
+
+| `ssmodel` | `mri_synthseg` flags | Notes |
+| --- | --- | --- |
+| `synthseg` | (none) | SynthSeg 2.0, the recommended default. |
+| `robust` | `--robust` | Slower but more reliable on low-quality clinical scans. `mri_synthseg` forces fast mode for this model, so `ssfast` is reported as enabled regardless of the GUI value. |
+| `v1` | `--v1` | The original 2021 SynthSeg model with the 1.0 label set, kept for reproducing older results. |
+
+`ssparc` adds `--parc` and loads `synthseg_parc_2.0.h5`. `ssqc` adds `--qc` and
+loads `synthseg_qc_2.0.h5`. Every model file required by the requested
+combination is checked before the subprocess starts, so a missing weight file
+fails immediately rather than part-way through inference.
+
+## Runtime Notes
+
+Runtime is dominated by the segmentation network. Fast mode on a GPU is the
+quickest configuration; disabling fast mode, enabling parcellation or QC, or
+forcing CPU inference each add a substantial amount of time. `robust` is the
+slowest model.
+
+`ssdebugthresholdsegment` is a diagnostic flag. When enabled, the wrapper still
+receives and sorts the source images, but skips the `mri_synthseg` command and
+creates a simple threshold plus largest-component mask using the same logic as
+`openreconi2iexample`. In that mode the returned pixel values are 12-bit
+intensities rather than FreeSurfer label indices.
+
+The OpenRecon label declares GPU support and requests at least 1 GPU, 10048 MB
+GPU memory, 40096 MB system memory, and 8 CPU cores.
+
+Returned images are always emitted as new scanner-visible series. Restamped
+originals are sent first with `Keep_image_geometry = 1` and a patched source
+`IceMiniHead`, so scanner-side processing stays attached to the original
+geometry. By default, the SynthSeg label map follows as a separate
+source-image-header 2D stream with `Keep_image_geometry = 1`,
+`DataRole = Image`, `SegmentSourceGeometry = 1`, `SegmentSourceImageHeader = 1`,
+`SegmentOutputGeometry = 2d`, the scanner post-processing child role, and the
+source `ImageType`, `DicomImageType`, and `ImageTypeValue4` identity. In normal
+mode, the segment stream strips `ImageTypeValue3` from MRD metadata and
+`IceMiniHead` so Siemens functors that select `ImageTypeValue3 = M` stay
+attached to the original stream.
+
+When `sssegmentheader` is enabled, SynthSeg instead mirrors the
+`openreconi2iexample` `2d_segment_header` path: the label map is sent as a 2D
+source-geometry segmentation-header stream with `DataRole = Segmentation`,
+`SegmentSourceGeometry = 1`, `SegmentOutputGeometry = 2d`,
+`SequenceDescriptionAdditional = openrecon`, no `SegmentSourceImageHeader`,
+scanner post-processing child-role metadata matching the segmentation
+`image_series_index`, and no `ImageTypeValue3`.
+
+Scanner logs include the resolved options on a single
+`OpenRecon SynthSeg options: ...` line, a `SynthSeg label map: ...` line with the
+distinct label values that were returned, a
+`SYNTHSEG_OPENRECON_POSTPROCESSING target=...` marker, and one
+`SYNTHSEG_OPENRECON_BATCH ...` marker before every MRD image send. Region volume
+and QC CSVs, when requested, are written to the reconstruction log in full.
+
+## Citation
+
+Please cite SynthSeg if you use this reconstruction in research:
+
+```bibtex
+@article{billot2023synthseg,
+  title = {{SynthSeg}: Segmentation of brain {MRI} scans of any contrast and resolution without retraining},
+  author = {Billot, Benjamin and Greve, Douglas N. and Puonti, Oula and Thielscher, Axel and Van Leemput, Koen and Fischl, Bruce and Dalca, Adrian V. and Iglesias, Juan Eugenio},
+  journal = {Medical Image Analysis},
+  volume = {86},
+  pages = {102789},
+  year = {2023},
+  doi = {10.1016/j.media.2023.102789}
+}
+
+@article{billot2023robust,
+  title = {Robust machine learning segmentation for large-scale analysis of heterogeneous clinical brain {MRI} datasets},
+  author = {Billot, Benjamin and Magdamo, Colin and Cheng, You and Arnold, Steven E. and Das, Sudeshna and Iglesias, Juan Eugenio},
+  journal = {Proceedings of the National Academy of Sciences},
+  volume = {120},
+  number = {9},
+  pages = {e2216399120},
+  year = {2023},
+  doi = {10.1073/pnas.2216399120}
+}
+```
+
+## Open Source Development
+
+The source for this OpenRecon package is in the NeuroContainers repository:
+https://github.com/NeuroDesk/neurocontainers/tree/main/recipes/synthseg
+
+For bugs and feature requests, opening an issue in the NeuroContainers
+repository is preferred: https://github.com/NeuroDesk/neurocontainers/issues.
+Questions can also be posted in the Neurodesk discussion forum at
+https://github.com/orgs/neurodesk/discussions or sent via
+https://neurodesk.org/contact/.

--- a/recipes/synthseg/build.yaml
+++ b/recipes/synthseg/build.yaml
@@ -1,0 +1,265 @@
+name: synthseg
+# The recipe version tracks the FreeSurfer release that publishes mri_synthseg
+# and its trained weights. That release ships SynthSeg 2.0 (plus SynthSeg 1.0,
+# SynthSeg-robust and Photo-SynthSeg 1.0).
+version: 8.2.0
+
+copyright:
+  - name: FreeSurfer Software License Agreement
+    url: https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+  - license: Apache-2.0
+    url: https://github.com/BBillot/SynthSeg/blob/master/LICENSE.txt
+
+architectures:
+  - x86_64
+
+variables:
+  # mri_synthseg and the small label/name .npy files live in the FreeSurfer
+  # source tree.
+  freesurfer_raw_url: "https://raw.githubusercontent.com/freesurfer/freesurfer/v{{ context.version }}"
+  # The trained .h5 weights are git-annex objects in the FreeSurfer source tree.
+  # They are served over plain HTTP from the public annex remote documented at
+  # https://surfer.nmr.mgh.harvard.edu/fswiki/GitAnnex, which avoids pulling the
+  # ~9.5 GB FreeSurfer tarball just to extract ~0.6 GB of SynthSeg models.
+  freesurfer_annex_url: "https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/repo/annex.git/annex/objects"
+  synthseg_home: /opt/freesurfer-synthseg
+
+build:
+  kind: neurodocker
+  # CUDA 11.8 + cuDNN 8 match the TensorFlow 2.13 build installed below, so
+  # inference uses the scanner GPU when one is available and transparently
+  # falls back to CPU when it is not.
+  base-image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+  pkg-manager: apt
+
+  directives:
+    - environment:
+        DEBIAN_FRONTEND: noninteractive
+
+    - install:
+        - bzip2
+        - ca-certificates
+        - curl
+        - git
+        - python3
+        - python3-dev
+        - python3-pip
+        - python-is-python3
+        - unzip
+
+    - include: macros/openrecon/neurodocker.yaml
+
+    # TensorFlow 2.13 is the last release whose bundled Keras still accepts the
+    # `fused=False` BatchNormalization argument that mri_synthseg 8.2.0 uses,
+    # and it caps numpy at 1.24.3 so the script's size-1-array-to-scalar
+    # assignments keep working. Do not bump either without re-testing
+    # mri_synthseg itself. scikit-image, matplotlib and h5py are re-pinned in
+    # the same resolve because the OpenRecon macro installs them unpinned
+    # against a newer numpy.
+    - run:
+        - python3 -m pip install --no-cache-dir "numpy==1.24.3" "tensorflow==2.13.1" "surfa==0.6.3" "nibabel==5.2.1" "scipy==1.10.1" "scikit-image==0.21.0" "matplotlib==3.7.5" "h5py==3.9.0"
+        - python3 -c "import tensorflow as tf; print('tensorflow', tf.__version__)"
+        - python3 -c "import numpy, scipy, nibabel, surfa, skimage; print('numpy', numpy.__version__)"
+        - python3 -c "import ismrmrd; print('ismrmrd ok')"
+
+    # mri_synthseg resolves every model and label file relative to
+    # FREESURFER_HOME, so lay out just that subtree instead of installing the
+    # whole FreeSurfer distribution.
+    - run:
+        - mkdir -p {{ context.synthseg_home }}/models
+        - install -m 0644 {{ get_file("FreeSurferColorLUT") }} {{ context.synthseg_home }}/FreeSurferColorLUT.txt
+        - install -m 0755 {{ get_file("mri_synthseg") }} /usr/local/bin/mri_synthseg
+
+    - run:
+        - install -m 0644 {{ get_file("synthseg_1.0.h5") }} {{ context.synthseg_home }}/models/synthseg_1.0.h5
+        - install -m 0644 {{ get_file("synthseg_2.0.h5") }} {{ context.synthseg_home }}/models/synthseg_2.0.h5
+        - install -m 0644 {{ get_file("synthseg_robust_2.0.h5") }} {{ context.synthseg_home }}/models/synthseg_robust_2.0.h5
+        - install -m 0644 {{ get_file("synthseg_parc_2.0.h5") }} {{ context.synthseg_home }}/models/synthseg_parc_2.0.h5
+        - install -m 0644 {{ get_file("synthseg_qc_2.0.h5") }} {{ context.synthseg_home }}/models/synthseg_qc_2.0.h5
+        - install -m 0644 {{ get_file("synthseg_photo_both_1.0.h5") }} {{ context.synthseg_home }}/models/synthseg_photo_both_1.0.h5
+        - install -m 0644 {{ get_file("synthseg_photo_single_1.0.h5") }} {{ context.synthseg_home }}/models/synthseg_photo_single_1.0.h5
+
+    - run:
+        - install -m 0644 {{ get_file("synthseg_segmentation_labels.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_labels.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_labels_2.0.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_labels_2.0.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_names.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_names.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_names_2.0.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_names_2.0.npy
+        - install -m 0644 {{ get_file("synthseg_denoiser_labels_2.0.npy") }} {{ context.synthseg_home }}/models/synthseg_denoiser_labels_2.0.npy
+        - install -m 0644 {{ get_file("synthseg_parcellation_labels.npy") }} {{ context.synthseg_home }}/models/synthseg_parcellation_labels.npy
+        - install -m 0644 {{ get_file("synthseg_parcellation_names.npy") }} {{ context.synthseg_home }}/models/synthseg_parcellation_names.npy
+        - install -m 0644 {{ get_file("synthseg_qc_labels.npy") }} {{ context.synthseg_home }}/models/synthseg_qc_labels.npy
+        - install -m 0644 {{ get_file("synthseg_qc_labels_2.0.npy") }} {{ context.synthseg_home }}/models/synthseg_qc_labels_2.0.npy
+        - install -m 0644 {{ get_file("synthseg_qc_names.npy") }} {{ context.synthseg_home }}/models/synthseg_qc_names.npy
+        - install -m 0644 {{ get_file("synthseg_qc_names_2.0.npy") }} {{ context.synthseg_home }}/models/synthseg_qc_names_2.0.npy
+        - install -m 0644 {{ get_file("synthseg_topological_classes.npy") }} {{ context.synthseg_home }}/models/synthseg_topological_classes.npy
+        - install -m 0644 {{ get_file("synthseg_topological_classes_2.0.npy") }} {{ context.synthseg_home }}/models/synthseg_topological_classes_2.0.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_labels_photo_both_1.0.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_labels_photo_both_1.0.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_labels_photo_single_1.0.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_labels_photo_single_1.0.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_names_photo_both_1.0.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_names_photo_both_1.0.npy
+        - install -m 0644 {{ get_file("synthseg_segmentation_names_photo_single_1.0.npy") }} {{ context.synthseg_home }}/models/synthseg_segmentation_names_photo_single_1.0.npy
+        - install -m 0644 {{ get_file("synthseg_topological_classes_photo_both_1.0.npy") }} {{ context.synthseg_home }}/models/synthseg_topological_classes_photo_both_1.0.npy
+        - install -m 0644 {{ get_file("synthseg_topological_classes_photo_single_1.0.npy") }} {{ context.synthseg_home }}/models/synthseg_topological_classes_photo_single_1.0.npy
+
+    - environment:
+        FREESURFER_HOME: "{{ context.synthseg_home }}"
+        # mri_synthseg is chatty on stderr without this; keep the scanner log
+        # readable.
+        TF_CPP_MIN_LOG_LEVEL: "3"
+        # Point transparent-singularity module loads at the in-container path so
+        # `mri_synthseg` also works from the host without exec-ing in.
+        DEPLOY_ENV_FREESURFER_HOME: "BASEPATH{{ context.synthseg_home }}"
+
+    # OpenRecon runtime: the MRD server wrapper and the NIfTI<->MRD helper.
+    - run:
+        - cp {{ get_file("synthseg.py") }} /opt/code/python-ismrmrd-server/synthseg.py
+        - cp {{ get_file("nifti2mrd.py") }} /opt/code/python-ismrmrd-server/nifti2mrd.py
+        - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
+        - cp {{ get_file("OpenReconREADME.md") }} /opt/code/python-ismrmrd-server/OpenReconREADME.md
+        - mkdir -p /tmp/share/debug
+        - chmod 1777 /tmp/share /tmp/share/debug
+
+    - workdir: /opt
+
+deploy:
+  bins:
+    - mri_synthseg
+
+categories:
+  - image segmentation
+  - structural imaging
+  - machine learning
+
+files:
+  - name: synthseg.py
+    filename: synthseg.py
+  - name: nifti2mrd.py
+    filename: nifti2mrd.py
+  - name: OpenReconLabel.json
+    filename: OpenReconLabel.json
+  - name: OpenReconREADME.md
+    filename: OpenReconREADME.md
+
+  - name: mri_synthseg
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/mri_synthseg"
+  - name: FreeSurferColorLUT
+    url: "{{ context.freesurfer_raw_url }}/distribution/FreeSurferColorLUT.txt"
+
+  # Trained weights (git-annex objects; the path is md5(key)[0:3]/md5(key)[3:6]).
+  - name: synthseg_1.0.h5
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_1.0.h5"
+  - name: synthseg_2.0.h5
+    url: "{{ context.freesurfer_annex_url }}/bee/241/SHA256E-s53079152--f190bfd742f450ef3ca2c9df9ed4d2e0232b3a74471da5e51b7770bacdf80c3e.0.h5/SHA256E-s53079152--f190bfd742f450ef3ca2c9df9ed4d2e0232b3a74471da5e51b7770bacdf80c3e.0.h5"
+  - name: synthseg_robust_2.0.h5
+    url: "{{ context.freesurfer_annex_url }}/187/db4/SHA256E-s214606800--7bc30bf5c3d204f20c4a6cb5a283aedbcab6af1de927cda783f59b67d19cb01c.0.h5/SHA256E-s214606800--7bc30bf5c3d204f20c4a6cb5a283aedbcab6af1de927cda783f59b67d19cb01c.0.h5"
+  - name: synthseg_parc_2.0.h5
+    url: "{{ context.freesurfer_annex_url }}/c04/403/SHA256E-s53090840--83bb1de76fb6f173c6dacacd433f81209fc6abb1dbc179a930ec06ecabbeb684.0.h5/SHA256E-s53090840--83bb1de76fb6f173c6dacacd433f81209fc6abb1dbc179a930ec06ecabbeb684.0.h5"
+  - name: synthseg_qc_2.0.h5
+    url: "{{ context.freesurfer_annex_url }}/3ac/fe4/SHA256E-s49878004--fb92e37daa0842bdd8a03bc06a3b36b0d38810e31c714659cedd09119c0abfb7.0.h5/SHA256E-s49878004--fb92e37daa0842bdd8a03bc06a3b36b0d38810e31c714659cedd09119c0abfb7.0.h5"
+  - name: synthseg_photo_both_1.0.h5
+    url: "{{ context.freesurfer_annex_url }}/2f7/609/SHA256E-s159121352--851ee7536cd3132d5e821ad76390bcd0a969651d3f9840dab9a6a5643fd5153f.0.h5/SHA256E-s159121352--851ee7536cd3132d5e821ad76390bcd0a969651d3f9840dab9a6a5643fd5153f.0.h5"
+  - name: synthseg_photo_single_1.0.h5
+    url: "{{ context.freesurfer_annex_url }}/695/8ef/SHA256E-s159114824--b8da211a79638e5a6920ce3d15e82fd613a6c8479b8abb3e1b83b6452c601274.0.h5/SHA256E-s159114824--b8da211a79638e5a6920ce3d15e82fd613a6c8479b8abb3e1b83b6452c601274.0.h5"
+
+  # Label indices, structure names and topology classes.
+  - name: synthseg_segmentation_labels.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_labels.npy"
+  - name: synthseg_segmentation_labels_2.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_labels_2.0.npy"
+  - name: synthseg_segmentation_names.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_names.npy"
+  - name: synthseg_segmentation_names_2.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_names_2.0.npy"
+  - name: synthseg_denoiser_labels_2.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_denoiser_labels_2.0.npy"
+  - name: synthseg_parcellation_labels.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_parcellation_labels.npy"
+  - name: synthseg_parcellation_names.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_parcellation_names.npy"
+  - name: synthseg_qc_labels.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_qc_labels.npy"
+  - name: synthseg_qc_labels_2.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_qc_labels_2.0.npy"
+  - name: synthseg_qc_names.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_qc_names.npy"
+  - name: synthseg_qc_names_2.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_qc_names_2.0.npy"
+  - name: synthseg_topological_classes.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_topological_classes.npy"
+  - name: synthseg_topological_classes_2.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_topological_classes_2.0.npy"
+  - name: synthseg_segmentation_labels_photo_both_1.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_labels_photo_both_1.0.npy"
+  - name: synthseg_segmentation_labels_photo_single_1.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_labels_photo_single_1.0.npy"
+  - name: synthseg_segmentation_names_photo_both_1.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_names_photo_both_1.0.npy"
+  - name: synthseg_segmentation_names_photo_single_1.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_segmentation_names_photo_single_1.0.npy"
+  - name: synthseg_topological_classes_photo_both_1.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_topological_classes_photo_both_1.0.npy"
+  - name: synthseg_topological_classes_photo_single_1.0.npy
+    url: "{{ context.freesurfer_raw_url }}/mri_synthseg/synthseg_topological_classes_photo_single_1.0.npy"
+
+readme: |-
+  ----------------------------------
+  ## synthseg/{{ context.version }} ##
+
+  SynthSeg is a contrast- and resolution-agnostic brain MRI segmentation tool.
+  It is trained on synthetic data generated with domain randomisation, so a
+  single network segments scans of any contrast and resolution without
+  retraining or preprocessing. This container packages `mri_synthseg` and the
+  trained weights from FreeSurfer {{ context.version }}: SynthSeg 2.0 (default),
+  SynthSeg 1.0 (`--v1`), SynthSeg-robust (`--robust`), the cortical
+  parcellation and QC networks, and Photo-SynthSeg 1.0 (`--photo`). Only that
+  subtree is installed, so this is much smaller than a full FreeSurfer image.
+
+  Segmentation runs at 1 mm isotropic regardless of the input resolution. Pass
+  `--keepgeom` to resample the label map back onto the input grid.
+
+  Example:
+  ```
+  mri_synthseg --i t1w.nii.gz --o t1w_synthseg.nii.gz --threads 8
+  mri_synthseg --i t1w.nii.gz --o seg.nii.gz --parc --vol volumes.csv --qc qc.csv
+  mri_synthseg --i t1w.nii.gz --o seg.nii.gz --robust --keepgeom
+  mri_synthseg --i indir/ --o outdir/ --fast --cpu --threads 16
+  ```
+
+  A CUDA GPU is used automatically when available; pass `--cpu` to force CPU
+  inference. Label indices in the output follow the FreeSurfer convention and
+  can be looked up in `$FREESURFER_HOME/FreeSurferColorLUT.txt`.
+
+  This container also ships an OpenRecon MRD wrapper so SynthSeg can run inline
+  on a Siemens scanner. See `recipes/synthseg/OpenReconREADME.md` for the
+  scanner parameters and output contract.
+
+  More documentation: https://surfer.nmr.mgh.harvard.edu/fswiki/SynthSeg
+
+  To run applications outside of this container: ml synthseg/{{ context.version }}
+
+  Citation:
+  ```{% raw %}
+  @article{Billot2023,
+    author = {Billot, Benjamin and Greve, Douglas N. and Puonti, Oula and Thielscher, Axel and Van Leemput, Koen and Fischl, Bruce and Dalca, Adrian V. and Iglesias, Juan Eugenio},
+    title = {{SynthSeg: Segmentation of brain MRI scans of any contrast and resolution without retraining}},
+    journal = {Medical Image Analysis},
+    volume = {86},
+    pages = {102789},
+    year = {2023},
+    doi = {10.1016/j.media.2023.102789}
+  }
+
+  @article{Billot2023pnas,
+    author = {Billot, Benjamin and Magdamo, Colin and Cheng, You and Arnold, Steven E. and Das, Sudeshna and Iglesias, Juan Eugenio},
+    title = {{Robust machine learning segmentation for large-scale analysis of heterogeneous clinical brain MRI datasets}},
+    journal = {Proceedings of the National Academy of Sciences},
+    volume = {120},
+    number = {9},
+    pages = {e2216399120},
+    year = {2023},
+    doi = {10.1073/pnas.2216399120}
+  }
+  {% endraw %}```
+
+  ----------------------------------
+
+icon: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iNCIgZmlsbD0iIzExMTgyNyIvPjxwYXRoIGQ9Ik0xMiA0Yy0zLjYgMC02LjUgMi42LTYuNSA1LjkgMCAxLjEuMyAyLjEuOSAzLS42LjgtLjkgMS43LS45IDIuNyAwIDIuNSAyLjEgNC40IDQuNyA0LjRoMy42YzIuNiAwIDQuNy0yIDQuNy00LjQgMC0xLS4zLTEuOS0uOS0yLjcuNi0uOS45LTEuOS45LTMgMC0zLjMtMi45LTUuOS02LjUtNS45WiIgZmlsbD0iIzFlMjkzYiIgc3Ryb2tlPSIjOTRhM2I4IiBzdHJva2Utd2lkdGg9IjEiLz48cGF0aCBkPSJNMTIgNC4yVjIwIiBzdHJva2U9IiM5NGEzYjgiIHN0cm9rZS13aWR0aD0iMSIvPjxwYXRoIGQ9Ik04LjIgOC4zYzEuMS0uNyAyLjEtLjcgMy4xLS4xIiBmaWxsPSJub25lIiBzdHJva2U9IiMzOGJkZjgiIHN0cm9rZS13aWR0aD0iMS40IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMTIuNyA4LjJjMS0uNiAyLTEuNiAzLjEuMSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZjQ3MmI2IiBzdHJva2Utd2lkdGg9IjEuNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+PHBhdGggZD0iTTcuNiAxMi44YzEuMy0uOSAyLjYtLjkgMy44LS4xIiBmaWxsPSJub25lIiBzdHJva2U9IiMzNGQzOTkiIHN0cm9rZS13aWR0aD0iMS40IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMTIuNiAxMi43YzEuMi0uOCAyLjUtLjggMy44LjEiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZiYmYyNCIgc3Ryb2tlLXdpZHRoPSIxLjQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxwYXRoIGQ9Ik04LjggMTYuOGMxLS42IDEuOC0uNiAyLjYtLjEiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2E3OGJmYSIgc3Ryb2tlLXdpZHRoPSIxLjQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxwYXRoIGQ9Ik0xMi42IDE2LjdjLjgtLjUgMS42LS41IDIuNi4xIiBmaWxsPSJub25lIiBzdHJva2U9IiNmODcxNzEiIHN0cm9rZS13aWR0aD0iMS40IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48L3N2Zz4=

--- a/recipes/synthseg/fulltest.yaml
+++ b/recipes/synthseg/fulltest.yaml
@@ -1,0 +1,181 @@
+# SynthSeg container test suite
+#
+# SynthSeg is a contrast- and resolution-agnostic brain MRI segmentation tool.
+# This container packages FreeSurfer's mri_synthseg together with the trained
+# weights published in FreeSurfer 8.2.0, plus the OpenRecon MRD wrapper.
+#
+# Test data: ds000001/sub-01 (OpenNeuro Balloon Analog Risk-taking Task)
+#   - T1w: 160x192x192, 1x1.33x1.33 mm (3D structural)
+#
+# Note: mri_synthseg is a deep learning model. The one end-to-end segmentation
+# below runs with --fast --cpu and still takes several minutes on CPU-only test
+# runners; every other test is a fast asset/interface check.
+
+name: synthseg
+version: 8.2.0
+container: synthseg_8.2.0_REFERENCE.simg
+
+required_files:
+  - dataset: ds000001
+    files:
+      - sub-01/anat/sub-01_T1w.nii.gz
+
+test_data:
+  t1w: ds000001/sub-01/anat/sub-01_T1w.nii.gz
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}/synthseg
+
+tests:
+  # ==========================================================================
+  # LAUNCHER AND ENVIRONMENT
+  # ==========================================================================
+  - name: mri_synthseg launcher available
+    description: Verify the main runtime entrypoint is installed and on PATH
+    command: command -v mri_synthseg
+    expected_output_contains: "mri_synthseg"
+
+  - name: mri_synthseg help
+    description: Verify mri_synthseg starts, imports TensorFlow, and prints usage
+    command: mri_synthseg --help
+    expected_output_contains: "--parc"
+
+  - name: FREESURFER_HOME is set
+    description: mri_synthseg resolves all models relative to FREESURFER_HOME
+    command: bash -lc 'test -n "$FREESURFER_HOME" && echo "FREESURFER_HOME=$FREESURFER_HOME"'
+    expected_output_contains: "FREESURFER_HOME=/opt/freesurfer-synthseg"
+
+  - name: FreeSurfer colour lookup table installed
+    description: mri_synthseg reads FreeSurferColorLUT.txt unless --noaddctab is used
+    command: bash -lc 'grep -c "Left-Hippocampus" "$FREESURFER_HOME/FreeSurferColorLUT.txt"'
+    expected_exit_code: 0
+
+  # ==========================================================================
+  # TRAINED MODELS
+  # ==========================================================================
+  - name: Segmentation models installed
+    description: Verify all SynthSeg network weights are present
+    command: |
+      bash -lc 'for m in synthseg_1.0.h5 synthseg_2.0.h5 synthseg_robust_2.0.h5 synthseg_parc_2.0.h5 synthseg_qc_2.0.h5 synthseg_photo_both_1.0.h5 synthseg_photo_single_1.0.h5; do
+        test -s "$FREESURFER_HOME/models/$m" || { echo "MISSING $m"; exit 1; }
+      done; echo "all synthseg models present"'
+    expected_output_contains: "all synthseg models present"
+
+  - name: Model weights are readable HDF5
+    description: Guard against truncated or HTML-error downloads of the annexed weights
+    command: |
+      bash -lc 'python -c "
+      import glob, h5py, os
+      paths = sorted(glob.glob(os.path.join(os.environ[\"FREESURFER_HOME\"], \"models\", \"*.h5\")))
+      assert paths, \"no model files found\"
+      for path in paths:
+          with h5py.File(path, \"r\") as handle:
+              assert len(handle.keys()) > 0, path
+      print(\"validated\", len(paths), \"hdf5 models\")
+      "'
+    expected_output_contains: "validated 7 hdf5 models"
+
+  - name: Label and structure-name arrays installed
+    description: Verify the .npy label/name/topology arrays load with numpy
+    command: |
+      bash -lc 'python -c "
+      import glob, numpy, os
+      paths = sorted(glob.glob(os.path.join(os.environ[\"FREESURFER_HOME\"], \"models\", \"*.npy\")))
+      for path in paths:
+          numpy.load(path, allow_pickle=False)
+      print(\"validated\", len(paths), \"npy arrays\")
+      "'
+    expected_output_contains: "validated 19 npy arrays"
+
+  # ==========================================================================
+  # PYTHON RUNTIME
+  # ==========================================================================
+  - name: TensorFlow pinned to a Keras 2 release
+    description: mri_synthseg 8.2.0 needs BatchNormalization(fused=False), removed in Keras 3
+    command: |
+      python -c "import tensorflow as tf; print('tensorflow', tf.__version__); assert tf.__version__.startswith('2.13.')"
+    expected_output_contains: "tensorflow 2.13."
+
+  - name: NumPy pinned below the scalar-conversion removal
+    description: mri_synthseg assigns size-1 arrays into scalar slots, which errors on numpy >= 2
+    command: |
+      python -c "import numpy; print('numpy', numpy.__version__); assert int(numpy.__version__.split('.')[0]) < 2"
+    expected_output_contains: "numpy 1."
+
+  - name: Imaging dependencies importable
+    description: Verify surfa, nibabel and scipy are available for mri_synthseg
+    command: |
+      python -c "import surfa, nibabel, scipy; print('surfa', surfa.__version__, 'nibabel', nibabel.__version__)"
+    expected_output_contains: "surfa"
+
+  # ==========================================================================
+  # OPENRECON RUNTIME
+  # ==========================================================================
+  - name: OpenRecon server help
+    description: Verify the python-ismrmrd server entrypoint starts correctly
+    command: |
+      bash -lc "python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p'"
+    expected_output_contains: "Example server for MRD streaming format"
+
+  - name: OpenRecon assets installed
+    description: Verify the scanner label and README are copied into the server directory
+    command: |
+      bash -lc 'python -c "
+      import json
+      from pathlib import Path
+      label = json.loads(Path(\"/opt/code/python-ismrmrd-server/OpenReconLabel.json\").read_text())
+      assert label[\"general\"][\"id\"] == \"synthseg\"
+      assert Path(\"/opt/code/python-ismrmrd-server/OpenReconREADME.md\").stat().st_size > 0
+      print(\"openrecon assets ok, parameters:\", len(label[\"parameters\"]))
+      "'
+    expected_output_contains: "openrecon assets ok"
+
+  - name: synthseg MRD wrapper imports
+    description: Verify the reconstruction module imports with server-side helpers
+    command: |
+      bash -lc 'PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import synthseg, ismrmrd, numpy; print(synthseg.__file__)"'
+    expected_output_contains: "/opt/code/python-ismrmrd-server/synthseg.py"
+
+  - name: OpenRecon parameter matrix generates
+    description: Verify the wrapper can emit a config for every scanner option combination
+    command: |
+      bash -lc 'PYTHONPATH=/opt/code/python-ismrmrd-server python /opt/code/python-ismrmrd-server/synthseg.py --write-openrecon-test-configs ${output_dir}/synthseg/configs | head -1'
+    expected_output_contains: "OpenRecon test config"
+
+  # ==========================================================================
+  # END-TO-END SEGMENTATION
+  # ==========================================================================
+  - name: Segment a T1w volume onto the input grid
+    description: >-
+      Run the real network in fast CPU mode with --keepgeom, which is the mode
+      the OpenRecon wrapper uses, and check that the output is a FreeSurfer
+      label map on the input grid.
+    command: |
+      bash -lc 'mri_synthseg --i "${t1w}" --o ${output_dir}/synthseg/t1w_seg.nii.gz \
+        --fast --cpu --threads 4 --keepgeom --noaddctab \
+        --vol ${output_dir}/synthseg/t1w_volumes.csv'
+    validate:
+      - output_exists: ${output_dir}/synthseg/t1w_seg.nii.gz
+      - output_exists: ${output_dir}/synthseg/t1w_volumes.csv
+
+  - name: Segmentation matches the input geometry and label set
+    description: >-
+      --keepgeom must return the label map on the source grid, and the values
+      must be FreeSurfer label indices rather than rescaled intensities.
+    command: |
+      bash -lc 'python -c "
+      import nibabel, numpy
+      source = nibabel.load(\"${t1w}\")
+      seg = nibabel.load(\"${output_dir}/synthseg/t1w_seg.nii.gz\")
+      assert seg.shape == source.shape, (seg.shape, source.shape)
+      assert numpy.allclose(seg.affine, source.affine, atol=1e-3)
+      labels = numpy.unique(numpy.asarray(seg.dataobj).astype(int))
+      # 2 = Left-Cerebral-White-Matter, 3 = Left-Cerebral-Cortex in FreeSurferColorLUT
+      assert {2, 3}.issubset(set(labels.tolist())), labels[:32]
+      print(\"segmentation ok, distinct labels:\", labels.size)
+      "'
+    expected_output_contains: "segmentation ok"

--- a/recipes/synthseg/nifti2mrd.py
+++ b/recipes/synthseg/nifti2mrd.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""
+NIfTI to ISMRMRD Converter
+Converts NIfTI files to ISMRMRD format for testing the OpenRecon pipeline
+adapted from: https://github.com/jlautman1/open-recon-fetal-brain-measurements/blob/main/nifti_to_ismrmrd_converter.py
+"""
+
+import os
+import sys
+import argparse
+import re
+import numpy as np
+import nibabel as nib
+import json
+from pathlib import Path
+
+try:
+    import ismrmrd
+    print("✅ Successfully imported ismrmrd module")
+except ImportError as e:
+    print(f"❌ Failed to import ismrmrd: {e}")
+    print("   Creating mock ISMRMRD classes for testing...")
+    
+    # Create mock ISMRMRD classes for testing
+    class MockImage:
+        def __init__(self, data):
+            # Keep data as-is, don't convert to complex
+            self.data = data
+            self.meta = {}
+            self.attribute_string = ""
+            self.image_type = 1  # IMTYPE_MAGNITUDE
+            self.image_index = 0
+            self.image_series_index = 1
+        
+        @classmethod
+        def from_array(cls, data, transpose=True):
+            return cls(data)
+    
+    class MockMeta:
+        def __init__(self):
+            self._data = {}
+        
+        def __setitem__(self, key, value):
+            self._data[key] = value
+        
+        def __getitem__(self, key):
+            return self._data[key]
+        
+        def get(self, key, default=None):
+            return self._data.get(key, default)
+        
+        def serialize(self):
+            return json.dumps(self._data)
+    
+    # Create a mock ismrmrd module
+    import types
+    ismrmrd = types.ModuleType('ismrmrd')
+    ismrmrd.Image = MockImage
+    ismrmrd.Meta = MockMeta
+    IMTYPE_MAGNITUDE = 1
+
+
+def extract_orientation_from_affine(affine, shape):
+    """
+    Extract position and direction vectors from NIfTI affine matrix
+    
+    The affine matrix transforms from voxel coordinates to world coordinates:
+    [x_world]   [r11 r12 r13 tx]   [i]
+    [y_world] = [r21 r22 r23 ty] * [j]
+    [z_world]   [r31 r32 r33 tz]   [k]
+    [   1   ]   [ 0   0   0   1]   [1]
+    
+    Returns:
+        position: [x, y, z] position of the first voxel center
+        read_dir: [x, y, z] direction vector for readout (columns)
+        phase_dir: [x, y, z] direction vector for phase encoding (rows)
+        slice_dir: [x, y, z] direction vector for slice (slices)
+    """
+    print("🧭 Extracting orientation from affine matrix...")
+    print(f"   Affine matrix:\n{affine}")
+    
+    # Extract the rotation/scaling part and translation
+    # First 3 columns are the direction vectors scaled by voxel size
+    rotation_scale = affine[:3, :3]
+    translation = affine[:3, 3]
+    
+    # Extract direction vectors (columns of the rotation matrix)
+    # These need to be normalized to get unit direction vectors
+    col0 = rotation_scale[:, 0]  # First axis (usually X/readout)
+    col1 = rotation_scale[:, 1]  # Second axis (usually Y/phase)
+    col2 = rotation_scale[:, 2]  # Third axis (usually Z/slice)
+    
+    # Calculate voxel sizes from the direction vectors
+    voxel_size_x = np.linalg.norm(col0)
+    voxel_size_y = np.linalg.norm(col1)
+    voxel_size_z = np.linalg.norm(col2)
+    
+    print(f"   Voxel sizes from affine: [{voxel_size_x:.4f}, {voxel_size_y:.4f}, {voxel_size_z:.4f}] mm")
+    
+    # Normalize to get unit direction vectors
+    read_dir = col0 / voxel_size_x if voxel_size_x > 0 else col0
+    phase_dir = col1 / voxel_size_y if voxel_size_y > 0 else col1
+    slice_dir = col2 / voxel_size_z if voxel_size_z > 0 else col2
+    
+    # Position is the translation (position of first voxel)
+    position = translation.copy()
+
+    # NIfTI affine is in RAS; MRD/DICOM uses LPS. Convert by negating x and y.
+    ras_to_lps = np.array([-1, -1, 1], dtype=float)
+    read_dir  = read_dir  * ras_to_lps
+    phase_dir = phase_dir * ras_to_lps
+    slice_dir = slice_dir * ras_to_lps
+    position  = position  * ras_to_lps
+
+    print("🔄 Converted from RAS to LPS...")
+    
+    print(f"   Position: [{position[0]:.4f}, {position[1]:.4f}, {position[2]:.4f}] mm")
+    print(f"   Read direction:  [{read_dir[0]:.4f}, {read_dir[1]:.4f}, {read_dir[2]:.4f}]")
+    print(f"   Phase direction: [{phase_dir[0]:.4f}, {phase_dir[1]:.4f}, {phase_dir[2]:.4f}]")
+    print(f"   Slice direction: [{slice_dir[0]:.4f}, {slice_dir[1]:.4f}, {slice_dir[2]:.4f}]")
+    
+    return {
+        'position': position.tolist(),
+        'read_dir': read_dir.tolist(),
+        'phase_dir': phase_dir.tolist(),
+        'slice_dir': slice_dir.tolist(),
+        'voxel_size': [voxel_size_x, voxel_size_y, voxel_size_z]
+    }
+
+
+def extract_metadata_from_filename(nifti_path):
+    """Extract patient and series metadata from NIfTI filename"""
+    filename = os.path.basename(nifti_path)
+    print(f"🏷️ Extracting metadata from filename: {filename}")
+    
+    # Default metadata
+    metadata = {
+        'config': 'openrecon',
+        'enable_measurements': True,
+        'enable_reporting': True,
+        'confidence_threshold': 0.5,
+        'PatientName': 'TEST^PATIENT',
+        'StudyDescription': 'OPENRECON TEST',
+        'SeriesDescription': 'TEST_SERIES',
+        'PixelSpacing': [0.8, 0.8],
+        'SliceThickness': 0.8,
+        'PatientID': 'TESTPAT001',
+        'SeriesNumber': 1
+    }
+    
+    # Try to parse filename format: Pat[PatientID]_Se[SeriesNumber]_Res[X]_[Y]_Spac[Z].nii.gz
+    if filename.startswith('Pat') and '_Se' in filename:
+        try:
+            # Remove either .nii.gz or .nii extension flexibly
+            base_name = re.sub(r'\.nii(\.gz)?$', '', filename, flags=re.IGNORECASE)
+            parts = base_name.split('_')
+            for part in parts:
+                if part.startswith('Pat'):
+                    patient_id = part[3:]  # Remove 'Pat' prefix
+                    metadata['PatientID'] = patient_id
+                    metadata['PatientName'] = f'PATIENT^{patient_id}'
+                elif part.startswith('Se'):
+                    series_num = int(part[2:])  # Remove 'Se' prefix
+                    metadata['SeriesNumber'] = series_num
+                elif part.startswith('Res'):
+                    # Next part should be the Y resolution
+                    idx = parts.index(part)
+                    if idx + 1 < len(parts):
+                        x_res = float(part[3:])  # Remove 'Res' prefix
+                        y_res = float(parts[idx + 1])
+                        metadata['PixelSpacing'] = [x_res, y_res]
+                elif part.startswith('Spac'):
+                    slice_thickness = float(part[4:])  # Remove 'Spac' prefix
+                    metadata['SliceThickness'] = slice_thickness
+            
+            print(f"✅ Parsed metadata from filename:")
+            print(f"   Series: {metadata['SeriesNumber']}")
+            print(f"   Resolution: {metadata['PixelSpacing']}")
+            print(f"   Slice thickness: {metadata['SliceThickness']}")
+            
+        except Exception as e:
+            print(f"⚠️ Warning: Could not parse filename completely: {e}")
+            print("   Using default metadata values")
+    
+    return metadata
+
+
+def convert_nifti_to_ismrmrd(nifti_path, output_path=None):
+    """Convert NIfTI file to ISMRMRD format"""
+    
+    if not os.path.exists(nifti_path):
+        raise FileNotFoundError(f"NIfTI file not found: {nifti_path}")
+    
+    print(f"🔄 Converting NIfTI to ISMRMRD format")
+    print(f"   Input: {nifti_path}")
+    
+    # Load NIfTI data
+    print("📖 Loading NIfTI file...")
+    nii = nib.load(nifti_path)
+    data = nii.get_fdata()
+    affine = nii.affine
+    
+    print(f"📐 Original data shape: {data.shape}")
+    print(f"🔢 Value range: {data.min():.2f} - {data.max():.2f}")
+    print(f"📊 Data type: {data.dtype}")
+    
+    # Extract orientation information from affine matrix
+    orientation_info = extract_orientation_from_affine(affine, data.shape)
+    
+    # Normalize data to reasonable range for medical imaging
+    if data.max() > 4095:  # If values are very high, normalize
+        data = (data / data.max()) * 4095
+        print(f"🔧 Normalized data to range: {data.min():.2f} - {data.max():.2f}")
+    
+    # Ensure we have 3D data
+    if len(data.shape) == 2:
+        data = data[:, :, np.newaxis]
+        print(f"📝 Expanded 2D to 3D: {data.shape}")
+    elif len(data.shape) == 4:
+        data = data[:, :, :, 0]  # Take first volume
+        print(f"📝 Reduced 4D to 3D: {data.shape}")
+
+    # No pixel-data flip needed: the direction vectors now correctly
+    # describe the voxel ordering after RAS-to-LPS conversion above.
+    
+    # Create ISMRMRD Image object
+    print("🏗️ Creating ISMRMRD Image object...")
+    
+    # For magnitude/T2W images, keep as real float32 data
+    if np.iscomplexobj(data):
+        # If complex, take magnitude
+        ismrmrd_data = np.abs(data).astype(np.float32)
+        print("🔧 Converted complex data to magnitude (float32)")
+    else:
+        # Keep as real float32
+        ismrmrd_data = data.astype(np.float32)
+    
+    print(f"📊 ISMRMRD data type: {ismrmrd_data.dtype}")
+    print(f"📐 NIfTI data shape [x, y, z]: {ismrmrd_data.shape}")
+
+    # ISMRMRD from_array(..., transpose=False) expects 3D data as [z, y, x].
+    # Keep canonical volume as [x, y, z] and provide [z, y, x] only at creation.
+    ismrmrd_volume = ismrmrd_data.transpose((2, 1, 0))
+    try:
+        ismrmrd_image = ismrmrd.Image.from_array(ismrmrd_volume, transpose=False)
+    except TypeError:
+        # Older versions don't support transpose parameter
+        ismrmrd_image = ismrmrd.Image.from_array(ismrmrd_volume)
+    
+    print(f"📐 ISMRMRD image data shape: {ismrmrd_image.data.shape}")
+    
+    # Set basic image properties
+    if hasattr(ismrmrd_image, 'image_type'):
+        ismrmrd_image.image_type = IMTYPE_MAGNITUDE if 'IMTYPE_MAGNITUDE' in globals() else 1
+    if hasattr(ismrmrd_image, 'image_series_index'):
+        ismrmrd_image.image_series_index = 1
+    if hasattr(ismrmrd_image, 'image_index'):
+        ismrmrd_image.image_index = 0
+    
+    # Extract metadata from filename
+    metadata = extract_metadata_from_filename(nifti_path)
+    
+    # Add orientation information to metadata
+    metadata['position'] = orientation_info['position']
+    metadata['read_dir'] = orientation_info['read_dir']
+    metadata['phase_dir'] = orientation_info['phase_dir']
+    metadata['slice_dir'] = orientation_info['slice_dir']
+    
+    # Update pixel spacing from actual affine-derived voxel sizes
+    voxel_size = orientation_info['voxel_size']
+    print(f"🔧 Voxel spacing from affine matrix: {voxel_size}")
+    
+    print(f"📏 Original data shape: {ismrmrd_data.shape}")
+    print(f"📏 ISMRMRD image.data shape: {ismrmrd_image.data.shape}")
+    
+    # Check if ISMRMRD image has matrix_size attribute
+    if hasattr(ismrmrd_image, 'matrix_size'):
+        print(f"📏 ISMRMRD matrix_size attribute: {ismrmrd_image.matrix_size}")
+    
+    # Canonical FOV in physical [x, y, z] (same convention used by enhanceddicom2mrd.py).
+    field_of_view = [
+        ismrmrd_data.shape[0] * voxel_size[0],  # X
+        ismrmrd_data.shape[1] * voxel_size[1],  # Y
+        ismrmrd_data.shape[2] * voxel_size[2]   # Z
+    ]
+    
+    # DICOM-style PixelSpacing is [row_spacing(Y), col_spacing(X)]
+    metadata['PixelSpacing'] = [voxel_size[1], voxel_size[0]]
+    metadata['SliceThickness'] = voxel_size[2]
+    metadata['field_of_view'] = field_of_view
+    
+    print(f"📏 Voxel spacing: [{voxel_size[0]}, {voxel_size[1]}, {voxel_size[2]}] mm")
+    print(f"📏 Field of view [x, y, z]: {field_of_view} mm")
+    print(f"📏 Target matrix: {ismrmrd_data.shape[0]} x {ismrmrd_data.shape[1]} x {ismrmrd_data.shape[2]}")
+    print(f"📏 Expected voxel: [{field_of_view[0]/ismrmrd_data.shape[0]:.8f}, {field_of_view[1]/ismrmrd_data.shape[1]:.8f}, {field_of_view[2]/ismrmrd_data.shape[2]:.8f}]")
+    
+    # Set image metadata
+    if hasattr(ismrmrd_image, 'meta'):
+        ismrmrd_image.meta = metadata
+    
+    # Set field_of_view on the image header if available
+    if hasattr(ismrmrd_image, 'field_of_view'):
+        ismrmrd_image.field_of_view[:] = field_of_view
+    
+    # Set position and orientation on the image header if available
+    if hasattr(ismrmrd_image, 'position'):
+        ismrmrd_image.position[:] = orientation_info['position']
+        print(f"✅ Set image position: {orientation_info['position']}")
+    
+    if hasattr(ismrmrd_image, 'read_dir'):
+        ismrmrd_image.read_dir[:] = orientation_info['read_dir']
+        print(f"✅ Set read direction: {orientation_info['read_dir']}")
+    
+    if hasattr(ismrmrd_image, 'phase_dir'):
+        ismrmrd_image.phase_dir[:] = orientation_info['phase_dir']
+        print(f"✅ Set phase direction: {orientation_info['phase_dir']}")
+    
+    if hasattr(ismrmrd_image, 'slice_dir'):
+        ismrmrd_image.slice_dir[:] = orientation_info['slice_dir']
+        print(f"✅ Set slice direction: {orientation_info['slice_dir']}")
+    
+    # Create XML metadata string for ISMRMRD
+    meta_obj = ismrmrd.Meta()
+    for key, value in metadata.items():
+        if isinstance(value, (list, tuple)):
+            meta_obj[key] = list(value)
+        else:
+            meta_obj[key] = str(value)
+    
+    meta_obj['DataRole'] = 'Image'
+    meta_obj['ImageProcessingHistory'] = ['NIfTI_CONVERSION']
+    meta_obj['Keep_image_geometry'] = 1
+    meta_obj['orientation_extracted'] = 'true'
+    
+    if hasattr(ismrmrd_image, 'attribute_string'):
+        ismrmrd_image.attribute_string = meta_obj.serialize()
+    
+    print(f"✅ Successfully created ISMRMRD Image")
+    print(f"   Data shape: {ismrmrd_image.data.shape}")
+    print(f"   Data type: {ismrmrd_image.data.dtype}")
+    
+    # Save to file if requested
+    if output_path:
+        print(f"💾 Saving to: {output_path}")
+        
+        # Remove existing file if it exists to avoid corruption
+        if os.path.exists(output_path):
+            os.remove(output_path)
+            print(f"🗑️  Removed existing file: {output_path}")
+        
+        try:
+            # Check if we have the real ismrmrd module (not mock)
+            if hasattr(ismrmrd, 'Dataset'):
+                print(f"📝 Creating proper ISMRMRD Dataset file...")
+                
+                # Ensure parent directory exists
+                os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+                
+                # Create ISMRMRD Dataset (this creates proper structure)
+                mrdDset = ismrmrd.Dataset(output_path, 'dataset')
+                mrdDset._file.require_group('dataset')
+                
+                # Create XML header with proper metadata
+                print(f"📋 Creating ISMRMRD XML header...")
+                mrdHead = ismrmrd.xsd.ismrmrdHeader()
+                
+                # Study Information
+                mrdHead.studyInformation = ismrmrd.xsd.studyInformationType()
+                mrdHead.studyInformation.studyDescription = metadata.get('StudyDescription', 'NIFTI_CONVERSION')
+                
+                # Patient Information
+                mrdHead.subjectInformation = ismrmrd.xsd.subjectInformationType()
+                mrdHead.subjectInformation.patientName = metadata.get('PatientName', 'TEST^PATIENT')
+                mrdHead.subjectInformation.patientID = metadata.get('PatientID', 'TEST001')
+                
+                # Acquisition System Information
+                mrdHead.acquisitionSystemInformation = ismrmrd.xsd.acquisitionSystemInformationType()
+                mrdHead.acquisitionSystemInformation.systemVendor = 'NIfTI_Converter'
+                mrdHead.acquisitionSystemInformation.systemModel = 'Virtual'
+                mrdHead.acquisitionSystemInformation.institutionName = 'Test'
+                
+                # Encoding information
+                encoding = ismrmrd.xsd.encodingType()
+                encoding.trajectory = ismrmrd.xsd.trajectoryType.CARTESIAN
+                
+                # Get voxel size and FOV from metadata
+                voxel_size = orientation_info['voxel_size']
+                
+                # Encoded space (acquisition space)
+                encoding.encodedSpace = ismrmrd.xsd.encodingSpaceType()
+                encoding.encodedSpace.matrixSize = ismrmrd.xsd.matrixSizeType()
+                encoding.encodedSpace.matrixSize.x = int(ismrmrd_data.shape[0])
+                encoding.encodedSpace.matrixSize.y = int(ismrmrd_data.shape[1])
+                encoding.encodedSpace.matrixSize.z = 1
+                
+                encoding.encodedSpace.fieldOfView_mm = ismrmrd.xsd.fieldOfViewMm()
+                encoding.encodedSpace.fieldOfView_mm.x = float(ismrmrd_data.shape[0] * voxel_size[0])
+                encoding.encodedSpace.fieldOfView_mm.y = float(ismrmrd_data.shape[1] * voxel_size[1])
+                encoding.encodedSpace.fieldOfView_mm.z = float(voxel_size[2])
+                
+                # Recon space (same as encoded for NIfTI conversion)
+                encoding.reconSpace = ismrmrd.xsd.encodingSpaceType()
+                encoding.reconSpace.matrixSize = ismrmrd.xsd.matrixSizeType()
+                encoding.reconSpace.matrixSize.x = int(ismrmrd_data.shape[0])
+                encoding.reconSpace.matrixSize.y = int(ismrmrd_data.shape[1])
+                encoding.reconSpace.matrixSize.z = 1
+                
+                encoding.reconSpace.fieldOfView_mm = ismrmrd.xsd.fieldOfViewMm()
+                encoding.reconSpace.fieldOfView_mm.x = float(ismrmrd_data.shape[0] * voxel_size[0])
+                encoding.reconSpace.fieldOfView_mm.y = float(ismrmrd_data.shape[1] * voxel_size[1])
+                encoding.reconSpace.fieldOfView_mm.z = float(voxel_size[2])
+                
+                # Encoding limits
+                encoding.encodingLimits = ismrmrd.xsd.encodingLimitsType()
+                
+                mrdHead.encoding.append(encoding)
+                
+                # Sequence parameters
+                mrdHead.sequenceParameters = ismrmrd.xsd.sequenceParametersType()
+                mrdHead.sequenceParameters.TR = [1.0]
+                mrdHead.sequenceParameters.TE = [1.0]
+                
+                print(f"   Matrix size: {ismrmrd_data.shape[0]} x {ismrmrd_data.shape[1]} x {ismrmrd_data.shape[2]}")
+                print(f"   FOV: {encoding.encodedSpace.fieldOfView_mm.x:.2f} x {encoding.encodedSpace.fieldOfView_mm.y:.2f} x {encoding.encodedSpace.fieldOfView_mm.z:.2f} mm")
+                print(f"   Voxel size: {voxel_size[0]:.4f} x {voxel_size[1]:.4f} x {voxel_size[2]:.4f} mm")
+                
+                # Write XML header
+                mrdDset.write_xml_header(mrdHead.toXML('utf-8'))
+                print(f"✅ Written XML header")
+                
+                # Create image with proper metadata
+                tmpMeta = ismrmrd.Meta()
+                for key, value in metadata.items():
+                    if isinstance(value, (list, tuple)):
+                        tmpMeta[key] = list(value)
+                    else:
+                        tmpMeta[key] = str(value)
+                
+                tmpMeta['DataRole'] = 'Image'
+                tmpMeta['ImageProcessingHistory'] = ['NIFTI_CONVERSION']
+                tmpMeta['Keep_image_geometry'] = 1
+                
+                ismrmrd_image.attribute_string = tmpMeta.serialize()
+                
+                # Set image series index
+                ismrmrd_image.image_series_index = metadata.get('SeriesNumber', 1)
+                
+                # Write each slice as a separate image
+                print(f"💾 Writing {ismrmrd_data.shape[2]} slices as separate images...")
+                
+                for slice_idx in range(ismrmrd_data.shape[2]):
+                    # Extract 2D slice as [rows(Y), cols(X)] to match enhanceddicom2mrd.py.
+                    slice_data = ismrmrd_data[:, :, slice_idx].T.astype(np.float32)
+                    
+                    # Create ISMRMRD image for this slice
+                    try:
+                        slice_image = ismrmrd.Image.from_array(slice_data, transpose=False)
+                    except TypeError:
+                        slice_image = ismrmrd.Image.from_array(slice_data)
+                    
+                    # Set image properties
+                    slice_image.image_type = IMTYPE_MAGNITUDE if 'IMTYPE_MAGNITUDE' in globals() else 1
+                    slice_image.image_series_index = metadata.get('SeriesNumber', 1)
+                    slice_image.image_index = slice_idx + 1
+                    
+                    # Calculate position for this slice
+                    # Position of slice = position of first slice + (slice_idx * slice_spacing * slice_direction)
+                    slice_position = (
+                        np.array(orientation_info['position']) + 
+                        slice_idx * voxel_size[2] * np.array(orientation_info['slice_dir'])
+                    )
+                    
+                    # Set position and orientation on the slice
+                    if hasattr(slice_image, 'position'):
+                        slice_image.position[:] = slice_position.tolist()
+                    
+                    if hasattr(slice_image, 'read_dir'):
+                        slice_image.read_dir[:] = orientation_info['read_dir']
+                    
+                    if hasattr(slice_image, 'phase_dir'):
+                        slice_image.phase_dir[:] = orientation_info['phase_dir']
+                    
+                    if hasattr(slice_image, 'slice_dir'):
+                        slice_image.slice_dir[:] = orientation_info['slice_dir']
+                    
+                    # 2D slice FOV in [x, y, z] with z being slice thickness.
+                    slice_fov = [
+                        ismrmrd_data.shape[0] * voxel_size[0],
+                        ismrmrd_data.shape[1] * voxel_size[1],
+                        voxel_size[2]
+                    ]
+                    
+                    if hasattr(slice_image, 'field_of_view'):
+                        slice_image.field_of_view[:] = slice_fov
+                    
+                    # Create metadata for this slice
+                    slice_meta = ismrmrd.Meta()
+                    for key, value in metadata.items():
+                        if isinstance(value, (list, tuple)):
+                            slice_meta[key] = list(value)
+                        else:
+                            slice_meta[key] = str(value)
+                    
+                    slice_meta['DataRole'] = 'Image'
+                    slice_meta['ImageProcessingHistory'] = ['NIFTI_CONVERSION']
+                    slice_meta['Keep_image_geometry'] = 1
+                    slice_meta['slice_number'] = slice_idx
+                    slice_meta['position'] = slice_position.tolist()
+                    
+                    slice_image.attribute_string = slice_meta.serialize()
+                    
+                    # Set slice and phase index
+                    slice_image.slice = slice_idx
+                    slice_image.phase = 0
+                    slice_image.acquisition_time_stamp = 0
+
+                    # Write slice to dataset
+                    # Use series index as key to group all slices in one series
+                    series_index = metadata.get('SeriesNumber', 1)
+                    mrdDset.append_image("image_%d" % series_index, slice_image)
+                    
+                    if (slice_idx + 1) % 50 == 0 or slice_idx == ismrmrd_data.shape[2] - 1:
+                        print(f"   Written {slice_idx + 1}/{ismrmrd_data.shape[2]} slices...")
+                
+                # Close dataset
+                mrdDset.close()
+                
+                print(f"✅ Saved {ismrmrd_data.shape[2]} slices to {output_path}")
+            else:
+                raise ImportError("ismrmrd.Dataset not available - cannot create proper ISMRMRD file")
+            
+        except (ImportError, AttributeError, Exception) as e:
+            print(f"❌ Could not save as ISMRMRD file: {e}")
+            import traceback
+            traceback.print_exc()
+            raise
+    
+    return ismrmrd_image, metadata
+
+
+def main():
+    """Main function to test the converter"""
+    print("🧪 NIfTI to ISMRMRD Converter")
+    print("=" * 50)
+    
+    # CLI arguments
+    parser = argparse.ArgumentParser(description="Convert a NIfTI file to ISMRMRD format for OpenRecon testing")
+    parser.add_argument(
+        "-i", "--input",
+        dest="nifti_file",
+        help="Path to the NIfTI file to convert, e.g. Pat[PatientID]_Se[SeriesNumber]_Res[X]_[Y]_Spac[Z].nii.gz",
+        default="Pat[PatientID]_Se[SeriesNumber]_Res[X]_[Y]_Spac[Z].nii.gz"
+    )
+    parser.add_argument(
+        "-o", "--output",
+        dest="output_path",
+        help="Optional output path for serialized ISMRMRD data (pickle)",
+        default="test_ismrmrd_output.h5"
+    )
+    args = parser.parse_args()
+
+    # Resolve inputs
+    nifti_file = args.nifti_file
+    output_path = args.output_path
+    
+    if not os.path.exists(nifti_file):
+        print(f"❌ Test file not found: {nifti_file}")
+        print("   Please check the file path")
+        return False
+    
+    try:
+        # Convert NIfTI to ISMRMRD
+        print(f"➡️  Using input: {nifti_file}")
+        print(f"➡️  Output path: {output_path}")
+        ismrmrd_image, metadata = convert_nifti_to_ismrmrd(nifti_file, output_path)
+        
+        print("\n📋 Conversion Summary:")
+        print(f"   Input file: {nifti_file}")
+        print(f"   Original 3D volume shape: {ismrmrd_image.data.shape}")
+        print(f"   Number of 2D slices saved: {ismrmrd_image.data.shape[2]}")
+        print(f"   Each slice shape: [{ismrmrd_image.data.shape[0]}, {ismrmrd_image.data.shape[1]}]")
+        print(f"   Series: {metadata.get('SeriesNumber', 'Unknown')}")
+        print(f"   PixelSpacing: {metadata.get('PixelSpacing', 'Unknown')}")
+        print(f"   SliceThickness: {metadata.get('SliceThickness', 'Unknown')}")
+        print(f"\n🧭 Orientation Information:")
+        print(f"   First slice position: {metadata.get('position', 'Unknown')}")
+        print(f"   Read direction: {metadata.get('read_dir', 'Unknown')}")
+        print(f"   Phase direction: {metadata.get('phase_dir', 'Unknown')}")
+        print(f"   Slice direction: {metadata.get('slice_dir', 'Unknown')}")
+        print(f"   Slice spacing: {metadata.get('SliceThickness', 'Unknown')} mm")
+        
+        return ismrmrd_image, metadata
+        
+    except Exception as e:
+        print(f"❌ Error during conversion: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    result = main()
+    if result:
+        print("\n🎉 Conversion completed successfully!")
+    else:
+        print("\n💥 Conversion failed!")

--- a/recipes/synthseg/synthseg.py
+++ b/recipes/synthseg/synthseg.py
@@ -1,0 +1,4042 @@
+import argparse
+import base64
+import ctypes
+import itertools
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import time
+from time import perf_counter
+import traceback
+import uuid
+
+import ismrmrd
+import nibabel as nib
+import numpy as np
+import numpy.fft as fft
+import scipy.ndimage as ndi
+
+import constants
+import mrdhelper
+
+
+# Folder for debug output files
+debugFolder = "/tmp/share/debug"
+OPENRECON_WORKSPACE_ROOT = "synthseg_openrecon"
+OPENRECON_OUTPUT_NAME_PARAM = "ssoutputname"
+OPENRECON_MODEL_DEFAULT = "synthseg"
+OPENRECON_MODEL_VALUES = ("synthseg", "robust", "v1")
+OPENRECON_SERIES_SUFFIX = "OR"
+OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX = "openrecon"
+SYNTHSEG_OUTPUT_GEOMETRY_2D = "2d"
+SYNTHSEG_SEGMENT_SEND_ORDER = "after_originals"
+SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY = "SegmentPostProcessing"
+SYNTHSEG_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY = "SegmentPostProcessingChildRole"
+SYNTHSEG_SEGMENT_SOURCE_GEOMETRY_META_KEY = "SegmentSourceGeometry"
+SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY = "SegmentSourceImageHeader"
+SYNTHSEG_SEGMENT_OUTPUT_GEOMETRY_META_KEY = "SegmentOutputGeometry"
+SYNTHSEG_REFORMAT_ORIENTATION_META_KEY = "SynthSegReformatOrientation"
+SYNTHSEG_REFORMAT_SLICE_INDEX_META_KEY = "SynthSegReformatSliceIndex"
+SYNTHSEG_REFORMAT_SLICE_COUNT_META_KEY = "SynthSegReformatSliceCount"
+SYNTHSEG_SEGMENTATION_LABEL = "synthseg"
+SYNTHSEG_SEGMENTATION_TYPE_TOKEN = SYNTHSEG_SEGMENTATION_LABEL.upper()
+SYNTHSEG_SOURCE_IMAGE_HEADER_FALLBACK_TYPE = (
+    f"DERIVED\\PRIMARY\\SEGMENTATION\\{SYNTHSEG_SEGMENTATION_LABEL}_source_image_header"
+)
+SYNTHSEG_SOURCE_IMAGE_HEADER_FALLBACK_VALUE4 = (
+    f"{SYNTHSEG_SEGMENTATION_LABEL}_source_image_header"
+)
+SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE = (
+    f"DERIVED\\PRIMARY\\SEGMENTATION\\{SYNTHSEG_SEGMENTATION_LABEL}_source_geometry"
+)
+SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4 = (
+    f"{SYNTHSEG_SEGMENTATION_LABEL}_source_geometry"
+)
+SYNTHSEG_ORIGINAL_LABEL = "original"
+SYNTHSEG_ORIGINAL_TYPE_TOKEN = SYNTHSEG_ORIGINAL_LABEL.upper()
+SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3 = "M"
+SCANNER_PARTITION_INDEX = 0
+SOURCE_PARENT_REFERENCE_META_KEYS = {
+    "DicomEngineDimString",
+    "MFInstanceNumber",
+    "MultiFrameSOPInstanceUID",
+    "PSMultiFrameSOPInstanceUID",
+    "PSSeriesInstanceUID",
+    "SOPInstanceUID",
+}
+SOURCE_PARENT_REFERENCE_META_PREFIXES = (
+    "ReferencedGSPS",
+    "ReferencedImageSequence",
+)
+SCANNER_WRITE_UNSAFE_META_KEYS = {
+    "ImageTypeValue3",
+}
+
+# mri_synthseg resolves every model and label file relative to FREESURFER_HOME.
+SYNTHSEG_COMMAND = "mri_synthseg"
+SYNTHSEG_MODEL_FILES = {
+    "synthseg": "synthseg_2.0.h5",
+    "robust": "synthseg_robust_2.0.h5",
+    "v1": "synthseg_1.0.h5",
+}
+SYNTHSEG_PARCELLATION_MODEL_FILE = "synthseg_parc_2.0.h5"
+SYNTHSEG_QC_MODEL_FILE = "synthseg_qc_2.0.h5"
+# SynthSeg emits FreeSurfer label indices (up to 2035 with --parc), which fit
+# into int16 without rescaling. Keeping the raw indices is what makes the
+# FreeSurferColorLUT lookup meaningful on the scanner.
+SYNTHSEG_MAX_LABEL_VALUE = 32767
+
+# Keep this overview aligned with recipes/synthseg/OpenReconLabel.json.
+# Tests can import it to build a minimal OpenRecon config payload.
+OPENRECON_DEFAULTS = {
+    "config": "synthseg",
+    "sendoriginal": True,
+    "ssmodel": OPENRECON_MODEL_DEFAULT,
+    "ssparc": False,
+    "ssfast": True,
+    "ssusegpu": True,
+    "ssthreads": 8,
+    "ssvolumes": False,
+    "ssqc": False,
+    "sssegmentheader": False,
+    "ssreslicesagittal": False,
+    "ssreslicecoronal": False,
+    "ssdebugthresholdsegment": False,
+}
+OPENRECON_DEFAULT_TEST_CONFIG = {
+    "parameters": OPENRECON_DEFAULTS.copy(),
+}
+
+OPENRECON_COMBINATION_PARAMETER_VALUES = {
+    "ssparc": (False, True),
+    "ssfast": (False, True),
+    "ssvolumes": (False, True),
+    "ssqc": (False, True),
+}
+
+
+def _log_array_summary(label: str, data: np.ndarray) -> None:
+    logging.info(
+        "%s summary: shape=%s ndim=%d dtype=%s is_complex=%s",
+        label,
+        data.shape,
+        data.ndim,
+        data.dtype,
+        np.iscomplexobj(data),
+    )
+
+    if data.size == 0:
+        logging.warning("%s is empty", label)
+        return
+
+    summary_data = np.abs(data) if np.iscomplexobj(data) else data
+    logging.info(
+        "%s value range: min=%s max=%s",
+        label,
+        float(np.min(summary_data)),
+        float(np.max(summary_data)),
+    )
+
+
+def _log_directory_contents(label: str, path: Path) -> None:
+    if not path.exists():
+        logging.info("%s does not exist: %s", label, path)
+        return
+
+    entries = sorted(child.name for child in path.iterdir())
+    logging.info("%s contents (%s): %s", label, path, entries)
+
+
+def _simple_threshold_segmentation_volume(input_yxz: np.ndarray, max_val: int) -> np.ndarray:
+    data = np.asarray(input_yxz)
+    if np.iscomplexobj(data):
+        data = np.abs(data)
+    data = np.asarray(data, dtype=np.float32)
+    if data.ndim == 2:
+        data = data[:, :, None]
+    if data.ndim != 3:
+        raise ValueError(
+            "Debug threshold segmentation expects a 2D or 3D input volume, "
+            f"got shape {data.shape}"
+        )
+
+    threshold = _bright_foreground_threshold(data)
+    foreground = data >= threshold
+    foreground &= np.isfinite(data)
+    segmentation_zyx = _largest_connected_component_per_plane(
+        foreground.transpose((2, 0, 1))
+    )
+    segmentation_yxz = segmentation_zyx.transpose((1, 2, 0))
+    logging.warning(
+        "Using debug simple threshold segmentation: threshold=%.6g "
+        "foreground_voxels=%d kept_voxels=%d",
+        float(threshold),
+        int(np.count_nonzero(foreground)),
+        int(np.count_nonzero(segmentation_yxz)),
+    )
+    return (segmentation_yxz.astype(np.int16) * int(max_val)).astype(np.int16)
+
+
+def _bright_foreground_threshold(data: np.ndarray) -> float:
+    finite_values = np.asarray(data, dtype=np.float32)
+    finite_values = finite_values[np.isfinite(finite_values)]
+    if finite_values.size == 0:
+        return np.inf
+
+    data_min = float(np.min(finite_values))
+    data_max = float(np.max(finite_values))
+    if data_max <= data_min:
+        return np.inf
+
+    background = float(np.percentile(finite_values, 50))
+    upper = float(np.percentile(finite_values, 95))
+    if upper <= background:
+        upper = data_max
+
+    threshold = background + 0.5 * (upper - background)
+    if threshold >= data_max:
+        threshold = background + 0.5 * (data_max - background)
+    return threshold
+
+
+def _largest_connected_component_per_plane(mask: np.ndarray) -> np.ndarray:
+    mask = np.asarray(mask, dtype=bool)
+    if mask.ndim < 2:
+        return _largest_connected_component_2d(mask.reshape(1, -1)).reshape(mask.shape)
+
+    result = np.zeros(mask.shape, dtype=bool)
+    planes = mask.reshape((-1,) + mask.shape[-2:])
+    result_planes = result.reshape((-1,) + mask.shape[-2:])
+    for index, plane in enumerate(planes):
+        result_planes[index] = _largest_connected_component_2d(plane)
+    return result
+
+
+def _largest_connected_component_2d(mask: np.ndarray) -> np.ndarray:
+    mask = np.asarray(mask, dtype=bool)
+    height, width = mask.shape
+    foreground = mask.ravel()
+    foreground_indices = np.flatnonzero(foreground)
+    if foreground_indices.size == 0:
+        return np.zeros(mask.shape, dtype=bool)
+
+    visited = np.zeros(foreground.size, dtype=bool)
+    best_component = []
+    for seed in foreground_indices:
+        if visited[seed]:
+            continue
+
+        component = []
+        stack = [int(seed)]
+        visited[seed] = True
+        while stack:
+            current = stack.pop()
+            component.append(current)
+            row, col = divmod(current, width)
+            neighbors = []
+            if row > 0:
+                neighbors.append(current - width)
+            if row + 1 < height:
+                neighbors.append(current + width)
+            if col > 0:
+                neighbors.append(current - 1)
+            if col + 1 < width:
+                neighbors.append(current + 1)
+            for neighbor in neighbors:
+                if foreground[neighbor] and not visited[neighbor]:
+                    visited[neighbor] = True
+                    stack.append(neighbor)
+
+        if len(component) > len(best_component):
+            best_component = component
+
+    result = np.zeros(foreground.size, dtype=bool)
+    result[best_component] = True
+    return result.reshape(mask.shape)
+
+
+def compute_nifti_affine(image_header, voxel_size):
+    # MRD stores geometry in DICOM/LPS. NIfTI uses RAS.
+    lps_to_ras = np.array([-1, -1, 1], dtype=float)
+
+    position = np.asarray(image_header.position, dtype=float) * lps_to_ras
+    read_dir = np.asarray(image_header.read_dir, dtype=float) * lps_to_ras
+    phase_dir = np.asarray(image_header.phase_dir, dtype=float) * lps_to_ras
+    slice_dir = np.asarray(image_header.slice_dir, dtype=float) * lps_to_ras
+
+    affine = np.eye(4)
+    affine[:3, :3] = np.column_stack(
+        [
+            voxel_size[0] * read_dir,
+            voxel_size[1] * phase_dir,
+            voxel_size[2] * slice_dir,
+        ]
+    )
+    affine[:3, 3] = position
+    return affine
+
+
+def _header_vector(image_header, field_name):
+    try:
+        return np.asarray(getattr(image_header, field_name), dtype=float)
+    except Exception:
+        return np.zeros(3, dtype=float)
+
+
+def _normalize_vector(vector):
+    vector = np.asarray(vector, dtype=float)
+    norm = float(np.linalg.norm(vector))
+    if norm < 1e-8:
+        return None
+    return vector / norm
+
+
+def _format_vector(vector):
+    return "[" + ", ".join(
+        f"{float(getattr(value, 'value', value)):.3f}" for value in vector
+    ) + "]"
+
+
+def _infer_slice_axis(image_headers):
+    for image_header in image_headers:
+        axis = _normalize_vector(_header_vector(image_header, "slice_dir"))
+        if axis is not None:
+            return axis
+
+    if len(image_headers) > 1:
+        axis = _normalize_vector(
+            _header_vector(image_headers[-1], "position")
+            - _header_vector(image_headers[0], "position")
+        )
+        if axis is not None:
+            return axis
+
+    return np.array([0.0, 0.0, 1.0], dtype=float)
+
+
+def _build_slice_geometry_records(image_headers, input_indices=None, slice_axis=None):
+    if input_indices is None:
+        input_indices = list(range(len(image_headers)))
+    if slice_axis is None:
+        slice_axis = _infer_slice_axis(image_headers)
+
+    records = []
+    for local_index, image_header in enumerate(image_headers):
+        position = _header_vector(image_header, "position")
+        slice_dir = _normalize_vector(_header_vector(image_header, "slice_dir"))
+        slice_dir_dot_axis = float(np.dot(slice_dir, slice_axis)) if slice_dir is not None else 0.0
+        records.append(
+            {
+                "local_index": local_index,
+                "input_index": int(input_indices[local_index]),
+                "image_index": int(getattr(image_header, "image_index", 0)),
+                "slice": int(getattr(image_header, "slice", 0)),
+                "phase": int(getattr(image_header, "phase", 0)),
+                "position": position,
+                "projected_position": float(np.dot(position, slice_axis)),
+                "slice_dir_dot_axis": slice_dir_dot_axis,
+            }
+        )
+
+    return slice_axis, records
+
+
+def _estimate_slice_spacing(image_headers, slice_axis=None):
+    if len(image_headers) < 2:
+        return None
+
+    slice_axis, records = _build_slice_geometry_records(image_headers, slice_axis=slice_axis)
+    projected_positions = np.array(
+        [record["projected_position"] for record in records],
+        dtype=float,
+    )
+    sorted_diffs = np.diff(np.sort(projected_positions))
+    nonzero_diffs = np.abs(sorted_diffs[np.abs(sorted_diffs) > 1e-4])
+    if nonzero_diffs.size == 0:
+        return None
+    return float(np.median(nonzero_diffs))
+
+
+def _slice_sort_indices(image_headers):
+    slice_axis, records = _build_slice_geometry_records(image_headers)
+    sorted_records = sorted(
+        records,
+        key=lambda record: (
+            round(record["projected_position"], 4),
+            record["slice"],
+            record["image_index"],
+            record["input_index"],
+        ),
+    )
+    return [record["input_index"] for record in sorted_records], slice_axis, records
+
+
+def _log_slice_geometry(label, image_headers, input_indices=None, slice_axis=None):
+    slice_axis, records = _build_slice_geometry_records(
+        image_headers,
+        input_indices=input_indices,
+        slice_axis=slice_axis,
+    )
+    projected_positions = np.array(
+        [record["projected_position"] for record in records],
+        dtype=float,
+    )
+    slice_dir_alignment = np.array(
+        [record["slice_dir_dot_axis"] for record in records],
+        dtype=float,
+    )
+    min_slice_dir_alignment = float(np.min(slice_dir_alignment)) if slice_dir_alignment.size else 1.0
+
+    if len(projected_positions) > 1:
+        current_diffs = np.diff(projected_positions)
+        sorted_diffs = np.diff(np.sort(projected_positions))
+        nonzero_sorted_diffs = np.abs(sorted_diffs[np.abs(sorted_diffs) > 1e-4])
+        median_spacing = float(np.median(nonzero_sorted_diffs)) if nonzero_sorted_diffs.size else 0.0
+        duplicate_positions = int(np.sum(np.abs(sorted_diffs) <= 1e-4))
+        monotonic_increasing = bool(np.all(current_diffs >= -1e-4))
+    else:
+        median_spacing = 0.0
+        duplicate_positions = 0
+        monotonic_increasing = True
+
+    logging.info(
+        "%s slice geometry: count=%d axis=%s projected_range=[%.3f, %.3f] "
+        "median_spacing=%.3f duplicates=%d order_inc=%s min_slice_dir_dot_axis=%.6f",
+        label,
+        len(records),
+        _format_vector(slice_axis),
+        float(np.min(projected_positions)) if projected_positions.size else 0.0,
+        float(np.max(projected_positions)) if projected_positions.size else 0.0,
+        median_spacing,
+        duplicate_positions,
+        monotonic_increasing,
+        min_slice_dir_alignment,
+    )
+
+    if not monotonic_increasing:
+        logging.warning(
+            "%s slice positions are not increasing along slice_dir in their current order",
+            label,
+        )
+    if duplicate_positions > 0:
+        logging.warning(
+            "%s has %d duplicate projected slice position(s)",
+            label,
+            duplicate_positions,
+        )
+    if min_slice_dir_alignment < 0.99:
+        logging.warning(
+            "%s has slice_dir vectors that are not aligned with the inferred slice axis",
+            label,
+        )
+
+    return slice_axis, records
+
+
+def _log_slice_sort_mapping(sort_indices):
+    identity = list(range(len(sort_indices)))
+    if sort_indices == identity:
+        logging.info("SynthSeg input slice order already matches physical slice order")
+        return
+
+    logging.warning(
+        "Reordering SynthSeg input slices by physical position: first mappings %s",
+        ", ".join(
+            f"out{output_index}->in{input_index}"
+            for output_index, input_index in enumerate(sort_indices[:24])
+        ),
+    )
+    if len(sort_indices) > 24:
+        logging.warning(
+            "Reordering mapping omitted %d additional slice(s)",
+            len(sort_indices) - 24,
+        )
+
+
+def _log_affine_slice_consistency(image_headers, voxel_size):
+    if len(image_headers) < 2:
+        return
+
+    _, records = _build_slice_geometry_records(image_headers)
+    projected_positions = np.array(
+        [record["projected_position"] for record in records],
+        dtype=float,
+    )
+    expected_positions = projected_positions[0] + np.arange(len(projected_positions)) * float(voxel_size[2])
+    residuals = projected_positions - expected_positions
+    max_abs_residual = float(np.max(np.abs(residuals))) if residuals.size else 0.0
+    logging.info(
+        "NIfTI affine slice consistency: z_spacing=%.6f residual_range=[%.6f, %.6f] max_abs_residual=%.6f",
+        float(voxel_size[2]),
+        float(np.min(residuals)),
+        float(np.max(residuals)),
+        max_abs_residual,
+    )
+    if max_abs_residual > max(0.25, 0.25 * float(voxel_size[2])):
+        logging.warning(
+            "Input slice positions are not well described by a single linear NIfTI z-spacing; "
+            "SynthSeg output will still reuse original per-slice MRD positions"
+        )
+
+
+def _is_nifti_file(path: Path) -> bool:
+    return path.is_file() and path.name.endswith((".nii", ".nii.gz"))
+
+
+def _find_output_nifti(output_dir: Path, expected_name: str) -> Path:
+    if not output_dir.exists():
+        raise FileNotFoundError(f"SynthSeg output directory does not exist: {output_dir}")
+
+    preferred_names = (
+        expected_name,
+        f"{expected_name}.gz" if expected_name.endswith(".nii") else expected_name,
+    )
+    for name in preferred_names:
+        candidate = output_dir / name
+        if candidate.exists():
+            return candidate
+
+    candidates = [
+        path for path in sorted(output_dir.iterdir())
+        if _is_nifti_file(path) and not path.name.startswith("SIGMOID_")
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+
+    output_files = sorted(path.name for path in output_dir.iterdir())
+    raise FileNotFoundError(
+        f"Could not find a SynthSeg segmentation in {output_dir}. "
+        f"Files present: {output_files}"
+    )
+
+
+def _freesurfer_home() -> Path:
+    env_home = os.environ.get("FREESURFER_HOME")
+    if not env_home:
+        raise RuntimeError(
+            "FREESURFER_HOME is not set, so mri_synthseg cannot locate its models."
+        )
+    return Path(env_home)
+
+
+def _resolve_synthseg_model(model_file: str) -> Path:
+    """Return the FreeSurfer model path mri_synthseg will load for `model_file`."""
+    model_path = _freesurfer_home() / "models" / model_file
+    if not model_path.exists():
+        raise FileNotFoundError(
+            f"Could not find SynthSeg model '{model_file}' at {model_path}."
+        )
+    logging.info("Using SynthSeg model %s", model_path)
+    return model_path
+
+
+def _resolve_synthseg_models(model: str, parcellation: bool, qc: bool) -> list[Path]:
+    """Validate every model file the requested SynthSeg run needs up front.
+
+    mri_synthseg only fails once TensorFlow tries to read a missing weight file,
+    which is a long way into a scanner run, so the models are checked before the
+    subprocess starts.
+    """
+    try:
+        segmentation_model = SYNTHSEG_MODEL_FILES[model]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported SynthSeg model requested: {model}. "
+            f"Valid models: {', '.join(sorted(SYNTHSEG_MODEL_FILES))}"
+        ) from None
+
+    model_files = [segmentation_model]
+    if parcellation:
+        model_files.append(SYNTHSEG_PARCELLATION_MODEL_FILE)
+    if qc:
+        model_files.append(SYNTHSEG_QC_MODEL_FILE)
+    return [_resolve_synthseg_model(model_file) for model_file in model_files]
+
+
+def _clone_mrd_image(image):
+    image_copy = ismrmrd.Image.from_array(
+        np.array(image.data, copy=True),
+        transpose=False,
+    )
+    image_copy.setHead(image.getHead())
+    image_copy.attribute_string = image.attribute_string
+    return image_copy
+
+
+def _meta_from_image(image):
+    if not getattr(image, "attribute_string", ""):
+        return ismrmrd.Meta()
+    return ismrmrd.Meta.deserialize(image.attribute_string)
+
+
+def _copy_meta(meta_obj):
+    try:
+        return ismrmrd.Meta.deserialize(meta_obj.serialize())
+    except Exception:
+        meta_copy = ismrmrd.Meta()
+        for key in meta_obj.keys():
+            try:
+                meta_copy[key] = meta_obj[key]
+            except Exception:
+                pass
+        return meta_copy
+
+
+def _strip_source_parent_refs(meta_obj):
+    for key in list(meta_obj.keys()):
+        if key in SOURCE_PARENT_REFERENCE_META_KEYS:
+            del meta_obj[key]
+            continue
+        if any(key.startswith(prefix) for prefix in SOURCE_PARENT_REFERENCE_META_PREFIXES):
+            del meta_obj[key]
+
+
+def _strip_scanner_write_unsafe_meta(meta_obj):
+    for key in SCANNER_WRITE_UNSAFE_META_KEYS:
+        if key in meta_obj:
+            del meta_obj[key]
+
+
+def _set_meta_scalar(meta_obj, key, value):
+    meta_obj[key] = str(int(value))
+
+
+def _first_non_empty_text(*values):
+    for value in values:
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                text = _first_non_empty_text(item)
+                if text:
+                    return text
+            continue
+
+        if value is None:
+            continue
+
+        text = str(value).strip()
+        if text and text.upper() != "N/A":
+            return text
+
+    return ""
+
+
+def _get_meta_text(meta_obj, key):
+    try:
+        return _first_non_empty_text(meta_obj.get(key))
+    except Exception:
+        return ""
+
+
+def _get_meta_values(meta_obj, key):
+    try:
+        value = meta_obj.get(key)
+    except Exception:
+        value = None
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)):
+        value = [value]
+    values = []
+    for item in value:
+        text = str(item or "").strip()
+        if text and text.upper() != "N/A":
+            values.append(text)
+    return values
+
+
+def _get_meta_int(meta_obj, key):
+    text = _get_meta_text(meta_obj, key)
+    if not text:
+        return None
+    try:
+        return int(float(text))
+    except ValueError:
+        return None
+
+
+def _meta_text_values(value):
+    if value is None:
+        return []
+
+    if isinstance(value, (list, tuple)):
+        raw_values = value
+    else:
+        raw_values = str(value).split("\\")
+
+    values = []
+    for raw_value in raw_values:
+        text = str(raw_value).strip()
+        if text:
+            values.append(text.upper())
+    return values
+
+
+def _extract_dicom_image_type_values(meta_obj):
+    dicom_values = _meta_text_values(meta_obj.get("DicomImageType"))
+    if dicom_values:
+        return dicom_values
+
+    image_type_values = _meta_text_values(meta_obj.get("ImageType"))
+    if not image_type_values:
+        return []
+
+    if len(image_type_values) >= 3:
+        return image_type_values
+
+    value3 = _meta_text_values(meta_obj.get("ImageTypeValue3"))
+    prefix = ["", "", value3[0] if value3 else ""]
+    return prefix + image_type_values
+
+
+def _get_dicom_image_type_value(meta_obj, index):
+    values = _extract_dicom_image_type_values(meta_obj)
+    if len(values) > index:
+        return values[index]
+    return ""
+
+
+def _decode_ice_minihead(meta_obj):
+    try:
+        encoded = meta_obj.get("IceMiniHead")
+        if encoded is None:
+            return ""
+        if isinstance(encoded, (list, tuple)):
+            encoded = encoded[0] if encoded else None
+        if not encoded:
+            return ""
+        return base64.b64decode(encoded).decode("utf-8")
+    except Exception:
+        return ""
+
+
+def _encode_ice_minihead(minihead_text):
+    return base64.b64encode(minihead_text.encode("utf-8")).decode("ascii")
+
+
+def _extract_minihead_string_value(minihead_text, name):
+    if not minihead_text:
+        return ""
+
+    match = re.search(
+        rf'<ParamString\."{re.escape(name)}">\s*\{{\s*"([^"]*)"\s*\}}',
+        minihead_text,
+    )
+    if match:
+        return match.group(1).strip()
+    try:
+        return _first_non_empty_text(
+            mrdhelper.extract_minihead_string_param(minihead_text, name)
+        )
+    except Exception:
+        pass
+    return ""
+
+
+def _extract_minihead_long_value(minihead_text, name):
+    if not minihead_text:
+        return None
+
+    match = re.search(
+        rf'<ParamLong\."{re.escape(name)}">\s*\{{\s*(-?\d*)\s*\}}',
+        minihead_text,
+    )
+    if not match:
+        return None
+    value = match.group(1).strip()
+    return int(value) if value not in {"", "-"} else None
+
+
+def _extract_minihead_array_tokens(minihead_text, name):
+    if not minihead_text:
+        return []
+
+    block_match = re.search(
+        rf'<ParamArray\."{re.escape(name)}">\s*\{{.*?^\s*\}}',
+        minihead_text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if not block_match:
+        return []
+
+    return [token.strip() for token in re.findall(r'\{\s*"([^"]+)"\s*\}', block_match.group(0))]
+
+
+def _sanitize_minihead_param_value(value):
+    text = _first_non_empty_text(value)
+    if not text:
+        return ""
+    return (
+        text.replace('"', "'")
+        .replace("\r", " ")
+        .replace("\n", " ")
+    )
+
+
+def _replace_or_append_minihead_string_param(minihead_text, name, value):
+    value = _sanitize_minihead_param_value(value)
+    if not minihead_text or not value:
+        return minihead_text, False
+
+    pattern = re.compile(
+        rf'(<ParamString\."{re.escape(name)}">\s*\{{\s*")([^"]*)("\s*\}})'
+    )
+    matches = list(pattern.finditer(minihead_text))
+    if matches:
+        if all(match.group(2) == value for match in matches):
+            return minihead_text, False
+        return (
+            pattern.sub(
+                lambda match: f"{match.group(1)}{value}{match.group(3)}",
+                minihead_text,
+            ),
+            True,
+        )
+
+    appended_param = f'\n<ParamString."{name}">\t{{ "{value}" }}\n'
+    return minihead_text.rstrip() + appended_param, True
+
+
+def _replace_or_append_minihead_long_param(minihead_text, name, value):
+    if not minihead_text or value is None:
+        return minihead_text, False
+
+    value = int(value)
+    pattern = re.compile(
+        rf'(<ParamLong\."{re.escape(name)}">\s*\{{\s*)(-?\d*)?(\s*\}})'
+    )
+    matches = list(pattern.finditer(minihead_text))
+    if matches:
+        if all((match.group(2) or "").strip() == str(value) for match in matches):
+            return minihead_text, False
+        return (
+            pattern.sub(
+                lambda match: f"{match.group(1)}{value}{match.group(3)}",
+                minihead_text,
+            ),
+            True,
+        )
+
+    appended_param = f'\n<ParamLong."{name}">\t{{ {value} }}\n'
+    return minihead_text.rstrip() + appended_param, True
+
+
+def _replace_minihead_array_token(minihead_text, name, target_token):
+    if not minihead_text or not target_token:
+        return minihead_text, False
+
+    block_pattern = re.compile(
+        rf'<ParamArray\."{re.escape(name)}">\s*\{{.*?^\s*\}}',
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    block_match = block_pattern.search(minihead_text)
+    if not block_match:
+        return minihead_text, False
+
+    block_text = block_match.group(0)
+    tokens = [token.strip() for token in re.findall(r'\{\s*"([^"]+)"\s*\}', block_text)]
+    if not tokens:
+        return minihead_text, False
+
+    if tokens == [target_token]:
+        return minihead_text, False
+
+    token_pattern = re.compile(r'\{\s*"[^"]*"\s*\}')
+    token_matches = list(token_pattern.finditer(block_text))
+    if not token_matches:
+        replaced_block = block_text.rstrip()[:-1] + f'\n\t{{ "{target_token}" }}\n}}'
+    else:
+        first_token = token_matches[0]
+        last_token = token_matches[-1]
+        replaced_block = (
+            block_text[:first_token.start()]
+            + f'{{ "{target_token}" }}'
+            + block_text[last_token.end():]
+        )
+    return (
+        minihead_text[:block_match.start()] + replaced_block + minihead_text[block_match.end():],
+        True,
+    )
+
+
+def _replace_or_append_minihead_array_token(minihead_text, name, source_token, target_token):
+    return _replace_or_append_minihead_array_tokens(minihead_text, name, [target_token])
+
+
+def _remove_minihead_string_param(minihead_text, name):
+    pattern = re.compile(
+        rf'^\s*<ParamString\."{re.escape(name)}">\s*\{{\s*"[^"]*"\s*\}}\s*\n?',
+        flags=re.MULTILINE,
+    )
+    updated_text, count = pattern.subn("", minihead_text)
+    return updated_text, bool(count)
+
+
+def _remove_minihead_array_param(minihead_text, name):
+    pattern = re.compile(
+        rf'^\s*<ParamArray\."{re.escape(name)}">\s*\{{.*?^\s*\}}\s*\n?',
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    updated_text, count = pattern.subn("", minihead_text)
+    return updated_text, bool(count)
+
+
+def _remove_minihead_exam_data_role(minihead_text):
+    pattern = re.compile(
+        r'^\s*<ParamString\."ExamDataRole">\s*\{\s*".*?</DataRole>"\s*\}\s*\n?',
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    updated_text, count = pattern.subn("", minihead_text)
+    return updated_text, bool(count)
+
+
+def _strip_scanner_write_unsafe_minihead(minihead_text):
+    current_text = minihead_text
+    changed = False
+    for key in SCANNER_WRITE_UNSAFE_META_KEYS:
+        current_text, did_change = _remove_minihead_string_param(current_text, key)
+        changed = changed or did_change
+        current_text, did_change = _remove_minihead_array_param(current_text, key)
+        changed = changed or did_change
+    return current_text, changed
+
+
+def _replace_or_append_minihead_array_tokens(minihead_text, name, target_tokens):
+    target_tokens = [
+        token
+        for token in (
+            _sanitize_minihead_param_value(token) for token in target_tokens
+        )
+        if token
+    ]
+    if not minihead_text or not target_tokens:
+        return minihead_text, False
+
+    line_ending = "\r\n" if "\r\n" in minihead_text else "\n"
+    block_pattern = re.compile(
+        rf'(<ParamArray\."{re.escape(name)}">\s*\{{)(.*?)(^\s*\}})',
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    block_match = block_pattern.search(minihead_text)
+    if not block_match:
+        token_lines = "".join(
+            f'{line_ending}\t{{ "{token}" }}' for token in target_tokens
+        )
+        appended_param = (
+            f'{line_ending}<ParamArray."{name}">\t{{'
+            f"{token_lines}{line_ending}}}{line_ending}"
+        )
+        return minihead_text.rstrip() + appended_param, True
+
+    block_text = block_match.group(0)
+    tokens = _extract_minihead_array_tokens(block_text, name)
+    if tokens == target_tokens:
+        return minihead_text, False
+
+    token_pattern = re.compile(r'\{\s*"[^"]*"\s*\}')
+    token_matches = list(token_pattern.finditer(block_text))
+    token_lines = "".join(
+        f'{line_ending}\t{{ "{token}" }}' for token in target_tokens
+    )
+    if not token_matches:
+        stripped_block = block_text.rstrip()
+        close_index = stripped_block.rfind("}")
+        if close_index >= 0:
+            replacement_block = (
+                stripped_block[:close_index]
+                + token_lines
+                + line_ending
+                + stripped_block[close_index:]
+            )
+        else:
+            replacement_block = stripped_block + token_lines
+    else:
+        first_token = token_matches[0]
+        last_token = token_matches[-1]
+        replacement_block = (
+            block_text[:first_token.start()]
+            + token_lines.lstrip(line_ending)
+            + block_text[last_token.end():]
+        )
+    return (
+        minihead_text[:block_match.start()]
+        + replacement_block
+        + minihead_text[block_match.end():],
+        True,
+    )
+
+
+def _format_exam_data_role_sequential_number(value):
+    return (
+        '<DataRole Version="DR2.0">\n'
+        ' <Categories>\n'
+        '  <Category Name="SequentialNumber">\n'
+        f"   <CategoryEntry>{int(value)}</CategoryEntry>\n"
+        "  </Category>\n"
+        " </Categories>\n"
+        "</DataRole>"
+    )
+
+
+def _minihead_string_literal(value):
+    return str(value).replace('"', '""')
+
+
+def _minihead_param_map_line_span(minihead_text, map_name):
+    lines = minihead_text.splitlines(keepends=True)
+    map_pattern = re.compile(rf'<ParamMap\."{re.escape(map_name)}">')
+
+    for map_index, line in enumerate(lines):
+        if not map_pattern.search(line):
+            continue
+
+        open_index = None
+        for candidate_index in range(map_index + 1, len(lines)):
+            stripped = lines[candidate_index].strip()
+            if stripped == "{":
+                open_index = candidate_index
+                break
+            if stripped.startswith('<ParamMap."'):
+                break
+        if open_index is None:
+            continue
+
+        depth = 1
+        for close_index in range(open_index + 1, len(lines)):
+            stripped = lines[close_index].strip()
+            if stripped == "{":
+                depth += 1
+            elif stripped == "}":
+                depth -= 1
+                if depth == 0:
+                    return lines, map_index, open_index, close_index
+
+    return lines, None, None, None
+
+
+def _minihead_param_map_text(minihead_text, map_name):
+    lines, map_index, _open_index, close_index = _minihead_param_map_line_span(
+        minihead_text,
+        map_name,
+    )
+    if map_index is None:
+        return ""
+    return "".join(lines[map_index:close_index + 1])
+
+
+def _insert_minihead_string_param_in_map(minihead_text, map_name, name, value):
+    literal = _minihead_string_literal(value)
+    lines, _map_index, open_index, close_index = _minihead_param_map_line_span(
+        minihead_text,
+        map_name,
+    )
+    if close_index is None:
+        appended_param = f'\n<ParamString."{name}">\t{{ "{literal}" }}\n'
+        return minihead_text.rstrip() + appended_param, True
+
+    indent = ""
+    for line in lines[open_index + 1:close_index]:
+        match = re.match(r'(\s*)<Param(?:Long|String|Array)\.', line)
+        if match:
+            indent = match.group(1)
+            break
+    if not indent:
+        indent_match = re.match(r"(\s*)", lines[open_index])
+        indent = indent_match.group(1) if indent_match else ""
+
+    line_ending = "\r\n" if "\r\n" in minihead_text else "\n"
+    param_line = f'{indent}<ParamString."{name}">\t{{ "{literal}" }}{line_ending}'
+    lines.insert(close_index, param_line)
+    return "".join(lines), True
+
+
+def _replace_or_insert_minihead_exam_data_role(minihead_text, exam_data_role):
+    if not minihead_text or not exam_data_role:
+        return minihead_text, False
+
+    literal = _minihead_string_literal(exam_data_role)
+    pattern = re.compile(
+        r'(<ParamString\."ExamDataRole">\s*\{\s*")(.*?</DataRole>)("\s*\})',
+        flags=re.DOTALL,
+    )
+    matches = list(pattern.finditer(minihead_text))
+    if matches:
+        if all(match.group(2).replace('""', '"') == exam_data_role for match in matches):
+            return minihead_text, False
+        return (
+            pattern.sub(
+                lambda match: f"{match.group(1)}{literal}{match.group(3)}",
+                minihead_text,
+            ),
+            True,
+        )
+
+    return _insert_minihead_string_param_in_map(
+        minihead_text,
+        "DICOM",
+        "ExamDataRole",
+        exam_data_role,
+    )
+
+
+def _patch_ice_minihead(
+    minihead_text,
+    series_description,
+    series_grouping,
+    source_type_token,
+    target_type_token,
+    target_display_token=None,
+    target_image_type_value3="M",
+    series_uid=None,
+    sop_uid=None,
+    output_index=None,
+):
+    if not minihead_text:
+        return minihead_text, False
+
+    changed = False
+    current_text = minihead_text
+    target_display_token = target_display_token or target_type_token
+
+    for param_name, param_value in (
+        ("SeriesDescription", series_description),
+        ("SequenceDescription", series_description),
+        ("ProtocolName", series_description),
+        ("SeriesNumberRangeNameUID", series_grouping),
+        ("SeriesInstanceUID", series_uid),
+        ("SOPInstanceUID", sop_uid),
+        ("ImageType", f"DERIVED\\PRIMARY\\{target_image_type_value3}\\{target_type_token}"),
+        ("ImageTypeValue3", "M"),
+        ("ComplexImageComponent", "MAGNITUDE"),
+    ):
+        if not param_value:
+            continue
+        current_text, did_change = _replace_or_append_minihead_string_param(
+            current_text,
+            param_name,
+            param_value,
+        )
+        changed = changed or did_change
+
+    current_text, did_change = _replace_or_append_minihead_array_token(
+        current_text,
+        "ImageTypeValue4",
+        source_type_token,
+        target_display_token,
+    )
+    changed = changed or did_change
+
+    if output_index is not None:
+        for param_name, param_value in (
+            ("Actual3DImagePartNumber", SCANNER_PARTITION_INDEX),
+            ("AnatomicalPartitionNo", SCANNER_PARTITION_INDEX),
+            ("AnatomicalSliceNo", output_index),
+            ("ChronSliceNo", output_index),
+            ("NumberInSeries", output_index + 1),
+            ("ProtocolSliceNumber", output_index),
+            ("SliceNo", output_index),
+        ):
+            current_text, did_change = _replace_or_append_minihead_long_param(
+                current_text,
+                param_name,
+                param_value,
+            )
+            changed = changed or did_change
+
+    return current_text, changed
+
+
+def _source_postprocessing_image_type_identity(source_meta, minihead_text):
+    image_type = (
+        _get_meta_text(source_meta, "ImageType")
+        or _extract_minihead_string_value(minihead_text, "ImageType")
+        or SYNTHSEG_SOURCE_IMAGE_HEADER_FALLBACK_TYPE
+    )
+    dicom_image_type = _get_meta_text(source_meta, "DicomImageType") or image_type
+    image_type_value4_tokens = (
+        _extract_minihead_array_tokens(minihead_text, "ImageTypeValue4")
+        or _get_meta_values(source_meta, "ImageTypeValue4")
+        or [SYNTHSEG_SOURCE_IMAGE_HEADER_FALLBACK_VALUE4]
+    )
+    return image_type, dicom_image_type, image_type_value4_tokens
+
+
+def _patch_source_image_header_ice_minihead(
+    minihead_text,
+    series_description,
+    series_grouping,
+    series_uid,
+    sop_uid,
+    image_type,
+    image_type_value4_tokens,
+    exam_data_role,
+    slice_index,
+    image_index,
+    image_type_value3=None,
+    sequence_description_additional=None,
+):
+    if not minihead_text:
+        return minihead_text, False
+
+    changed = False
+    current_text = minihead_text
+    for param_name, param_value in (
+        ("SeriesDescription", series_description),
+        ("SequenceDescription", series_description),
+        ("ProtocolName", series_description),
+        ("SeriesNumberRangeNameUID", series_grouping),
+        ("SeriesInstanceUID", series_uid),
+        ("SOPInstanceUID", sop_uid),
+        ("ImageType", image_type),
+        ("ComplexImageComponent", "MAGNITUDE"),
+        ("SequenceDescriptionAdditional", sequence_description_additional),
+    ):
+        if not param_value:
+            continue
+        current_text, did_change = _replace_or_append_minihead_string_param(
+            current_text,
+            param_name,
+            param_value,
+        )
+        changed = changed or did_change
+
+    current_text, did_change = _replace_or_append_minihead_array_tokens(
+        current_text,
+        "ImageTypeValue4",
+        image_type_value4_tokens,
+    )
+    changed = changed or did_change
+
+    current_text, did_change = _replace_or_insert_minihead_exam_data_role(
+        current_text,
+        exam_data_role,
+    )
+    changed = changed or did_change
+    if not exam_data_role:
+        current_text, did_change = _remove_minihead_exam_data_role(current_text)
+        changed = changed or did_change
+    current_text, did_change = _strip_scanner_write_unsafe_minihead(current_text)
+    changed = changed or did_change
+    if image_type_value3:
+        current_text, did_change = _replace_or_append_minihead_string_param(
+            current_text,
+            "ImageTypeValue3",
+            image_type_value3,
+        )
+        changed = changed or did_change
+
+    for param_name, param_value in (
+        ("Actual3DImagePartNumber", SCANNER_PARTITION_INDEX),
+        ("AnatomicalPartitionNo", SCANNER_PARTITION_INDEX),
+        ("AnatomicalSliceNo", slice_index),
+        ("ChronSliceNo", max(int(image_index), 1) - 1),
+        ("NumberInSeries", max(int(image_index), 1)),
+        ("ProtocolSliceNumber", slice_index),
+        ("SliceNo", slice_index),
+    ):
+        current_text, did_change = _replace_or_append_minihead_long_param(
+            current_text,
+            param_name,
+            param_value,
+        )
+        changed = changed or did_change
+
+    return current_text, changed
+
+
+def _patch_original_passthrough_ice_minihead(
+    minihead_text,
+    series_description,
+    series_grouping,
+    series_uid,
+    sop_uid,
+    image_type,
+    image_type_value4_tokens,
+    slice_index,
+    image_index,
+):
+    # Native original passthrough: keep the source's inherited ImageType (e.g.
+    # ORIGINAL\PRIMARY\M\ND), drop the standalone ImageTypeValue3, refresh the
+    # derived series identity, and do NOT tag an ExamDataRole post-processing
+    # child. Mirrors openreconi2iexample._patch_original_ice_minihead so the
+    # scanner keeps the originals as the primary acquisition (still inline-MIP'd)
+    # while the segment remains the only post-processing child.
+    if not minihead_text:
+        return minihead_text, False
+
+    changed = False
+    current_text = minihead_text
+    for param_name, param_value in (
+        ("SeriesDescription", series_description),
+        ("SequenceDescription", series_description),
+        ("ProtocolName", series_description),
+        ("SeriesNumberRangeNameUID", series_grouping),
+        ("SeriesInstanceUID", series_uid),
+        ("SOPInstanceUID", sop_uid),
+        ("ImageType", image_type),
+        ("ComplexImageComponent", "MAGNITUDE"),
+    ):
+        if not param_value:
+            continue
+        current_text, did_change = _replace_or_append_minihead_string_param(
+            current_text,
+            param_name,
+            param_value,
+        )
+        changed = changed or did_change
+
+    if image_type_value4_tokens:
+        current_text, did_change = _replace_or_append_minihead_array_tokens(
+            current_text,
+            "ImageTypeValue4",
+            image_type_value4_tokens,
+        )
+        changed = changed or did_change
+
+    current_text, did_change = _strip_scanner_write_unsafe_minihead(current_text)
+    changed = changed or did_change
+
+    for param_name, param_value in (
+        ("Actual3DImagePartNumber", SCANNER_PARTITION_INDEX),
+        ("AnatomicalPartitionNo", SCANNER_PARTITION_INDEX),
+        ("AnatomicalSliceNo", slice_index),
+        ("ChronSliceNo", max(int(image_index), 1) - 1),
+        ("NumberInSeries", max(int(image_index), 1)),
+        ("ProtocolSliceNumber", slice_index),
+        ("SliceNo", slice_index),
+    ):
+        current_text, did_change = _replace_or_append_minihead_long_param(
+            current_text,
+            param_name,
+            param_value,
+        )
+        changed = changed or did_change
+
+    return current_text, changed
+
+
+def _resolve_source_series_identity(meta_obj):
+    minihead_text = _decode_ice_minihead(meta_obj)
+    series_description = _get_meta_text(meta_obj, "SeriesDescription")
+    parent_sequence = _first_non_empty_text(
+        _get_meta_text(meta_obj, "SequenceDescription"),
+        _extract_minihead_string_value(minihead_text, "SequenceDescription"),
+        series_description,
+    )
+    parent_grouping = _first_non_empty_text(
+        _extract_minihead_string_value(minihead_text, "SeriesNumberRangeNameUID"),
+        parent_sequence,
+    )
+    source_type_token = _first_non_empty_text(
+        _get_meta_text(meta_obj, "ImageTypeValue4"),
+        _get_dicom_image_type_value(meta_obj, 3),
+    )
+    series_uid = _first_non_empty_text(
+        _get_meta_text(meta_obj, "SeriesInstanceUID"),
+        _extract_minihead_string_value(minihead_text, "SeriesInstanceUID"),
+    )
+    sop_uid = _first_non_empty_text(
+        _get_meta_text(meta_obj, "SOPInstanceUID"),
+        _extract_minihead_string_value(minihead_text, "SOPInstanceUID"),
+    )
+
+    return {
+        "series_description": _first_non_empty_text(
+            series_description,
+            parent_sequence,
+        ),
+        "parent_sequence": parent_sequence,
+        "parent_grouping": parent_grouping,
+        "source_type_token": source_type_token,
+        "series_uid": series_uid,
+        "sop_uid": sop_uid,
+    }
+
+
+def _build_synthseg_series_name(source_series_description, suffix=""):
+    source_series_description = _first_non_empty_text(source_series_description)
+    if source_series_description:
+        name = f"{source_series_description}_{SYNTHSEG_SEGMENTATION_LABEL}"
+    else:
+        name = SYNTHSEG_SEGMENTATION_LABEL
+    if suffix:
+        name = f"{name}_{suffix}"
+    return name
+
+
+def _build_synthseg_grouping(source_parent_grouping, fallback_series_name, suffix=""):
+    source_parent_grouping = _first_non_empty_text(source_parent_grouping)
+    if source_parent_grouping:
+        grouping = f"{source_parent_grouping}_{SYNTHSEG_SEGMENTATION_LABEL}"
+    else:
+        grouping = fallback_series_name
+    if suffix:
+        grouping = f"{grouping}_{suffix}"
+    return grouping
+
+
+def _build_openrecon_output_identity(source_identity, orientation=None, series_index=None):
+    orientation = _first_non_empty_text(orientation).lower()
+    base_series_description = _build_synthseg_series_name(
+        source_identity.get("series_description", ""),
+    )
+    base_grouping = _build_synthseg_grouping(
+        source_identity.get("parent_grouping", ""),
+        fallback_series_name=base_series_description,
+    )
+    series_description = (
+        f"{base_series_description}_{orientation}"
+        if orientation
+        else base_series_description
+    )
+    grouping = f"{base_grouping}_{orientation}" if orientation else base_grouping
+    image_comment = (
+        f"{SYNTHSEG_SEGMENTATION_LABEL}_{orientation}"
+        if orientation
+        else SYNTHSEG_SEGMENTATION_LABEL
+    )
+    identity = {
+        "series_description": series_description,
+        "sequence_description": series_description,
+        "grouping": grouping,
+        "display_token": SYNTHSEG_SEGMENTATION_LABEL,
+        "type_token": SYNTHSEG_SEGMENTATION_TYPE_TOKEN,
+        "image_comment": image_comment,
+    }
+    if series_index is not None:
+        identity["series_index"] = int(series_index)
+        identity["series_uid"] = _derived_synthseg_series_uid(
+            source_identity,
+            int(series_index),
+            series_description,
+        )
+    return identity
+
+
+def _build_synthseg_original_identity(source_identity, series_index=None):
+    source_series_description = _first_non_empty_text(
+        source_identity.get("series_description", ""),
+        "source",
+    )
+    source_parent_grouping = _first_non_empty_text(
+        source_identity.get("parent_grouping", ""),
+        source_series_description,
+    )
+    series_description = f"{source_series_description}_{SYNTHSEG_ORIGINAL_LABEL}"
+    grouping = f"{source_parent_grouping}_{SYNTHSEG_ORIGINAL_LABEL}"
+    identity = {
+        "series_description": series_description,
+        "sequence_description": series_description,
+        "grouping": grouping,
+        "display_token": SYNTHSEG_ORIGINAL_LABEL,
+        "type_token": SYNTHSEG_ORIGINAL_TYPE_TOKEN,
+        "image_comment": SYNTHSEG_ORIGINAL_LABEL,
+    }
+    if series_index is not None:
+        identity["series_index"] = int(series_index)
+        identity["series_uid"] = _derived_synthseg_series_uid(
+            source_identity,
+            int(series_index),
+            series_description,
+        )
+    return identity
+
+
+def _derived_synthseg_series_uid(source_identity, series_index, series_name):
+    seed = "|".join(
+        [
+            "synthseg-series",
+            _first_non_empty_text(
+                source_identity.get("series_uid", ""),
+                source_identity.get("series_description", ""),
+                "source",
+            ),
+            str(int(series_index)),
+            _first_non_empty_text(series_name, "synthseg"),
+        ]
+    )
+    return f"2.25.{uuid.uuid5(uuid.NAMESPACE_URL, seed).int}"
+
+
+def _derived_synthseg_instance_uid(
+    source_image,
+    source_identity,
+    series_index,
+    series_name,
+    output_index,
+    series_uid=None,
+):
+    source_instance_uid = ""
+    try:
+        source_meta = _meta_from_image(source_image)
+        minihead_text = _decode_ice_minihead(source_meta)
+        source_instance_uid = _first_non_empty_text(
+            _get_meta_text(source_meta, "SOPInstanceUID"),
+            _extract_minihead_string_value(minihead_text, "SOPInstanceUID"),
+        )
+    except Exception:
+        source_instance_uid = ""
+    if not source_instance_uid:
+        source_instance_uid = _first_non_empty_text(
+            source_identity.get("sop_uid", ""),
+            str(output_index),
+        )
+    series_uid = series_uid or _derived_synthseg_series_uid(
+        source_identity,
+        series_index,
+        series_name,
+    )
+    seed = "|".join(
+        [
+            "synthseg-instance",
+            series_uid,
+            source_instance_uid,
+            str(int(output_index)),
+        ]
+    )
+    return f"2.25.{uuid.uuid5(uuid.NAMESPACE_URL, seed).int}"
+
+
+def _stamp_synthseg_output_image(
+    image,
+    source_image,
+    output_identity,
+    source_identity,
+    series_index,
+    output_index,
+    source_type_token,
+    processing_history,
+    extra_meta=None,
+    keep_image_geometry=1,
+    patch_minihead=True,
+    data_role="Image",
+    source_image_header_identity=False,
+    segment_source_geometry_identity=False,
+    original_passthrough_identity=False,
+    segment_scanner_postprocessing=True,
+    segment_scanner_mip_processing=False,
+    source_geometry_header_from_output_index=False,
+):
+    source_meta = _copy_meta(_meta_from_image(source_image))
+    header = image.getHead()
+    header.image_series_index = int(series_index)
+    source_geometry_identity = (
+        source_image_header_identity or segment_source_geometry_identity
+    )
+    if source_geometry_identity:
+        if source_geometry_header_from_output_index:
+            header.image_index = int(output_index) + 1
+            header.slice = int(output_index)
+        else:
+            header.image_index = _source_geometry_header_image_index(
+                source_image,
+                output_index,
+            )
+            header.slice = _source_geometry_header_slice(source_image, output_index)
+    else:
+        header.image_index = int(output_index) + 1
+        header.slice = int(output_index)
+    header.contrast = 0
+    header.image_type = ismrmrd.IMTYPE_MAGNITUDE
+    image.setHead(header)
+    image.image_series_index = int(series_index)
+
+    tmp_meta = _copy_meta(source_meta)
+    _strip_source_parent_refs(tmp_meta)
+    series_name = output_identity["series_description"]
+    series_uid = output_identity.get("series_uid") or _derived_synthseg_series_uid(
+        source_identity,
+        series_index,
+        series_name,
+    )
+    sop_uid = _derived_synthseg_instance_uid(
+        source_image,
+        source_identity,
+        series_index,
+        series_name,
+        output_index,
+        series_uid=series_uid,
+    )
+    minihead_text = _decode_ice_minihead(source_meta)
+    # Originals and 2D source-image-header segments inherit the source's native
+    # ImageType identity (e.g. ORIGINAL\PRIMARY\M\ND). The source-geometry
+    # segmentation-header path intentionally does not; it mirrors the
+    # openreconi2iexample 2d_segment_header family.
+    inherit_source_image_type = (
+        source_image_header_identity or original_passthrough_identity
+    )
+    source_image_type = None
+    source_dicom_image_type = None
+    source_image_type_value4 = None
+    exam_data_role = None
+    source_image_header_image_type_value3 = None
+    output_image_type = f"DERIVED\\PRIMARY\\M\\{output_identity['type_token']}"
+    output_dicom_image_type = output_image_type
+    output_image_type_value4 = output_identity["display_token"]
+    if inherit_source_image_type:
+        (
+            source_image_type,
+            source_dicom_image_type,
+            source_image_type_value4,
+        ) = _source_postprocessing_image_type_identity(source_meta, minihead_text)
+        output_image_type = source_image_type
+        output_dicom_image_type = source_dicom_image_type
+        output_image_type_value4 = source_image_type_value4
+    elif segment_source_geometry_identity:
+        output_image_type = SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE
+        output_dicom_image_type = SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE
+        output_image_type_value4 = SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4
+    if source_geometry_identity and segment_scanner_postprocessing:
+        exam_data_role = _format_exam_data_role_sequential_number(series_index)
+    if source_image_header_identity and segment_scanner_mip_processing:
+        source_image_header_image_type_value3 = (
+            SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3
+        )
+
+    tmp_meta["DataRole"] = "Image" if source_image_header_identity else data_role
+    tmp_meta["ImageProcessingHistory"] = processing_history
+    tmp_meta["SeriesDescription"] = series_name
+    tmp_meta["SequenceDescription"] = output_identity["sequence_description"]
+    tmp_meta["ProtocolName"] = series_name
+    tmp_meta["SeriesNumberRangeNameUID"] = output_identity["grouping"]
+    tmp_meta["SeriesInstanceUID"] = series_uid
+    tmp_meta["SOPInstanceUID"] = sop_uid
+    tmp_meta["ImageType"] = output_image_type
+    if not inherit_source_image_type and not segment_source_geometry_identity:
+        tmp_meta["ImageTypeValue3"] = "M"
+    tmp_meta["ImageTypeValue4"] = output_image_type_value4
+    tmp_meta["DicomImageType"] = output_dicom_image_type
+    if source_geometry_identity and segment_scanner_postprocessing:
+        tmp_meta["ExamDataRole"] = exam_data_role
+    elif source_geometry_identity:
+        for key in (
+            "ExamDataRole",
+            SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY,
+            SYNTHSEG_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY,
+        ):
+            if key in tmp_meta:
+                del tmp_meta[key]
+    tmp_meta["ComplexImageComponent"] = "MAGNITUDE"
+    tmp_meta["ImageComments"] = (
+        series_name if source_geometry_identity else output_identity["image_comment"]
+    )
+    tmp_meta["ImageComment"] = (
+        series_name if source_geometry_identity else output_identity["image_comment"]
+    )
+    sequence_description_additional = (
+        OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX
+        if segment_source_geometry_identity
+        else OPENRECON_SERIES_SUFFIX
+    )
+    tmp_meta["SequenceDescriptionAdditional"] = sequence_description_additional
+    tmp_meta["Keep_image_geometry"] = str(int(keep_image_geometry))
+    _set_output_position_meta(
+        tmp_meta,
+        int(header.slice),
+        image_index=int(header.image_index),
+    )
+    if source_geometry_identity:
+        tmp_meta[SYNTHSEG_SEGMENT_SOURCE_GEOMETRY_META_KEY] = "1"
+        if segment_source_geometry_identity and (
+            SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY in tmp_meta
+        ):
+            del tmp_meta[SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY]
+    if source_image_header_identity:
+        tmp_meta[SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY] = "1"
+    if source_geometry_identity and segment_scanner_postprocessing:
+        tmp_meta[SYNTHSEG_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY] = str(
+            int(series_index)
+        )
+
+    if extra_meta:
+        for key, value in extra_meta.items():
+            if value is not None:
+                tmp_meta[key] = value
+    sequence_description_additional = _get_meta_text(
+        tmp_meta,
+        "SequenceDescriptionAdditional",
+    )
+    if inherit_source_image_type or segment_source_geometry_identity:
+        _strip_scanner_write_unsafe_meta(tmp_meta)
+    if source_image_header_image_type_value3:
+        tmp_meta["ImageTypeValue3"] = source_image_header_image_type_value3
+
+    minihead_text = _decode_ice_minihead(tmp_meta)
+    if not patch_minihead:
+        if "IceMiniHead" in tmp_meta:
+            try:
+                del tmp_meta["IceMiniHead"]
+            except Exception:
+                tmp_meta["IceMiniHead"] = ""
+    elif minihead_text:
+        if source_geometry_identity:
+            patched_minihead_text, minihead_changed = (
+                _patch_source_image_header_ice_minihead(
+                    minihead_text,
+                    series_name,
+                    output_identity["grouping"],
+                    series_uid,
+                    sop_uid,
+                    output_image_type,
+                    (
+                        output_image_type_value4
+                        if isinstance(output_image_type_value4, (list, tuple))
+                        else [output_image_type_value4]
+                    ),
+                    exam_data_role,
+                    int(header.slice),
+                    int(header.image_index),
+                    image_type_value3=source_image_header_image_type_value3,
+                    sequence_description_additional=sequence_description_additional,
+                )
+            )
+        elif original_passthrough_identity:
+            patched_minihead_text, minihead_changed = (
+                _patch_original_passthrough_ice_minihead(
+                    minihead_text,
+                    series_name,
+                    output_identity["grouping"],
+                    series_uid,
+                    sop_uid,
+                    source_image_type,
+                    source_image_type_value4,
+                    int(header.slice),
+                    int(header.image_index),
+                )
+            )
+        else:
+            patched_minihead_text, minihead_changed = _patch_ice_minihead(
+                minihead_text,
+                series_name,
+                output_identity["grouping"],
+                source_type_token,
+                output_identity["type_token"],
+                target_display_token=output_identity["display_token"],
+                series_uid=series_uid,
+                sop_uid=sop_uid,
+                output_index=output_index,
+            )
+        if minihead_changed:
+            tmp_meta["IceMiniHead"] = _encode_ice_minihead(patched_minihead_text)
+        else:
+            logging.warning(
+                "IceMiniHead was present but not updated for %s",
+                output_identity["series_description"],
+            )
+
+    image.attribute_string = tmp_meta.serialize()
+
+
+def _source_geometry_header_image_index(source_image, output_index):
+    try:
+        source_image_index = int(source_image.getHead().image_index)
+    except Exception:
+        source_image_index = 0
+    if source_image_index >= 1:
+        return source_image_index
+    return int(output_index) + 1
+
+
+def _source_geometry_header_slice(source_image, output_index):
+    try:
+        source_slice = int(source_image.getHead().slice)
+    except Exception:
+        source_slice = int(output_index)
+    return source_slice if source_slice >= 0 else int(output_index)
+
+
+def _build_synthseg_original_images(
+    ordered_original_images,
+    ordered_source_images,
+    source_identity,
+    series_index,
+):
+    if len(ordered_original_images) != len(ordered_source_images):
+        raise ValueError(
+            "Original/source image count mismatch: "
+            f"{len(ordered_original_images)} != {len(ordered_source_images)}"
+        )
+
+    original_identity = _build_synthseg_original_identity(
+        source_identity,
+        series_index=series_index,
+    )
+    logging.info(
+        "Preparing original MRA images as first derived original series "
+        "(series_index=%d, name=%s)",
+        series_index,
+        original_identity["series_description"],
+    )
+
+    outputs = []
+    for output_index, (original_image, source_image) in enumerate(
+        zip(ordered_original_images, ordered_source_images)
+    ):
+        _stamp_synthseg_output_image(
+            original_image,
+            source_image,
+            original_identity,
+            source_identity,
+            series_index,
+            output_index,
+            source_identity["source_type_token"],
+            ["PYTHON", "SYNTHSEG", "ORIGINAL"],
+            extra_meta=_explicit_header_geometry_meta(original_image.getHead()),
+            keep_image_geometry=1,
+            patch_minihead=True,
+            original_passthrough_identity=True,
+        )
+        outputs.append(original_image)
+
+    return outputs
+
+
+def _set_output_position_meta(meta_obj, slice_index, image_index=None):
+    slice_index = int(slice_index)
+    image_index = int(image_index) if image_index is not None else slice_index + 1
+    for key in ("Actual3DImagePartNumber", "AnatomicalPartitionNo"):
+        _set_meta_scalar(meta_obj, key, SCANNER_PARTITION_INDEX)
+    for key, value in (
+        ("AnatomicalSliceNo", slice_index),
+        ("ChronSliceNo", max(image_index, 1) - 1),
+        ("NumberInSeries", max(image_index, 1)),
+        ("ProtocolSliceNumber", slice_index),
+        ("SliceNo", slice_index),
+        ("IsmrmrdSliceNo", slice_index),
+    ):
+        _set_meta_scalar(meta_obj, key, value)
+
+
+def _explicit_header_geometry_meta(header):
+    return {
+        "ImageRowDir": _meta_vector(_header_vector(header, "read_dir")),
+        "ImageColumnDir": _meta_vector(_header_vector(header, "phase_dir")),
+        "ImageSliceNormDir": _meta_vector(_header_vector(header, "slice_dir")),
+        "SlicePosLightMarker": _meta_vector(_header_vector(header, "position")),
+    }
+
+
+def _meta_vector(values):
+    return [f"{float(value):.18f}" for value in values]
+
+
+def _validate_synthseg_output_contract(
+    images,
+    source_series_indices,
+    source_identity,
+    context,
+):
+    # This runs before any send. Raising here makes OpenRecon log the error and
+    # close cleanly instead of partially returning images with unsafe identity.
+    source_series_indices = {int(index) for index in source_series_indices}
+    source_values = {
+        _first_non_empty_text(value)
+        for value in (
+            source_identity.get("series_description", ""),
+            source_identity.get("parent_grouping", ""),
+            source_identity.get("parent_sequence", ""),
+            source_identity.get("series_uid", ""),
+            source_identity.get("sop_uid", ""),
+        )
+        if _first_non_empty_text(value)
+    }
+
+    errors = []
+    seen_image_keys = {}
+    seen_storage_keys = {}
+    seen_sop_uids = {}
+    series_identity = {}
+    series_by_uid = {}
+    for index, image in enumerate(_as_image_list(images)):
+        header = image.getHead()
+        series_index = int(getattr(header, "image_series_index", 0))
+        try:
+            meta_obj = ismrmrd.Meta.deserialize(image.attribute_string)
+        except Exception as exc:
+            errors.append(f"image {index}: invalid MRD Meta attributes: {exc}")
+            continue
+
+        minihead_text = _decode_ice_minihead(meta_obj)
+        image_key = (
+            series_index,
+            int(getattr(header, "slice", 0)),
+            int(getattr(header, "image_index", 0)),
+        )
+        previous_image = seen_image_keys.setdefault(image_key, index)
+        if previous_image != index:
+            errors.append(
+                f"image {index}: duplicates output image key {image_key} "
+                f"from image {previous_image}"
+            )
+
+        identity = {
+            "SeriesDescription": _get_meta_text(meta_obj, "SeriesDescription"),
+            "SequenceDescription": _get_meta_text(meta_obj, "SequenceDescription"),
+            "ProtocolName": _get_meta_text(meta_obj, "ProtocolName"),
+            "SeriesNumberRangeNameUID": _get_meta_text(
+                meta_obj,
+                "SeriesNumberRangeNameUID",
+            ),
+            "SeriesInstanceUID": _get_meta_text(meta_obj, "SeriesInstanceUID"),
+            "SOPInstanceUID": _get_meta_text(meta_obj, "SOPInstanceUID"),
+            "ImageTypeValue4": _get_meta_text(meta_obj, "ImageTypeValue4"),
+            "ImageTypeValue4Values": _get_meta_values(meta_obj, "ImageTypeValue4"),
+            "ComplexImageComponent": _get_meta_text(meta_obj, "ComplexImageComponent"),
+            "SequenceDescriptionAdditional": _get_meta_text(
+                meta_obj,
+                "SequenceDescriptionAdditional",
+            ),
+        }
+        minihead_identity = {
+            "SeriesDescription": _extract_minihead_string_value(
+                minihead_text,
+                "SeriesDescription",
+            ),
+            "SequenceDescription": _extract_minihead_string_value(
+                minihead_text,
+                "SequenceDescription",
+            ),
+            "ProtocolName": _extract_minihead_string_value(
+                minihead_text,
+                "ProtocolName",
+            ),
+            "SeriesNumberRangeNameUID": _extract_minihead_string_value(
+                minihead_text,
+                "SeriesNumberRangeNameUID",
+            ),
+            "SeriesInstanceUID": _extract_minihead_string_value(
+                minihead_text,
+                "SeriesInstanceUID",
+            ),
+            "SOPInstanceUID": _extract_minihead_string_value(
+                minihead_text,
+                "SOPInstanceUID",
+            ),
+        }
+
+        if series_index in source_series_indices:
+            errors.append(
+                f"image {index}: output still uses source image_series_index={series_index}"
+            )
+        for field in (
+            "SeriesDescription",
+            "SequenceDescription",
+            "ProtocolName",
+            "SeriesNumberRangeNameUID",
+            "SeriesInstanceUID",
+            "SOPInstanceUID",
+        ):
+            if not identity[field]:
+                errors.append(f"image {index}: output is missing Meta {field}")
+            if identity[field] and identity[field] in source_values:
+                errors.append(
+                    f"image {index}: output Meta reuses source {field}={identity[field]}"
+                )
+            minihead_value = minihead_identity[field]
+            if minihead_value and minihead_value != identity[field]:
+                errors.append(
+                    f"image {index}: Meta/IceMiniHead {field} mismatch: "
+                    f"{identity[field]} != {minihead_value}"
+                )
+            if minihead_value and minihead_value in source_values:
+                errors.append(
+                    f"image {index}: output IceMiniHead reuses source "
+                    f"{field}={minihead_value}"
+                )
+
+        if not identity["ImageTypeValue4Values"]:
+            errors.append(f"image {index}: output is missing ImageTypeValue4")
+        if identity["ComplexImageComponent"] != "MAGNITUDE":
+            errors.append(
+                f"image {index}: ComplexImageComponent={identity['ComplexImageComponent']}, "
+                "expected MAGNITUDE"
+            )
+        expected_sequence_description_additional = (
+            OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX
+            if _is_synthseg_source_geometry_output(meta_obj)
+            else OPENRECON_SERIES_SUFFIX
+        )
+        if (
+            identity["SequenceDescriptionAdditional"]
+            != expected_sequence_description_additional
+        ):
+            errors.append(
+                f"image {index}: SequenceDescriptionAdditional="
+                f"{identity['SequenceDescriptionAdditional']!r}, expected "
+                f"{expected_sequence_description_additional!r}"
+            )
+
+        keep_image_geometry = _get_meta_int(meta_obj, "Keep_image_geometry")
+        if keep_image_geometry is None:
+            errors.append(f"image {index}: missing Keep_image_geometry")
+        if _is_synthseg_source_image_header_output(meta_obj):
+            data_role = _get_meta_text(meta_obj, "DataRole")
+            if data_role != "Image":
+                errors.append(
+                    f"image {index}: source-image-header output DataRole={data_role}, "
+                    "expected Image"
+                )
+            if keep_image_geometry != 1:
+                errors.append(
+                    f"image {index}: source-image-header output Keep_image_geometry="
+                    f"{keep_image_geometry}, expected 1"
+                )
+            segment_output_geometry = _get_meta_text(
+                meta_obj,
+                SYNTHSEG_SEGMENT_OUTPUT_GEOMETRY_META_KEY,
+            )
+            if segment_output_geometry != SYNTHSEG_OUTPUT_GEOMETRY_2D:
+                errors.append(
+                    f"image {index}: SegmentOutputGeometry={segment_output_geometry}, "
+                    f"expected {SYNTHSEG_OUTPUT_GEOMETRY_2D}"
+                )
+            if _get_meta_text(meta_obj, SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY):
+                errors.append(
+                    f"image {index}: source-image-header output still carries "
+                    f"{SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY}"
+                )
+            child_role = _get_meta_int(
+                meta_obj,
+                SYNTHSEG_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY,
+            )
+            exam_data_role = _get_meta_text(meta_obj, "ExamDataRole")
+            # Segmentation-MIP mode should still be a post-processing child; the
+            # child-role check is conditional only to keep this validator usable
+            # for older detached/debug outputs.
+            segment_is_postprocessing_child = (
+                child_role is not None or bool(exam_data_role)
+            )
+            image_type_value3 = _get_meta_text(meta_obj, "ImageTypeValue3")
+            if segment_is_postprocessing_child:
+                if child_role != series_index:
+                    errors.append(
+                        f"image {index}: SegmentPostProcessingChildRole={child_role}, "
+                        f"expected {series_index}"
+                    )
+                expected_exam_data_role = _format_exam_data_role_sequential_number(
+                    series_index
+                )
+                if exam_data_role != expected_exam_data_role:
+                    errors.append(
+                        f"image {index}: ExamDataRole does not match image_series_index "
+                        f"{series_index}"
+                    )
+                for field in SCANNER_WRITE_UNSAFE_META_KEYS:
+                    field_value = _get_meta_text(meta_obj, field)
+                    if (
+                        field == "ImageTypeValue3"
+                        and field_value == SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3
+                    ):
+                        continue
+                    if field_value:
+                        errors.append(
+                            f"image {index}: source-image-header output still carries "
+                            f"unsafe scanner Meta {field}"
+                        )
+            elif image_type_value3 != SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3:
+                errors.append(
+                    f"image {index}: segmentation-MIP output ImageTypeValue3="
+                    f"{image_type_value3!r}, expected "
+                    f"{SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3!r}"
+                )
+            if minihead_text:
+                dicom_map = _minihead_param_map_text(minihead_text, "DICOM")
+                if segment_is_postprocessing_child:
+                    if '<ParamString."ExamDataRole">' not in dicom_map:
+                        errors.append(
+                            f"image {index}: source-image-header IceMiniHead is missing "
+                            "ExamDataRole inside the DICOM ParamMap"
+                        )
+                    expected_entry = f"<CategoryEntry>{series_index}</CategoryEntry>"
+                    if expected_entry not in dicom_map:
+                        errors.append(
+                            f"image {index}: source-image-header IceMiniHead DICOM "
+                            f"ExamDataRole is missing {expected_entry}"
+                        )
+                    for field in SCANNER_WRITE_UNSAFE_META_KEYS:
+                        minihead_string_value = _extract_minihead_string_value(
+                            minihead_text,
+                            field,
+                        )
+                        minihead_array_tokens = _extract_minihead_array_tokens(
+                            minihead_text,
+                            field,
+                        )
+                        if (
+                            field == "ImageTypeValue3"
+                            and minihead_string_value
+                            == SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3
+                            and not minihead_array_tokens
+                        ):
+                            continue
+                        if minihead_string_value or minihead_array_tokens:
+                            errors.append(
+                                f"image {index}: source-image-header IceMiniHead still "
+                                f"carries unsafe scanner {field}"
+                            )
+                else:
+                    minihead_image_type_value3 = _extract_minihead_string_value(
+                        minihead_text,
+                        "ImageTypeValue3",
+                    )
+                    if (
+                        minihead_image_type_value3
+                        != SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3
+                    ):
+                        errors.append(
+                            f"image {index}: segmentation-MIP IceMiniHead "
+                            f"ImageTypeValue3={minihead_image_type_value3!r}, "
+                            f"expected {SYNTHSEG_SCANNER_MIP_IMAGE_TYPE_VALUE3!r}"
+                        )
+        elif _is_synthseg_source_geometry_output(meta_obj):
+            data_role = _get_meta_text(meta_obj, "DataRole")
+            if data_role != "Segmentation":
+                errors.append(
+                    f"image {index}: source-geometry segment DataRole={data_role}, "
+                    "expected Segmentation"
+                )
+            if keep_image_geometry != 1:
+                errors.append(
+                    f"image {index}: source-geometry segment Keep_image_geometry="
+                    f"{keep_image_geometry}, expected 1"
+                )
+            segment_output_geometry = _get_meta_text(
+                meta_obj,
+                SYNTHSEG_SEGMENT_OUTPUT_GEOMETRY_META_KEY,
+            )
+            if segment_output_geometry != SYNTHSEG_OUTPUT_GEOMETRY_2D:
+                errors.append(
+                    f"image {index}: source-geometry segment "
+                    f"SegmentOutputGeometry={segment_output_geometry}, expected "
+                    f"{SYNTHSEG_OUTPUT_GEOMETRY_2D}"
+                )
+            image_type = _get_meta_text(meta_obj, "ImageType")
+            dicom_image_type = _get_meta_text(meta_obj, "DicomImageType")
+            image_type_value4 = _get_meta_text(meta_obj, "ImageTypeValue4")
+            if image_type != SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE:
+                errors.append(
+                    f"image {index}: source-geometry segment ImageType={image_type}, "
+                    f"expected {SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE}"
+                )
+            if dicom_image_type != SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE:
+                errors.append(
+                    f"image {index}: source-geometry segment DicomImageType="
+                    f"{dicom_image_type}, expected "
+                    f"{SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE}"
+                )
+            if image_type_value4 != SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4:
+                errors.append(
+                    f"image {index}: source-geometry segment ImageTypeValue4="
+                    f"{image_type_value4}, expected "
+                    f"{SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4}"
+                )
+            child_role = _get_meta_int(
+                meta_obj,
+                SYNTHSEG_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY,
+            )
+            exam_data_role = _get_meta_text(meta_obj, "ExamDataRole")
+            if child_role is None:
+                if exam_data_role:
+                    errors.append(
+                        f"image {index}: source-geometry segment carries ExamDataRole "
+                        "without a scanner postprocessing child role"
+                    )
+            else:
+                if child_role != series_index:
+                    errors.append(
+                        f"image {index}: source-geometry segment "
+                        f"SegmentPostProcessingChildRole={child_role}, expected "
+                        f"{series_index}"
+                    )
+                expected_exam_data_role = _format_exam_data_role_sequential_number(
+                    series_index
+                )
+                if exam_data_role != expected_exam_data_role:
+                    errors.append(
+                        f"image {index}: source-geometry segment ExamDataRole "
+                        f"does not match image_series_index {series_index}"
+                    )
+            for field in (
+                SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY,
+                SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY,
+                "ImageTypeValue3",
+            ):
+                if _get_meta_text(meta_obj, field):
+                    errors.append(
+                        f"image {index}: source-geometry segment still carries {field}"
+                    )
+            if minihead_text:
+                dicom_map = _minihead_param_map_text(minihead_text, "DICOM")
+                if child_role is None and '<ParamString."ExamDataRole">' in dicom_map:
+                    errors.append(
+                        f"image {index}: source-geometry segment IceMiniHead still "
+                        "carries ExamDataRole"
+                    )
+                elif child_role is not None:
+                    if '<ParamString."ExamDataRole">' not in dicom_map:
+                        errors.append(
+                            f"image {index}: source-geometry segment IceMiniHead is "
+                            "missing ExamDataRole inside the DICOM ParamMap"
+                        )
+                    expected_entry = f"<CategoryEntry>{series_index}</CategoryEntry>"
+                    if expected_entry not in dicom_map:
+                        errors.append(
+                            f"image {index}: source-geometry segment IceMiniHead DICOM "
+                            f"ExamDataRole is missing {expected_entry}"
+                        )
+                minihead_image_type = _extract_minihead_string_value(
+                    minihead_text,
+                    "ImageType",
+                )
+                if minihead_image_type and minihead_image_type != image_type:
+                    errors.append(
+                        f"image {index}: source-geometry segment IceMiniHead "
+                        f"ImageType={minihead_image_type}, expected {image_type}"
+                    )
+                minihead_sequence_description_additional = (
+                    _extract_minihead_string_value(
+                        minihead_text,
+                        "SequenceDescriptionAdditional",
+                    )
+                )
+                if (
+                    minihead_sequence_description_additional
+                    != OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX
+                ):
+                    errors.append(
+                        "image "
+                        f"{index}: source-geometry segment IceMiniHead "
+                        "SequenceDescriptionAdditional="
+                        f"{minihead_sequence_description_additional}, expected "
+                        f"{OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX}"
+                    )
+                minihead_image_type_value4 = _extract_minihead_array_tokens(
+                    minihead_text,
+                    "ImageTypeValue4",
+                )
+                if minihead_image_type_value4 != [
+                    SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4
+                ]:
+                    errors.append(
+                        f"image {index}: source-geometry segment IceMiniHead "
+                        f"ImageTypeValue4={minihead_image_type_value4}, expected "
+                        f"{[SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4]}"
+                    )
+                for field in SCANNER_WRITE_UNSAFE_META_KEYS:
+                    if (
+                        _extract_minihead_string_value(minihead_text, field)
+                        or _extract_minihead_array_tokens(minihead_text, field)
+                    ):
+                        errors.append(
+                            f"image {index}: source-geometry segment IceMiniHead "
+                            f"still carries {field}"
+                        )
+        if keep_image_geometry == 0:
+            header_matrix_z = int(getattr(header, "matrix_size", [0, 0, 0])[2])
+            if minihead_text:
+                errors.append(
+                    f"image {index}: explicit-geometry output still carries IceMiniHead"
+                )
+            partition_count = _get_meta_int(meta_obj, "partition_count")
+            slice_count = _get_meta_int(meta_obj, "slice_count")
+            if partition_count is None or partition_count < 1:
+                errors.append(
+                    f"image {index}: invalid partition_count={partition_count}"
+                )
+            if slice_count is None or slice_count < 1:
+                errors.append(f"image {index}: invalid slice_count={slice_count}")
+            elif int(getattr(header, "slice", 0)) >= slice_count:
+                errors.append(
+                    f"image {index}: slice {int(getattr(header, 'slice', 0))} "
+                    f"outside explicit slice_count={slice_count}"
+                )
+            elif header_matrix_z > 1 and header_matrix_z != slice_count:
+                errors.append(
+                    f"image {index}: matrix_size[2]={header_matrix_z}, "
+                    f"expected explicit slice_count={slice_count}"
+                )
+
+            number_of_slices = _get_meta_int(meta_obj, "NumberOfSlices")
+            if number_of_slices is None:
+                errors.append(f"image {index}: missing NumberOfSlices")
+            elif slice_count is not None and number_of_slices != slice_count:
+                errors.append(
+                    f"image {index}: NumberOfSlices={number_of_slices}, "
+                    f"expected {slice_count}"
+                )
+
+            images_in_acquisition = _get_meta_int(meta_obj, "ImagesInAcquisition")
+            if images_in_acquisition is None:
+                errors.append(f"image {index}: missing ImagesInAcquisition")
+            elif slice_count is not None and images_in_acquisition != slice_count:
+                errors.append(
+                    f"image {index}: ImagesInAcquisition={images_in_acquisition}, "
+                    f"expected {slice_count}"
+                )
+
+        expected_position_fields = {
+            "Actual3DImagePartNumber": SCANNER_PARTITION_INDEX,
+            "AnatomicalPartitionNo": SCANNER_PARTITION_INDEX,
+            "AnatomicalSliceNo": int(getattr(header, "slice", 0)),
+            "ChronSliceNo": max(int(getattr(header, "image_index", 0)), 1) - 1,
+            "NumberInSeries": int(getattr(header, "image_index", 0)),
+            "ProtocolSliceNumber": int(getattr(header, "slice", 0)),
+            "SliceNo": int(getattr(header, "slice", 0)),
+            "IsmrmrdSliceNo": int(getattr(header, "slice", 0)),
+        }
+        for field, expected in expected_position_fields.items():
+            meta_value = _get_meta_int(meta_obj, field)
+            if meta_value is None:
+                errors.append(f"image {index}: missing Meta {field}")
+            elif meta_value != expected:
+                errors.append(
+                    f"image {index}: Meta {field}={meta_value}, expected {expected}"
+                )
+            if field == "IsmrmrdSliceNo":
+                continue
+            minihead_value = _extract_minihead_long_value(minihead_text, field)
+            if minihead_text and minihead_value is None:
+                errors.append(f"image {index}: missing IceMiniHead {field}")
+            elif minihead_value is not None and minihead_value != expected:
+                errors.append(
+                    f"image {index}: IceMiniHead {field}={minihead_value}, "
+                    f"expected {expected}"
+                )
+
+        minihead_type_tokens = _extract_minihead_array_tokens(
+            minihead_text,
+            "ImageTypeValue4",
+        )
+        if minihead_text and minihead_type_tokens != identity["ImageTypeValue4Values"]:
+            errors.append(
+                f"image {index}: IceMiniHead ImageTypeValue4={minihead_type_tokens}, "
+                f"expected {identity['ImageTypeValue4Values']}"
+            )
+
+        storage_key = (
+            identity["SeriesInstanceUID"],
+            _get_meta_int(meta_obj, "SliceNo"),
+            _get_meta_int(meta_obj, "ChronSliceNo"),
+            _get_meta_int(meta_obj, "NumberInSeries"),
+        )
+        previous_storage = seen_storage_keys.setdefault(storage_key, index)
+        if previous_storage != index:
+            errors.append(
+                f"image {index}: duplicates scanner storage key {storage_key} "
+                f"from image {previous_storage}"
+            )
+        uid = identity["SOPInstanceUID"]
+        previous_uid = seen_sop_uids.setdefault(uid, index)
+        if uid and previous_uid != index:
+            errors.append(
+                f"image {index}: SOPInstanceUID {uid} is shared with "
+                f"image {previous_uid}"
+            )
+
+        comparable_identity = (
+            identity["SeriesDescription"],
+            identity["SequenceDescription"],
+            identity["ProtocolName"],
+            identity["SeriesNumberRangeNameUID"],
+            identity["SeriesInstanceUID"],
+        )
+        previous_identity = series_identity.setdefault(
+            series_index,
+            comparable_identity,
+        )
+        if previous_identity != comparable_identity:
+            errors.append(
+                f"image {index}: inconsistent identity within series "
+                f"{series_index}: {comparable_identity} != {previous_identity}"
+            )
+        if identity["SeriesInstanceUID"]:
+            previous_series = series_by_uid.setdefault(
+                identity["SeriesInstanceUID"],
+                series_index,
+            )
+            if previous_series != series_index:
+                errors.append(
+                    f"SeriesInstanceUID {identity['SeriesInstanceUID']} is shared by "
+                    f"image_series_index {previous_series} and {series_index}"
+                )
+
+    if errors:
+        raise ValueError(
+            f"Invalid SynthSeg output identity contract for {context}: "
+            + "; ".join(errors[:10])
+        )
+
+
+def _safe_path_component(value: str) -> str:
+    safe_value = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value)).strip("._")
+    return safe_value[:120] or "default"
+
+
+def _openrecon_run_name(
+    model: str,
+    parcellation: bool,
+    fast: bool,
+    config,
+) -> str:
+    requested_name = mrdhelper.get_json_config_param(
+        config,
+        OPENRECON_OUTPUT_NAME_PARAM,
+        default="",
+        type='str',
+    )
+    if requested_name:
+        return _safe_path_component(requested_name)
+
+    return _safe_path_component(
+        f"{model}_parc{int(parcellation)}_fast{int(fast)}"
+    )
+
+
+def iter_openrecon_parameter_combinations(
+    models: tuple[str, ...] | None = None,
+):
+    model_values = models or OPENRECON_MODEL_VALUES
+    bool_keys = ("ssparc", "ssfast", "ssvolumes", "ssqc")
+    bool_value_sets = [
+        OPENRECON_COMBINATION_PARAMETER_VALUES[key] for key in bool_keys
+    ]
+
+    for model, bool_values in itertools.product(
+        model_values,
+        itertools.product(*bool_value_sets),
+    ):
+        parameters = OPENRECON_DEFAULTS.copy()
+        parameters["ssmodel"] = model
+        parameters.update(dict(zip(bool_keys, bool_values)))
+        # SynthSeg-robust always runs in fast mode and rejects the v1 label set,
+        # so the matrix only emits combinations mri_synthseg actually accepts.
+        if model == "robust":
+            parameters["ssfast"] = True
+
+        name = (
+            f"{model}"
+            f"_parc{int(parameters['ssparc'])}"
+            f"_fast{int(parameters['ssfast'])}"
+            f"_vol{int(parameters['ssvolumes'])}"
+            f"_qc{int(parameters['ssqc'])}"
+        )
+        parameters[OPENRECON_OUTPUT_NAME_PARAM] = name
+        yield name, {"parameters": parameters}
+
+
+def write_openrecon_parameter_combinations(
+    output_dir: Path,
+    models: tuple[str, ...] | None = None,
+) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written_paths = []
+    seen_names = set()
+
+    for name, config in iter_openrecon_parameter_combinations(models=models):
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        output_path = output_dir / f"{name}.json"
+        output_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        written_paths.append(output_path)
+
+    return written_paths
+
+
+def _parse_model_list(value: str) -> tuple[str, ...]:
+    models = tuple(model.strip() for model in value.split(",") if model.strip())
+    valid_models = set(OPENRECON_MODEL_VALUES)
+    invalid_models = sorted(set(models) - valid_models)
+    if invalid_models:
+        raise ValueError(
+            "Invalid model(s): "
+            f"{', '.join(invalid_models)}. "
+            f"Valid models: {', '.join(sorted(valid_models))}"
+        )
+    return models
+
+
+def _main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="SynthSeg OpenRecon testing helpers"
+    )
+    parser.add_argument(
+        "--write-openrecon-test-configs",
+        type=Path,
+        metavar="DIR",
+        help="Write JSON configs for all finite OpenRecon choice/boolean combinations.",
+    )
+    parser.add_argument(
+        "--models",
+        default=",".join(OPENRECON_MODEL_VALUES),
+        help="Comma-separated SynthSeg model list for generated configs.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.write_openrecon_test_configs is None:
+        parser.print_help()
+        return 0
+
+    try:
+        models = _parse_model_list(args.models)
+    except ValueError as exc:
+        parser.error(str(exc))
+    written_paths = write_openrecon_parameter_combinations(
+        args.write_openrecon_test_configs,
+        models=models,
+    )
+    print(f"Wrote {len(written_paths)} OpenRecon test config(s)")
+    for path in written_paths:
+        print(path)
+    return 0
+
+
+def _square_pixel_target_shape(
+    input_shape: tuple[int, int],
+    row_spacing: float,
+    col_spacing: float,
+) -> tuple[tuple[int, int], float]:
+    target_spacing = float(min(row_spacing, col_spacing))
+    target_rows = max(
+        1,
+        int(round(input_shape[0] * float(row_spacing) / target_spacing)),
+    )
+    target_cols = max(
+        1,
+        int(round(input_shape[1] * float(col_spacing) / target_spacing)),
+    )
+    return (target_rows, target_cols), target_spacing
+
+
+def _ice_compatible_target_shape(
+    target_shape: tuple[int, int],
+    orientation: str,
+) -> tuple[int, int]:
+    """Keep reformat image dimensions acceptable to Siemens ICE orientation code."""
+    rows, cols = target_shape
+    if rows % 2 == cols % 2:
+        return target_shape
+
+    adjusted_shape = (
+        rows + (rows % 2),
+        cols + (cols % 2),
+    )
+    logging.info(
+        "Adjusted %s reformat target_shape from %s to %s so row/column "
+        "dimensions have matching parity for ICE orientation handling",
+        orientation,
+        target_shape,
+        adjusted_shape,
+    )
+    return adjusted_shape
+
+
+def _diagnostic_reformat_target_shape(
+    target_shape: tuple[int, int],
+    target_spacing: float,
+    orientation: str,
+) -> tuple[tuple[int, int], float]:
+    downsample_factor = _env_positive_float(OPENRECON_REFORMAT_DOWNSAMPLE_ENV, 1.0)
+    if downsample_factor == 1.0:
+        return target_shape, target_spacing
+
+    adjusted_shape = (
+        max(1, int(round(target_shape[0] / downsample_factor))),
+        max(1, int(round(target_shape[1] / downsample_factor))),
+    )
+    adjusted_shape = _ice_compatible_target_shape(adjusted_shape, orientation)
+    adjusted_spacing = float(target_spacing) * downsample_factor
+    logging.info(
+        "Applying diagnostic %s=%.3f for %s reformat: target_shape %s -> %s, "
+        "target_spacing %.4f -> %.4f",
+        OPENRECON_REFORMAT_DOWNSAMPLE_ENV,
+        downsample_factor,
+        orientation,
+        target_shape,
+        adjusted_shape,
+        target_spacing,
+        adjusted_spacing,
+    )
+    return adjusted_shape, adjusted_spacing
+
+
+def _resize_2d_nearest(
+    data: np.ndarray,
+    target_shape: tuple[int, int],
+) -> np.ndarray:
+    if data.shape == target_shape:
+        return np.ascontiguousarray(data)
+
+    zoom_factors = (
+        target_shape[0] / data.shape[0],
+        target_shape[1] / data.shape[1],
+    )
+    resized = ndi.zoom(data, zoom_factors, order=0, prefilter=False)
+
+    if resized.shape != target_shape:
+        corrected = np.zeros(target_shape, dtype=resized.dtype)
+        rows = min(target_shape[0], resized.shape[0])
+        cols = min(target_shape[1], resized.shape[1])
+        corrected[:rows, :cols] = resized[:rows, :cols]
+        resized = corrected
+
+    if resized.dtype != data.dtype:
+        resized = np.rint(resized).astype(data.dtype, copy=False)
+
+    return np.ascontiguousarray(resized)
+
+
+def _build_reformatted_images(
+    volume_yxz: np.ndarray,
+    head_template,
+    source_image,
+    source_identity: dict,
+    output_identity: dict,
+    voxel_size: np.ndarray,
+    fov: np.ndarray,
+    orientation: str,
+    series_index: int,
+    max_val: int,
+):
+    """Build a 2D segmentation-header MRD series for a sagittal/coronal reformat.
+
+    volume_yxz is an int16 array with shape (N_y, N_x, N_z), where the axes map
+    to the original axial phase_dir, read_dir and slice_dir respectively.
+    """
+    if orientation not in ("sagittal", "coronal"):
+        raise ValueError(f"Unsupported reformat orientation: {orientation}")
+
+    N_y, N_x, N_z = volume_yxz.shape
+    read_dir = np.asarray(head_template.read_dir, dtype=float)
+    phase_dir = np.asarray(head_template.phase_dir, dtype=float)
+    slice_dir = np.asarray(head_template.slice_dir, dtype=float)
+
+    first_position = np.asarray(head_template.position, dtype=float)
+    # Center of the 3D volume in world space (slice 0 position is the slice
+    # center, so the stack center is offset by half of the remaining slices).
+    volume_center = first_position + 0.5 * (N_z - 1) * slice_dir * float(voxel_size[2])
+
+    if orientation == "sagittal":
+        n_slices = N_x
+        new_read_dir = phase_dir
+        new_phase_dir = slice_dir
+        new_slice_dir = read_dir
+        slice_spacing = float(voxel_size[0])
+        inplane_row_spacing = float(voxel_size[2])
+        inplane_col_spacing = float(voxel_size[1])
+        inplane_input_shape = (N_z, N_y)
+        orthogonal_fov = float(fov[0])
+    else:  # coronal
+        n_slices = N_y
+        new_read_dir = read_dir
+        new_phase_dir = slice_dir
+        new_slice_dir = phase_dir
+        slice_spacing = float(voxel_size[1])
+        inplane_row_spacing = float(voxel_size[2])
+        inplane_col_spacing = float(voxel_size[0])
+        inplane_input_shape = (N_z, N_x)
+        orthogonal_fov = float(fov[1])
+
+    target_inplane_shape, target_inplane_spacing = _square_pixel_target_shape(
+        inplane_input_shape,
+        row_spacing=inplane_row_spacing,
+        col_spacing=inplane_col_spacing,
+    )
+    target_inplane_shape = _ice_compatible_target_shape(
+        target_inplane_shape,
+        orientation,
+    )
+    target_inplane_shape, target_inplane_spacing = _diagnostic_reformat_target_shape(
+        target_inplane_shape,
+        target_inplane_spacing,
+        orientation,
+    )
+    new_fov = (
+        float(target_inplane_shape[1] * target_inplane_spacing),
+        float(target_inplane_shape[0] * target_inplane_spacing),
+        orthogonal_fov,
+    )
+
+    logging.info(
+        "Building %s reformat: n_slices=%d slice_policy=2d_segmentation_header "
+        "slice_spacing=%.4f new_fov=%s series_index=%d target_shape=%s "
+        "target_spacing=%.4f",
+        orientation,
+        n_slices,
+        slice_spacing,
+        new_fov,
+        series_index,
+        target_inplane_shape,
+        target_inplane_spacing,
+    )
+
+    first_slice_position = (
+        volume_center - 0.5 * (n_slices - 1) * slice_spacing * new_slice_dir
+    )
+    outputs = []
+    for j in range(n_slices):
+        if orientation == "sagittal":
+            # volume_yxz[:, j, :] has shape (N_y, N_z) -> transpose to (N_z, N_y)
+            # so rows = Z (phase_dir), cols = Y (read_dir).
+            slice2d = np.ascontiguousarray(volume_yxz[:, j, :].T)
+        else:
+            # volume_yxz[j, :, :] has shape (N_x, N_z) -> transpose to (N_z, N_x)
+            # so rows = Z (phase_dir), cols = X (read_dir).
+            slice2d = np.ascontiguousarray(volume_yxz[j, :, :].T)
+
+        slice2d = _resize_2d_nearest(slice2d, target_inplane_shape)
+
+        mrd_image = ismrmrd.Image.from_array(
+            slice2d[np.newaxis, np.newaxis, :, :],
+            transpose=False,
+        )
+
+        generated_header = mrd_image.getHead()
+        new_header = generated_header
+        new_header.data_type = mrd_image.data_type
+        new_header.image_type = ismrmrd.IMTYPE_MAGNITUDE
+        new_header.position = tuple(
+            float(v) for v in (first_slice_position + j * slice_spacing * new_slice_dir)
+        )
+        new_header.read_dir = tuple(float(v) for v in new_read_dir)
+        new_header.phase_dir = tuple(float(v) for v in new_phase_dir)
+        new_header.slice_dir = tuple(float(v) for v in new_slice_dir)
+        new_header.field_of_view = (
+            ctypes.c_float(new_fov[0]),
+            ctypes.c_float(new_fov[1]),
+            ctypes.c_float(slice_spacing),
+        )
+        new_header.image_index = j + 1
+        new_header.image_series_index = series_index
+        new_header.slice = j
+        new_header.contrast = 0
+
+        for attr in (
+            "measurement_uid",
+            "patient_table_position",
+            "acquisition_time_stamp",
+            "physiology_time_stamp",
+            "user_int",
+            "user_float",
+        ):
+            try:
+                setattr(new_header, attr, getattr(head_template, attr))
+            except Exception:
+                pass
+        mrd_image.setHead(new_header)
+
+        extra_meta = {
+            "WindowCenter": str((max_val + 1) / 2),
+            "WindowWidth": str(max_val + 1),
+            "SynthSegOutputGeometry": SYNTHSEG_OUTPUT_GEOMETRY_2D,
+            SYNTHSEG_SEGMENT_OUTPUT_GEOMETRY_META_KEY: SYNTHSEG_OUTPUT_GEOMETRY_2D,
+            SYNTHSEG_REFORMAT_ORIENTATION_META_KEY: orientation,
+            SYNTHSEG_REFORMAT_SLICE_INDEX_META_KEY: str(j),
+            SYNTHSEG_REFORMAT_SLICE_COUNT_META_KEY: str(n_slices),
+        }
+        _stamp_synthseg_output_image(
+            mrd_image,
+            source_image,
+            output_identity,
+            source_identity,
+            series_index,
+            j,
+            source_identity.get("source_type_token", ""),
+            ["PYTHON", "SYNTHSEG", f"RESLICE_{orientation.upper()}"],
+            extra_meta=extra_meta,
+            keep_image_geometry=1,
+            patch_minihead=True,
+            data_role="Segmentation",
+            segment_source_geometry_identity=True,
+            segment_scanner_postprocessing=True,
+            source_geometry_header_from_output_index=True,
+        )
+        outputs.append(mrd_image)
+
+    logging.info(
+        "Built SynthSeg %s reformat as %d source-geometry "
+        "segmentation-header 2D image(s): series_index=%d matrix_size=%s "
+        "field_of_view=%s first_position=%s last_position=%s",
+        orientation,
+        len(outputs),
+        series_index,
+        _format_vector(outputs[0].getHead().matrix_size) if outputs else "[]",
+        _format_vector(outputs[0].getHead().field_of_view) if outputs else "[]",
+        [round(float(v), 6) for v in first_slice_position],
+        [
+            round(float(v), 6)
+            for v in (first_slice_position + (n_slices - 1) * slice_spacing * new_slice_dir)
+        ],
+    )
+    return outputs
+
+
+def _build_synthseg_segmentation_images(
+    volume_yxz: np.ndarray,
+    ordered_source_images,
+    source_identity: dict,
+    output_identity: dict,
+    series_index: int,
+    max_val: int,
+    scanner_postprocessing: bool = True,
+    segmentation_header: bool = False,
+):
+    """Build one 2D MRD segmentation image per source image.
+
+    ``segmentation_header`` switches to the openreconi2iexample
+    ``2d_segment_header`` contract: source-geometry segmentation headers, no
+    source-image-header marker, and scanner post-processing targeted at the
+    segment stream.
+    """
+    if volume_yxz.ndim != 3:
+        raise ValueError(
+            "SynthSeg segmentation image stack must be 3D, "
+            f"got shape {volume_yxz.shape}"
+        )
+
+    ordered_source_images = list(ordered_source_images)
+    if volume_yxz.shape[2] != len(ordered_source_images):
+        raise ValueError(
+            "SynthSeg 2D segmentation slice count does not match sources: "
+            f"output_z={volume_yxz.shape[2]} input_images={len(ordered_source_images)}"
+        )
+
+    use_source_geometry_identity = bool(segmentation_header)
+    segment_scanner_postprocessing = bool(scanner_postprocessing)
+    processing_history = (
+        ["PYTHON", "SYNTHSEG", "SEGMENT_SOURCE_GEOMETRY_2D"]
+        if use_source_geometry_identity
+        else ["PYTHON", "SYNTHSEG", "SOURCE_IMAGE_HEADER_2D"]
+    )
+
+    outputs = []
+    for output_index, source_image in enumerate(ordered_source_images):
+        source_shape = np.asarray(source_image.data).shape
+        expected_yx = tuple(int(value) for value in source_shape[-2:])
+        slice_yx = np.ascontiguousarray(volume_yxz[:, :, output_index])
+        if expected_yx and slice_yx.shape != expected_yx:
+            raise ValueError(
+                "SynthSeg 2D segmentation slice shape does not match source: "
+                f"slice={output_index} output_yx={slice_yx.shape} "
+                f"source_yx={expected_yx}"
+            )
+
+        mrd_image = ismrmrd.Image.from_array(
+            slice_yx[np.newaxis, np.newaxis, :, :],
+            transpose=False,
+        )
+        new_header = source_image.getHead()
+        new_header.data_type = mrd_image.data_type
+        new_header.image_type = ismrmrd.IMTYPE_MAGNITUDE
+        mrd_image.setHead(new_header)
+
+        extra_meta = {
+            "WindowCenter": str((max_val + 1) / 2),
+            "WindowWidth": str(max_val + 1),
+            "SynthSegOutputGeometry": SYNTHSEG_OUTPUT_GEOMETRY_2D,
+            SYNTHSEG_SEGMENT_OUTPUT_GEOMETRY_META_KEY: SYNTHSEG_OUTPUT_GEOMETRY_2D,
+        }
+        _stamp_synthseg_output_image(
+            mrd_image,
+            source_image,
+            output_identity,
+            source_identity,
+            series_index,
+            output_index,
+            source_identity.get("source_type_token", ""),
+            processing_history,
+            extra_meta=extra_meta,
+            keep_image_geometry=1,
+            patch_minihead=True,
+            data_role="Segmentation" if use_source_geometry_identity else "Image",
+            source_image_header_identity=not use_source_geometry_identity,
+            segment_source_geometry_identity=use_source_geometry_identity,
+            segment_scanner_postprocessing=segment_scanner_postprocessing,
+            segment_scanner_mip_processing=False,
+        )
+        outputs.append(mrd_image)
+
+    segment_contract = (
+        "source-geometry segmentation-header"
+        if segmentation_header
+        else "source-image-header"
+    )
+    logging.info(
+        "Built SynthSeg axial segmentation as %d %s 2D image(s): "
+        "series_index=%d matrix_yx=%s outputgeometry=%s scanner_postprocessing=%s "
+        "segmentation_header=%s",
+        len(outputs),
+        segment_contract,
+        series_index,
+        tuple(int(value) for value in volume_yxz.shape[:2]),
+        SYNTHSEG_OUTPUT_GEOMETRY_2D,
+        segment_scanner_postprocessing,
+        segmentation_header,
+    )
+    return outputs
+
+
+OPENRECON_SEND_IMAGE_CHUNK_SIZE = 96
+OPENRECON_SEND_CHUNK_SIZE_ENV = "SYNTHSEG_OPENRECON_SEND_IMAGE_CHUNK_SIZE"
+OPENRECON_REFORMAT_DOWNSAMPLE_ENV = "SYNTHSEG_OPENRECON_REFORMAT_DOWNSAMPLE_FACTOR"
+OPENRECON_DELAY_BEFORE_SERIES_ENV = "SYNTHSEG_OPENRECON_DELAY_BEFORE_SERIES"
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None or raw_value == "":
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logging.warning(
+            "Ignoring invalid %s=%r; expected a positive integer",
+            name,
+            raw_value,
+        )
+        return default
+
+    if value <= 0:
+        logging.warning(
+            "Ignoring invalid %s=%r; expected a positive integer",
+            name,
+            raw_value,
+        )
+        return default
+
+    return value
+
+
+def _env_positive_float(name: str, default: float) -> float:
+    raw_value = os.environ.get(name)
+    if raw_value is None or raw_value == "":
+        return default
+
+    try:
+        value = float(raw_value)
+    except ValueError:
+        logging.warning(
+            "Ignoring invalid %s=%r; expected a positive number",
+            name,
+            raw_value,
+        )
+        return default
+
+    if value <= 0:
+        logging.warning(
+            "Ignoring invalid %s=%r; expected a positive number",
+            name,
+            raw_value,
+        )
+        return default
+
+    return value
+
+
+def _series_send_delay_seconds(series_index: int) -> float:
+    """Return an optional diagnostic delay before sending a series.
+
+    Format: SYNTHSEG_OPENRECON_DELAY_BEFORE_SERIES="3:5,4:5".
+    This is intentionally opt-in so normal OpenRecon behavior is unchanged.
+    """
+    raw_value = os.environ.get(OPENRECON_DELAY_BEFORE_SERIES_ENV, "")
+    if not raw_value:
+        return 0.0
+
+    for entry in raw_value.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            raw_series, raw_delay = entry.split(":", 1)
+            candidate_series = int(raw_series.strip())
+            delay_seconds = float(raw_delay.strip())
+        except ValueError:
+            logging.warning(
+                "Ignoring invalid %s entry %r; expected '<series>:<seconds>'",
+                OPENRECON_DELAY_BEFORE_SERIES_ENV,
+                entry,
+            )
+            continue
+        if candidate_series == series_index:
+            return max(0.0, delay_seconds)
+
+    return 0.0
+
+
+def _image_payload_bytes(image) -> int:
+    try:
+        return int(np.asarray(image.data).nbytes)
+    except Exception:
+        return 0
+
+
+def _image_header_field(image, name: str, default=None):
+    try:
+        header = image.getHead()
+        return getattr(header, name, default)
+    except Exception:
+        return getattr(image, name, default)
+
+
+def _format_chunk_image_summary(chunk) -> dict:
+    if not chunk:
+        return {}
+
+    first = chunk[0]
+    last = chunk[-1]
+    try:
+        matrix = tuple(int(v) for v in _image_header_field(first, "matrix_size", [])[:])
+    except Exception:
+        matrix = None
+    try:
+        dtype = str(np.asarray(first.data).dtype)
+    except Exception:
+        dtype = "unknown"
+
+    return {
+        "matrix": matrix,
+        "dtype": dtype,
+        "payload_bytes": sum(_image_payload_bytes(image) for image in chunk),
+        "first_image_index": int(_image_header_field(first, "image_index", -1)),
+        "last_image_index": int(_image_header_field(last, "image_index", -1)),
+        "first_slice": int(_image_header_field(first, "slice", -1)),
+        "last_slice": int(_image_header_field(last, "slice", -1)),
+    }
+
+
+def _ordered_unique_strings(values):
+    ordered_values = []
+    seen = set()
+    for value in values:
+        text = str(value)
+        if text in seen:
+            continue
+        seen.add(text)
+        ordered_values.append(text)
+    return ordered_values
+
+
+def _is_synthseg_source_image_header_output(meta_obj):
+    return (
+        _get_meta_int(meta_obj, SYNTHSEG_SEGMENT_SOURCE_GEOMETRY_META_KEY) == 1
+        and _get_meta_int(meta_obj, SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY) == 1
+    )
+
+
+def _is_synthseg_source_geometry_output(meta_obj):
+    return (
+        _get_meta_int(meta_obj, SYNTHSEG_SEGMENT_SOURCE_GEOMETRY_META_KEY) == 1
+        and _get_meta_int(meta_obj, SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY) != 1
+    )
+
+
+def _output_role(image):
+    meta_obj = _meta_from_image(image)
+    if _is_synthseg_source_image_header_output(meta_obj):
+        return "segment_source_image_header"
+    if _is_synthseg_source_geometry_output(meta_obj):
+        return "segment_source_geometry"
+    if _get_meta_text(meta_obj, "ImageTypeValue4") == SYNTHSEG_ORIGINAL_LABEL:
+        return "original_passthrough"
+    if _get_meta_int(meta_obj, "Keep_image_geometry") == 0:
+        return "segment_reformat"
+    return "image"
+
+
+def _send_batch_summary(context, images):
+    images = list(images)
+    series = _ordered_unique_strings(
+        int(image.image_series_index) for image in images
+    )
+    keep_geometry = _ordered_unique_strings(
+        _get_meta_text(_meta_from_image(image), "Keep_image_geometry") or "missing"
+        for image in images
+    )
+    names = _ordered_unique_strings(
+        _get_meta_text(_meta_from_image(image), "SeriesDescription") or "missing"
+        for image in images
+    )
+    targets = _ordered_unique_strings(_output_role(image) for image in images)
+    return (
+        "SYNTHSEG_OPENRECON_BATCH context=%s images=%d target=%s "
+        "series=%s keep_geometry=%s names=%s"
+        % (
+            context,
+            len(images),
+            "+".join(targets) if targets else "empty",
+            ",".join(series) if series else "empty",
+            ",".join(keep_geometry) if keep_geometry else "empty",
+            "|".join(names) if names else "empty",
+        )
+    )
+
+
+def _send_images_by_series(connection, images, context: str = "images") -> None:
+    """Send MRD images in series-preserving chunks."""
+    if images is None:
+        return
+    if isinstance(images, ismrmrd.Image):
+        images = [images]
+    images = list(images)
+    if not images:
+        logging.info("Skipping send for %s because there are no images", context)
+        return
+
+    batch = []
+    batch_series = None
+    delayed_series = set()
+    chunk_size = _env_positive_int(
+        OPENRECON_SEND_CHUNK_SIZE_ENV,
+        OPENRECON_SEND_IMAGE_CHUNK_SIZE,
+    )
+    if chunk_size != OPENRECON_SEND_IMAGE_CHUNK_SIZE:
+        logging.info(
+            "Using diagnostic OpenRecon send chunk size %d from %s",
+            chunk_size,
+            OPENRECON_SEND_CHUNK_SIZE_ENV,
+        )
+
+    def flush_batch():
+        nonlocal batch, batch_series
+        if not batch:
+            return
+        if batch_series not in delayed_series:
+            delay_seconds = _series_send_delay_seconds(batch_series)
+            if delay_seconds > 0:
+                logging.info(
+                    "Applying diagnostic delay before sending series_index=%s: %.3f seconds",
+                    batch_series,
+                    delay_seconds,
+                )
+                time.sleep(delay_seconds)
+            delayed_series.add(batch_series)
+
+        logging.info(_send_batch_summary(context, batch))
+        for chunk_start in range(0, len(batch), chunk_size):
+            chunk = batch[chunk_start:chunk_start + chunk_size]
+            chunk_summary = _format_chunk_image_summary(chunk)
+            logging.info(
+                "Sending %s batch: series_index=%s chunk=%d-%d/%d "
+                "image_count=%d matrix=%s dtype=%s payload_bytes=%d "
+                "first_image_index=%d last_image_index=%d first_slice=%d last_slice=%d",
+                context,
+                batch_series,
+                chunk_start + 1,
+                chunk_start + len(chunk),
+                len(batch),
+                len(chunk),
+                chunk_summary.get("matrix"),
+                chunk_summary.get("dtype", "unknown"),
+                chunk_summary.get("payload_bytes", 0),
+                chunk_summary.get("first_image_index", -1),
+                chunk_summary.get("last_image_index", -1),
+                chunk_summary.get("first_slice", -1),
+                chunk_summary.get("last_slice", -1),
+            )
+            send_start = perf_counter()
+            try:
+                connection.send_image(chunk)
+            except Exception:
+                logging.error(
+                    "Failed sending %s batch: series_index=%s chunk=%d-%d/%d "
+                    "image_count=%d matrix=%s payload_bytes=%d elapsed_seconds=%.3f",
+                    context,
+                    batch_series,
+                    chunk_start + 1,
+                    chunk_start + len(chunk),
+                    len(batch),
+                    len(chunk),
+                    chunk_summary.get("matrix"),
+                    chunk_summary.get("payload_bytes", 0),
+                    perf_counter() - send_start,
+                )
+                raise
+            logging.info(
+                "Finished sending %s batch: series_index=%s chunk=%d-%d/%d "
+                "elapsed_seconds=%.3f",
+                context,
+                batch_series,
+                chunk_start + 1,
+                chunk_start + len(chunk),
+                len(batch),
+                perf_counter() - send_start,
+            )
+        batch = []
+        batch_series = None
+
+    for image in images:
+        series_index = int(getattr(image, "image_series_index", 0))
+        if batch and series_index != batch_series:
+            flush_batch()
+        batch.append(image)
+        batch_series = series_index
+
+    flush_batch()
+
+
+def _as_image_list(images):
+    if images is None:
+        return []
+    if isinstance(images, ismrmrd.Image):
+        return [images]
+    return list(images)
+
+
+def process(connection, config, metadata):
+    logging.info("Config: \n%s", config)
+
+    # Metadata should be MRD formatted header, but may be a string
+    # if it failed conversion earlier
+    try:
+        # Disabled due to incompatibility between PyXB and Python 3.8:
+        # https://github.com/pabigot/pyxb/issues/123
+        # # logging.info("Metadata: \n%s", metadata.toxml('utf-8'))
+
+        logging.info("Incoming dataset contains %d encodings", len(metadata.encoding))
+        logging.info("First encoding is of type '%s', with a matrix size of (%s x %s x %s) and a field of view of (%s x %s x %s)mm^3", 
+            metadata.encoding[0].trajectory, 
+            metadata.encoding[0].encodedSpace.matrixSize.x, 
+            metadata.encoding[0].encodedSpace.matrixSize.y, 
+            metadata.encoding[0].encodedSpace.matrixSize.z, 
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.x, 
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.y, 
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.z)
+
+    except:
+        logging.info("Improperly formatted metadata: \n%s", metadata)
+
+    # Continuously parse incoming data parsed from MRD messages
+    acqGroup = []
+    imageGroups = {}
+    skipped_passthrough_images = 0
+    waveformGroup = []
+    try:
+        for item in connection:
+            # ----------------------------------------------------------
+            # Raw k-space data messages
+            # ----------------------------------------------------------
+            if isinstance(item, ismrmrd.Acquisition):
+                # Accumulate all imaging readouts in a group
+                if (not item.is_flag_set(ismrmrd.ACQ_IS_NOISE_MEASUREMENT) and
+                    not item.is_flag_set(ismrmrd.ACQ_IS_PARALLEL_CALIBRATION) and
+                    not item.is_flag_set(ismrmrd.ACQ_IS_PHASECORR_DATA) and
+                    not item.is_flag_set(ismrmrd.ACQ_IS_NAVIGATION_DATA)):
+                    acqGroup.append(item)
+
+                # When this criteria is met, run process_raw() on the accumulated
+                # data, which returns images that are sent back to the client.
+                if item.is_flag_set(ismrmrd.ACQ_LAST_IN_SLICE):
+                    logging.info("Processing a group of k-space data")
+                    image = process_raw(acqGroup, connection, config, metadata)
+                    _send_images_by_series(connection, image, "processed raw output")
+                    acqGroup = []
+
+            # ----------------------------------------------------------
+            # Image data messages
+            # ----------------------------------------------------------
+            elif isinstance(item, ismrmrd.Image):
+                # Only process magnitude images -- send phase images back without modification (fallback for images with unknown type)
+                if (item.image_type is ismrmrd.IMTYPE_MAGNITUDE) or (item.image_type == 0):
+                    imageGroups.setdefault(int(item.image_series_index), []).append(item)
+                else:
+                    skipped_passthrough_images += 1
+                    continue
+
+            # ----------------------------------------------------------
+            # Waveform data messages
+            # ----------------------------------------------------------
+            elif isinstance(item, ismrmrd.Waveform):
+                waveformGroup.append(item)
+
+            elif item is None:
+                break
+
+            else:
+                logging.error("Unsupported data type %s", type(item).__name__)
+
+        logging.info(
+            "Input stream drained before SynthSeg image processing: "
+            "processable_series=%d processable_images=%d skipped_non_magnitude_images=%d",
+            len(imageGroups),
+            sum(len(group) for group in imageGroups.values()),
+            skipped_passthrough_images,
+        )
+
+        if skipped_passthrough_images:
+            logging.warning(
+                "Skipped %d non-magnitude input image(s). SynthSeg only returns "
+                "derived outputs and optional restamped originals.",
+                skipped_passthrough_images,
+            )
+
+        for series_index, images in imageGroups.items():
+            logging.info(
+                "Processing buffered SynthSeg image series after input drain: "
+                "series_index=%d images=%d",
+                series_index,
+                len(images),
+            )
+            image = process_image(images, connection, config, metadata)
+            _send_images_by_series(
+                connection,
+                image,
+                "processed image output after input drain",
+            )
+
+        imageGroups.clear()
+
+        # Extract raw ECG waveform data. Basic sorting to make sure that data 
+        # is time-ordered, but no additional checking for missing data.
+        # ecgData has shape (5 x timepoints)
+        if len(waveformGroup) > 0:
+            waveformGroup.sort(key = lambda item: item.time_stamp)
+            ecgData = [item.data for item in waveformGroup if item.waveform_id == 0]
+            ecgData = np.concatenate(ecgData,1)
+
+        # Process any remaining groups of raw data.  This can
+        # happen if the trigger condition for these groups are not met.
+        if len(acqGroup) > 0:
+            logging.info("Processing a group of k-space data (untriggered)")
+            image = process_raw(acqGroup, connection, config, metadata)
+            _send_images_by_series(connection, image, "processed raw output")
+            acqGroup = []
+
+    except Exception as e:
+        logging.error(traceback.format_exc())
+        connection.send_logging(constants.MRD_LOGGING_ERROR, traceback.format_exc())
+
+    finally:
+        connection.send_close()
+
+
+def process_raw(group, connection, config, metadata):
+        
+    if len(group) == 0:
+        return []
+
+    # Start timer
+    tic = perf_counter()
+
+    # Create folder, if necessary
+    if not os.path.exists(debugFolder):
+        os.makedirs(debugFolder)
+        logging.debug("Created folder " + debugFolder + " for debug output files")
+
+    # Format data into single [cha PE RO phs] array
+    lin = [acquisition.idx.kspace_encode_step_1 for acquisition in group]
+    phs = [acquisition.idx.phase                for acquisition in group]
+
+    # Use the zero-padded matrix size
+    data = np.zeros((group[0].data.shape[0], 
+                     metadata.encoding[0].encodedSpace.matrixSize.y, 
+                     metadata.encoding[0].encodedSpace.matrixSize.x, 
+                     max(phs)+1), 
+                    group[0].data.dtype)
+
+    rawHead = [None]*(max(phs)+1)
+
+    for acq, lin, phs in zip(group, lin, phs):
+        if (lin < data.shape[1]) and (phs < data.shape[3]):
+            # TODO: Account for asymmetric echo in a better way
+            data[:,lin,-acq.data.shape[1]:,phs] = acq.data
+
+            # center line of k-space is encoded in user[5]
+            if (rawHead[phs] is None) or (np.abs(acq.getHead().idx.kspace_encode_step_1 - acq.getHead().idx.user[5]) < np.abs(rawHead[phs].idx.kspace_encode_step_1 - rawHead[phs].idx.user[5])):
+                rawHead[phs] = acq.getHead()
+
+    # Flip matrix in RO/PE to be consistent with ICE
+    data = np.flip(data, (1, 2))
+
+    logging.debug("Raw data is size %s" % (data.shape,))
+    np.save(debugFolder + "/" + "raw.npy", data)
+
+    # Fourier Transform
+    data = fft.fftshift( data, axes=(1, 2))
+    data = fft.ifft2(    data, axes=(1, 2))
+    data = fft.ifftshift(data, axes=(1, 2))
+    data *= np.prod(data.shape) # FFT scaling for consistency with ICE
+
+    # Sum of squares coil combination
+    # Data will be [PE RO phs]
+    data = np.abs(data)
+    data = np.square(data)
+    data = np.sum(data, axis=0)
+    data = np.sqrt(data)
+
+    logging.debug("Image data is size %s" % (data.shape,))
+    np.save(debugFolder + "/" + "img.npy", data)
+
+    # Remove readout oversampling
+    offset = int((data.shape[1] - metadata.encoding[0].reconSpace.matrixSize.x)/2)
+    data = data[:,offset:offset+metadata.encoding[0].reconSpace.matrixSize.x]
+
+    # Remove phase oversampling
+    offset = int((data.shape[0] - metadata.encoding[0].reconSpace.matrixSize.y)/2)
+    data = data[offset:offset+metadata.encoding[0].reconSpace.matrixSize.y,:]
+
+    logging.debug("Image without oversampling is size %s" % (data.shape,))
+    np.save(debugFolder + "/" + "imgCrop.npy", data)
+
+    # Measure processing time
+    toc = perf_counter()
+    strProcessTime = "Total processing time: %.2f ms" % ((toc-tic)*1000.0)
+    logging.info(strProcessTime)
+
+    # Send this as a text message back to the client
+    connection.send_logging(constants.MRD_LOGGING_INFO, strProcessTime)
+
+    # Format as ISMRMRD image data
+    imagesOut = []
+    for phs in range(data.shape[2]):
+        # Create new MRD instance for the processed image
+        # data has shape [PE RO phs], i.e. [y x].
+        # from_array() should be called with 'transpose=False' to avoid warnings, and when called
+        # with this option, can take input as: [cha z y x], [z y x], or [y x]
+        tmpImg = ismrmrd.Image.from_array(data[...,phs], transpose=False)
+
+        # Set the header information
+        tmpImg.setHead(mrdhelper.update_img_header_from_raw(tmpImg.getHead(), rawHead[phs]))
+        tmpImg.field_of_view = (ctypes.c_float(metadata.encoding[0].reconSpace.fieldOfView_mm.x), 
+                                ctypes.c_float(metadata.encoding[0].reconSpace.fieldOfView_mm.y), 
+                                ctypes.c_float(metadata.encoding[0].reconSpace.fieldOfView_mm.z))
+        tmpImg.image_index = phs
+
+        # Set ISMRMRD Meta Attributes
+        tmpMeta = ismrmrd.Meta()
+        tmpMeta['DataRole']               = 'Image'
+        tmpMeta['ImageProcessingHistory'] = ['FIRE', 'PYTHON']
+        tmpMeta['Keep_image_geometry']    = 1
+
+        xml = tmpMeta.serialize()
+        # logging.debug("Image MetaAttributes: %s", xml)
+        tmpImg.attribute_string = xml
+        imagesOut.append(tmpImg)
+
+    # Call process_image() to run synthseg on the images
+    imagesOut = process_image(imagesOut, connection, config, metadata)
+
+    return imagesOut
+
+
+def process_image(images, connection, config, metadata):
+    if len(images) == 0:
+        return []
+
+    def boolean_checker(id:str, default_val:bool=False):
+        option = mrdhelper.get_json_config_param(config, id, default_val, type='bool')
+        if isinstance(option, str):
+            return option.strip().lower() in ("1", "true", "yes", "on")
+        else:
+            return bool(option)
+
+    send_original = boolean_checker(
+        "sendoriginal",
+        default_val=OPENRECON_DEFAULTS["sendoriginal"],
+    )
+    called_from_raw = traceback.extract_stack()[-2].name == "process_raw"
+    original_images = []
+    if send_original and not called_from_raw:
+        original_images = [_clone_mrd_image(image) for image in images]
+    logging.info("sendoriginal resolved to %s", send_original)
+
+    source_identity = _resolve_source_series_identity(_meta_from_image(images[0]))
+
+    # Create folder, if necessary
+    if not os.path.exists(debugFolder):
+        os.makedirs(debugFolder)
+        logging.debug("Created folder " + debugFolder + " for debug output files")
+
+    if hasattr(ismrmrd, "get_dtype_from_data_type"):
+        data_type = ismrmrd.get_dtype_from_data_type(images[0].data_type)
+    else:
+        # Fallback for pyismrmrd versions that removed get_dtype_from_data_type
+        data_type = images[0].data.dtype
+
+    logging.debug("Processing data with %d images of type %s", len(images), data_type)
+
+    # Note: The MRD Image class stores data as [cha z y x]
+    unsorted_head = [img.getHead() for img in images]
+    slice_sort_indices, slice_axis, _ = _slice_sort_indices(unsorted_head)
+    _log_slice_geometry(
+        "Incoming SynthSeg source",
+        unsorted_head,
+        slice_axis=slice_axis,
+    )
+    _log_slice_sort_mapping(slice_sort_indices)
+
+    ordered_images = [images[index] for index in slice_sort_indices]
+
+    # Extract image data into a 5D array of size [img cha z y x]
+    data = np.stack([img.data for img in ordered_images])
+    head = [unsorted_head[index] for index in slice_sort_indices]
+    source_series_indices = [
+        int(getattr(image_header, "image_series_index", 0))
+        for image_header in head
+    ]
+    first_output_series_index = max(source_series_indices, default=0) + 1
+    if send_original and not called_from_raw:
+        original_series_index = first_output_series_index
+        segmentation_series_index = first_output_series_index + 1
+    else:
+        original_series_index = None
+        segmentation_series_index = first_output_series_index
+        if send_original and called_from_raw:
+            logging.warning(
+                "sendoriginal is true, but input was raw data, so no original images to return."
+            )
+    segmentation_identity = _build_openrecon_output_identity(
+        source_identity,
+        series_index=segmentation_series_index,
+    )
+    logging.info(
+        "SynthSeg output identity: source_series=%s source_sequence=%s "
+        "source_grouping=%s source_series_uid=%s derived_series=%s "
+        "derived_grouping=%s derived_series_uid=%s source_type=%s "
+        "output_type=%s display_token=%s image_series_index=%d "
+        "(source series indices=%s)",
+        source_identity["series_description"] or "N/A",
+        source_identity["parent_sequence"] or "N/A",
+        source_identity["parent_grouping"] or "N/A",
+        source_identity["series_uid"] or "N/A",
+        segmentation_identity["series_description"],
+        segmentation_identity["grouping"],
+        segmentation_identity["series_uid"],
+        source_identity["source_type_token"] or "N/A",
+        segmentation_identity["type_token"],
+        segmentation_identity["display_token"],
+        segmentation_series_index,
+        sorted(set(source_series_indices)),
+    )
+    imagesOut = []
+    original_output_images = []
+    if original_series_index is not None:
+        ordered_original_images = [
+            original_images[index] for index in slice_sort_indices
+        ]
+        original_output_images = _build_synthseg_original_images(
+            ordered_original_images,
+            ordered_images,
+            source_identity,
+            original_series_index,
+        )
+        imagesOut.extend(original_output_images)
+
+    legacy_option = None
+    if isinstance(config, dict):
+        parameters = config.get("parameters")
+        if isinstance(parameters, dict):
+            legacy_option = parameters.get("options")
+
+    _log_slice_geometry(
+        "Sorted SynthSeg source",
+        head,
+        input_indices=slice_sort_indices,
+        slice_axis=slice_axis,
+    )
+
+    matrix = np.asarray(head[0].matrix_size[:], dtype=float)
+    fov = np.asarray(head[0].field_of_view[:], dtype=float)
+    if matrix.size < 3 or fov.size < 3:
+        raise ValueError(
+            "MRD image geometry is incomplete: "
+            f"matrix_size={matrix.tolist()} field_of_view={fov.tolist()}"
+        )
+
+    matrix = matrix[:3].copy()
+    fov = fov[:3].copy()
+    if matrix[2] != len(ordered_images):
+        matrix[2] = len(ordered_images)
+
+    slice_thickness = float(fov[2])
+    measured_slice_spacing = _estimate_slice_spacing(head, slice_axis=slice_axis)
+    if measured_slice_spacing is not None:
+        if abs(float(measured_slice_spacing) - slice_thickness) > 0.05:
+            logging.warning(
+                "MRD slice thickness %.6f differs from measured slice spacing %.6f; "
+                "using measured spacing for NIfTI affine",
+                slice_thickness,
+                float(measured_slice_spacing),
+            )
+        fov[2] = measured_slice_spacing * len(ordered_images)
+    else:
+        fov[2] = slice_thickness * len(ordered_images)
+
+    if np.any(matrix <= 0) or np.any(fov <= 0):
+        raise ValueError(
+            "MRD image geometry has non-positive matrix or FOV values: "
+            f"matrix_size={matrix.tolist()} field_of_view={fov.tolist()}"
+        )
+
+    voxel_size = fov / matrix
+    _log_affine_slice_consistency(head, voxel_size)
+
+    # Reformat data to [y x img cha z], i.e. [row ~col] for the first two dimensions
+    data = data.transpose((3, 4, 0, 1, 2))
+
+    logging.debug("Original image data is size %s" % (data.shape,))
+    # e.g. gre with 128x128x10 with phase and magnitude results in [128 128 1 1 1]
+    # np.save(debugFolder + "/" + "imgOrig.npy", data)
+
+    # convert data to nifti using nibabel
+    # synthseg needs 3D data:
+    _log_array_summary("OpenRecon input before squeeze", data)
+    data = np.squeeze(data)
+    logging.debug("Cropped to 3D from Original image data is size %s" % (data.shape,))
+    if data.ndim != 3:
+        logging.warning(
+            "OpenRecon input shape after squeeze is %s (%dD). "
+            "SynthSeg expects 3D input and preprocessing or inference may fail.",
+            data.shape,
+            data.ndim,
+        )
+    if np.iscomplexobj(data):
+        logging.warning(
+            "Complex-valued input received. SynthSeg expects real-valued data, "
+            "so the input will be converted to magnitude before inference."
+        )
+        data = np.abs(data)
+    _log_array_summary("OpenRecon input after squeeze", data)
+
+    # Read the user's choice of SynthSeg model and inference options.
+    model = str(
+        mrdhelper.get_json_config_param(
+            config,
+            "ssmodel",
+            default=OPENRECON_MODEL_DEFAULT,
+            type='str',
+        )
+    ).strip().lower()
+    if model not in SYNTHSEG_MODEL_FILES:
+        logging.warning(
+            "Unsupported SynthSeg model %r requested. Falling back to %s.",
+            model,
+            OPENRECON_MODEL_DEFAULT,
+        )
+        model = OPENRECON_MODEL_DEFAULT
+
+    parcellation = boolean_checker("ssparc", default_val=OPENRECON_DEFAULTS["ssparc"])
+    fast = boolean_checker("ssfast", default_val=OPENRECON_DEFAULTS["ssfast"])
+    if model == "robust" and not fast:
+        # mri_synthseg forces --fast for SynthSeg-robust, so report the value
+        # that will actually be used instead of the requested one.
+        logging.info("SynthSeg-robust always runs in fast mode; enabling fast.")
+        fast = True
+
+    use_gpu = boolean_checker("ssusegpu", default_val=OPENRECON_DEFAULTS["ssusegpu"])
+    threads = int(
+        mrdhelper.get_json_config_param(
+            config,
+            "ssthreads",
+            default=OPENRECON_DEFAULTS["ssthreads"],
+            type='int',
+        )
+    )
+    if threads < 1:
+        logging.warning(
+            "Invalid thread count %s requested. Falling back to %s.",
+            threads,
+            OPENRECON_DEFAULTS["ssthreads"],
+        )
+        threads = OPENRECON_DEFAULTS["ssthreads"]
+
+    write_volumes = boolean_checker(
+        "ssvolumes",
+        default_val=OPENRECON_DEFAULTS["ssvolumes"],
+    )
+    write_qc = boolean_checker("ssqc", default_val=OPENRECON_DEFAULTS["ssqc"])
+    if write_qc and model == "v1":
+        # --qc uses the 2.0 QC label set, which mri_synthseg swaps out under --v1.
+        logging.info("QC scores are reported with the SynthSeg 1.0 label set.")
+
+    reslice_sagittal = boolean_checker(
+        "ssreslicesagittal",
+        default_val=OPENRECON_DEFAULTS["ssreslicesagittal"],
+    )
+    reslice_coronal = boolean_checker(
+        "ssreslicecoronal",
+        default_val=OPENRECON_DEFAULTS["ssreslicecoronal"],
+    )
+    output_geometry = SYNTHSEG_OUTPUT_GEOMETRY_2D
+    debug_threshold_segment = boolean_checker(
+        "ssdebugthresholdsegment",
+        default_val=OPENRECON_DEFAULTS["ssdebugthresholdsegment"],
+    )
+    segmentation_header = boolean_checker(
+        "sssegmentheader",
+        default_val=OPENRECON_DEFAULTS["sssegmentheader"],
+    )
+    logging.info("sssegmentheader resolved to %s", segmentation_header)
+    run_name = _openrecon_run_name(model, parcellation, fast, config)
+
+    workspace_root = Path(debugFolder) / OPENRECON_WORKSPACE_ROOT
+    work_dir = workspace_root / run_name
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+
+    input_dir = work_dir / "synthseg_input"
+    output_dir = work_dir / "synthseg_output"
+    input_name = "input.nii.gz"
+    output_name = "input_synthseg.nii.gz"
+    input_path = input_dir / input_name
+    output_path = output_dir / output_name
+    volumes_csv_path = output_dir / "synthseg_volumes.csv"
+    qc_csv_path = output_dir / "synthseg_qc.csv"
+
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    affine = compute_nifti_affine(head[0], voxel_size)
+    logging.info("Computed SynthSeg input NIfTI affine:\n%s", affine)
+
+    if data.ndim == 2:
+        data_nifti = np.asarray(data.T[:, :, None])
+    elif data.ndim == 3:
+        data_nifti = np.asarray(data.transpose((1, 0, 2)))
+    else:
+        data_nifti = np.asarray(data)
+
+    new_img = nib.nifti1.Nifti1Image(data_nifti, affine)
+    new_img.header.set_xyzt_units(xyz="mm", t="sec")
+    new_img.header.set_dim_info(freq=1, phase=0, slice=2)
+    new_img.set_qform(affine, code=1)
+    new_img.set_sform(affine, code=1)
+    nib.save(new_img, str(input_path))
+    logging.info(
+        "Saved OpenRecon input image to %s with shape=%s dtype=%s zooms=%s",
+        input_path,
+        new_img.shape,
+        new_img.get_data_dtype(),
+        new_img.header.get_zooms(),
+    )
+    logging.info("Using SynthSeg workspace %s", work_dir)
+
+    # Determine max value (12 or 16 bit)
+    BitsStored = 12
+    # if (mrdhelper.get_userParameterLong_value(metadata, "BitsStored") is not None):
+    #     BitsStored = mrdhelper.get_userParameterLong_value(metadata, "BitsStored")
+    maxVal = 2**BitsStored - 1
+
+    model_paths = []
+    if not debug_threshold_segment:
+        model_paths = _resolve_synthseg_models(model, parcellation, write_qc)
+    logging.info(
+        "OpenRecon SynthSeg options: run_name=%s model=%s model_files=%s "
+        "parcellation=%s fast=%s use_gpu=%s threads=%s volumes_csv=%s qc_csv=%s "
+        "outputgeometry=%s segmentation_send_order=%s "
+        "debug_threshold_segment=%s "
+        "reslice_sagittal=%s reslice_coronal=%s",
+        run_name,
+        model,
+        [path.name for path in model_paths],
+        parcellation,
+        fast,
+        use_gpu,
+        threads,
+        write_volumes,
+        write_qc,
+        output_geometry,
+        SYNTHSEG_SEGMENT_SEND_ORDER,
+        debug_threshold_segment,
+        reslice_sagittal,
+        reslice_coronal,
+    )
+
+    def build_synthseg_command():
+        # --keepgeom is mandatory here: mri_synthseg segments at 1 mm isotropic
+        # and would otherwise return a volume that no longer matches the source
+        # MRD slice grid, so the labels could not be stamped back onto the
+        # incoming image headers.
+        cmd = [
+            SYNTHSEG_COMMAND,
+            "--i", str(input_path),
+            "--o", str(output_path),
+            "--keepgeom",
+            "--noaddctab",
+            "--threads", str(threads),
+        ]
+        if model == "robust":
+            cmd.append("--robust")
+        elif model == "v1":
+            cmd.append("--v1")
+        if fast and model != "robust":
+            # --robust implies --fast; passing both is accepted but noisy.
+            cmd.append("--fast")
+        if parcellation:
+            cmd.append("--parc")
+        if not use_gpu:
+            cmd.append("--cpu")
+        if write_volumes:
+            cmd.extend(["--vol", str(volumes_csv_path)])
+        if write_qc:
+            cmd.extend(["--qc", str(qc_csv_path)])
+        return cmd
+
+    def log_csv_output(label, csv_path):
+        if not csv_path.exists():
+            logging.warning("SynthSeg did not write the %s CSV at %s", label, csv_path)
+            return
+        try:
+            logging.info(
+                "SynthSeg %s CSV (%s):\n%s",
+                label,
+                csv_path,
+                csv_path.read_text(encoding="utf-8").rstrip(),
+            )
+        except OSError as exc:
+            logging.warning("Could not read the SynthSeg %s CSV: %s", label, exc)
+
+    def run_synthseg_command(ss_cmd):
+        logging.info("Running SynthSeg command: %s", " ".join(ss_cmd))
+        started = perf_counter()
+        result = subprocess.run(ss_cmd, check=False, capture_output=True, text=True)
+
+        if result.stdout and result.stdout.strip():
+            logging.info("SynthSeg stdout:\n%s", result.stdout.rstrip())
+        if result.stderr and result.stderr.strip():
+            logging.info("SynthSeg stderr:\n%s", result.stderr.rstrip())
+
+        logging.info(
+            "SynthSeg inference finished in %.1f s with exit code %s",
+            perf_counter() - started,
+            result.returncode,
+        )
+        _log_directory_contents("SynthSeg input directory", input_dir)
+        _log_directory_contents("SynthSeg output directory", output_dir)
+
+        if result.returncode != 0:
+            logging.error("SynthSeg command failed with exit code %s", result.returncode)
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                ss_cmd,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+
+    if debug_threshold_segment:
+        logging.warning(
+            "ssdebugthresholdsegment is enabled; skipping SynthSeg model "
+            "execution and using the openreconi2iexample-style simple threshold "
+            "segmentation instead."
+        )
+        volume_yxz = _simple_threshold_segmentation_volume(data, maxVal)
+        debug_output_data = np.asarray(volume_yxz).transpose((1, 0, 2))
+        debug_img = nib.nifti1.Nifti1Image(debug_output_data, affine)
+        debug_img.header.set_xyzt_units(xyz="mm", t="sec")
+        debug_img.header.set_dim_info(freq=1, phase=0, slice=2)
+        debug_img.set_qform(affine, code=1)
+        debug_img.set_sform(affine, code=1)
+        nib.save(debug_img, str(output_path))
+        logging.info(
+            "Saved debug threshold segmentation to %s with shape=%s dtype=%s",
+            output_path,
+            debug_img.shape,
+            debug_img.get_data_dtype(),
+        )
+        print('Debug threshold processing done')
+
+    else:
+        run_synthseg_command(build_synthseg_command())
+        if write_volumes:
+            log_csv_output("region volume", volumes_csv_path)
+        if write_qc:
+            log_csv_output("QC score", qc_csv_path)
+
+        print('Processing done')
+        output_image = _find_output_nifti(output_dir, output_name)
+        logging.info("Loading SynthSeg output image %s", output_image)
+        img = nib.load(str(output_image))
+        data = img.get_fdata(dtype=np.float32)
+
+        # Reformat data
+        print("shape after loading with nibabel")
+        print(data.shape)
+        if data.ndim == 2:
+            data = data[:, :, None]
+        if data.ndim == 3:
+            # Bring NIfTI [x, y, z] back to OpenRecon/MRD convenience [y, x, z].
+            data = data.transpose((1, 0, 2))
+        if data.ndim != 3:
+            raise ValueError(
+                f"SynthSeg output must be 3D after squeezing, got shape {data.shape}"
+            )
+        if data.shape[-1] != len(head):
+            raise ValueError(
+                "SynthSeg output slice count does not match MRD input: "
+                f"output_z={data.shape[-1]} input_images={len(head)}. "
+                "mri_synthseg was run with --keepgeom, so this means the "
+                "segmentation was not resampled back onto the source grid."
+            )
+
+        if legacy_option == "complex":
+            logging.warning(
+                "Ignoring legacy complex output request because SynthSeg returns "
+                "integer label maps."
+            )
+
+        # SynthSeg emits FreeSurfer label indices, not intensities. They are
+        # carried through unscaled so downstream tooling can look them up in
+        # FreeSurferColorLUT.txt; only the display window is derived from them.
+        data = np.nan_to_num(data, nan=0.0, posinf=0.0, neginf=0.0)
+        if np.min(data) < 0:
+            logging.warning("Negative label values in SynthSeg output; clipping to zero.")
+            data = np.clip(data, 0, None)
+
+        label_max = float(np.max(data))
+        if label_max > SYNTHSEG_MAX_LABEL_VALUE:
+            raise ValueError(
+                "SynthSeg label values exceed the int16 range used for MRD "
+                f"export: max_label={label_max}"
+            )
+        if label_max <= 0:
+            logging.warning("SynthSeg output is all zeros; returning a zero-valued image.")
+        volume_yxz = np.rint(data).astype(np.int16)
+        label_values = np.unique(volume_yxz)
+        logging.info(
+            "SynthSeg label map: distinct_labels=%d max_label=%d labels=%s",
+            label_values.size,
+            int(label_max),
+            label_values.tolist()[:64],
+        )
+        # Window the label range rather than the 12-bit intensity range so the
+        # segmentation is visible on the scanner without manual windowing.
+        maxVal = max(int(label_max), 1)
+
+    if volume_yxz.shape[-1] != len(head):
+        raise ValueError(
+            "SynthSeg output slice count does not match MRD input: "
+            f"output_z={volume_yxz.shape[-1]} input_images={len(head)}"
+        )
+
+    segmentation_images = _build_synthseg_segmentation_images(
+        volume_yxz=volume_yxz,
+        ordered_source_images=ordered_images,
+        source_identity=source_identity,
+        output_identity=segmentation_identity,
+        series_index=segmentation_series_index,
+        max_val=maxVal,
+        scanner_postprocessing=True,
+        segmentation_header=segmentation_header,
+    )
+    imagesOut.extend(segmentation_images)
+
+    segmentation_contract = (
+        "source-geometry segmentation-header 2D"
+        if segmentation_header
+        else "source-image-header 2D"
+    )
+    if original_series_index is not None:
+        logging.info(
+            "SynthSeg send order is source-geometry originals first, then "
+            "%s segmentation images",
+            segmentation_contract,
+        )
+    else:
+        logging.info(
+            "SynthSeg send order is %s segmentation images",
+            segmentation_contract,
+        )
+
+    if reslice_sagittal or reslice_coronal:
+        base_series = segmentation_series_index + 1
+        reformat_images = []
+
+        if reslice_sagittal:
+            sagittal_identity = _build_openrecon_output_identity(
+                source_identity,
+                orientation="sagittal",
+                series_index=base_series,
+            )
+            logging.info(
+                "Appending sagittal reformat output series (series_index=%d, name=%s)",
+                base_series,
+                sagittal_identity["series_description"],
+            )
+            sagittal_images = _build_reformatted_images(
+                volume_yxz=volume_yxz,
+                head_template=head[0],
+                source_image=ordered_images[0],
+                source_identity=source_identity,
+                output_identity=sagittal_identity,
+                voxel_size=voxel_size,
+                fov=fov,
+                orientation="sagittal",
+                series_index=base_series,
+                max_val=maxVal,
+            )
+            imagesOut.extend(sagittal_images)
+            reformat_images.extend(sagittal_images)
+            base_series += 1
+
+        if reslice_coronal:
+            coronal_identity = _build_openrecon_output_identity(
+                source_identity,
+                orientation="coronal",
+                series_index=base_series,
+            )
+            logging.info(
+                "Appending coronal reformat output series (series_index=%d, name=%s)",
+                base_series,
+                coronal_identity["series_description"],
+            )
+            coronal_images = _build_reformatted_images(
+                volume_yxz=volume_yxz,
+                head_template=head[0],
+                source_image=ordered_images[0],
+                source_identity=source_identity,
+                output_identity=coronal_identity,
+                voxel_size=voxel_size,
+                fov=fov,
+                orientation="coronal",
+                series_index=base_series,
+                max_val=maxVal,
+            )
+            imagesOut.extend(coronal_images)
+            reformat_images.extend(coronal_images)
+    else:
+        reformat_images = []
+
+    if segmentation_header:
+        segment_header_geometry = "2d_segment_header"
+        postprocessing_target = "segment_2d_source_geometry"
+    else:
+        segment_header_geometry = "2d_source_image_header"
+        postprocessing_target = (
+            "originals+segment_2d_source_image_header"
+            if original_series_index is not None
+            else "segment_2d_source_image_header"
+        )
+    logging.info(
+        "Configured outputs: original=%s segment=True "
+        "segmentheadergeometry=%s postprocessing_target=%s "
+        "reformat_sagittal=%s reformat_coronal=%s",
+        original_series_index is not None,
+        segment_header_geometry,
+        postprocessing_target,
+        reslice_sagittal,
+        reslice_coronal,
+    )
+    logging.info("SYNTHSEG_OPENRECON_POSTPROCESSING target=%s", postprocessing_target)
+    logging.info(
+        "Sending %d original image(s), %d segmentation image(s), and %d reformat image(s)",
+        len(original_output_images),
+        len(segmentation_images),
+        len(reformat_images),
+    )
+
+    _validate_synthseg_output_contract(
+        imagesOut,
+        source_series_indices,
+        source_identity,
+        "processed image output",
+    )
+
+    return imagesOut
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/recipes/synthseg/test_synthseg_openrecon.py
+++ b/recipes/synthseg/test_synthseg_openrecon.py
@@ -1,0 +1,353 @@
+import ast
+import copy
+import ctypes
+import itertools
+import json
+import re
+import uuid
+from pathlib import Path
+
+import numpy as np
+
+
+RECIPE_DIR = Path(__file__).resolve().parent
+WRAPPER_PATH = RECIPE_DIR / "synthseg.py"
+LABEL_PATH = RECIPE_DIR / "OpenReconLabel.json"
+
+
+def _load_runtime_helpers_for_test(function_names, assignments=()):
+    tree = ast.parse(WRAPPER_PATH.read_text())
+    helper_nodes = []
+    wanted = set(function_names)
+    wanted_assignments = set(assignments)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = {
+                target.id
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            if names & wanted_assignments:
+                helper_nodes.append(node)
+        elif isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in wanted:
+            helper_nodes.append(node)
+
+    class FakeMrdHelper:
+        @staticmethod
+        def extract_minihead_string_param(_minihead_text, _name):
+            return ""
+
+    class FakeMeta(dict):
+        def serialize(self):
+            return json.dumps(dict(self))
+
+        @staticmethod
+        def deserialize(value):
+            if isinstance(value, FakeMeta):
+                return FakeMeta(value)
+            if isinstance(value, dict):
+                return FakeMeta(value)
+            return FakeMeta(json.loads(value or "{}"))
+
+    class FakeHead:
+        def __init__(self):
+            self.data_type = 2
+            self.image_type = 1
+            self.image_series_index = 1
+            self.image_index = 1
+            self.slice = 0
+            self.contrast = 0
+            self.matrix_size = [2, 2, 1]
+            self.field_of_view = [2.0, 2.0, 1.0]
+            self.position = [0.0, 0.0, 0.0]
+            self.read_dir = [1.0, 0.0, 0.0]
+            self.phase_dir = [0.0, 1.0, 0.0]
+            self.slice_dir = [0.0, 0.0, 1.0]
+            self.measurement_uid = 42
+            self.patient_table_position = [0.0, 0.0, 0.0]
+            self.acquisition_time_stamp = 0
+            self.physiology_time_stamp = [0, 0, 0]
+            self.user_int = [0] * 8
+            self.user_float = [0.0] * 8
+
+    class FakeImage:
+        def __init__(self, data):
+            self.data = np.array(data, copy=True)
+            self.data_type = 2
+            self._head = FakeHead()
+            if self.data.ndim >= 2:
+                rows, cols = self.data.shape[-2:]
+                self._head.matrix_size = [int(cols), int(rows), 1]
+                self._head.field_of_view = [float(cols), float(rows), 1.0]
+            self.image_series_index = self._head.image_series_index
+            self.attribute_string = "{}"
+
+        @staticmethod
+        def from_array(data, transpose=False):
+            return FakeImage(data)
+
+        def setHead(self, head):
+            self._head = copy.deepcopy(head)
+            self.image_series_index = self._head.image_series_index
+
+        def getHead(self):
+            return copy.deepcopy(self._head)
+
+    class FakeIsmrmrd:
+        Image = FakeImage
+        Meta = FakeMeta
+        DATATYPE_CXFLOAT = 7
+        DATATYPE_CXDOUBLE = 8
+        IMTYPE_COMPLEX = 2
+        IMTYPE_MAGNITUDE = 1
+
+    namespace = {
+        "base64": __import__("base64"),
+        "copy": copy,
+        "ctypes": ctypes,
+        "ismrmrd": FakeIsmrmrd,
+        "json": json,
+        "logging": type(
+            "Logger",
+            (),
+            {
+                "info": staticmethod(lambda *args, **kwargs: None),
+                "warning": staticmethod(lambda *args, **kwargs: None),
+            },
+        ),
+        "mrdhelper": FakeMrdHelper,
+        "np": np,
+        "ndi": type("FakeNdi", (), {"zoom": staticmethod(lambda *args, **kwargs: None)}),
+        "os": __import__("os"),
+        "re": re,
+        "itertools": itertools,
+        "uuid": uuid,
+    }
+    exec(
+        compile(
+            ast.Module(body=helper_nodes, type_ignores=[]),
+            str(WRAPPER_PATH),
+            "exec",
+        ),
+        namespace,
+    )
+    namespace["FakeImage"] = FakeImage
+    namespace["FakeMeta"] = FakeMeta
+    return namespace
+
+
+def _helpers():
+    return _load_runtime_helpers_for_test(
+        [
+            "_build_reformatted_images",
+            "_copy_meta",
+            "_decode_ice_minihead",
+            "_derived_synthseg_instance_uid",
+            "_derived_synthseg_series_uid",
+            "_diagnostic_reformat_target_shape",
+            "_encode_ice_minihead",
+            "_env_positive_float",
+            "_extract_minihead_string_value",
+            "_first_non_empty_text",
+            "_format_exam_data_role_sequential_number",
+            "_format_vector",
+            "_get_meta_text",
+            "_ice_compatible_target_shape",
+            "_meta_from_image",
+            "_resize_2d_nearest",
+            "_set_meta_scalar",
+            "_set_output_position_meta",
+            "_square_pixel_target_shape",
+            "_stamp_synthseg_output_image",
+            "_strip_scanner_write_unsafe_meta",
+            "_strip_source_parent_refs",
+        ],
+        assignments=[
+            "OPENRECON_REFORMAT_DOWNSAMPLE_ENV",
+            "OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX",
+            "OPENRECON_SERIES_SUFFIX",
+            "SCANNER_PARTITION_INDEX",
+            "SCANNER_WRITE_UNSAFE_META_KEYS",
+            "SOURCE_PARENT_REFERENCE_META_KEYS",
+            "SOURCE_PARENT_REFERENCE_META_PREFIXES",
+            "SYNTHSEG_OUTPUT_GEOMETRY_2D",
+            "SYNTHSEG_REFORMAT_ORIENTATION_META_KEY",
+            "SYNTHSEG_REFORMAT_SLICE_COUNT_META_KEY",
+            "SYNTHSEG_REFORMAT_SLICE_INDEX_META_KEY",
+            "SYNTHSEG_SEGMENT_OUTPUT_GEOMETRY_META_KEY",
+            "SYNTHSEG_SEGMENT_POSTPROCESSING_CHILD_ROLE_META_KEY",
+            "SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY",
+            "SYNTHSEG_SEGMENT_SOURCE_GEOMETRY_META_KEY",
+            "SYNTHSEG_SEGMENT_SOURCE_IMAGE_HEADER_META_KEY",
+            "SYNTHSEG_SEGMENTATION_LABEL",
+            "SYNTHSEG_SEGMENTATION_TYPE_TOKEN",
+            "SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE",
+            "SYNTHSEG_SOURCE_GEOMETRY_IMAGE_TYPE_VALUE4",
+        ],
+    )
+
+
+def _source_image(helpers):
+    image = helpers["FakeImage"](np.zeros((1, 1, 2, 2), dtype=np.int16))
+    head = image.getHead()
+    head.image_series_index = 1
+    head.image_index = 1
+    head.slice = 0
+    image.setHead(head)
+    image.attribute_string = helpers["FakeMeta"](
+        {
+            "SeriesDescription": "source_t1w",
+            "SequenceDescription": "source_t1w",
+            "ProtocolName": "source_t1w",
+            "SeriesNumberRangeNameUID": "source_group",
+            "SeriesInstanceUID": "1.2.3",
+            "SOPInstanceUID": "1.2.3.4",
+            "ImageType": "ORIGINAL\\PRIMARY\\M\\ND",
+            "DicomImageType": "ORIGINAL\\PRIMARY\\M\\ND",
+            "ImageTypeValue3": "M",
+            "ImageTypeValue4": "ND",
+            "Keep_image_geometry": "1",
+        }
+    ).serialize()
+    return image
+
+
+def test_reformat_outputs_use_2d_segmentation_header_contract():
+    helpers = _helpers()
+    source_image = _source_image(helpers)
+    source_identity = {
+        "series_description": "source_t1w",
+        "parent_grouping": "source_group",
+        "series_uid": "1.2.3",
+        "sop_uid": "1.2.3.4",
+        "source_type_token": "ND",
+    }
+    output_identity = {
+        "series_description": "source_t1w_synthseg_coronal",
+        "sequence_description": "source_t1w_synthseg_coronal",
+        "grouping": "source_group_synthseg_coronal",
+        "display_token": "synthseg",
+        "type_token": "SYNTHSEG",
+        "image_comment": "synthseg_coronal",
+        "series_uid": "2.25.999",
+    }
+
+    images = helpers["_build_reformatted_images"](
+        volume_yxz=np.arange(12, dtype=np.int16).reshape((3, 2, 2)),
+        head_template=source_image.getHead(),
+        source_image=source_image,
+        source_identity=source_identity,
+        output_identity=output_identity,
+        voxel_size=np.array([1.0, 1.0, 1.0]),
+        fov=np.array([2.0, 3.0, 2.0]),
+        orientation="coronal",
+        series_index=4,
+        max_val=4095,
+    )
+
+    assert len(images) == 3
+    for index, image in enumerate(images):
+        head = image.getHead()
+        meta = helpers["FakeMeta"].deserialize(image.attribute_string)
+
+        assert image.data.shape == (1, 1, 2, 2)
+        assert head.image_series_index == 4
+        assert head.image_index == index + 1
+        assert head.slice == index
+        assert meta["DataRole"] == "Segmentation"
+        assert meta["Keep_image_geometry"] == "1"
+        assert meta["SegmentSourceGeometry"] == "1"
+        assert "SegmentSourceImageHeader" not in meta
+        assert meta["SegmentOutputGeometry"] == "2d"
+        assert meta["SynthSegReformatOrientation"] == "coronal"
+        assert meta["SynthSegReformatSliceIndex"] == str(index)
+        assert meta["SynthSegReformatSliceCount"] == "3"
+        assert meta["SegmentPostProcessingChildRole"] == "4"
+        assert "<CategoryEntry>4</CategoryEntry>" in meta["ExamDataRole"]
+        assert meta["SliceNo"] == str(index)
+        assert meta["ChronSliceNo"] == str(index)
+        assert meta["NumberInSeries"] == str(index + 1)
+        assert "ImageTypeValue3" not in meta
+        assert "partition_count" not in meta
+        assert "slice_count" not in meta
+        assert "NumberOfSlices" not in meta
+        assert "ImagesInAcquisition" not in meta
+
+
+def _openrecon_helpers():
+    return _load_runtime_helpers_for_test(
+        [
+            "_openrecon_run_name",
+            "_parse_model_list",
+            "_safe_path_component",
+            "iter_openrecon_parameter_combinations",
+        ],
+        assignments=[
+            "OPENRECON_DEFAULTS",
+            "OPENRECON_COMBINATION_PARAMETER_VALUES",
+            "OPENRECON_MODEL_DEFAULT",
+            "OPENRECON_MODEL_VALUES",
+            "OPENRECON_OUTPUT_NAME_PARAM",
+            "SYNTHSEG_MODEL_FILES",
+        ],
+    )
+
+
+def test_openrecon_defaults_match_the_scanner_label():
+    """The wrapper reads every scanner parameter by id, so the two must agree.
+
+    A parameter present in only one of the two files is silently ignored at the
+    scanner: the GUI would offer a control the wrapper never reads, or the
+    wrapper would fall back to a default the operator cannot change.
+    """
+    helpers = _openrecon_helpers()
+    label = json.loads(LABEL_PATH.read_text())
+
+    label_ids = [parameter["id"] for parameter in label["parameters"]]
+    assert len(label_ids) == len(set(label_ids)), "duplicate parameter ids in label"
+    assert set(label_ids) == set(helpers["OPENRECON_DEFAULTS"])
+
+    for parameter in label["parameters"]:
+        default = helpers["OPENRECON_DEFAULTS"][parameter["id"]]
+        if parameter["type"] == "boolean":
+            assert isinstance(default, bool)
+            assert default == parameter["default"]
+        elif parameter["type"] == "int":
+            assert isinstance(default, int) and not isinstance(default, bool)
+            assert default == parameter["default"]
+            assert parameter["minimum"] <= default <= parameter["maximum"]
+        elif parameter["type"] == "choice":
+            assert default == parameter["default"]
+            assert default in {value["id"] for value in parameter["values"]}
+
+
+def test_label_model_choices_have_installed_weights():
+    helpers = _openrecon_helpers()
+    label = json.loads(LABEL_PATH.read_text())
+    ssmodel = next(p for p in label["parameters"] if p["id"] == "ssmodel")
+
+    choice_ids = {value["id"] for value in ssmodel["values"]}
+    assert choice_ids == set(helpers["SYNTHSEG_MODEL_FILES"])
+    assert choice_ids == set(helpers["OPENRECON_MODEL_VALUES"])
+    assert helpers["OPENRECON_MODEL_DEFAULT"] in choice_ids
+
+
+def test_parameter_matrix_only_emits_runnable_combinations():
+    """SynthSeg-robust forces fast mode, so the matrix must not claim otherwise."""
+    helpers = _openrecon_helpers()
+    combinations = list(helpers["iter_openrecon_parameter_combinations"]())
+
+    assert combinations
+    for name, config in combinations:
+        parameters = config["parameters"]
+        assert parameters["ssoutputname"] == name
+        assert parameters["ssmodel"] in helpers["OPENRECON_MODEL_VALUES"]
+        if parameters["ssmodel"] == "robust":
+            assert parameters["ssfast"] is True
+
+    robust_names = {
+        name
+        for name, config in combinations
+        if config["parameters"]["ssmodel"] == "robust"
+    }
+    assert all("_fast1" in name for name in robust_names)


### PR DESCRIPTION
SynthSeg is a contrast- and resolution-agnostic brain MRI segmentation
network. NeuroDesk had no standalone SynthSeg container, so this adds one
that also runs inline on a Siemens scanner via OpenRecon, following the
musclemap / vesselboost / spinalcordtoolbox pattern.

Packaging: rather than installing all of FreeSurfer (a 9.5 GB download) to
get mri_synthseg, the recipe installs just the subtree the tool resolves
relative to FREESURFER_HOME. The script, label/name/topology arrays and
FreeSurferColorLUT.txt come from the FreeSurfer 8.2.0 source tree; the
trained .h5 weights come from FreeSurfer's public git-annex remote, which
is ~0.6 GB in total. All seven networks are installed (SynthSeg 1.0/2.0,
SynthSeg-robust, parcellation, QC, and both Photo-SynthSeg models).

TensorFlow is pinned to 2.13.1 and numpy to 1.24.3: mri_synthseg 8.2.0
calls BatchNormalization(fused=False), removed in Keras 3, and assigns
size-1 arrays into scalar slots, which errors on numpy 2. Verified
end-to-end against the real networks (default, --parc --qc, --robust and
--v1) with these pins.

OpenRecon wrapper: adapted from the vesselboost handler, which shares the
same 3D-volume-in / label-volume-out contract. SynthSeg-specific changes:

- runs mri_synthseg with --keepgeom, which is mandatory here because
  SynthSeg segments at 1 mm isotropic and the label map has to come back
  on the source MRD slice grid before it can be stamped onto the incoming
  image headers
- returns raw FreeSurfer label indices instead of rescaling to 12 bit, so
  values stay meaningful against FreeSurferColorLUT.txt; only the display
  window is derived from the label range
- validates every required model file before starting inference rather
  than failing part-way through
- exposes model choice, parcellation, fast mode, GPU/threads, region
  volume and QC reporting as scanner parameters

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VWcdoKpEdvGYPDcPVeMQqz