### PR TITLE
Keep workshopdemo out of the Neurodesk menu

### DIFF
--- a/recipes/workshopdemo/build.yaml
+++ b/recipes/workshopdemo/build.yaml
@@ -3,6 +3,12 @@ version: 1.0.0
 architectures:
   - x86_64
   - aarch64
+# Kept out of the Neurodesk menu and applist: this is the shared throwaway used
+# to exercise the build/release pipeline, not a tool anyone should install. It
+# has never had a release file, so it has never appeared in apps.json; without
+# these it would show up the first time it is promoted.
+show_in_menu: false
+show_in_applist: false
 structured_readme:
   description: This tool was committed for the workshop.
   example: hello


### PR DESCRIPTION
Adds `show_in_menu: false` and `show_in_applist: false` to `recipes/workshopdemo/build.yaml`.

`workshopdemo` is the shared throwaway we use to exercise the build and release pipeline (`install: hello` on `ubuntu:24.04`). It has never had a release file, so it has never reached `apps.json` and no user has ever seen it. The first time it is promoted it would appear in the Neurodesk menu and applist alongside real tools, which nobody wants.

Both variants carry the flags, so `workshopdemo_arm64` is covered too. Verified through `release_data()`:

```
workshopdemo           show_in_menu=False show_in_applist=False variant=None  arch=None
workshopdemo_arm64     show_in_menu=False show_in_applist=False variant=arm64 arch=aarch64
```

### Why this PR now

It doubles as the first end-to-end exercise of the one-PR release pipeline. Nothing has published since the rewrite landed on 2026-08-01, because the x86 candidate leg could not execute a container: `/dev/fuse` exists on the ARC pods but the device cgroup denied `open()`, so Apptainer could build a SIF and not run one. The cluster team has since deployed a FUSE device plugin and confirmed `open("/dev/fuse")` succeeds on the live runner pod, but everything they have is probe-level. This is the first real workflow-level dispatch.

It exercises, in one go:

- the x86 candidate leg on ARC, which is the `/dev/fuse` path
- the aarch64 leg on Blacksmith and the named-variant fan-out from #2913, which has not run since it merged
- `promote-container-candidate.yml`, including two fixes landed today (below)
- promote's multi-manifest publish loop, which has never run with more than zero manifests

`workshopdemo` was chosen deliberately: it has no release history, does not appear in `apps.json`, and nothing downstream consumes it, so a failure costs nothing.

### Related fixes already on main

- `9a41e0d5` moved promote from `pull_request` to `pull_request_target`. Under `pull_request` a fork supplied the workflow file, and secrets are withheld from fork PRs, so a merged community recipe PR could never publish.
- `150302a0` narrowed promote's `paths` filter to `recipes/*/build.yaml` to match `detect_recipes()`. It previously fired on `recipes/**`, so fulltest- and README-only PRs merged green and then failed promote with `No unexpired candidate artifacts found` (#2990).

### On merge

Publishes `workshopdemo` and `workshopdemo_arm64` to GHCR, Quay, Docker Hub, Nectar and S3 and creates their first two release files. This moves the `quay.io/neurodesk/workshopdemo` tags off the multi-arch OCI index left over from the (since-conceded) #2919 experiment; that is intended.

No user-visible change, because of the flags above.
