### PR TITLE
Install datalad on the PR candidate runner

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -86,6 +86,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Install test data tooling
+        run: |
+          # fulltest suites declare required_files: from OpenNeuro, which
+          # builder/run_tests.py fetches with datalad. Without this the runner
+          # raises FileNotFoundError: 'datalad' and the candidate fails after a
+          # full image build. Mirrors the install in run-fulltest.yml.
+          uv pip install --system datalad datalad-installer
+          datalad-installer --sudo ok git-annex -m datalad/packages
+          git-annex version
+          datalad --version
+      - name: Configure git for DataLad
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Install Apptainer
         uses: ./.github/actions/setup-apptainer
         with:
@@ -141,20 +155,6 @@ jobs:
           mkdir -p "candidate/${CONTAINER}"
           docker save "${CANDIDATE_TAG}" --output "candidate/${CONTAINER}/${DOCKER_ARCHIVE}"
           apptainer build "candidate/${CONTAINER}/${SIF}" "docker-archive://candidate/${CONTAINER}/${DOCKER_ARCHIVE}"
-      - name: Install fulltest data dependencies
-        # A fulltest.yaml may declare required_files, which run_tests.py fetches
-        # with datalad. Without these the suite dies on FileNotFoundError before
-        # a single assertion runs. run-fulltest.yml and test-release-pr.yml
-        # provision the same way.
-        run: |
-          uv pip install --system datalad datalad-installer
-          datalad-installer --sudo ok git-annex -m datalad/packages
-          git-annex version
-          datalad --version
-      - name: Configure git for DataLad
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Run deploy and fulltest checks
         id: fulltest
         continue-on-error: true


### PR DESCRIPTION
The candidate gate fails the fulltest step for every recipe that needs test data:

```
FileNotFoundError: [Errno 2] No such file or directory: 'datalad'
```

`fulltest.yaml` suites declare `required_files:` against OpenNeuro datasets, and
[`builder/run_tests.py`](https://github.com/neurodesk/neurocontainers/blob/main/builder/run_tests.py#L218)
shells out to `datalad install` / `datalad get` to fetch them. The candidate job only ran
`pip install -r requirements.txt`, which does not provide datalad or git-annex — so the
step dies *after* a full container build has already run.

This mirrors the install `run-fulltest.yml` already uses, plus the git identity datalad
needs. Seen on [#2986](https://github.com/neurodesk/neurocontainers/pull/2986), where
niimath's suite pulls `ds000001`.