### PR TITLE
Make the container release gate passable on both arch legs

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -93,7 +93,15 @@ jobs:
           # raises FileNotFoundError: 'datalad' and the candidate fails after a
           # full image build. Mirrors the install in run-fulltest.yml.
           uv pip install --system datalad datalad-installer
-          datalad-installer --sudo ok git-annex -m datalad/packages
+          if [ "$(uname -m)" = "x86_64" ]; then
+            datalad-installer --sudo ok git-annex -m datalad/packages
+          else
+            # datalad/packages publishes amd64 .debs only, so dpkg -i fails on
+            # the arm64 runners. The distro package is older but sufficient for
+            # fetching required_files.
+            sudo apt-get update
+            sudo apt-get install -y git-annex
+          fi
           git-annex version
           datalad --version
       - name: Configure git for DataLad

--- a/builder/release_artifact.py
+++ b/builder/release_artifact.py
@@ -323,7 +323,11 @@ def resolve_suite_container(
     wins — CI resolves the release itself and passes the resulting file through.
     """
     if override:
-        override_path = Path(override)
+        # Absolute, because the caller's cwd and the test runner's cwd are not
+        # the same directory: run_tests.py invokes the container runtime with
+        # cwd set to the suite work dir, so a relative override resolves against
+        # that instead and the runtime is handed a doubled path.
+        override_path = Path(override).resolve()
         if not override_path.is_file():
             return ContainerResolution(
                 reference=str(override_path),

--- a/builder/tests/test_release_artifact.py
+++ b/builder/tests/test_release_artifact.py
@@ -180,6 +180,32 @@ def test_override_wins_over_release_metadata(tmp_path: Path) -> None:
     assert resolution.source == "override"
 
 
+def test_override_is_resolved_to_an_absolute_path(tmp_path: Path, monkeypatch) -> None:
+    """run_tests.py runs the container runtime from the suite work dir.
+
+    A relative override is resolved against that directory rather than the
+    caller's, which hands the runtime a doubled path and fails every test in the
+    suite on the container health check.
+    """
+    candidate = touch(tmp_path / "candidates", "tool-candidate.simg")
+    monkeypatch.chdir(tmp_path)
+
+    resolution = resolve_suite_container(
+        recipe="tool",
+        version="1.2.3",
+        declared=None,
+        pinned=False,
+        containers_dir=tmp_path / "containers",
+        releases_dir=None,
+        override="candidates/tool-candidate.simg",
+    )
+
+    assert resolution.error is None
+    assert resolution.path is not None
+    assert resolution.path.is_absolute()
+    assert resolution.path == candidate.resolve()
+
+
 def test_locally_built_sif_satisfies_the_release_artifact(tmp_path: Path) -> None:
     """`sf-make` writes sifs/<name>_<version>.sif, which carries no build date."""
     releases = tmp_path / "releases"


### PR DESCRIPTION
Two independent faults, both surfaced by #2986 — the first pull request to reach the fulltest step after the Apptainer fix (#2988) and the datalad fix (#2993). Neither is a problem with that version bump; the gate simply had not been exercised this far before.

## 1. The container override is passed as a relative path

`run_tests.py` invokes the container runtime with `cwd` set to the suite work dir, but `resolve_suite_container` kept the override exactly as the caller wrote it — relative to the repo root. Apptainer was handed a doubled path:

```
/…/neurocontainers/candidate/niimath/test-output/fulltest-work-niimath/candidate/niimath/test-output/fulltest-containers/niimath_1.0.20260720_20260731.simg
```

It fails the container health check, and the health check gates the whole suite, so **all 115 niimath tests reported as failures** without a single one running:

```
✗ niimath > Container health check
  Container cannot execute commands (exit 255): FATAL: While checking container
  encryption: could not open image …: lstat …
✗ niimath > Version check
  Skipped: container health check failed
…
Tests: 0 passed, 115 failed (115 total)
```

Every other branch of `resolve_suite_container` derives its path from `containers_dir`, which `run_tests.py:1081` already resolves. Only the override path kept the caller's cwd, so this fixes it there — at the seam every caller goes through, rather than in the workflow.

## 2. `git-annex` cannot install on the arm64 leg

`datalad-installer … -m datalad/packages` publishes amd64 `.deb`s only, so the arm64 candidate job died in the install step itself:

```
subprocess.CalledProcessError: Command '['sudo', 'dpkg', '-i',
'/tmp/…/git-annex-standalone_10.20260525-1~ndall+1_amd64.deb']' returned non-zero exit status 1.
```

Now selected by `uname -m`: x86_64 keeps the datalad/packages build, everything else takes the distro package. It is older, but it only has to fetch `required_files`.

## Validation

- Added `test_override_is_resolved_to_an_absolute_path`. Verified it **fails** against the unfixed `release_artifact.py` (`PosixPath('candidates/tool-candidate.simg')` is not absolute) and passes with the fix.
- Full builder suite: 195 passed.
- The arm64 install path is only really provable on the runner; #2986 going green is the check.