### PR TITLE
Pass the Dive rules file with --ci-config, not --config

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${PWD}/.github/.dive-ci.yml:/.dive-ci.yml:ro" \
-            wagoodman/dive:latest "${CANDIDATE_TAG}" --ci --config /.dive-ci.yml
+            wagoodman/dive:latest "${CANDIDATE_TAG}" --ci --ci-config /.dive-ci.yml
       - name: Generate manifest and release preview
         env:
           RECIPE: ${{ matrix.recipe }}


### PR DESCRIPTION
`.github/.dive-ci.yml` has never taken effect.

The candidate job runs:

```
wagoodman/dive:latest "${CANDIDATE_TAG}" --ci --config /.dive-ci.yml
```

but per `dive --help` those are two different flags:

```
--ci-config string   If CI=true in the environment, use the given yaml to drive validation rules. (default ".dive-ci")
--config string      config file (default is $HOME/.dive.yaml, ...)
--highestUserWastedPercent string   ... (default "0.1")
```

`--config` is dive's own general config, so the rules file was ignored and dive validated
against its built-in defaults. That is why [#2986](https://github.com/neurodesk/neurocontainers/pull/2986)
reports

```
FAIL: highestUserWastedPercent: ... 0.10363437998235947 > threshold=0.1
```

`0.1` is dive's default. `.github/.dive-ci.yml` sets `highestUserWastedPercent: 0.3`,
`lowestEfficiency: 0.8` and `highestWastedBytes: 4000MB` — the comments there explain
these were deliberately loosened for inherited upstream layers, and none of it has been
applied. Every recipe has been checked against stricter thresholds than intended.

One flag. niimath at 0.1036 passes comfortably under the intended 0.3.