### PR TITLE
Fix the container release gate so pull requests can merge again

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -1,10 +1,12 @@
 name: PR container candidate
 
 on:
+  # No paths filter: "Container release gate" is a required status check, so it
+  # has to report on every pull request. A path-filtered workflow never runs for
+  # non-recipe changes, and a required check that never reports blocks the merge
+  # forever. The gate short-circuits below when no recipes changed.
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "recipes/**"
 
 permissions:
   contents: read
@@ -58,6 +60,7 @@ jobs:
   candidate:
     name: candidate (${{ matrix.recipe }})
     needs: detect
+    if: ${{ needs.detect.outputs.recipes != '[]' }}
     # ARC pods are ephemeral; untrusted recipe build commands never run on a
     # persistent self-hosted machine.
     runs-on: neurodesk-syd-arcrunner-neurocontainers
@@ -192,6 +195,11 @@ jobs:
         env:
           DETECT_RESULT: ${{ needs.detect.result }}
           CANDIDATE_RESULT: ${{ needs.candidate.result }}
+          RECIPES: ${{ needs.detect.outputs.recipes }}
         run: |
           test "${DETECT_RESULT}" = success
+          if [ "${RECIPES}" = "[]" ]; then
+            echo "No recipe changes in this pull request; nothing to build."
+            exit 0
+          fi
           test "${CANDIDATE_RESULT}" = success

--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -85,6 +85,20 @@ jobs:
         uses: ./.github/actions/setup-apptainer
         with:
           apptainer-version: 1.4.3
+      - name: Prepare Apptainer scratch directories
+        run: |
+          set -euo pipefail
+          # Apptainer otherwise falls back to $HOME/.apptainer, which does not
+          # exist on the ARC runner pods and fails the build with
+          # "failed to create build parent dir".
+          BASE_PATH="${RUNNER_TEMP:-/tmp}"
+          mkdir -p "$BASE_PATH/apptainer/cache" "$BASE_PATH/apptainer/tmp"
+          {
+            echo "APPTAINER_CACHEDIR=$BASE_PATH/apptainer/cache"
+            echo "APPTAINER_TMPDIR=$BASE_PATH/apptainer/tmp"
+            echo "SINGULARITY_CACHEDIR=$BASE_PATH/apptainer/cache"
+            echo "SINGULARITY_TMPDIR=$BASE_PATH/apptainer/tmp"
+          } >> "$GITHUB_ENV"
       - name: Inspect recipe
         id: info
         env:

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -99,6 +99,19 @@ def test_detect_recipes_accepts_recipe_only_change(tmp_path: Path, monkeypatch) 
     assert one_pr_release.detect_recipes("base", "head") == ["demo"]
 
 
+def test_detect_recipes_allows_pr_without_recipes(tmp_path: Path, monkeypatch) -> None:
+    """The release gate is required on every PR, so a non-recipe PR must pass."""
+    write_recipe(tmp_path)
+    monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        one_pr_release,
+        "changed_files",
+        lambda base, head: ["builder/cli.py", "README.md"],
+    )
+
+    assert one_pr_release.detect_recipes("base", "head") == []
+
+
 def test_detect_recipes_rejects_mixed_pr(tmp_path: Path, monkeypatch) -> None:
     """Mixed automation and recipe changes cannot cross the trust boundary."""
     write_recipe(tmp_path)

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -104,7 +104,10 @@ def detect_recipes(base: str, head: str) -> list[str]:
         and parts[2] == "build.yaml"
     }
     if not recipes:
-        raise RuntimeError("No recipes/*/build.yaml change found")
+        # Not an error: the release gate is a required status check, so it also
+        # runs on pull requests that touch no recipe. An empty list tells the
+        # workflow there is nothing to build.
+        return []
 
     allowed = tuple(f"recipes/{recipe}/" for recipe in recipes)
     unrelated = [path for path in paths if not path.startswith(allowed)]


### PR DESCRIPTION
The one-PR container release flow (#2914) left `main` unmergeable. Nothing has merged since it landed, and every open pull request is currently `BLOCKED`. There are two independent causes.

### 1. The required check never reports on non-recipe pull requests

The `pull-requests-only` ruleset requires the **Container release gate** status check on every pull request to `main`. But the workflow that produces it was filtered to `paths: recipes/**`, so for any pull request that does not touch a recipe the workflow never runs, the check never reports, and the pull request can never satisfy the rule. #2987 and this one are both stuck that way.

The filter is removed so the gate always reports. To keep that cheap, the `candidate` matrix job is skipped when `detect` finds no recipes, and the gate treats "no recipes changed" as a pass instead of failing on a skipped dependency — which it would have done, since it asserts `needs.candidate.result == success`.

### 2. Recipe pull requests fail converting the image to a SIF

The gate's [first real run](https://github.com/neurodesk/neurocontainers/actions/runs/30687679640/job/91336652922) built the Docker image fine and then died:

```
FATAL: Unable to create build: failed to create build parent dir:
       stat /home/runner/_work/.apptainer/tmp: no such file or directory
```

`apptainer build` runs without `APPTAINER_TMPDIR` set, so Apptainer falls back to `$HOME/.apptainer/tmp`, which does not exist on the ARC runner pods. [`build-app.yml`](https://github.com/neurodesk/neurocontainers/blob/main/.github/workflows/build-app.yml#L691-L713) already creates and exports these directories before shelling out to singularity; the candidate job now does the same under `RUNNER_TEMP`. Scoped to this workflow rather than the shared `setup-apptainer` action, to leave the production build path alone.

### Merging this

This is the fix for the condition that blocks merges, so it cannot merge through the gate it repairs. It needs an admin merge; #2986 and #2987 should then go green and merge normally.