### PR TITLE
Track upstream releases for 63 more recipes

### DIFF
--- a/recipes/aidamri/build.yaml
+++ b/recipes/aidamri/build.yaml
@@ -15,6 +15,9 @@ variables:
   niftyreg_revision: 83d8d1182ed4c227ce4764f1fdab3b1797eecd8d
   fsl_version: 5.0.11
 
+auto_update:
+  method: github_release
+  repo: Aswendt-Lab/AIDAmri
 build:
   kind: neurodocker
   base-image: ubuntu:20.04

--- a/recipes/amico/build.yaml
+++ b/recipes/amico/build.yaml
@@ -49,6 +49,9 @@ structured_readme:
 
     Neuroimage 215 (2020): 116835.
     https://doi.org/10.1016/j.neuroimage.2020.116835
+auto_update:
+  method: github_release
+  repo: daducci/AMICO
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/ants/build.yaml
+++ b/recipes/ants/build.yaml
@@ -7,6 +7,9 @@ copyright:
 
 architectures:
   - x86_64
+auto_update:
+  method: github_release
+  repo: ANTsX/ANTs
 build:
   kind: neurodocker
 

--- a/recipes/aslprep/build.yaml
+++ b/recipes/aslprep/build.yaml
@@ -5,6 +5,9 @@ copyright:
     url: https://github.com/pennlinc/aslprep/blob/main/LICENSE.md
 architectures:
   - x86_64
+auto_update:
+  method: github_release
+  repo: pennlinc/aslprep
 build:
   kind: neurodocker
   base-image: pennlinc/aslprep:{{ context.version }}

--- a/recipes/bidsappbaracus/build.yaml
+++ b/recipes/bidsappbaracus/build.yaml
@@ -5,6 +5,9 @@ version: 1.1.4
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: bids-apps/baracus
 build:
   kind: neurodocker
   base-image: bids/baracus:v1.1.4

--- a/recipes/bidsappbrainsuite/build.yaml
+++ b/recipes/bidsappbrainsuite/build.yaml
@@ -5,6 +5,9 @@ version: "21a"
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: bids-apps/BrainSuite
 build:
   kind: neurodocker
   base-image: bids/brainsuite:v21a

--- a/recipes/bidsapphcppipelines/build.yaml
+++ b/recipes/bidsapphcppipelines/build.yaml
@@ -5,6 +5,9 @@ version: 4.3.0
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: bids-apps/HCPPipelines
 build:
   kind: neurodocker
   base-image: bids/hcppipelines:v4.3.0-3

--- a/recipes/bidsapppymvpa/build.yaml
+++ b/recipes/bidsapppymvpa/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: bids-apps/PyMVPA
 build:
   kind: neurodocker
 

--- a/recipes/bidsappspm/build.yaml
+++ b/recipes/bidsappspm/build.yaml
@@ -5,6 +5,9 @@ version: 0.0.20
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: bids-apps/SPM
 build:
   kind: neurodocker
   base-image: bids/spm:v0.0.20

--- a/recipes/bidscoin/build.yaml
+++ b/recipes/bidscoin/build.yaml
@@ -10,6 +10,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: Donders-Institute/bidscoin
 build:
   kind: neurodocker
 

--- a/recipes/bidsvue/build.yaml
+++ b/recipes/bidsvue/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: niivue/BIDSvue
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/brainsuite/build.yaml
+++ b/recipes/brainsuite/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: bids-apps/BrainSuite
 build:
   kind: neurodocker
   base-image: bids/brainsuite:v{{ context.version }}

--- a/recipes/cartool/build.yaml
+++ b/recipes/cartool/build.yaml
@@ -14,6 +14,9 @@ files:
   - name: cartool_installer
     url: "{{ context.cartool_installer_url }}"
 
+auto_update:
+  method: github_release
+  repo: DenisBrunet/Cartool
 build:
   kind: neurodocker
   base-image: ubuntu:22.04

--- a/recipes/cat12/build.yaml
+++ b/recipes/cat12/build.yaml
@@ -22,6 +22,9 @@ files:
   - name: cat12.zip
     url: https://github.com/ChristianGaser/cat12/releases/download/{{ context.version }}/cat-standalone-Linux.zip
 
+auto_update:
+  method: github_release
+  repo: ChristianGaser/cat12
 build:
   kind: neurodocker
 

--- a/recipes/cpac/build.yaml
+++ b/recipes/cpac/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: FCP-INDI/C-PAC
 build:
   kind: neurodocker
 

--- a/recipes/dcm2bids/build.yaml
+++ b/recipes/dcm2bids/build.yaml
@@ -9,6 +9,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: UNFmontreal/Dcm2Bids
 build:
   kind: neurodocker
 

--- a/recipes/dcm2niix/build.yaml
+++ b/recipes/dcm2niix/build.yaml
@@ -12,6 +12,9 @@ architectures:
 variables:
   dcm2niix_source_dir: dcm2niix-{{ context.version | replace('v', '', 1) }}
 
+auto_update:
+  method: github_release
+  repo: rordenlab/dcm2niix
 build:
   kind: neurodocker
 

--- a/recipes/deepisles/build.yaml
+++ b/recipes/deepisles/build.yaml
@@ -49,6 +49,9 @@ readme: |-
 
   ----------------------------------
 
+auto_update:
+  method: github_release
+  repo: ezequieldlrosa/DeepIsles
 build:
   kind: neurodocker
 

--- a/recipes/deepretinotopy/build.yaml
+++ b/recipes/deepretinotopy/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: felenitaribeiro/deepRetinotopy_TheToolbox
 build:
   kind: neurodocker
 

--- a/recipes/dhcpstructuralpipeline/build.yaml
+++ b/recipes/dhcpstructuralpipeline/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: BioMedIA/dhcp-structural-pipeline
 build:
   kind: neurodocker
   base-image: biomedia/dhcp-structural-pipeline:latest

--- a/recipes/dicompare/build.yaml
+++ b/recipes/dicompare/build.yaml
@@ -14,6 +14,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: astewartau/dicompare-web
 build:
   kind: neurodocker
   base-image: ubuntu:22.04

--- a/recipes/dwidenoise2/build.yaml
+++ b/recipes/dwidenoise2/build.yaml
@@ -17,6 +17,9 @@ variables:
   mrtrix3_source_dir: /src/mrtrix3
   install_path: /opt/mrtrix3
 
+auto_update:
+  method: github_release
+  repo: Lestropie/dwidenoise2
 build:
   kind: neurodocker
   base-image: debian:bookworm-slim

--- a/recipes/elastix/build.yaml
+++ b/recipes/elastix/build.yaml
@@ -5,6 +5,9 @@ version: 5.1.0
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: SuperElastix/elastix
 build:
   kind: neurodocker
 

--- a/recipes/fastsurfer/build.yaml
+++ b/recipes/fastsurfer/build.yaml
@@ -76,6 +76,9 @@ readme: |-
   To run container outside of this environment: ml fastsurfer/{{ context.version }}
 
   ----------------------------------
+auto_update:
+  method: github_release
+  repo: Deep-MI/FastSurfer
 build:
   kind: neurodocker
   base-image: deepmi/fastsurfer:cpu-v{{ context.version }}

--- a/recipes/fitlins/build.yaml
+++ b/recipes/fitlins/build.yaml
@@ -4,6 +4,9 @@ epoch: 1
 architectures:
   - x86_64
   - aarch64
+auto_update:
+  method: github_release
+  repo: poldracklab/fitlins
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/fmriprep/build.yaml
+++ b/recipes/fmriprep/build.yaml
@@ -5,6 +5,9 @@ copyright:
     url: https://github.com/nipreps/fmriprep/blob/master/LICENSE
 architectures:
   - x86_64
+auto_update:
+  method: github_release
+  repo: nipreps/fmriprep
 build:
   kind: neurodocker
   base-image: nipreps/fmriprep:{{ context.version }}

--- a/recipes/freesurfer/build.yaml
+++ b/recipes/freesurfer/build.yaml
@@ -10,6 +10,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: freesurfer/freesurfer
 build:
   kind: neurodocker
 

--- a/recipes/fsqc/build.yaml
+++ b/recipes/fsqc/build.yaml
@@ -68,6 +68,9 @@ readme: |-
   To run container outside of this environment: ml fsqc/{{ context.version }}
 
   ----------------------------------
+auto_update:
+  method: github_release
+  repo: deep-mi/fsqc
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/functionnectome/build.yaml
+++ b/recipes/functionnectome/build.yaml
@@ -14,6 +14,9 @@ architectures:
 variables:
   setuptools_version: 80.9.0
 
+auto_update:
+  method: github_release
+  repo: NotaCS/Functionnectome
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/hcpasl/build.yaml
+++ b/recipes/hcpasl/build.yaml
@@ -33,6 +33,9 @@ files:
       pandas==2.2.3
       matplotlib==3.9.4
 
+auto_update:
+  method: github_release
+  repo: physimals/hcp-asl
 build:
   kind: neurodocker
   base-image: ubuntu:22.04

--- a/recipes/hdbet/build.yaml
+++ b/recipes/hdbet/build.yaml
@@ -5,6 +5,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: MIC-DKFZ/HD-BET
 build:
   kind: neurodocker
   base-image: ubuntu:20.04

--- a/recipes/heudiconv/build.yaml
+++ b/recipes/heudiconv/build.yaml
@@ -9,6 +9,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: nipy/heudiconv
 build:
   kind: neurodocker
 

--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: hMRI-group/hMRI-toolbox
 build:
   kind: neurodocker
 

--- a/recipes/hnncore/build.yaml
+++ b/recipes/hnncore/build.yaml
@@ -9,6 +9,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: jonescompneurolab/hnn-core
 build:
   kind: neurodocker
 

--- a/recipes/jidt/build.yaml
+++ b/recipes/jidt/build.yaml
@@ -17,6 +17,9 @@ files:
   - name: dependencies.R
     filename: dependencies.R
 
+auto_update:
+  method: github_release
+  repo: jlizier/jidt
 build:
   kind: neurodocker
   base-image: ubuntu:22.04

--- a/recipes/lashis/build.yaml
+++ b/recipes/lashis/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: thomshaw92/LASHiS
 build:
   kind: neurodocker
 

--- a/recipes/linda/build.yaml
+++ b/recipes/linda/build.yaml
@@ -21,6 +21,9 @@ structured_readme:
         --outdir /custom/output/directory
   documentation: https://github.com/dorianps/LINDA
   citation: "Pustina, D., Coslett, H. B., Turkeltaub, P. E., Tustison, N., Schwartz, M. F., & Avants, B. (2016). Automated segmentation of chronic stroke lesions using LINDA: Lesion identification with neighborhood data analysis. Hum Brain Mapp, 37(4), 1405-1421. https://doi.org/10.1002/hbm.23110 "
+auto_update:
+  method: github_release
+  repo: dorianps/LINDA
 build:
   kind: neurodocker
   base-image: dorianps/linda

--- a/recipes/lipsia/build.yaml
+++ b/recipes/lipsia/build.yaml
@@ -5,6 +5,9 @@ copyright:
     url: https://github.com/lipsia-fmri/lipsia/blob/master/LICENSE.md
 architectures:
   - x86_64
+auto_update:
+  method: github_release
+  repo: lipsia-fmri/lipsia
 build:
   kind: neurodocker
   base-image: ubuntu:18.04

--- a/recipes/mfcsc/build.yaml
+++ b/recipes/mfcsc/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: civier/mfcsc
 build:
   kind: neurodocker
   base-image: ubuntu:18.04

--- a/recipes/mricrogl/build.yaml
+++ b/recipes/mricrogl/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: rordenlab/MRIcroGL
 build:
   kind: neurodocker
 

--- a/recipes/mricron/build.yaml
+++ b/recipes/mricron/build.yaml
@@ -6,6 +6,9 @@ copyright:
 architectures:
   - x86_64
   - aarch64
+auto_update:
+  method: github_release
+  repo: neurolabusc/MRIcron
 build:
   kind: neurodocker
   base-image: centos:7

--- a/recipes/mritools/build.yaml
+++ b/recipes/mritools/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: korbinian90/CompileMRI.jl
 build:
   kind: neurodocker
 

--- a/recipes/mrtrix3/build.yaml
+++ b/recipes/mrtrix3/build.yaml
@@ -5,6 +5,9 @@ copyright:
     url: https://github.com/MRtrix3/mrtrix3/blob/master/LICENCE.txt
 architectures:
   - x86_64
+auto_update:
+  method: github_release
+  repo: MRtrix3/mrtrix3
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/nesvor/build.yaml
+++ b/recipes/nesvor/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: daviddmc/NeSVoR
 build:
   kind: neurodocker
   base-image: junshenxu/nesvor:v0.5.0

--- a/recipes/networkcorrespondancetoolkit/build.yaml
+++ b/recipes/networkcorrespondancetoolkit/build.yaml
@@ -55,6 +55,9 @@ readme: |-
 
   ----------------------------------
 
+auto_update:
+  method: github_release
+  repo: rubykong/cbig_network_correspondence
 build:
   kind: neurodocker
 

--- a/recipes/niistat/build.yaml
+++ b/recipes/niistat/build.yaml
@@ -5,6 +5,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: neurolabusc/NiiStat
 build:
   kind: neurodocker
   base-image: ubuntu:22.04

--- a/recipes/oshyx/build.yaml
+++ b/recipes/oshyx/build.yaml
@@ -4,6 +4,9 @@ version: "0.4"
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: Cadaei-Yuvxvs/OSHy-X
 build:
   kind: neurodocker
   base-image: jerync/oshyx_0.4:20220614

--- a/recipes/panoptica/build.yaml
+++ b/recipes/panoptica/build.yaml
@@ -4,6 +4,9 @@ version: 2.1.3
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: BrainLesion/panoptica
 build:
   kind: neurodocker
   base-image: ubuntu:22.04

--- a/recipes/pcntoolkit/build.yaml
+++ b/recipes/pcntoolkit/build.yaml
@@ -33,6 +33,9 @@ structured_readme:
     Al-Khaledi, A., Wolfers, T., Beckmann, C. F., Kia, S. M., & Marquand, A. F. (2026). 
     Protocol update: The Normative Modelling Paradigm for Computational Psychiatry. 
     bioRxiv [Preprint]. https://doi.org/10.64898/2026.02.17.706268.
+auto_update:
+  method: github_release
+  repo: predictive-clinical-neuroscience/PCNtoolkit
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/petprep/build.yaml
+++ b/recipes/petprep/build.yaml
@@ -5,6 +5,9 @@ copyright:
     url: https://github.com/nipreps/petprep/blob/main/LICENSE
 architectures:
   - x86_64
+auto_update:
+  method: github_release
+  repo: nipreps/petprep
 build:
   kind: neurodocker
   base-image: nipreps/petprep:{{ context.version }}

--- a/recipes/prequal/build.yaml
+++ b/recipes/prequal/build.yaml
@@ -11,6 +11,9 @@ architectures:
 variables:
   prequal_dir: /opt/PreQual-{{ context.version }}
 
+auto_update:
+  method: github_release
+  repo: MASILab/PreQual
 build:
   kind: neurodocker
   base-image: ubuntu:20.04

--- a/recipes/pydeface/build.yaml
+++ b/recipes/pydeface/build.yaml
@@ -13,6 +13,9 @@ variables:
   conda_dir: /opt/miniconda-{{ context.conda_version }}
   conda_download_url: https://repo.anaconda.com/miniconda/Miniconda3-{{ context.conda_version }}-Linux-x86_64.sh
 
+auto_update:
+  method: github_release
+  repo: poldracklab/pydeface
 build:
   kind: neurodocker
 

--- a/recipes/qsiprep/build.yaml
+++ b/recipes/qsiprep/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: pennlinc/qsiprep
 build:
   kind: neurodocker
 

--- a/recipes/qsirecon/build.yaml
+++ b/recipes/qsirecon/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: pennlinc/qsirecon
 build:
   kind: neurodocker
 

--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -18,6 +18,9 @@ variables:
       - value: qsmxt_aarch64_tar_gz
         condition: arch == "aarch64"
 
+auto_update:
+  method: github_release
+  repo: QSMxT/QSMxT
 build:
   kind: neurodocker
   # QSMxT v9 is a single self-contained Rust binary (https://github.com/QSMxT/QSMxT).

--- a/recipes/qupath/build.yaml
+++ b/recipes/qupath/build.yaml
@@ -100,6 +100,9 @@ structured_readme:
   documentation: https://qupath.github.io/
   citation: ''
 
+auto_update:
+  method: github_release
+  repo: qupath/qupath
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/rabies/build.yaml
+++ b/recipes/rabies/build.yaml
@@ -56,6 +56,9 @@ readme: |
 
   To run container outside of this environment: ml rabies/{{context.version}}
 
+auto_update:
+  method: github_release
+  repo: CoBrALab/RABIES
 build:
   kind: neurodocker
 

--- a/recipes/samri/build.yaml
+++ b/recipes/samri/build.yaml
@@ -45,6 +45,9 @@ files:
   - name: mouse_brain_atlases_generator_source
     url: https://codeload.github.com/IBT-FMI/mouse-brain-atlases_generator/tar.gz/{{ context.mouse_brain_atlases_generator_commit }}
 
+auto_update:
+  method: github_release
+  repo: IBT-FMI/SAMRI
 build:
   kind: neurodocker
   base-image: vnmd/fsl_6.0.3:20200905

--- a/recipes/segmentator/build.yaml
+++ b/recipes/segmentator/build.yaml
@@ -21,6 +21,9 @@ structured_readme:
     Gulban, O. F., Schneider, M., Marquardt, I., Haast, R., & De Martino, F. (2023). A scalable method to improve gray matter segmentation at ultra high field MRI. In (Version v{{ context.version }}) Zenodo.
     Gulban, O. F., Schneider, M., Marquardt, I., Haast, R. A. M., & De Martino, F. (2018). A scalable method to improve gray matter segmentation at ultra high field MRI. PLoS One, 13(6), e0198335. https://doi.org/10.1371/journal.pone.0198335
 
+auto_update:
+  method: github_release
+  repo: ofgulban/segmentator
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/sigviewer/build.yaml
+++ b/recipes/sigviewer/build.yaml
@@ -8,6 +8,9 @@ copyright:
 architectures:
   - x86_64
 
+auto_update:
+  method: github_release
+  repo: cbrnr/sigviewer
 build:
   kind: neurodocker
   base-image: neurodebian:bullseye

--- a/recipes/spmpython/build.yaml
+++ b/recipes/spmpython/build.yaml
@@ -6,6 +6,9 @@ copyright:
 architectures:
   - x86_64
   - aarch64
+auto_update:
+  method: github_release
+  repo: spm/spm-python
 build:
   kind: neurodocker
   base-image: ubuntu:24.04

--- a/recipes/vina/build.yaml
+++ b/recipes/vina/build.yaml
@@ -9,6 +9,9 @@ architectures:
   - x86_64
   - aarch64
 
+auto_update:
+  method: github_release
+  repo: ccsb-scripps/AutoDock-Vina
 build:
   kind: neurodocker
 

--- a/recipes/vmtk/build.yaml
+++ b/recipes/vmtk/build.yaml
@@ -12,6 +12,9 @@ variables:
   miniforge_version: 24.7.1-2
   python_version: "3.10"
 
+auto_update:
+  method: github_release
+  repo: vmtk/vmtk
 build:
   kind: neurodocker
   base-image: ubuntu:24.04


### PR DESCRIPTION
Only `niimath`, `mede` and `emuses` carried an `auto_update` block, so the weekly
checker was looking at 3 recipes out of 237. This adds one to **63** more.

### How the list was chosen

A recipe is only included when **the version currently in the recipe matches a real
tag on the candidate repo**. That is the property `check_version.py` depends on — it
maps an upstream tag onto a recipe version — so proving it holds today is what makes
the mapping trustworthy tomorrow. Every candidate was additionally checked to be sure
the repo is the recipe's actual upstream and not a coincidence: `quickshear` matched
`ismrmrd/siemens_to_ismrmrd` purely because both happen to have a `1.2.0` tag, and was
dropped.

All 63 pass `builder/validation.py`. Each diff is the same three lines.

### Deliberately excluded

**16 recipes hardcode their version somewhere a bump would not reach**, so an
automated bump would relabel the container while still building the old release —
the same trap that made the `niimath` bump in #2986 a two-line change. Examples:
`base-image: halfpipe/halfpipe:1.2.3`, `pip install TractSeg==2.9`,
`workdir: /opt/laynii-2.2.1/`, `julia-1.9.4-linux-x86_64.tar.gz`. Full list:
`bart`, `bidsappmrtrix3connectome`, `connectomemapper3`, `dsistudio`, `eeglab`,
`exploreasl`, `halfpipe`, `julia`, `laynii`, `mipview`, `mriqc`, `nipype`, `romeo`,
`topaz`, `tractseg`, `vesselvio`. These are worth fixing separately to use
`{{ context.version }}` per AGENTS.md; each would then become trackable.

**5 recipes have no `fulltest.yaml`** (`brainles-preprocessing`, `openrefine`,
`qsmbly`, `rshrf`, `tinyrange`), which the release gate requires, so including them
would fail this PR outright.

### Before merging, please read

`detect_recipes` treats any changed `recipes/*/build.yaml` as a release candidate, so
merging this as one PR queues **63 container builds**, and the promotion flow
would publish a release for each — for a three-line metadata change that alters
nothing about the images. Worth deciding between landing it in batches, or teaching
the release flow to skip changes that cannot affect the built image.

Once merged, 32 of these recipes are already behind upstream. The `--max-prs` cap
added in #2987 (default 5/run) is what keeps that backlog from opening at once.

### Recipes added

| Recipe | Upstream | Version verified against a tag |
|---|---|---|
| `aidamri` | `Aswendt-Lab/AIDAmri` | `2.0` |
| `amico` | `daducci/AMICO` | `2.1.0` |
| `ants` | `ANTsX/ANTs` | `2.6.5` |
| `aslprep` | `pennlinc/aslprep` | `26.0.2` |
| `bidsappbaracus` | `bids-apps/baracus` | `1.1.4` |
| `bidsappbrainsuite` | `bids-apps/BrainSuite` | `21a` |
| `bidsapphcppipelines` | `bids-apps/HCPPipelines` | `4.3.0` |
| `bidsapppymvpa` | `bids-apps/PyMVPA` | `2.0.2` |
| `bidsappspm` | `bids-apps/SPM` | `0.0.20` |
| `bidscoin` | `Donders-Institute/bidscoin` | `4.6.2` |
| `bidsvue` | `niivue/BIDSvue` | `0.1.20260704` |
| `brainsuite` | `bids-apps/BrainSuite` | `23a` |
| `cartool` | `DenisBrunet/Cartool` | `5.06.04` |
| `cat12` | `ChristianGaser/cat12` | `26.0.rc3` |
| `cpac` | `FCP-INDI/C-PAC` | `1.8.7` |
| `dcm2bids` | `UNFmontreal/Dcm2Bids` | `3.2.0` |
| `dcm2niix` | `rordenlab/dcm2niix` | `v1.0.20240202` |
| `deepisles` | `ezequieldlrosa/DeepIsles` | `1.1` |
| `deepretinotopy` | `felenitaribeiro/deepRetinotopy_TheToolbox` | `1.0.19` |
| `dhcpstructuralpipeline` | `BioMedIA/dhcp-structural-pipeline` | `1.1` |
| `dicompare` | `astewartau/dicompare-web` | `0.5.4` |
| `dwidenoise2` | `Lestropie/dwidenoise2` | `1.0.0` |
| `elastix` | `SuperElastix/elastix` | `5.1.0` |
| `fastsurfer` | `Deep-MI/FastSurfer` | `2.4.2` |
| `fitlins` | `poldracklab/fitlins` | `0.11.0` |
| `fmriprep` | `nipreps/fmriprep` | `25.2.5` |
| `freesurfer` | `freesurfer/freesurfer` | `8.2.0` |
| `fsqc` | `deep-mi/fsqc` | `2.1.4` |
| `functionnectome` | `NotaCS/Functionnectome` | `2.5.0` |
| `hcpasl` | `physimals/hcp-asl` | `0.2.0` |
| `hdbet` | `MIC-DKFZ/HD-BET` | `2.0.1` |
| `heudiconv` | `nipy/heudiconv` | `1.3.1` |
| `hmri` | `hMRI-group/hMRI-toolbox` | `0.6.1` |
| `hnncore` | `jonescompneurolab/hnn-core` | `0.3` |
| `jidt` | `jlizier/jidt` | `1.6` |
| `lashis` | `thomshaw92/LASHiS` | `2.0.0` |
| `linda` | `dorianps/LINDA` | `0.5.1` |
| `lipsia` | `lipsia-fmri/lipsia` | `3.1.1` |
| `mfcsc` | `civier/mfcsc` | `1.1` |
| `mricrogl` | `rordenlab/MRIcroGL` | `1.2.20211006` |
| `mricron` | `neurolabusc/MRIcron` | `1.0.20190902` |
| `mritools` | `korbinian90/CompileMRI.jl` | `3.3.0` |
| `mrtrix3` | `MRtrix3/mrtrix3` | `3.0.8` |
| `nesvor` | `daviddmc/NeSVoR` | `0.5.0` |
| `networkcorrespondancetoolkit` | `rubykong/cbig_network_correspondence` | `0.3.3` |
| `niistat` | `neurolabusc/NiiStat` | `1.0.20191216` |
| `oshyx` | `Cadaei-Yuvxvs/OSHy-X` | `0.4` |
| `panoptica` | `BrainLesion/panoptica` | `2.1.3` |
| `pcntoolkit` | `predictive-clinical-neuroscience/PCNtoolkit` | `1.3.0` |
| `petprep` | `nipreps/petprep` | `0.0.5` |
| `prequal` | `MASILab/PreQual` | `1.1.0` |
| `pydeface` | `poldracklab/pydeface` | `2.0.2` |
| `qsiprep` | `pennlinc/qsiprep` | `1.0.1` |
| `qsirecon` | `pennlinc/qsirecon` | `1.1.0` |
| `qsmxt` | `QSMxT/QSMxT` | `9.8.1` |
| `qupath` | `qupath/qupath` | `0.7.0` |
| `rabies` | `CoBrALab/RABIES` | `0.5.3` |
| `samri` | `IBT-FMI/SAMRI` | `0.5` |
| `segmentator` | `ofgulban/segmentator` | `1.6.1` |
| `sigviewer` | `cbrnr/sigviewer` | `0.6.4` |
| `spmpython` | `spm/spm-python` | `25.1.2.post1` |
| `vina` | `ccsb-scripps/AutoDock-Vina` | `1.2.3` |
| `vmtk` | `vmtk/vmtk` | `1.5.0` |
