### PR TITLE
Make the automated version bump safe to apply unattended

### DIFF
--- a/builder/check_version.py
+++ b/builder/check_version.py
@@ -154,7 +154,9 @@ def resolve_tag_commit(repo, tag):
         return None
 
 
-VERSION_LINE = re.compile(r"^version:[ \t]*(?P<value>.*?)[ \t]*$", re.M)
+VERSION_LINE = re.compile(
+    r"^version:[ \t]*(?P<value>.*?)[ \t]*(?P<comment>#.*)?$", re.M
+)
 REVISION_LINE = re.compile(
     r"^(?P<indent>[ \t]*)revision:[ \t]*"
     r"(?P<quote>[\"']?)(?P<sha>[0-9a-fA-F]{7,40})(?P=quote)[ \t]*$",
@@ -163,24 +165,82 @@ REVISION_LINE = re.compile(
 
 
 def rewrite_version(text, new_version):
-    """Replace the top-level version field, preserving its original quoting."""
+    """Replace the top-level version field so it reads back as the same string.
+
+    Original quoting is preserved where it survives a round trip. It often does
+    not: `version: 1.9` is a float, and bumping it to an unquoted 1.10 would
+    reload as 1.1. Most recipes leave the version unquoted, so the fallback to
+    an explicitly quoted scalar is the common path for any two-part version.
+    """
     match = VERSION_LINE.search(text)
     if not match:
         return None
     raw = match.group("value")
     quote = raw[0] if raw[:1] in ("'", '"') else ""
-    return f"{text[:match.start()]}version: {quote}{new_version}{quote}{text[match.end():]}"
+    comment = match.group("comment")
+    trailer = f"  {comment}" if comment else ""
+
+    for candidate_quote in (quote, '"'):
+        updated = (
+            f"{text[:match.start()]}version: "
+            f"{candidate_quote}{new_version}{candidate_quote}{trailer}"
+            f"{text[match.end():]}"
+        )
+        try:
+            reloaded = yaml.safe_load(updated)
+        except Exception as e:
+            dbg("rewrite_version reload failed:", e)
+            continue
+        if isinstance(reloaded, dict) and str(reloaded.get("version")) == new_version:
+            return updated
+    return None
+
+
+def revisions_owned_by(text, repo):
+    """Return the pinned shas that sit in a mapping also naming the upstream repo.
+
+    Proximity in the raw text is not evidence of ownership: the auto_update.repo
+    line is itself usually within a few hundred characters of the revision, so a
+    character window matches almost anything. Ownership is a structural claim --
+    the sha and the repo URL have to be siblings in the same YAML mapping -- so
+    it is decided on the parsed document.
+    """
+    try:
+        with_repo = set()
+
+        def walk(node):
+            if isinstance(node, dict):
+                sha = node.get("revision")
+                if isinstance(sha, str) and re.fullmatch(r"[0-9a-fA-F]{7,40}", sha):
+                    siblings = " ".join(
+                        str(value)
+                        for key, value in node.items()
+                        if key != "revision" and not isinstance(value, (dict, list))
+                    )
+                    if repo.lower() in siblings.lower():
+                        with_repo.add(sha.lower())
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for value in node:
+                    walk(value)
+
+        walk(yaml.safe_load(text))
+        return with_repo
+    except Exception as e:
+        dbg("revisions_owned_by parse failed:", e)
+        return set()
 
 
 def rewrite_revision(text, repo, new_sha):
     """Repoint pinned commit revisions that belong to the upstream repo."""
+    owned = revisions_owned_by(text, repo)
     changed = []
 
     def replace(match):
-        window = match.string[max(0, match.start() - 600) : match.end() + 600]
-        if repo.lower() not in window.lower():
-            return match.group(0)
         old_sha = match.group("sha")
+        if old_sha.lower() not in owned:
+            return match.group(0)
         if new_sha.lower().startswith(old_sha.lower()):
             return match.group(0)
         changed.append((old_sha, new_sha))
@@ -194,7 +254,9 @@ def issue_exists(fp):
     if not REPO:
         dbg("Skip issue_exists: REPO is not set.")
         return False
-    q = f'repo:{REPO} in:title "{fp}" state:open'
+    # The fingerprint is only ever written into the issue body, so searching
+    # in:title never matches and every recurring failure opens a fresh issue.
+    q = f'repo:{REPO} in:body "{fp}" state:open'
     dbg("Search issues query:", q)
     try:
         response = session.get(
@@ -214,9 +276,15 @@ def issue_exists(fp):
         return False
 
 
+DRY_RUN = False
+
+
 def open_issue(title, body, labels=None):
     if labels is None:
         labels = ["auto-update"]
+    if DRY_RUN:
+        print(f"=== dry run: would open issue === {title}")
+        return
     if not REPO:
         print("GITHUB_REPOSITORY not set; skip creating issue.")
         return
@@ -350,11 +418,14 @@ def prepare_bump(path, current_version, new_version, repo, tag):
 
     updated = rewrite_version(original, new_version)
     if updated is None:
-        return None, "no top-level version field to rewrite"
+        return None, "no top-level version field to rewrite as an equal string"
 
     changes = [f"`version`: `{current_version}` → `{new_version}`"]
 
-    if REVISION_LINE.search(updated):
+    # Only revisions pinned alongside the upstream repo need to move. A recipe
+    # may also pin a helper from some other repo, and that sha has nothing to do
+    # with this release.
+    if revisions_owned_by(updated, repo):
         commit = resolve_tag_commit(repo, tag)
         if not commit:
             return None, f"recipe pins a commit revision but tag {tag} could not be resolved"
@@ -375,9 +446,17 @@ def prepare_bump(path, current_version, new_version, repo, tag):
 def submit_bump(path, name, current_version, new_version, repo, tag, base_branch, dry_run):
     branch = f"auto-update/{name}-{new_version}"
 
-    if not dry_run and (pull_request_exists(branch) or remote_branch_exists(branch)):
-        print(f"branch/PR already exists for {branch}; skipping.")
-        return "exists"
+    orphan_branch = False
+    if not dry_run:
+        if pull_request_exists(branch):
+            print(f"a pull request already exists for {branch}; skipping.")
+            return "exists"
+        if remote_branch_exists(branch):
+            # Pushed, but the pull request call never succeeded. Skipping here
+            # would strand the recipe: the branch keeps the bump from being
+            # retried, and no pull request ever carries it.
+            print(f"branch {branch} exists with no pull request; opening one for it.")
+            orphan_branch = True
 
     updated, result = prepare_bump(path, current_version, new_version, repo, tag)
     if updated is None:
@@ -409,24 +488,21 @@ def submit_bump(path, name, current_version, new_version, repo, tag, base_branch
         body_lines += ["", *[f"Closes #{number}" for number in closes]]
     body = "\n".join(body_lines)
 
+    title = f"Bump {name} from {current_version} to {new_version}"
+
+    if orphan_branch:
+        # The commit is already on the remote; only the pull request is missing.
+        open_pull_request(branch, base_branch, title, body, labels=["auto-update"])
+        return "opened"
+
     git("checkout", "-B", branch, base_branch)
     try:
         with open(path, "w", encoding="utf-8") as f:
             f.write(updated)
         git("add", "--", path)
-        git(
-            "commit",
-            "-m",
-            f"Bump {name} from {current_version} to {new_version}",
-        )
+        git("commit", "-m", title)
         git("push", "origin", branch)
-        open_pull_request(
-            branch,
-            base_branch,
-            f"Bump {name} from {current_version} to {new_version}",
-            body,
-            labels=["auto-update"],
-        )
+        open_pull_request(branch, base_branch, title, body, labels=["auto-update"])
     finally:
         git("checkout", "--force", base_branch, check=False)
         git("clean", "-fd", "--", os.path.dirname(path) or ".", check=False)
@@ -474,13 +550,17 @@ def main():
         "through over several weekly runs rather than all at once.",
     )
     args = parser.parse_args()
-    dry_run = args.dry_run
+    global DRY_RUN
+    DRY_RUN = dry_run = args.dry_run
     opened = 0
     deferred = []
 
     base_branch = "main"
     if not dry_run:
-        base_branch = git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip() or "main"
+        head = git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        # A detached checkout reports "HEAD", which is not a branch the pull
+        # request API will accept as a base.
+        base_branch = head if head and head != "HEAD" else "main"
     print(f"Base branch: {base_branch} (dry_run={dry_run})")
 
     files = glob.glob("recipes/**/*.y*ml", recursive=True)

--- a/builder/tests/test_check_version.py
+++ b/builder/tests/test_check_version.py
@@ -1,0 +1,100 @@
+"""Tests for the pure rewrite helpers in builder/check_version.py.
+
+These cover the two ways an automated bump can corrupt a recipe: writing a
+version that reloads as a different value, and moving a pinned revision that
+belongs to some other project.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "check_version.py"
+spec = importlib.util.spec_from_file_location("check_version", MODULE_PATH)
+check_version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_version)
+
+
+def test_rewrite_version_quotes_a_version_that_would_reload_as_a_float() -> None:
+    """`version: 1.10` unquoted reloads as 1.1, silently mislabelling the image."""
+    updated = check_version.rewrite_version("name: demo\nversion: 1.9\n", "1.10")
+
+    assert str(yaml.safe_load(updated)["version"]) == "1.10"
+
+
+def test_rewrite_version_preserves_existing_quoting() -> None:
+    updated = check_version.rewrite_version('name: demo\nversion: "1.2.3"\n', "1.2.4")
+
+    assert 'version: "1.2.4"' in updated
+    assert yaml.safe_load(updated)["version"] == "1.2.4"
+
+
+def test_rewrite_version_ignores_nested_version_keys() -> None:
+    text = (
+        "name: demo\n"
+        "version: 1.2.3\n"
+        "build:\n"
+        "  directives:\n"
+        "    - template:\n"
+        "        name: ants\n"
+        "        version: 2.4.3\n"
+    )
+
+    updated = check_version.rewrite_version(text, "1.2.4")
+    reloaded = yaml.safe_load(updated)
+
+    assert reloaded["version"] == "1.2.4"
+    assert reloaded["build"]["directives"][0]["template"]["version"] == "2.4.3"
+
+
+def test_rewrite_version_keeps_a_trailing_comment() -> None:
+    updated = check_version.rewrite_version(
+        "name: demo\nversion: 1.2.3  # keep in sync with the base image\n", "1.2.4"
+    )
+
+    assert "# keep in sync with the base image" in updated
+    assert yaml.safe_load(updated)["version"] == "1.2.4"
+
+
+RECIPE_WITH_TWO_PINS = """name: demo
+version: 1.0.0
+build:
+  directives:
+    - group:
+        - variables:
+            github_url: https://github.com/someoneelse/helper.git
+            revision: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    - group:
+        - variables:
+            github_url: https://github.com/rordenlab/niimath.git
+            revision: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+"""
+
+
+def test_revision_rewrite_leaves_another_projects_pin_alone() -> None:
+    """Proximity is not ownership: only the sha beside the upstream URL moves."""
+    updated, changed = check_version.rewrite_revision(
+        RECIPE_WITH_TWO_PINS, "rordenlab/niimath", "c" * 40
+    )
+
+    assert changed == [("b" * 40, "c" * 40)]
+    assert "a" * 40 in updated
+    assert "b" * 40 not in updated
+
+
+def test_revision_rewrite_skips_a_recipe_that_pins_only_foreign_shas() -> None:
+    assert check_version.revisions_owned_by(
+        RECIPE_WITH_TWO_PINS, "unrelated/project"
+    ) == set()
+
+    _, changed = check_version.rewrite_revision(
+        RECIPE_WITH_TWO_PINS, "unrelated/project", "c" * 40
+    )
+    assert changed == []
+
+
+@pytest.mark.parametrize("repo", ["rordenlab/niimath", "RordenLab/NiiMath"])
+def test_revisions_owned_by_matches_case_insensitively(repo: str) -> None:
+    assert check_version.revisions_owned_by(RECIPE_WITH_TWO_PINS, repo) == {"b" * 40}


### PR DESCRIPTION
Follow-up to #2987, which merged before this review landed. The bump path it introduced runs from the weekly cron with nobody watching, and four defects in it can corrupt a recipe or spam the tracker. All four are reachable today.

### 1. Revision ownership was decided by a character window

`rewrite_revision` accepted a pinned sha if the upstream repo name appeared within ±600 characters. The `auto_update.repo` line is itself usually inside that window — for `niimath` it sits 259 characters before the revision — so the check was close to vacuous. A recipe pinning a helper commit from a *different* project had that sha overwritten with the upstream one as well.

Ownership is a structural claim, so it is now decided on the parsed document: a sha moves only when it is a sibling of the repo URL in the same YAML mapping. This also unsticks the inverse case — `if REVISION_LINE.search(...)` fired on *any* revision line, so a recipe pinning an unrelated commit could never be auto-bumped and fell into the manual-issue path forever.

### 2. A bumped version could silently change type

`version: 1.9` is a YAML float. Rewriting it to an unquoted `1.10` reloads as `1.1`, relabelling the container with a version nobody asked for. **202 of 234 recipes leave the version unquoted, and `recipes/niftymic/build.yaml` carries `version: 0.9` today**, so the shape already exists in-tree.

`rewrite_version` now re-parses its own output and asserts the value reads back as the string it wrote, falling back to an explicitly quoted scalar. Verified across all 234 recipes: 234 rewrite cleanly, 0 failures.

### 3. Issue dedup never matched

`issue_exists` searched `in:title "{fingerprint}"`, but the fingerprint is only ever written into the issue *body*. The search returned nothing every time. Since #2987 newly routes a recurring failure through this path ("An automatic version-bump pull request could not be created"), a persistently failing bump would open a fresh issue every Monday. Now searches `in:body`.

### 4. `--dry-run` still wrote to GitHub

`open_invalid_recipe_issue` and `open_manual_issue` POSTed regardless, contradicting the flag's own help text ("without touching git or the GitHub API") and the workflow input description.

### Also

- A branch that was pushed before `open_pull_request` failed is no longer stranded. Previously `submit_bump` returned `"exists"` for it, which `main` counts as success, so no PR and no issue — the recipe would never be bumped again. It now opens the pull request against the existing branch.
- A trailing comment on the version line is preserved rather than deleted.
- A detached checkout no longer yields `base: "HEAD"`, which the pull request API rejects.

### Validation

- `builder/tests/test_check_version.py` added — 8 tests over the pure rewrite helpers, which had no coverage at all before.
- Full suite: 194 passed.
- `rewrite_version` swept over all 234 `recipes/*/build.yaml`: 0 failures, and the one non-string version (`niftymic`) is now quoted.
- `revisions_owned_by` correctly identifies `niimath`'s pinned sha as the only repo-owned revision, matching what #2986 did by hand.
- codespell clean.