### PR TITLE
Install datalad in the container candidate job

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -141,6 +141,20 @@ jobs:
           mkdir -p "candidate/${CONTAINER}"
           docker save "${CANDIDATE_TAG}" --output "candidate/${CONTAINER}/${DOCKER_ARCHIVE}"
           apptainer build "candidate/${CONTAINER}/${SIF}" "docker-archive://candidate/${CONTAINER}/${DOCKER_ARCHIVE}"
+      - name: Install fulltest data dependencies
+        # A fulltest.yaml may declare required_files, which run_tests.py fetches
+        # with datalad. Without these the suite dies on FileNotFoundError before
+        # a single assertion runs. run-fulltest.yml and test-release-pr.yml
+        # provision the same way.
+        run: |
+          uv pip install --system datalad datalad-installer
+          datalad-installer --sudo ok git-annex -m datalad/packages
+          git-annex version
+          datalad --version
+      - name: Configure git for DataLad
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Run deploy and fulltest checks
         id: fulltest
         continue-on-error: true


### PR DESCRIPTION
The container release gate cannot pass for any recipe whose `fulltest.yaml` declares `required_files`.

`builder/run_tests.py:213` shells out to `datalad` to populate the dataset cache, but the `candidate` job in `pr-container-candidate.yml` never installs it. The suite dies before running a single assertion:

```
Cloning ds000001 into cache...
FileNotFoundError: [Errno 2] No such file or directory: 'datalad'
run_tests.py failed before writing results: exit 1
```

#2986 is the live example — a one-line version bump that is correct on the merits and cannot merge. Its candidate builds now get as far as the SIF (the Apptainer fix from #2988 works), then fail here on both `niimath` and `niimath_arm64`.

`run-fulltest.yml:136-139` and `test-release-pr.yml:88-94` already provision this exact way; the candidate job was simply missing the step. This copies it verbatim, including the git identity DataLad needs to clone.

### Note on cost

This installs `datalad` and `git-annex` on every candidate run, including recipes whose fulltest needs no data. That is a modest fixed cost against the alternative of the gate being unpassable for data-driven recipes. If it proves noticeable it could be made conditional on `required_files` being present in the recipe's fulltest.yaml, but that check is more machinery than the install it would skip.

### Validation

Workflow YAML parses, and the two new steps land between the SIF build and the fulltest run. Real verification is #2986 going green once this lands.