### PR TITLE
Rebuild lcmodel: its license cleanup never went through the gate

### DIFF
--- a/recipes/lcmodel/build.yaml
+++ b/recipes/lcmodel/build.yaml
@@ -73,6 +73,11 @@ build:
     # LCModel has been free since 2021 and only checks that .lcmodel/license
     # exists - the file must stay EMPTY. The licence key that used to be shipped
     # here was deliberately removed in 9fe69805; do not add content back.
+    #
+    # This replaced a `copy: license` directive in 0639afca, alongside deleting
+    # the now-unused recipes/lcmodel/license. That commit went straight to main,
+    # so it never passed through the candidate gate and was never built, tested
+    # or published: the recipe and the shipped container have disagreed since.
     - run:
         - mkdir -p /opt/lcmodel-{{ context.version }}/.lcmodel
         - touch /opt/lcmodel-{{ context.version }}/.lcmodel/license


### PR DESCRIPTION
`recipes/lcmodel/build.yaml` on `main` describes a container nobody has ever built.

`0639afca` replaced lcmodel's `copy: license` directive with a `mkdir`/`touch`, and deleted the now-unused `recipes/lcmodel/license` alongside `basissets.txt` and `datasets.txt`. The change itself is correct — LCModel has been free since 2021 and only checks that `.lcmodel/license` exists, so the file must stay empty.

But that commit went straight to `main` with no pull request, so it never passed through the candidate gate: never built, never tested, never published. The recipe and the shipped container have disagreed since 1 August.

This PR adds a comment recording that provenance, which is enough of a `build.yaml` change to route the recipe through the gate and rebuild it.

### What this exercises

The publish half of the one-PR release pipeline, which has not run successfully since the rewrite landed on 1 August. The build and test half was verified earlier today in run `30785153782`, where a container was built and executed on the ARC pool for the first time since the `/dev/fuse` device grant landed.

lcmodel is `architectures: [x86_64]` only, so this is a single candidate leg and a single published container, with no named-variant fan-out.

### On merge

Publishes `lcmodel 6.3` with a new build date to GHCR, Quay, Docker Hub, Nectar and S3, and commits `releases/lcmodel/6.3.json`. lcmodel appears in the Neurodesk menu, so this is the container users receive.

The recipe content is unchanged by this PR — the only edit is a comment. What changes is that the version already sitting on `main` finally gets built and tested before shipping.
