### PR TITLE
Bump pcntoolkit from 0.35 to 1.3.0

### DIFF
--- a/recipes/pcntoolkit/build.yaml
+++ b/recipes/pcntoolkit/build.yaml
@@ -1,67 +1,38 @@
 name: pcntoolkit
-version: '0.35'
+version: 1.3.0
 architectures:
   - x86_64
 structured_readme:
   description: Toolbox for normative modelling and spatial inference of neuroimaging data. https://pcntoolkit.readthedocs.io/en/latest/
   example: |
-    python normative.py -c /path/to/training/covariates -t /path/to/test/covariates -r /path/to/test/response/variables /path/to/my/training/response/variables
+    # PCNtoolkit 1.x uses an object-oriented API.
+    # Note: version 0.x code is NOT compatible with 1.x.
 
+    from pcntoolkit import BLR, NormativeModel, NormData, load_fcon1000
 
-    pcn.normative.estimate(covfile = 'covariate_normsample.txt',
-                           respfile = 'features_normsample.txt',
-                           cvfolds = 2,
-                           alg = 'gpr',
-                           outputsuffix = '_2fold')
+    # Load a dataset and split it into train and test sets
+    data = load_fcon1000()
+    train, test = data.train_test_split()
 
-    from pcntoolkit.normative import estimate, predict
+    # Build a normative model around a Bayesian Linear Regression estimator
+    model = NormativeModel(
+        BLR(heteroskedastic=True),
+        inscaler='standardize',
+        outscaler='standardize',
+        savemodel=True,
+        save_dir='/tmp/pcn_output',
+    )
 
-    # fit a normative model, using training covariates and responses
-    # then apply to test dataset. Saved with file suffix '_estimate'
-    estimate(cov_file_tr, resp_file_tr, testresp=resp_file_te, \
-            testcov=cov_file_te, alg='blr', optimizer = 'powell', \
-            savemodel=True, standardize = False)
+    # Fit on the training set and apply to the test set in one step
+    model.fit_predict(train, test)
 
-    # make predictions on a set of dummy covariates (with no responses)
-    # Saved with file suffix '_predict'
-    yhat, s2 = predict(cov_file_dummy)
-  documentation: https://pcntoolkit.readthedocs.io/en/latest/index.html
+  documentation: https://pcntoolkit.readthedocs.io/en/stable/
   citation: |-
-    If you use the PCNtoolkit, please consider citing some of the following work:
-
-    Marquand, A. F., Wolfers, T., Mennes, M., Buitelaar, J., & Beckmann, C. F. (2016). Beyond Lumping and Splitting: A Review of Computational Approaches for Stratifying Psychiatric Disorders. Biological Psychiatry: Cognitive Neuroscience and Neuroimaging. https://doi.org/10.1016/j.bpsc.2016.04.002
-
-    Marquand, A. F., Rezek, I., Buitelaar, J., & Beckmann, C. F. (2016). Understanding Heterogeneity in Clinical Cohorts Using Normative Models: Beyond Case-Control Studies. Biological Psychiatry. https://doi.org/10.1016/j.biopsych.2015.12.023
-
-    Marquand, A. F., Kia, S. M., Zabihi, M., Wolfers, T., Buitelaar, J. K., & Beckmann, C. F. (2019). Conceptualizing mental disorders as deviations from normative functioning. Molecular Psychiatry. https://doi.org/10.1038/s41380-019-0441-1
-
-    Marquand, A. F., Haak, K. V., & Beckmann, C. F. (2017). Functional corticostriatal connection topographies predict goal directed behaviour in humans. Nature Human Behaviour. https://doi.org/10.1038/s41562-017-0146
-
-    Wolfers, T., Beckmann, C. F., Hoogman, M., Buitelaar, J. K., Franke, B., & Marquand, A. F. (2020). Individual differences v. the average patient: Mapping the heterogeneity in ADHD using normative models. Psychological Medicine. https://doi.org/10.1017/S0033291719000084
-
-    Wolfers, T., Rokicki, J., Alnæs, D., Berthet, P., Agartz, I., Kia, S. M., Kaufmann, T., Zabihi, M., Moberget, T., Melle, I., Beckmann, C. F., Andreassen, O. A., Marquand, A. F., & Westlye, L. T. (n.d.). Replicating extensive brain structural heterogeneity in individuals with schizophrenia and bipolar disorder. Human Brain Mapping. https://doi.org/10.1002/hbm.25386
-
-    Zabihi, M., Floris, D. L., Kia, S. M., Wolfers, T., Tillmann, J., Arenas, A. L., Moessnang, C., Banaschewski, T., Holt, R., Baron-Cohen, S., Loth, E., Charman, T., Bourgeron, T., Murphy, D., Ecker, C., Buitelaar, J. K., Beckmann, C. F., & Marquand, A. (2020). Fractionating autism based on neuroanatomical normative modeling. Translational Psychiatry. https://doi.org/10.1038/s41398-020-01057-0
-
-    Zabihi, M., Oldehinkel, M., Wolfers, T., Frouin, V., Goyard, D., Loth, E., Charman, T., Tillmann, J., Banaschewski, T., Dumas, G., Holt, R., Baron-Cohen, S., Durston, S., Bölte, S., Murphy, D., Ecker, C., Buitelaar, J. K., Beckmann, C. F., & Marquand, A. F. (2019). Dissecting the Heterogeneous Cortical Anatomy of Autism Spectrum Disorder Using Normative Models. Biological Psychiatry: Cognitive Neuroscience and Neuroimaging. https://doi.org/10.1016/j.bpsc.2018.11.013
-
-    Kia, S. M., & Marquand, A. (2018). Normative Modeling of Neuroimaging Data using Scalable Multi-Task Gaussian Processes. ArXiv. https://arxiv.org/abs/1806.01047
-
-    Kia, S. M., Beckmann, C. F., & Marquand, A. F. (2018). Scalable Multi-Task Gaussian Process Tensor Regression for Normative Modeling of Structured Variation in Neuroimaging Data. ArXiv. https://arxiv.org/abs/1808.00036
-
-    Kia, S. M., Huijsdens, H., Dinga, R., Wolfers, T., Mennes, M., Andreassen, O. A., Westlye, L. T., Beckmann, C. F., & Marquand, A. F. (2020). Hierarchical Bayesian Regression for Multi-site Normative Modeling of Neuroimaging Data. In A. L. Martel, P. Abolmaesumi, D. Stoyanov, D. Mateus, M. A. Zuluaga, S. K. Zhou, D. Racoceanu, & L. Joskowicz (Eds.), Medical Image Computing and Computer Assisted Intervention – MICCAI 2020. Springer International Publishing. https://doi.org/10.1007/978-3-030-59728-3_68
-
-    Huertas, I., Oldehinkel, M., van Oort, E. S. B., Garcia-Solis, D., Mir, P., Beckmann, C. F., & Marquand, A. F. (2017). A Bayesian spatial model for neuroimaging data based on biologically informed basis functions. NeuroImage. https://doi.org/10.1016/j.neuroimage.2017.08.009
-
-    Fraza, C. J., Dinga, R., Beckmann, C. F., & Marquand, A. F. (2021). Warped Bayesian Linear Regression for Normative Modelling of Big Data. NeuroImage, https://doi.org/10.1016/j.neuroimage.2021.118715.
-
-    Rutherford, S., Kia, S. M., Wolfers, T., … Beckmann, C. F., & Marquand, A. F. (2022). The Normative Modeling Framework for Computational Psychiatry. Nature Protocols. https://www.nature.com/articles/s41596-022-00696-5.
-
-    Rutherford, S., Fraza, C., … Beckmann, C. F., & Marquand, A. F. (2022). Charting Brain Growth and Aging at High Spatial Precision. eLife. https://elifesciences.org/articles/72904
-
-    de Boer, A., Kia, S., … & Marquand A. F. (2022). Non-Gaussian Normative Modelling With Hierarchical Bayesian Regression. bioRxiv. https://www.biorxiv.org/content/10.1101/2022.10.05.510988v1
-
-    Fraza, C., Zabihi, M., Beckmann, C. F., & Marquand, A. F. (2022). The Extremes of Normative Modelling. bioRxiv. https://www.biorxiv.org/content/10.1101/2022.08.23.505049v1
+    de Boer, A. A. A., Bayer, J. M. M., Fraza, C., Chavanne, A., Buckova, B. R., 
+    Tsilimparis, K., Serin, E., Bernas, A., Cirstian, R., Zabihi, M., Rutherford, S., 
+    Al-Khaledi, A., Wolfers, T., Beckmann, C. F., Kia, S. M., & Marquand, A. F. (2026). 
+    Protocol update: The Normative Modelling Paradigm for Computational Psychiatry. 
+    bioRxiv [Preprint]. https://doi.org/10.64898/2026.02.17.706268.
 build:
   kind: neurodocker
   base-image: ubuntu:24.04
@@ -69,9 +40,9 @@ build:
   directives:
     - template:
         name: miniconda
-        version: py310_25.5.1-0
+        version: py312_25.5.1-0
         install_path: /opt/miniconda
-        pip_install: pcntoolkit
+        pip_install: pcntoolkit=={{ context.version }}
     - deploy:
         path: []
         bins:
@@ -82,76 +53,44 @@ icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAOxElE
 
 readme: |-
   ----------------------------------
-  ## pcntoolkit/0.35 ##
+  ## pcntoolkit/{{ context.version }} ##
 
   Toolbox for normative modelling and spatial inference of neuroimaging data. https://pcntoolkit.readthedocs.io/en/latest/
 
-  Example:
-  ```
-  python normative.py -c /path/to/training/covariates -t /path/to/test/covariates -r /path/to/test/response/variables /path/to/my/training/response/variables
+  PCNtoolkit is an open-source Python package for Normative Modelling of neuroimaging data.
 
+  ## Deprecation warning
 
-  pcn.normative.estimate(covfile = 'covariate_normsample.txt',
-                         respfile = 'features_normsample.txt',
-                         cvfolds = 2,
-                         alg = 'gpr',
-                         outputsuffix = '_2fold')
+  With version 1.X.X (June 2025), PCNtoolkit was rewritten to be object-oriented, making it more extendable and maintainable. As a result, version 0.X.X is not compatible with 1.X.X and is no longer actively maintained.
 
-  from pcntoolkit.normative import estimate, predict
+  ## Installation
 
-  # fit a normative model, using training covariates and responses
-  # then apply to test dataset. Saved with file suffix '_estimate'
-  estimate(cov_file_tr, resp_file_tr, testresp=resp_file_te, \
-          testcov=cov_file_te, alg='blr', optimizer = 'powell', \
-          savemodel=True, standardize = False)
-
-  # make predictions on a set of dummy covariates (with no responses)
-  # Saved with file suffix '_predict'
-  yhat, s2 = predict(cov_file_dummy)
+  ```bash
+  pip install pcntoolkit
   ```
 
-  More documentation can be found here: https://pcntoolkit.readthedocs.io/en/latest/index.html
+  ## Help and support
 
-  Citation:
-  ```
-  If you use the PCNtoolkit, please consider citing some of the following work:
+  ### Users
+  The best place to learn Normative Modelling and the PCNtoolkit is our [website documentation](https://pcntoolkit.readthedocs.io/en/latest/).
 
-  Marquand, A. F., Wolfers, T., Mennes, M., Buitelaar, J., & Beckmann, C. F. (2016). Beyond Lumping and Splitting: A Review of Computational Approaches for Stratifying Psychiatric Disorders. Biological Psychiatry: Cognitive Neuroscience and Neuroimaging. https://doi.org/10.1016/j.bpsc.2016.04.002
+  Feel free to ask your questions and engage in discussions with the community on the [NeuroStars online forum](https://neurostars.org/tags/pcntoolkit). Please add the tag *pcntoolkit* to your post.
 
-  Marquand, A. F., Rezek, I., Buitelaar, J., & Beckmann, C. F. (2016). Understanding Heterogeneity in Clinical Cohorts Using Normative Models: Beyond Case-Control Studies. Biological Psychiatry. https://doi.org/10.1016/j.biopsych.2015.12.023
+  ### Contributors
 
-  Marquand, A. F., Kia, S. M., Zabihi, M., Wolfers, T., Buitelaar, J. K., & Beckmann, C. F. (2019). Conceptualizing mental disorders as deviations from normative functioning. Molecular Psychiatry. https://doi.org/10.1038/s41380-019-0441-1
+  Contributions are always welcome! To start see our [website contributing guidelines](https://pcntoolkit.readthedocs.io/en/stable/pages/contributing.html).
 
-  Marquand, A. F., Haak, K. V., & Beckmann, C. F. (2017). Functional corticostriatal connection topographies predict goal directed behaviour in humans. Nature Human Behaviour. https://doi.org/10.1038/s41562-017-0146
+  You can find more in depth guidelines in our [GitHub Wiki](https://github.com/predictive-clinical-neuroscience/PCNtoolkit/wiki).
 
-  Wolfers, T., Beckmann, C. F., Hoogman, M., Buitelaar, J. K., Franke, B., & Marquand, A. F. (2020). Individual differences v. the average patient: Mapping the heterogeneity in ADHD using normative models. Psychological Medicine. https://doi.org/10.1017/S0033291719000084
+  ## Funding
 
-  Wolfers, T., Rokicki, J., Alnæs, D., Berthet, P., Agartz, I., Kia, S. M., Kaufmann, T., Zabihi, M., Moberget, T., Melle, I., Beckmann, C. F., Andreassen, O. A., Marquand, A. F., & Westlye, L. T. (n.d.). Replicating extensive brain structural heterogeneity in individuals with schizophrenia and bipolar disorder. Human Brain Mapping. https://doi.org/10.1002/hbm.25386
+  This software has received funding from the:
+  - Wellcome Trust (Digital Innovator award 'BRAINCHART', 215698/Z/19/Z),
+  - European Research Council (ERC grant 'MENTALPRECISION', 101001118),
+  - Dutch Research Council (NWO VIDI grants 016.156.415, 864.12.003 and NWO Gravitation grant 024.001.006),
+  - Dutch Sectorplan 'AI and data-driven Innovation'.
 
-  Zabihi, M., Floris, D. L., Kia, S. M., Wolfers, T., Tillmann, J., Arenas, A. L., Moessnang, C., Banaschewski, T., Holt, R., Baron-Cohen, S., Loth, E., Charman, T., Bourgeron, T., Murphy, D., Ecker, C., Buitelaar, J. K., Beckmann, C. F., & Marquand, A. (2020). Fractionating autism based on neuroanatomical normative modeling. Translational Psychiatry. https://doi.org/10.1038/s41398-020-01057-0
-
-  Zabihi, M., Oldehinkel, M., Wolfers, T., Frouin, V., Goyard, D., Loth, E., Charman, T., Tillmann, J., Banaschewski, T., Dumas, G., Holt, R., Baron-Cohen, S., Durston, S., Bölte, S., Murphy, D., Ecker, C., Buitelaar, J. K., Beckmann, C. F., & Marquand, A. F. (2019). Dissecting the Heterogeneous Cortical Anatomy of Autism Spectrum Disorder Using Normative Models. Biological Psychiatry: Cognitive Neuroscience and Neuroimaging. https://doi.org/10.1016/j.bpsc.2018.11.013
-
-  Kia, S. M., & Marquand, A. (2018). Normative Modeling of Neuroimaging Data using Scalable Multi-Task Gaussian Processes. ArXiv. https://arxiv.org/abs/1806.01047
-
-  Kia, S. M., Beckmann, C. F., & Marquand, A. F. (2018). Scalable Multi-Task Gaussian Process Tensor Regression for Normative Modeling of Structured Variation in Neuroimaging Data. ArXiv. https://arxiv.org/abs/1808.00036
-
-  Kia, S. M., Huijsdens, H., Dinga, R., Wolfers, T., Mennes, M., Andreassen, O. A., Westlye, L. T., Beckmann, C. F., & Marquand, A. F. (2020). Hierarchical Bayesian Regression for Multi-site Normative Modeling of Neuroimaging Data. In A. L. Martel, P. Abolmaesumi, D. Stoyanov, D. Mateus, M. A. Zuluaga, S. K. Zhou, D. Racoceanu, & L. Joskowicz (Eds.), Medical Image Computing and Computer Assisted Intervention – MICCAI 2020. Springer International Publishing. https://doi.org/10.1007/978-3-030-59728-3_68
-
-  Huertas, I., Oldehinkel, M., van Oort, E. S. B., Garcia-Solis, D., Mir, P., Beckmann, C. F., & Marquand, A. F. (2017). A Bayesian spatial model for neuroimaging data based on biologically informed basis functions. NeuroImage. https://doi.org/10.1016/j.neuroimage.2017.08.009
-
-  Fraza, C. J., Dinga, R., Beckmann, C. F., & Marquand, A. F. (2021). Warped Bayesian Linear Regression for Normative Modelling of Big Data. NeuroImage, https://doi.org/10.1016/j.neuroimage.2021.118715.
-
-  Rutherford, S., Kia, S. M., Wolfers, T., … Beckmann, C. F., & Marquand, A. F. (2022). The Normative Modeling Framework for Computational Psychiatry. Nature Protocols. https://www.nature.com/articles/s41596-022-00696-5.
-
-  Rutherford, S., Fraza, C., … Beckmann, C. F., & Marquand, A. F. (2022). Charting Brain Growth and Aging at High Spatial Precision. eLife. https://elifesciences.org/articles/72904
-
-  de Boer, A., Kia, S., … & Marquand A. F. (2022). Non-Gaussian Normative Modelling With Hierarchical Bayesian Regression. bioRxiv. https://www.biorxiv.org/content/10.1101/2022.10.05.510988v1
-
-  Fraza, C., Zabihi, M., Beckmann, C. F., & Marquand, A. F. (2022). The Extremes of Normative Modelling. bioRxiv. https://www.biorxiv.org/content/10.1101/2022.08.23.505049v1
-  ```
-
-  To run container outside of this environment: ml pcntoolkit/0.35
+  To run container outside of this environment: ml pcntoolkit/{{ context.version }}
 
   ----------------------------------
 copyright:

--- a/recipes/pcntoolkit/fulltest.yaml
+++ b/recipes/pcntoolkit/fulltest.yaml
@@ -1,12 +1,14 @@
 # pcntoolkit container test suite
-# Tests for PCNtoolkit v0.35 - Predictive Clinical Neuroscience toolkit
-# for normative modeling and spatial inference of neuroimaging data
+# Tests for PCNtoolkit v1.3.0
+#
+# NOTE: PCNtoolkit 1.x is an object-oriented rewrite and is NOT API-compatible
+# with 0.x. These tests target the 1.x public API exported from pcntoolkit/__init__.py
 #
 # Documentation: https://pcntoolkit.readthedocs.io/en/latest/
 
 name: pcntoolkit
-version: "0.35"
-container: pcntoolkit_0.35_20250628.simg
+version: "1.3.0"
+container: pcntoolkit_1.3.0_REFERENCE.simg
 
 test_data:
   output_dir: test_output
@@ -19,833 +21,172 @@ setup:
 
 tests:
   # ==========================================================================
-  # CORE MODULE IMPORTS
+  # PACKAGE METADATA
   # ==========================================================================
-  - name: Import pcntoolkit main module
-    description: Verify pcntoolkit package can be imported
-    command: python -c "import pcntoolkit; print('pcntoolkit imported successfully')"
-    expected_output_contains: "pcntoolkit imported successfully"
+  - name: Import pcntoolkit and check version
+    description: Verify the package imports and reports the expected version
+    command: python -c "import pcntoolkit; print(f'pcntoolkit {pcntoolkit.__version__}')"
+    expected_output_contains: "pcntoolkit 1.3.0"
     expected_exit_code: 0
 
-  - name: Import normative module
-    description: Verify normative modeling module loads
-    command: python -c "from pcntoolkit import normative; print('normative module loaded')"
-    expected_output_contains: "normative module loaded"
+  - name: Verify Python version constraint
+    description: pcntoolkit 1.3.0 requires Python >=3.11,<3.13
+    command: |
+      python -c "
+      import sys
+      print(f'python {sys.version_info.major}.{sys.version_info.minor}')
+      assert (3, 11) <= sys.version_info[:2] < (3, 13), 'unsupported python for pcntoolkit 1.3.0'
+      print('python version constraint satisfied')
+      "
+    expected_output_contains: "python version constraint satisfied"
     expected_exit_code: 0
 
-  - name: Import util module
-    description: Verify utility module loads
-    command: python -c "from pcntoolkit import util; print('util module loaded')"
-    expected_output_contains: "util module loaded"
-    expected_exit_code: 0
-
-  - name: Import dataio module
-    description: Verify data I/O module loads
-    command: python -c "from pcntoolkit import dataio; print('dataio module loaded')"
-    expected_output_contains: "dataio module loaded"
-    expected_exit_code: 0
-
-  - name: Import model module
-    description: Verify model module loads
-    command: python -c "from pcntoolkit import model; print('model module loaded')"
-    expected_output_contains: "model module loaded"
-    expected_exit_code: 0
-
-  - name: Import trendsurf module
-    description: Verify trend surface module loads
-    command: python -c "from pcntoolkit import trendsurf; print('trendsurf module loaded')"
-    expected_output_contains: "trendsurf module loaded"
-    expected_exit_code: 0
-
-  - name: Import normative_model module
-    description: Verify normative model module loads
-    command: python -c "from pcntoolkit import normative_model; print('normative_model module loaded')"
-    expected_output_contains: "normative_model module loaded"
-    expected_exit_code: 0
-
-  - name: Import configs module
-    description: Verify configs module loads
-    command: python -c "from pcntoolkit import configs; print('configs module loaded')"
-    expected_output_contains: "configs module loaded"
+  # ==========================================================================
+  # PUBLIC API SURFACE
+  # ==========================================================================
+  - name: Import top-level public API
+    description: Verify all names in pcntoolkit.__all__ are importable
+    command: |
+      python -c "
+      import pcntoolkit
+      missing = [n for n in pcntoolkit.__all__ if not hasattr(pcntoolkit, n)]
+      assert not missing, f'missing exports: {missing}'
+      print(f'all {len(pcntoolkit.__all__)} public exports available')
+      "
+    expected_output_contains: "public exports available"
     expected_exit_code: 0
 
   # ==========================================================================
   # DEPENDENCY PACKAGE IMPORTS
   # ==========================================================================
-  - name: Import numpy
-    description: Verify numpy is available
-    command: python -c "import numpy as np; print(f'numpy {np.__version__}')"
-    expected_output_contains: "numpy"
-    expected_exit_code: 0
-
-  - name: Import scipy
-    description: Verify scipy is available
-    command: python -c "import scipy; print(f'scipy {scipy.__version__}')"
-    expected_output_contains: "scipy"
-    expected_exit_code: 0
-
-  - name: Import pandas
-    description: Verify pandas is available
-    command: python -c "import pandas as pd; print(f'pandas {pd.__version__}')"
-    expected_output_contains: "pandas"
-    expected_exit_code: 0
-
-  - name: Import nibabel
-    description: Verify nibabel is available for neuroimaging I/O
-    command: python -c "import nibabel as nib; print(f'nibabel {nib.__version__}')"
-    expected_output_contains: "nibabel"
-    expected_exit_code: 0
-
-  - name: Import sklearn
-    description: Verify scikit-learn is available
-    command: python -c "import sklearn; print(f'sklearn {sklearn.__version__}')"
-    expected_output_contains: "sklearn"
-    expected_exit_code: 0
-
-  - name: Import pymc
-    description: Verify PyMC is available for Bayesian modeling
-    command: python -c "import pymc; print(f'pymc {pymc.__version__}')"
-    expected_output_contains: "pymc"
-    expected_exit_code: 0
-
-  - name: Import arviz
-    description: Verify ArviZ is available for Bayesian diagnostics
-    command: python -c "import arviz; print(f'arviz {arviz.__version__}')"
-    expected_output_contains: "arviz"
-    expected_exit_code: 0
-
-  - name: Import torch
-    description: Verify PyTorch is available
-    command: python -c "import torch; print(f'torch {torch.__version__}')"
-    expected_output_contains: "torch"
-    expected_exit_code: 0
-
-  - name: Import xarray
-    description: Verify xarray is available
-    command: python -c "import xarray; print(f'xarray {xarray.__version__}')"
-    expected_output_contains: "xarray"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # NORMATIVE MODELING FUNCTION IMPORTS
-  # ==========================================================================
-  - name: Import normative.estimate
-    description: Verify normative estimate function can be imported
-    command: python -c "from pcntoolkit.normative import estimate; print('estimate function imported')"
-    expected_output_contains: "estimate function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.predict
-    description: Verify normative predict function can be imported
-    command: python -c "from pcntoolkit.normative import predict; print('predict function imported')"
-    expected_output_contains: "predict function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.transfer
-    description: Verify normative transfer function can be imported
-    command: python -c "from pcntoolkit.normative import transfer; print('transfer function imported')"
-    expected_output_contains: "transfer function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.evaluate
-    description: Verify normative evaluate function can be imported
-    command: python -c "from pcntoolkit.normative import evaluate; print('evaluate function imported')"
-    expected_output_contains: "evaluate function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.fit
-    description: Verify normative fit function can be imported
-    command: python -c "from pcntoolkit.normative import fit; print('fit function imported')"
-    expected_output_contains: "fit function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.merge
-    description: Verify normative merge function can be imported
-    command: python -c "from pcntoolkit.normative import merge; print('merge function imported')"
-    expected_output_contains: "merge function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.extend
-    description: Verify normative extend function can be imported
-    command: python -c "from pcntoolkit.normative import extend; print('extend function imported')"
-    expected_output_contains: "extend function imported"
-    expected_exit_code: 0
-
-  - name: Import normative.tune
-    description: Verify normative tune function can be imported
-    command: python -c "from pcntoolkit.normative import tune; print('tune function imported')"
-    expected_output_contains: "tune function imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # NORMATIVE MODEL CLASSES
-  # ==========================================================================
-  - name: Import NormBLR class
-    description: Verify Bayesian Linear Regression normative model class
-    command: python -c "from pcntoolkit.normative_model.norm_blr import NormBLR; print('NormBLR class imported')"
-    expected_output_contains: "NormBLR class imported"
-    expected_exit_code: 0
-
-  - name: Import NormGPR class
-    description: Verify Gaussian Process Regression normative model class
-    command: python -c "from pcntoolkit.normative_model.norm_gpr import NormGPR; print('NormGPR class imported')"
-    expected_output_contains: "NormGPR class imported"
-    expected_exit_code: 0
-
-  - name: Import NormHBR class
-    description: Verify Hierarchical Bayesian Regression normative model class
-    command: python -c "from pcntoolkit.normative_model.norm_hbr import NormHBR; print('NormHBR class imported')"
-    expected_output_contains: "NormHBR class imported"
-    expected_exit_code: 0
-
-  - name: Import NormRFA class
-    description: Verify Random Feature Approximation normative model class
-    command: python -c "from pcntoolkit.normative_model.norm_rfa import NormRFA; print('NormRFA class imported')"
-    expected_output_contains: "NormRFA class imported"
-    expected_exit_code: 0
-
-  - name: Import NormBase class
-    description: Verify base normative model class
-    command: python -c "from pcntoolkit.normative_model.norm_base import NormBase; print('NormBase class imported')"
-    expected_output_contains: "NormBase class imported"
-    expected_exit_code: 0
-
-  - name: Import norm_init function
-    description: Verify normative model initialization function
-    command: python -c "from pcntoolkit.normative_model.norm_utils import norm_init; print('norm_init imported')"
-    expected_output_contains: "norm_init imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # MODEL CLASSES (LOW-LEVEL)
-  # ==========================================================================
-  - name: Import BLR class
-    description: Verify Bayesian Linear Regression model class
-    command: python -c "from pcntoolkit.model.bayesreg import BLR; print('BLR class imported')"
-    expected_output_contains: "BLR class imported"
-    expected_exit_code: 0
-
-  - name: Import GPR class
-    description: Verify Gaussian Process Regression model class
-    command: python -c "from pcntoolkit.model.gp import GPR; print('GPR class imported')"
-    expected_output_contains: "GPR class imported"
-    expected_exit_code: 0
-
-  - name: Import covariance functions
-    description: Verify GP covariance function classes
-    command: python -c "from pcntoolkit.model.gp import CovSqExp, CovLin, CovSqExpARD, CovSum; print('Covariance classes imported')"
-    expected_output_contains: "Covariance classes imported"
-    expected_exit_code: 0
-
-  - name: Import HBR class
-    description: Verify Hierarchical Bayesian Regression model class
-    command: python -c "from pcntoolkit.model.hbr import HBR; print('HBR class imported')"
-    expected_output_contains: "HBR class imported"
-    expected_exit_code: 0
-
-  - name: Import GPRRFA class
-    description: Verify GP Random Feature Approximation model class
-    command: python -c "from pcntoolkit.model.rfa import GPRRFA; print('GPRRFA class imported')"
-    expected_output_contains: "GPRRFA class imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # UTILITY FUNCTIONS
-  # ==========================================================================
-  - name: Import create_bspline_basis
-    description: Verify B-spline basis creation function
-    command: python -c "from pcntoolkit.util.utils import create_bspline_basis; print('create_bspline_basis imported')"
-    expected_output_contains: "create_bspline_basis imported"
-    expected_exit_code: 0
-
-  - name: Import create_design_matrix
-    description: Verify design matrix creation function
-    command: python -c "from pcntoolkit.util.utils import create_design_matrix; print('create_design_matrix imported')"
-    expected_output_contains: "create_design_matrix imported"
-    expected_exit_code: 0
-
-  - name: Import create_poly_basis
-    description: Verify polynomial basis creation function
-    command: python -c "from pcntoolkit.util.utils import create_poly_basis; print('create_poly_basis imported')"
-    expected_output_contains: "create_poly_basis imported"
-    expected_exit_code: 0
-
-  - name: Import z_score function
-    description: Verify z-score computation function
-    command: python -c "from pcntoolkit.util.utils import z_score; print('z_score imported')"
-    expected_output_contains: "z_score imported"
-    expected_exit_code: 0
-
-  - name: Import compute_MSLL function
-    description: Verify MSLL computation function
-    command: python -c "from pcntoolkit.util.utils import compute_MSLL; print('compute_MSLL imported')"
-    expected_output_contains: "compute_MSLL imported"
-    expected_exit_code: 0
-
-  - name: Import compute_pearsonr function
-    description: Verify Pearson correlation function
-    command: python -c "from pcntoolkit.util.utils import compute_pearsonr; print('compute_pearsonr imported')"
-    expected_output_contains: "compute_pearsonr imported"
-    expected_exit_code: 0
-
-  - name: Import explained_var function
-    description: Verify explained variance function
-    command: python -c "from pcntoolkit.util.utils import explained_var; print('explained_var imported')"
-    expected_output_contains: "explained_var imported"
-    expected_exit_code: 0
-
-  - name: Import scaler function
-    description: Verify scaler utility function
-    command: python -c "from pcntoolkit.util.utils import scaler; print('scaler imported')"
-    expected_output_contains: "scaler imported"
-    expected_exit_code: 0
-
-  - name: Import simulate_data function
-    description: Verify data simulation function
-    command: python -c "from pcntoolkit.util.utils import simulate_data; print('simulate_data imported')"
-    expected_output_contains: "simulate_data imported"
-    expected_exit_code: 0
-
-  - name: Import calibration_error function
-    description: Verify calibration error function
-    command: python -c "from pcntoolkit.util.utils import calibration_error; print('calibration_error imported')"
-    expected_output_contains: "calibration_error imported"
-    expected_exit_code: 0
-
-  - name: Import FDR function
-    description: Verify false discovery rate function
-    command: python -c "from pcntoolkit.util.utils import FDR; print('FDR imported')"
-    expected_output_contains: "FDR imported"
-    expected_exit_code: 0
-
-  - name: Import squared_dist function
-    description: Verify squared distance function
-    command: python -c "from pcntoolkit.util.utils import squared_dist; print('squared_dist imported')"
-    expected_output_contains: "squared_dist imported"
-    expected_exit_code: 0
-
-  - name: Import Welford class
-    description: Verify Welford online statistics class
-    command: python -c "from pcntoolkit.util.utils import Welford; print('Welford class imported')"
-    expected_output_contains: "Welford class imported"
-    expected_exit_code: 0
-
-  - name: Import CustomCV class
-    description: Verify custom cross-validation class
-    command: python -c "from pcntoolkit.util.utils import CustomCV; print('CustomCV class imported')"
-    expected_output_contains: "CustomCV class imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # WARP TRANSFORMATION CLASSES
-  # ==========================================================================
-  - name: Import WarpBoxCox
-    description: Verify Box-Cox warp transformation class
-    command: python -c "from pcntoolkit.util.utils import WarpBoxCox; print('WarpBoxCox imported')"
-    expected_output_contains: "WarpBoxCox imported"
-    expected_exit_code: 0
-
-  - name: Import WarpSinArcsinh
-    description: Verify Sin-Arcsinh warp transformation class
-    command: python -c "from pcntoolkit.util.utils import WarpSinArcsinh; print('WarpSinArcsinh imported')"
-    expected_output_contains: "WarpSinArcsinh imported"
-    expected_exit_code: 0
-
-  - name: Import WarpCompose
-    description: Verify composed warp transformation class
-    command: python -c "from pcntoolkit.util.utils import WarpCompose; print('WarpCompose imported')"
-    expected_output_contains: "WarpCompose imported"
-    expected_exit_code: 0
-
-  - name: Import WarpAffine
-    description: Verify affine warp transformation class
-    command: python -c "from pcntoolkit.util.utils import WarpAffine; print('WarpAffine imported')"
-    expected_output_contains: "WarpAffine imported"
-    expected_exit_code: 0
-
-  - name: Import WarpLog
-    description: Verify log warp transformation class
-    command: python -c "from pcntoolkit.util.utils import WarpLog; print('WarpLog imported')"
-    expected_output_contains: "WarpLog imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # BSPLINE MODULE
-  # ==========================================================================
-  - name: Import BSpline class
-    description: Verify B-spline class
-    command: python -c "from pcntoolkit.util.bspline import BSpline; print('BSpline class imported')"
-    expected_output_contains: "BSpline class imported"
-    expected_exit_code: 0
-
-  - name: Import BSplineBasis class
-    description: Verify B-spline basis class
-    command: python -c "from pcntoolkit.util.bspline import BSplineBasis; print('BSplineBasis class imported')"
-    expected_output_contains: "BSplineBasis class imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FILE I/O FUNCTIONS
-  # ==========================================================================
-  - name: Import fileio.load
-    description: Verify generic load function
-    command: python -c "from pcntoolkit.dataio.fileio import load; print('fileio.load imported')"
-    expected_output_contains: "fileio.load imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.save
-    description: Verify generic save function
-    command: python -c "from pcntoolkit.dataio.fileio import save; print('fileio.save imported')"
-    expected_output_contains: "fileio.save imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.load_nifti
-    description: Verify NIfTI load function
-    command: python -c "from pcntoolkit.dataio.fileio import load_nifti; print('load_nifti imported')"
-    expected_output_contains: "load_nifti imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.save_nifti
-    description: Verify NIfTI save function
-    command: python -c "from pcntoolkit.dataio.fileio import save_nifti; print('save_nifti imported')"
-    expected_output_contains: "save_nifti imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.load_ascii
-    description: Verify ASCII load function
-    command: python -c "from pcntoolkit.dataio.fileio import load_ascii; print('load_ascii imported')"
-    expected_output_contains: "load_ascii imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.save_ascii
-    description: Verify ASCII save function
-    command: python -c "from pcntoolkit.dataio.fileio import save_ascii; print('save_ascii imported')"
-    expected_output_contains: "save_ascii imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.load_cifti
-    description: Verify CIFTI load function
-    command: python -c "from pcntoolkit.dataio.fileio import load_cifti; print('load_cifti imported')"
-    expected_output_contains: "load_cifti imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.save_cifti
-    description: Verify CIFTI save function
-    command: python -c "from pcntoolkit.dataio.fileio import save_cifti; print('save_cifti imported')"
-    expected_output_contains: "save_cifti imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.create_mask
-    description: Verify mask creation function
-    command: python -c "from pcntoolkit.dataio.fileio import create_mask; print('create_mask imported')"
-    expected_output_contains: "create_mask imported"
-    expected_exit_code: 0
-
-  - name: Import fileio.vol2vec
-    description: Verify volume to vector conversion function
-    command: python -c "from pcntoolkit.dataio.fileio import vol2vec; print('vol2vec imported')"
-    expected_output_contains: "vol2vec imported"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - UTILITY COMPUTATIONS
-  # ==========================================================================
-  - name: Test create_bspline_basis function
-    description: Create B-spline basis and verify output shape
+  - name: Import scientific stack
+    description: Verify numpy, scipy, pandas and xarray are available
     command: |
       python -c "
-      from pcntoolkit.util.utils import create_bspline_basis
-      import numpy as np
-      B = create_bspline_basis(0, 100, p=3, nknots=5)
-      print(f'B-spline basis created, type: {type(B).__name__}')
+      import numpy, scipy, pandas, xarray
+      print(f'numpy {numpy.__version__} scipy {scipy.__version__} pandas {pandas.__version__} xarray {xarray.__version__}')
+      print('scientific stack available')
       "
-    expected_output_contains: "B-spline basis created"
+    expected_output_contains: "scientific stack available"
     expected_exit_code: 0
 
-  - name: Test create_poly_basis function
-    description: Create polynomial basis and verify output shape
+  - name: Import Bayesian modelling stack
+    description: Verify pymc, pytensor, arviz and nutpie are available for HBR
     command: |
       python -c "
-      from pcntoolkit.util.utils import create_poly_basis
-      import numpy as np
-      X = np.linspace(0, 100, 50).reshape(-1, 1)
-      Phi = create_poly_basis(X, 3)
-      print(f'Polynomial basis shape: {Phi.shape}')
-      assert Phi.shape == (50, 3), 'Unexpected shape'
-      print('create_poly_basis test passed')
+      import pymc, pytensor, arviz, nutpie
+      print(f'pymc {pymc.__version__} pytensor {pytensor.__version__} arviz {arviz.__version__}')
+      print('bayesian stack available')
       "
-    expected_output_contains: "create_poly_basis test passed"
+    expected_output_contains: "bayesian stack available"
     expected_exit_code: 0
 
-  - name: Test squared_dist function
-    description: Compute squared distances between vectors
+  - name: Import supporting libraries
+    description: Verify nibabel, sklearn, matplotlib, seaborn and dask are available
     command: |
       python -c "
-      from pcntoolkit.util.utils import squared_dist
-      import numpy as np
-      X = np.array([[0, 0], [1, 0], [0, 1]])
-      D = squared_dist(X)
-      print(f'Squared distance matrix shape: {D.shape}')
-      assert D.shape == (3, 3), 'Unexpected shape'
-      assert D[0, 0] == 0, 'Diagonal should be 0'
-      print('squared_dist test passed')
+      import nibabel, sklearn, matplotlib, seaborn, dask
+      print(f'nibabel {nibabel.__version__} sklearn {sklearn.__version__}')
+      print('supporting libraries available')
       "
-    expected_output_contains: "squared_dist test passed"
+    expected_output_contains: "supporting libraries available"
     expected_exit_code: 0
 
-  - name: Test explained_var function
-    description: Compute explained variance
+  # ==========================================================================
+  # FUNCTIONAL TESTS - DATA HANDLING
+  # ==========================================================================
+  - name: Test NormData.from_ndarrays and train_test_split
+    description: Build a NormData object from arrays and split it
     command: |
       python -c "
       import numpy as np
-      from pcntoolkit.util.utils import explained_var
-      ytrue = np.array([1, 2, 3, 4, 5]).reshape(-1, 1)
-      ypred = np.array([1, 2, 3, 4, 5]).reshape(-1, 1)
-      ev = explained_var(ytrue, ypred)
-      print(f'Explained variance: {ev[0]:.4f}')
-      assert ev[0] == 1.0, 'Perfect prediction expected'
-      print('explained_var test passed')
+      from pcntoolkit import NormData
+      rng = np.random.default_rng(42)
+      X = rng.normal(size=(100, 1))
+      Y = X[:, :1] * 2.0 + rng.normal(size=(100, 1)) * 0.1
+      be = np.zeros((100, 1), dtype=int)
+      data = NormData.from_ndarrays('synthetic', X, Y, batch_effects=be)
+      train, test = data.train_test_split()
+      print(f'train subjects: {train.subjects.size}, test subjects: {test.subjects.size}')
+      assert train.subjects.size + test.subjects.size == 100, 'split lost subjects'
+      print('NormData split test passed')
       "
-    expected_output_contains: "explained_var test passed"
+    expected_output_contains: "NormData split test passed"
     expected_exit_code: 0
 
-  - name: Test scaler function creation
-    description: Create scaler objects for data normalization
+  - name: Test NormData.from_dataframe
+    description: Build a NormData object from a pandas DataFrame
     command: |
       python -c "
-      from pcntoolkit.util.utils import scaler
-      s = scaler(scaler_type='standardize')
-      print(f'Scaler created: {type(s).__name__}')
-      print('scaler test passed')
+      import numpy as np, pandas as pd
+      from pcntoolkit import NormData
+      rng = np.random.default_rng(0)
+      df = pd.DataFrame({
+          'age': rng.uniform(20, 80, 50),
+          'site': ['a'] * 25 + ['b'] * 25,
+          'thickness': rng.normal(size=50),
+      })
+      data = NormData.from_dataframe('df_data', df, covariates=['age'],
+                                     batch_effects=['site'], response_vars=['thickness'])
+      print(f'covariates: {list(data.covariate.values)}')
+      print('NormData from_dataframe test passed')
       "
-    expected_output_contains: "scaler test passed"
-    expected_exit_code: 0
-
-  - name: Test Welford online statistics
-    description: Test Welford algorithm for online mean/variance
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import Welford
-      w = Welford()
-      for x in [1, 2, 3, 4, 5]:
-          w.update(x)
-      mean = w.mean
-      std = w.std
-      print(f'Online mean: {mean}, std: {std}')
-      assert abs(mean - 3.0) < 0.001, 'Mean should be 3'
-      print('Welford test passed')
-      "
-    expected_output_contains: "Welford test passed"
-    expected_exit_code: 0
-
-  - name: Test simulate_data function
-    description: Generate simulated data for testing
-    command: |
-      python -c "
-      from pcntoolkit.util.utils import simulate_data
-      result = simulate_data(method='linear', n_samples=100, n_features=2, random_state=42)
-      X = result[0]  # covariates
-      Y = result[1]  # response
-      print(f'Simulated X shape: {X.shape}, Y shape: {Y.shape}')
-      assert X.shape == (100, 2), 'X shape mismatch'
-      assert Y.shape[0] == 100, 'Y shape mismatch'
-      print('simulate_data test passed')
-      "
-    expected_output_contains: "simulate_data test passed"
+    expected_output_contains: "NormData from_dataframe test passed"
     expected_exit_code: 0
 
   # ==========================================================================
-  # FUNCTIONAL TESTS - WARP TRANSFORMATIONS
+  # FUNCTIONAL TESTS - MODEL CONSTRUCTION
   # ==========================================================================
-  - name: Test WarpBoxCox transformation
-    description: Apply Box-Cox warp transformation
+  - name: Test BLR and NormativeModel construction
+    description: Instantiate a normative model wrapping a BLR estimator
     command: |
       python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import WarpBoxCox
-      warp = WarpBoxCox()
-      x = np.array([1, 2, 3, 4, 5]).astype(float)
-      y = warp.f(x, np.array([0.5]))
-      print(f'Box-Cox transformed: {y[:3]}')
-      print('WarpBoxCox test passed')
+      from pcntoolkit import BLR, NormativeModel
+      model = NormativeModel(BLR(heteroskedastic=True),
+                             inscaler='standardize', outscaler='standardize')
+      print(f'model created: {type(model).__name__}')
+      print('NormativeModel BLR construction test passed')
       "
-    expected_output_contains: "WarpBoxCox test passed"
+    expected_output_contains: "NormativeModel BLR construction test passed"
     expected_exit_code: 0
 
-  - name: Test WarpSinArcsinh transformation
-    description: Apply Sin-Arcsinh warp transformation
+  - name: Test HBR construction
+    description: Instantiate a normative model wrapping an HBR estimator
+    command: |
+      python -c "
+      from pcntoolkit import HBR, NormativeModel
+      model = NormativeModel(HBR())
+      print(f'model created: {type(model).__name__}')
+      print('NormativeModel HBR construction test passed')
+      "
+    expected_output_contains: "NormativeModel HBR construction test passed"
+    expected_exit_code: 0
+
+  # ==========================================================================
+  # INTEGRATION TEST - FIT AND PREDICT
+  # ==========================================================================
+  - name: Test end-to-end BLR fit_predict workflow
+    description: Fit a BLR normative model on synthetic data and predict on a test split
     command: |
       python -c "
       import numpy as np
-      from pcntoolkit.util.utils import WarpSinArcsinh
-      warp = WarpSinArcsinh()
-      x = np.array([0, 1, 2, -1, -2]).astype(float)
-      y = warp.f(x, np.array([0.0, 1.0]))
-      print(f'Sin-Arcsinh transformed shape: {y.shape}')
-      print('WarpSinArcsinh test passed')
-      "
-    expected_output_contains: "WarpSinArcsinh test passed"
-    expected_exit_code: 0
-
-  - name: Test WarpAffine transformation
-    description: Apply affine warp transformation
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import WarpAffine
-      warp = WarpAffine()
-      x = np.array([1, 2, 3, 4, 5]).astype(float)
-      y = warp.f(x, np.array([2.0, 1.0]))  # scale=2, shift=1
-      print(f'Affine transformed: {y[:3]}')
-      print('WarpAffine test passed')
-      "
-    expected_output_contains: "WarpAffine test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - BSPLINE
-  # ==========================================================================
-  - name: Test BSplineBasis fit and transform
-    description: Fit and transform using B-spline basis
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.bspline import BSplineBasis
-      X = np.linspace(0, 10, 100).reshape(-1, 1)
-      bs = BSplineBasis(order=3, nknots=5)
-      bs.fit(X)
-      Xt = bs.transform(X)
-      print(f'B-spline transformed shape: {Xt.shape}')
-      assert Xt.shape[0] == 100, 'Row count mismatch'
-      print('BSplineBasis test passed')
-      "
-    expected_output_contains: "BSplineBasis test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - BAYESIAN LINEAR REGRESSION
-  # ==========================================================================
-  - name: Test BLR model creation
-    description: Create Bayesian Linear Regression model instance
-    command: |
-      python -c "
-      from pcntoolkit.model.bayesreg import BLR
-      blr = BLR()
-      print(f'BLR model created: {type(blr).__name__}')
-      print('BLR creation test passed')
-      "
-    expected_output_contains: "BLR creation test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - GAUSSIAN PROCESS REGRESSION
-  # ==========================================================================
-  - name: Test GPR model creation
-    description: Create Gaussian Process Regression model instance
-    command: |
-      python -c "
-      from pcntoolkit.model.gp import GPR, CovSqExp
-      gpr = GPR()
-      print(f'GPR model created: {type(gpr).__name__}')
-      print('GPR creation test passed')
-      "
-    expected_output_contains: "GPR creation test passed"
-    expected_exit_code: 0
-
-  - name: Test CovSqExp covariance function
-    description: Test squared exponential covariance function
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.model.gp import CovSqExp
-      cov = CovSqExp()
-      X = np.random.randn(10, 2)
-      hyp = np.array([0.0, 0.0])  # log length scale, log signal variance
-      K = cov.cov(hyp, X)
-      print(f'Covariance matrix shape: {K.shape}')
-      assert K.shape == (10, 10), 'Shape mismatch'
-      print('CovSqExp test passed')
-      "
-    expected_output_contains: "CovSqExp test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - NORMATIVE MODEL CLASSES
-  # ==========================================================================
-  # ==========================================================================
-  # FUNCTIONAL TESTS - EVALUATION METRICS
-  # ==========================================================================
-  - name: Test normative.evaluate function
-    description: Evaluate normative model predictions
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.normative import evaluate
-      np.random.seed(42)
-      Y = np.random.randn(100, 5)
-      Yhat = Y + np.random.randn(100, 5) * 0.1
-      S2 = np.ones((100, 5)) * 0.01
-      results = evaluate(Y, Yhat, S2)
-      print(f'Evaluation results keys: {list(results.keys())}')
-      print('evaluate function test passed')
-      "
-    expected_output_contains: "evaluate function test passed"
-    expected_exit_code: 0
-
-  - name: Test compute_MSLL function
-    description: Compute Mean Standardized Log Loss
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import compute_MSLL
-      np.random.seed(42)
-      ytrue = np.random.randn(100, 1)
-      ypred = ytrue + np.random.randn(100, 1) * 0.1
-      ypred_var = np.ones((100, 1)) * 0.01
-      msll = compute_MSLL(ytrue, ypred, ypred_var)
-      print(f'MSLL: {msll[0]:.4f}')
-      print('compute_MSLL test passed')
-      "
-    expected_output_contains: "compute_MSLL test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - DATA I/O
-  # ==========================================================================
-  - name: Test save and load ASCII
-    description: Save and load data in ASCII format
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.dataio.fileio import save_ascii, load_ascii
-      data = np.random.randn(10, 5)
-      save_ascii(data, 'test_output/test_data.txt')
-      loaded = load_ascii('test_output/test_data.txt')
-      print(f'Saved shape: {data.shape}, Loaded shape: {loaded.shape}')
-      assert np.allclose(data, loaded), 'Data mismatch'
-      print('ASCII save/load test passed')
+      from pcntoolkit import BLR, NormativeModel, NormData
+      rng = np.random.default_rng(42)
+      n = 200
+      age = rng.uniform(20, 80, n).reshape(-1, 1)
+      y = 0.05 * age[:, :1] + rng.normal(size=(n, 1)) * 0.2
+      be = np.zeros((n, 1), dtype=int)
+      data = NormData.from_ndarrays('synthetic', age, y, batch_effects=be)
+      train, test = data.train_test_split()
+      model = NormativeModel(BLR(), inscaler='standardize', outscaler='standardize',
+                             savemodel=True, save_dir='test_output/model')
+      model.fit_predict(train, test)
+      print('fit_predict completed')
+      print('end-to-end BLR workflow test passed')
       "
     validate:
-      - output_exists: ${output_dir}/test_data.txt
-    expected_output_contains: "ASCII save/load test passed"
-    expected_exit_code: 0
-
-  - name: Test fileio save and load
-    description: Test generic save/load functions
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.dataio.fileio import save, load
-      data = np.random.randn(20, 3)
-      save(data, 'test_output/test_generic.txt', text=True)
-      loaded = load('test_output/test_generic.txt', text=True)
-      print(f'Generic save/load: {loaded.shape}')
-      print('fileio save/load test passed')
-      "
-    validate:
-      - output_exists: ${output_dir}/test_generic.txt
-    expected_output_contains: "fileio save/load test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - Z-SCORE AND DEVIATION
-  # ==========================================================================
-  - name: Test z_score function
-    description: Compute z-scores from mean and std
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import z_score
-      y = np.array([10, 20, 30, 40, 50]).astype(float)
-      mean = np.array([30, 30, 30, 30, 30]).astype(float)
-      std = np.array([10, 10, 10, 10, 10]).astype(float)
-      z = z_score(y, mean, std)
-      print(f'Z-scores: {z}')
-      expected = np.array([-2, -1, 0, 1, 2])
-      assert np.allclose(z, expected), 'Z-score mismatch'
-      print('z_score test passed')
-      "
-    expected_output_contains: "z_score test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - CROSS-VALIDATION
-  # ==========================================================================
-  # ==========================================================================
-  # FUNCTIONAL TESTS - CALIBRATION
-  # ==========================================================================
-  - name: Test calibration_descriptives function
-    description: Compute calibration descriptive statistics
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import calibration_descriptives
-      x = np.random.randn(100)
-      stats = calibration_descriptives(x)
-      print(f'Calibration descriptives: {type(stats)}')
-      print('calibration_descriptives test passed')
-      "
-    expected_output_contains: "calibration_descriptives test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # FUNCTIONAL TESTS - RAVEL/UNRAVEL
-  # ==========================================================================
-  - name: Test ravel_2D and unravel_2D
-    description: Test array reshaping utilities
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import ravel_2D, unravel_2D
-      a = np.random.randn(10, 5, 3)
-      shape_orig = a.shape
-      a_flat = ravel_2D(a)
-      print(f'Raveled shape: {a_flat.shape}')
-      a_restored = unravel_2D(a_flat, shape_orig)
-      print(f'Unraveled shape: {a_restored.shape}')
-      assert a_restored.shape == shape_orig, 'Shape mismatch'
-      print('ravel/unravel test passed')
-      "
-    expected_output_contains: "ravel/unravel test passed"
-    expected_exit_code: 0
-
-  # ==========================================================================
-  # INTEGRATION TESTS - SIMPLE NORMATIVE MODELING WORKFLOW
-  # ==========================================================================
-  - name: Test simple data simulation and save workflow
-    description: End-to-end test of data simulation and file I/O
-    command: |
-      python -c "
-      import numpy as np
-      from pcntoolkit.util.utils import simulate_data
-      from pcntoolkit.dataio.fileio import save_ascii, load_ascii
-
-      # Generate simulated data
-      np.random.seed(42)
-      train_result = simulate_data(method='linear', n_samples=80, n_features=2, random_state=42)
-      X_train, Y_train = train_result[0], train_result[1]
-      test_result = simulate_data(method='linear', n_samples=20, n_features=2, random_state=43)
-      X_test, Y_test = test_result[0], test_result[1]
-
-      # Save data
-      save_ascii(X_train, 'test_output/cov_train.txt')
-      save_ascii(Y_train.reshape(-1, 1), 'test_output/resp_train.txt')
-      save_ascii(X_test, 'test_output/cov_test.txt')
-      save_ascii(Y_test.reshape(-1, 1), 'test_output/resp_test.txt')
-
-      # Reload and verify
-      X_reload = load_ascii('test_output/cov_train.txt')
-      print(f'Train X shape: {X_train.shape}, Reloaded shape: {X_reload.shape}')
-      assert np.allclose(X_train, X_reload), 'Data mismatch'
-      print('Data workflow test passed')
-      "
-    validate:
-      - output_exists: ${output_dir}/cov_train.txt
-      - output_exists: ${output_dir}/resp_train.txt
-      - output_exists: ${output_dir}/cov_test.txt
-      - output_exists: ${output_dir}/resp_test.txt
-    expected_output_contains: "Data workflow test passed"
+      - output_exists: ${output_dir}/model
+    expected_output_contains: "end-to-end BLR workflow test passed"
     expected_exit_code: 0
 
 cleanup:


### PR DESCRIPTION
Hey :)

I rewrote both build yaml and the deployment tests for pcntoolkit. Note that with version 1.X.X (June 2025), PCNtoolkit was rewritten to be object-oriented. As a result, version 0.X.X is not compatible with 1.X.X and is no longer actively maintained.

`builder generate pcntoolkit --recreate` worked fine  (the website btw says to run `./builder/build.py generate` which probably needs to be updated to `builder generate`?)

I could not run `builder generate pcntoolkit --build --test` cause I can't use docker locally (due to lack of permissions in my work laptop) and the gh codespaces fail to start inside neurocontrainers repo (i get an error: 

```
#12 0.238 Feature       : Docker (docker-outside-of-docker)
#12 0.238 Description   : Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.
#12 0.238 Id            : ghcr.io/devcontainers/features/docker-outside-of-docker
#12 0.238 Version       : 1.10.0
#12 0.238 Documentation : ********/devcontainers/features/tree/main/src/docker-outside-of-docker
#12 0.238 Options       :
#12 0.238     VERSION="latest"
#12 0.238     MOBY="********"
#12 0.238     MOBYBUILDXVERSION="latest"
#12 0.238     DOCKERDASHCOMPOSEVERSION="latest"
#12 0.238     INSTALLDOCKERBUILDX="********"
#12 0.238     INSTALLDOCKERCOMPOSESWITCH="false"
#12 0.238     SOCKETPATH="/var/run/docker-host.sock"
#12 0.238 ===========================================================================
2026-07-31 14:35:05.207Z: #12 0.267 Updating certificates in /etc/ssl/certs...
2026-07-31 14:35:05.977Z: #12 1.187 0 added, 0 removed; done.
2026-07-31 14:35:06.101Z: #12 1.187 Running hooks in /etc/ca-certificates/update.d...
2026-07-31 14:35:06.102Z: #12 1.190 done.
#12 1.198 (!) The 'moby' option is not supported on debian 'trixie' because 'moby-cli' and related system packages are not available in that distribution.
#12 1.199 ERROR: Feature "Docker (docker-outside-of-docker)" (ghcr.io/devcontainers/features/docker-outside-of-docker) failed to install! Look at the documentation at ********/devcontainers/features/tree/main/src/docker-outside-of-docker for help troubleshooting this error.
#12 1.199 (!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
#12 ERROR: process "/bin/sh -c cp -ar /tmp/build-features-src/docker-outside-of-docker_0 /tmp/dev-container-features  && chmod -R 0755 /tmp/dev-container-features/docker-outside-of-docker_0  && cd /tmp/dev-container-features/docker-outside-of-docker_0  && chmod +x ./devcontainer-features-install.sh  && ./devcontainer-features-install.sh  && rm -rf /tmp/dev-container-features/docker-outside-of-docker_0" did not complete successfully: exit code: 1

```

