### PR TITLE
Add sodiumgridding ptpi

### DIFF
--- a/recipes/sodiumgridding_ptpi/OpenReconLabel.json
+++ b/recipes/sodiumgridding_ptpi/OpenReconLabel.json
@@ -1,0 +1,213 @@
+{
+  "general": {
+    "name": { "en": "sodiumgridding_pTPI" },
+    "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+    "vendor": "neurodesk",
+    "information": { "en": "Dual-echo palindromic TPI Kaiser-Bessel gridding with low-rank phase correction." },
+    "id": "sodiumgridding_ptpi",
+    "regulatory_information": {
+      "device_trade_name": "sodiumgridding_pTPI",
+      "production_identifier": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "manufacturer_address": "Erlangen, Germany",
+      "made_in": "DE",
+      "manufacture_date": "2026/07/28",
+      "material_number": "sodiumgridding_ptpi_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
+      "gtin": "00860000171212",
+      "udi": "(01)00860000171212(21)1.3.0",
+      "safety_advices": "",
+      "special_operating_instructions": "OpenRecon dual-echo pTPI reconstruction from raw k-space to TE1/TE2 magnitude image data",
+      "additional_relevant_information": ""
+    }
+  },
+  "reconstruction": {
+    "transfer_protocol": {
+      "protocol": "ISMRMRD",
+      "version": "1.4.1"
+    },
+    "port": 9003,
+    "emitter": "raw",
+    "injector": "compleximage",
+    "can_process_adjustment_data": true,
+    "can_use_gpu": false,
+    "min_required_memory": 32000,
+    "min_count_required_cpu_cores": 10,
+    "content_qualification_type": "RESEARCH"
+  },
+  "parameters": [
+    {
+      "id": "config",
+      "label": { "en": "config" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "sodiumgridding_ptpi",
+          "name": { "en": "sodiumgridding_pTPI" }
+        }
+      ],
+      "default": "sodiumgridding_ptpi",
+      "information": { "en": "Define the config to be executed by the MRD server." }
+    },
+    {
+      "id": "trajectoryfile",
+      "label": { "en": "Bundled trajectory" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5",
+          "name": { "en": "pTPI 23Na n28 g50 p5" }
+        },
+        {
+          "id": "/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g70_p5traj.h5",
+          "name": { "en": "pTPI 23Na n28 g70 p5" }
+        },
+        {
+          "id": "/opt/sodiumgridding_ptpi/23Na_pTPI_n50_g70_p5traj.h5",
+          "name": { "en": "pTPI 23Na n50 g70 p5" }
+        }
+      ],
+      "default": "/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5",
+      "information": { "en": "Dual-echo pTPI HDF5 trajectory. Uses k_echo1/k_echo2_forward_order and timing datasets when present." }
+    },
+    {
+      "id": "matrixsize",
+      "label": { "en": "Matrix size" },
+      "type": "int",
+      "minimum": 32,
+      "maximum": 512,
+      "default": 128,
+      "information": { "en": "Final isotropic gridding reconstruction matrix. Oversampling is fixed at 2." }
+    },
+    {
+      "id": "fovcm",
+      "label": { "en": "FOV cm" },
+      "type": "string",
+      "default": "22.0",
+      "information": { "en": "Reconstruction field of view in centimetres. Trajectories are interpreted in 1/cm units." }
+    },
+    {
+      "id": "dcfiterations",
+      "label": { "en": "DCF iterations" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 50,
+      "default": 5,
+      "information": { "en": "Number of iterative Kaiser-Bessel density compensation updates. Use 0 for uniform weights." }
+    },
+    {
+      "id": "maxcoils",
+      "label": { "en": "Max coils" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 128,
+      "default": 0,
+      "information": { "en": "Limit physical coils before compression. Use 0 for all coils." }
+    },
+    {
+      "id": "maxworkers",
+      "label": { "en": "Max workers" },
+      "type": "int",
+      "minimum": 1,
+      "maximum": 64,
+      "default": 8,
+      "information": { "en": "Maximum number of parallel coil reconstructions." }
+    },
+    {
+      "id": "coilcompression",
+      "label": { "en": "Coil compression" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Compress physical coils with the variance-retention PCA basis before splitting TE1/TE2." }
+    },
+    {
+      "id": "coilvarianceretention",
+      "label": { "en": "Coil variance" },
+      "type": "string",
+      "default": "0.9",
+      "information": { "en": "Fraction of physical-coil signal variance retained during virtual coil compression, from 0 to 1." }
+    },
+    {
+      "id": "coilcombinemode",
+      "label": { "en": "Coil combination" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "AC",
+          "name": { "en": "Adaptive combine" }
+        },
+        {
+          "id": "SoS",
+          "name": { "en": "Sum of squares" }
+        }
+      ],
+      "default": "AC",
+      "information": { "en": "Combine reconstructed virtual coils using sensitivity-weighted adaptive combination or sum of squares." }
+    },
+    {
+      "id": "echonormalizationmode",
+      "label": { "en": "Echo normalization" },
+      "type": "choice",
+      "values": [
+        { "id": "none", "name": { "en": "None" } },
+        { "id": "te1", "name": { "en": "TE1 shared" } },
+        { "id": "independent", "name": { "en": "Independent" } }
+      ],
+      "default": "none",
+      "information": { "en": "Controls TE1/TE2 centre-sample normalization before gridding." }
+    },
+    {
+      "id": "fieldmapdeltates",
+      "label": { "en": "Delta TE s" },
+      "type": "string",
+      "default": "0.005",
+      "information": { "en": "TE2-TE1 spacing in seconds for B0 field-map estimation." }
+    },
+    {
+      "id": "runphasecorrection",
+      "label": { "en": "Phase correction" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Run low-rank phase correction for both echoes using the estimated field map." }
+    },
+    {
+      "id": "phaselowrankrank",
+      "label": { "en": "Low-rank rank" },
+      "type": "int",
+      "minimum": 1,
+      "maximum": 32,
+      "default": 10,
+      "information": { "en": "Rank used for the low-rank phase table." }
+    },
+    {
+      "id": "applyn4biascorrection",
+      "label": { "en": "N4 correction" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Estimate an N4 bias field and apply it to the selected echoes." }
+    },
+    {
+      "id": "orientation",
+      "label": { "en": "Orientation" },
+      "type": "choice",
+      "values": [
+        { "id": "zyx", "name": { "en": "zyx (component 0 = read)" } },
+        { "id": "zyx_fx", "name": { "en": "zyx, reverse columns" } },
+        { "id": "zyx_fy", "name": { "en": "zyx, reverse rows" } },
+        { "id": "zyx_fxy", "name": { "en": "zyx, reverse rows and columns" } },
+        { "id": "zxy", "name": { "en": "zxy (component 0 = phase)" } },
+        { "id": "zxy_fx", "name": { "en": "zxy, reverse columns" } },
+        { "id": "zxy_fy", "name": { "en": "zxy, reverse rows" } },
+        { "id": "zxy_fxy", "name": { "en": "zxy, reverse rows and columns" } },
+        { "id": "debug", "name": { "en": "Debug sweep (all orientations)" } }
+      ],
+      "default": "zyx",
+      "information": { "en": "Map trajectory components into acquisition read/phase axes. Debug emits every mapping with slice kept/reversed." }
+    },
+    {
+      "id": "orientationflipslice",
+      "label": { "en": "Reverse slice axis" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Reverse trajectory component 2 before display-frame canonicalization." }
+    }
+  ]
+}

--- a/recipes/sodiumgridding_ptpi/OpenReconLabel.json
+++ b/recipes/sodiumgridding_ptpi/OpenReconLabel.json
@@ -3,7 +3,7 @@
     "name": { "en": "sodiumgridding_pTPI" },
     "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
     "vendor": "neurodesk",
-    "information": { "en": "Dual-echo palindromic TPI Kaiser-Bessel gridding with low-rank phase correction." },
+    "information": { "en": "Multi-echo palindromic TPI Kaiser-Bessel gridding with low-rank phase correction." },
     "id": "sodiumgridding_ptpi",
     "regulatory_information": {
       "device_trade_name": "sodiumgridding_pTPI",
@@ -15,7 +15,7 @@
       "gtin": "00860000171212",
       "udi": "(01)00860000171212(21)1.3.0",
       "safety_advices": "",
-      "special_operating_instructions": "OpenRecon dual-echo pTPI reconstruction from raw k-space to TE1/TE2 magnitude image data",
+      "special_operating_instructions": "OpenRecon multi-echo pTPI reconstruction from raw k-space to echo-resolved magnitude image data",
       "additional_relevant_information": ""
     }
   },
@@ -24,7 +24,7 @@
       "protocol": "ISMRMRD",
       "version": "1.4.1"
     },
-    "port": 9003,
+    "port": 9002,
     "emitter": "raw",
     "injector": "compleximage",
     "can_process_adjustment_data": true,
@@ -66,7 +66,7 @@
         }
       ],
       "default": "/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5",
-      "information": { "en": "Dual-echo pTPI HDF5 trajectory. Uses k_echo1/k_echo2_forward_order and timing datasets when present." }
+      "information": { "en": "pTPI HDF5 trajectory. Odd echoes use k_echo1; even echoes use k_echo2_forward_order when present." }
     },
     {
       "id": "matrixsize",
@@ -94,29 +94,20 @@
       "information": { "en": "Number of iterative Kaiser-Bessel density compensation updates. Use 0 for uniform weights." }
     },
     {
-      "id": "maxcoils",
-      "label": { "en": "Max coils" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 128,
-      "default": 0,
-      "information": { "en": "Limit physical coils before compression. Use 0 for all coils." }
+      "id": "svdretainfraction",
+      "label": { "en": "SVD threshold fraction" },
+      "type": "string",
+      "default": "0.2",
+      "information": { "en": "Keep singular values at least this fraction of the largest singular value in each temporal SVD patch. Larger values denoise more strongly." }
     },
     {
-      "id": "maxworkers",
-      "label": { "en": "Max workers" },
+      "id": "phaselowrankrank",
+      "label": { "en": "Low-rank rank" },
       "type": "int",
       "minimum": 1,
-      "maximum": 64,
-      "default": 8,
-      "information": { "en": "Maximum number of parallel coil reconstructions." }
-    },
-    {
-      "id": "coilcompression",
-      "label": { "en": "Coil compression" },
-      "type": "boolean",
-      "default": true,
-      "information": { "en": "Compress physical coils with the variance-retention PCA basis before splitting TE1/TE2." }
+      "maximum": 32,
+      "default": 10,
+      "information": { "en": "Rank used for the low-rank phase table." }
     },
     {
       "id": "coilvarianceretention",
@@ -143,46 +134,25 @@
       "information": { "en": "Combine reconstructed virtual coils using sensitivity-weighted adaptive combination or sum of squares." }
     },
     {
-      "id": "echonormalizationmode",
-      "label": { "en": "Echo normalization" },
-      "type": "choice",
-      "values": [
-        { "id": "none", "name": { "en": "None" } },
-        { "id": "te1", "name": { "en": "TE1 shared" } },
-        { "id": "independent", "name": { "en": "Independent" } }
-      ],
-      "default": "none",
-      "information": { "en": "Controls TE1/TE2 centre-sample normalization before gridding." }
-    },
-    {
       "id": "fieldmapdeltates",
       "label": { "en": "Delta TE s" },
       "type": "string",
       "default": "0.005",
-      "information": { "en": "TE2-TE1 spacing in seconds for B0 field-map estimation." }
+      "information": { "en": "Constant echo spacing in seconds. Echoes 1/2 provide the B0 field map; later echoes use this spacing for phase correction." }
     },
     {
       "id": "runphasecorrection",
       "label": { "en": "Phase correction" },
       "type": "boolean",
       "default": true,
-      "information": { "en": "Run low-rank phase correction for both echoes using the estimated field map." }
-    },
-    {
-      "id": "phaselowrankrank",
-      "label": { "en": "Low-rank rank" },
-      "type": "int",
-      "minimum": 1,
-      "maximum": 32,
-      "default": 10,
-      "information": { "en": "Rank used for the low-rank phase table." }
+      "information": { "en": "Run low-rank phase correction for all echoes using the echo 1/2 field map." }
     },
     {
       "id": "applyn4biascorrection",
       "label": { "en": "N4 correction" },
       "type": "boolean",
       "default": true,
-      "information": { "en": "Estimate an N4 bias field and apply it to the selected echoes." }
+      "information": { "en": "Estimate an N4 bias field from echoes 1/2 and apply it to the selected echoes." }
     },
     {
       "id": "orientation",

--- a/recipes/sodiumgridding_ptpi/OpenReconLabel.json
+++ b/recipes/sodiumgridding_ptpi/OpenReconLabel.json
@@ -169,14 +169,14 @@
         { "id": "zxy_fxy", "name": { "en": "zxy, reverse rows and columns" } },
         { "id": "debug", "name": { "en": "Debug sweep (all orientations)" } }
       ],
-      "default": "zyx",
+      "default": "zyx_fy",
       "information": { "en": "Map trajectory components into acquisition read/phase axes. Debug emits every mapping with slice kept/reversed." }
     },
     {
       "id": "orientationflipslice",
       "label": { "en": "Reverse slice axis" },
       "type": "boolean",
-      "default": false,
+      "default": true,
       "information": { "en": "Reverse trajectory component 2 before display-frame canonicalization." }
     }
   ]

--- a/recipes/sodiumgridding_ptpi/OpenReconREADME.md
+++ b/recipes/sodiumgridding_ptpi/OpenReconREADME.md
@@ -1,0 +1,94 @@
+# sodiumgridding_pTPI OpenRecon
+
+`sodiumgridding_pTPI` reconstructs dual-echo palindromic TPI raw data from an
+ISMRMRD stream. It adapts
+`ptpi_dual_echo_lowrank_core.py` from the standalone HDF5 workflow into the
+same OpenRecon container contract used by `sodiumgridding`.
+
+The reconstruction performs these steps:
+
+1. Read alternating TE1/TE2 raw acquisitions from the MRD stream.
+2. Optionally limit and variance-compress physical coils.
+3. Split interleaved echoes; reverse TE2 sample order for forward-order gridding.
+4. Load the bundled pTPI trajectory and echo timing arrays.
+5. Estimate separate Kaiser-Bessel DCF weights for TE1 and TE2.
+6. Grid each echo, estimate a TE1/TE2 B0 field map, and optionally rerun both
+   echoes with low-rank phase correction.
+7. Combine coils using adaptive combination or sum-of-squares.
+8. Optionally estimate an N4 bias field and apply it to the final echoes.
+
+The output is two explicit 3D derived magnitude images named
+`<protocol>_sodiumgridding_pTPI_te1` and
+`<protocol>_sodiumgridding_pTPI_te2`. Both images
+reuse the geometry/output helper from `sodiumgridding`, so display-frame
+canonicalization, `Keep_image_geometry`, orientation debug sweeps, and scanner
+prediction logging are intentionally identical.
+
+## Input Requirements
+
+The app expects raw acquisitions ordered as alternating TE1/TE2 readouts:
+
+```text
+TE1 readout 0, TE2 readout 0, TE1 readout 1, TE2 readout 1, ...
+```
+
+The bundled trajectory choices are:
+
+```text
+/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5
+/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g70_p5traj.h5
+/opt/sodiumgridding_ptpi/23Na_pTPI_n50_g70_p5traj.h5
+```
+
+When available, the container uses:
+
+- `k_echo1`
+- `k_echo2_forward_order`
+- `t_echo1_relative_s`
+- `t_echo2_forward_relative_s`
+
+If the dual-echo trajectory datasets are absent, it falls back to dataset `k`
+for both echoes and infers sample timing from `sampling_time_us`.
+
+## GUI Parameters
+
+| GUI label | Parameter id | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| config | `config` | choice | `sodiumgridding_ptpi` | Select the MRD server configuration. |
+| Bundled trajectory | `trajectoryfile` | choice | `/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5` | Bundled pTPI trajectory. |
+| Matrix size | `matrixsize` | int | `128` | Final isotropic reconstruction matrix. |
+| FOV cm | `fovcm` | string | `22.0` | Reconstruction field of view in centimetres. |
+| DCF iterations | `dcfiterations` | int | `5` | Kaiser-Bessel density compensation iterations. |
+| Max coils | `maxcoils` | int | `0` | Limit physical coils before compression; `0` uses all. |
+| Max workers | `maxworkers` | int | `8` | Parallel coil reconstruction workers. |
+| Coil compression | `coilcompression` | boolean | `true` | Use PCA variance-retention coil compression. |
+| Coil variance | `coilvarianceretention` | string | `0.9` | Variance retained by the compression basis. |
+| Coil combination | `coilcombinemode` | choice | `AC` | Adaptive combine or sum-of-squares. |
+| Echo normalization | `echonormalizationmode` | choice | `none` | TE1/TE2 centre-sample normalization mode. |
+| Delta TE s | `fieldmapdeltates` | string | `0.005` | Echo spacing used for B0 field-map estimation. |
+| Phase correction | `runphasecorrection` | boolean | `true` | Run low-rank phase correction for both echoes. |
+| Low-rank rank | `phaselowrankrank` | int | `10` | Rank used for the low-rank phase table. |
+| N4 correction | `applyn4biascorrection` | boolean | `true` | Apply N4 bias correction to the final echoes. |
+| Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping. |
+| Reverse slice axis | `orientationflipslice` | boolean | `false` | Reverse trajectory component 2 before display canonicalization. |
+
+## Runtime Notes
+
+- The OpenRecon wrapper disables standalone plotting and file-output flags from
+  the original script.
+- Debug arrays are written below `/tmp/share/debug` with the `sodiumgridding_ptpi_`
+  prefix, including TE1, TE2, the B0 field map, and N4 outputs when available.
+- The wrapper keeps the original low-rank correction signs and N4 defaults from
+  the supplied standalone script.
+- Geometry handling is delegated to `sodiumgridding.py`, so orientation changes
+  should be validated the same way: use `orientation=debug` on an asymmetric
+  object or a known-side marker, then set `orientation` and
+  `orientationflipslice` to the matching result.
+
+## Build
+
+```bash
+source env/bin/activate
+python -m builder generate sodiumgridding_ptpi --recreate --architecture x86_64
+sf-build sodiumgridding_ptpi --architecture x86_64
+```

--- a/recipes/sodiumgridding_ptpi/OpenReconREADME.md
+++ b/recipes/sodiumgridding_ptpi/OpenReconREADME.md
@@ -1,35 +1,46 @@
 # sodiumgridding_pTPI OpenRecon
 
-`sodiumgridding_pTPI` reconstructs dual-echo palindromic TPI raw data from an
+`sodiumgridding_pTPI` reconstructs multi-echo palindromic TPI raw data from an
 ISMRMRD stream. It adapts
 `ptpi_dual_echo_lowrank_core.py` from the standalone HDF5 workflow into the
 same OpenRecon container contract used by `sodiumgridding`.
 
 The reconstruction performs these steps:
 
-1. Read alternating TE1/TE2 raw acquisitions from the MRD stream.
+1. Read interleaved echo raw acquisitions from the MRD stream.
 2. Optionally limit and variance-compress physical coils.
-3. Split interleaved echoes; reverse TE2 sample order for forward-order gridding.
-4. Load the bundled pTPI trajectory and echo timing arrays.
-5. Estimate separate Kaiser-Bessel DCF weights for TE1 and TE2.
-6. Grid each echo, estimate a TE1/TE2 B0 field map, and optionally rerun both
-   echoes with low-rank phase correction.
+3. Split interleaved echoes; reverse echoes 2, 4, 6, ... for forward-order gridding.
+4. Load the bundled pTPI forward/reverse trajectories and timing arrays.
+5. Estimate Kaiser-Bessel DCF weights for the forward and reverse trajectories.
+6. Grid each echo. For two or more echoes, estimate a TE1/TE2 B0 field map and
+   optionally rerun all echoes with low-rank phase correction.
 7. Combine coils using adaptive combination or sum-of-squares.
 8. Optionally estimate an N4 bias field and apply it to the final echoes.
+9. For two or more echoes, optionally denoise the final echo volumes with
+   patch-wise temporal SVD.
 
-The output is two explicit 3D derived magnitude images named
-`<protocol>_sodiumgridding_pTPI_te1` and
-`<protocol>_sodiumgridding_pTPI_te2`. Both images
+The output is one explicit 3D derived magnitude image per detected echo, named
+`pTPI_TE1`, `pTPI_TE2`, etc. The short names avoid scanner-side sequence name
+truncation, while echo time is stored in the image metadata. The images
 reuse the geometry/output helper from `sodiumgridding`, so display-frame
 canonicalization, `Keep_image_geometry`, orientation debug sweeps, and scanner
 prediction logging are intentionally identical.
 
+When multiple repetitions are present, each echo/repetition pair is emitted as
+its own series, for example `pTPI_TE1_rep1`, `pTPI_TE1_rep2`,
+`pTPI_TE2_rep1`, and `pTPI_TE2_rep2`.
+
+All echoes from one repetition are sent with a shared scanner display scale by
+default, so relative echo brightness reflects the reconstructed magnitude
+decay instead of independent per-echo windowing.
+
 ## Input Requirements
 
-The app expects raw acquisitions ordered as alternating TE1/TE2 readouts:
+The app expects raw acquisitions ordered as interleaved echo readouts:
 
 ```text
-TE1 readout 0, TE2 readout 0, TE1 readout 1, TE2 readout 1, ...
+TE1 readout 0, TE2 readout 0, TE3 readout 0, ..., TEn readout 0,
+TE1 readout 1, TE2 readout 1, TE3 readout 1, ...
 ```
 
 The bundled trajectory choices are:
@@ -47,8 +58,22 @@ When available, the container uses:
 - `t_echo1_relative_s`
 - `t_echo2_forward_relative_s`
 
-If the dual-echo trajectory datasets are absent, it falls back to dataset `k`
-for both echoes and infers sample timing from `sampling_time_us`.
+If the forward/reverse trajectory datasets are absent, it falls back to dataset
+`k` for all echoes and infers sample timing from `sampling_time_us`.
+
+The number of echoes is detected from acquisition contrast indices first and
+then from the MRD `encodingLimits.contrast` range. A manual `numechoes` JSON
+setting is available as a fallback, but it is intentionally not exposed in the
+scanner GUI.
+
+Single-echo acquisitions are supported. In that mode the container reconstructs
+`pTPI_TE1` only and skips field-map phase correction and temporal SVD denoising
+because those steps need at least two echoes. N4 bias correction can still run
+from the single TE1 magnitude image.
+
+Echo times are read from MRD `sequenceParameters.TE` when available. If the
+header provides only one TE or no TE values, later echo times are inferred from
+`fieldmapdeltates`.
 
 ## GUI Parameters
 
@@ -59,25 +84,32 @@ for both echoes and infers sample timing from `sampling_time_us`.
 | Matrix size | `matrixsize` | int | `128` | Final isotropic reconstruction matrix. |
 | FOV cm | `fovcm` | string | `22.0` | Reconstruction field of view in centimetres. |
 | DCF iterations | `dcfiterations` | int | `5` | Kaiser-Bessel density compensation iterations. |
-| Max coils | `maxcoils` | int | `0` | Limit physical coils before compression; `0` uses all. |
-| Max workers | `maxworkers` | int | `8` | Parallel coil reconstruction workers. |
-| Coil compression | `coilcompression` | boolean | `true` | Use PCA variance-retention coil compression. |
+| SVD threshold fraction | `svdretainfraction` | string | `0.2` | Keep singular values at least this fraction of the largest singular value in each temporal SVD patch. |
+| Low-rank rank | `phaselowrankrank` | int | `10` | Rank used for the low-rank phase table. |
 | Coil variance | `coilvarianceretention` | string | `0.9` | Variance retained by the compression basis. |
 | Coil combination | `coilcombinemode` | choice | `AC` | Adaptive combine or sum-of-squares. |
-| Echo normalization | `echonormalizationmode` | choice | `none` | TE1/TE2 centre-sample normalization mode. |
-| Delta TE s | `fieldmapdeltates` | string | `0.005` | Echo spacing used for B0 field-map estimation. |
-| Phase correction | `runphasecorrection` | boolean | `true` | Run low-rank phase correction for both echoes. |
-| Low-rank rank | `phaselowrankrank` | int | `10` | Rank used for the low-rank phase table. |
+| Delta TE s | `fieldmapdeltates` | string | `0.005` | Constant echo spacing used for B0 field-map estimation and later echo timing. |
+| Phase correction | `runphasecorrection` | boolean | `true` | Run low-rank phase correction for all echoes. |
 | N4 correction | `applyn4biascorrection` | boolean | `true` | Apply N4 bias correction to the final echoes. |
 | Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping. |
 | Reverse slice axis | `orientationflipslice` | boolean | `false` | Reverse trajectory component 2 before display canonicalization. |
+
+The scanner GUI is limited to 14 parameters. Advanced pTPI defaults remain
+fixed in the wrapper: coil compression is enabled, echo normalization is
+`none`, temporal SVD denoising is enabled, `maxcoils` is `0` (all coils), and
+the worker cap is `8`.
+
+Additional hidden JSON-capable SVD denoising defaults are
+`denoisetemporalsvd=true`, `svdpatchsize=7`, and `svdstride=4`. Shared echo
+display scaling is enabled with `sharedechodisplayscale=true`.
 
 ## Runtime Notes
 
 - The OpenRecon wrapper disables standalone plotting and file-output flags from
   the original script.
 - Debug arrays are written below `/tmp/share/debug` with the `sodiumgridding_ptpi_`
-  prefix, including TE1, TE2, the B0 field map, and N4 outputs when available.
+  prefix, including every echo, pre-SVD echoes when denoising is enabled, the
+  B0 field map, and N4 outputs when available.
 - The wrapper keeps the original low-rank correction signs and N4 defaults from
   the supplied standalone script.
 - Geometry handling is delegated to `sodiumgridding.py`, so orientation changes

--- a/recipes/sodiumgridding_ptpi/OpenReconREADME.md
+++ b/recipes/sodiumgridding_ptpi/OpenReconREADME.md
@@ -91,8 +91,8 @@ header provides only one TE or no TE values, later echo times are inferred from
 | Delta TE s | `fieldmapdeltates` | string | `0.005` | Constant echo spacing used for B0 field-map estimation and later echo timing. |
 | Phase correction | `runphasecorrection` | boolean | `true` | Run low-rank phase correction for all echoes. |
 | N4 correction | `applyn4biascorrection` | boolean | `true` | Apply N4 bias correction to the final echoes. |
-| Orientation | `orientation` | choice | `zyx` | Shared sodiumgridding trajectory/display mapping. |
-| Reverse slice axis | `orientationflipslice` | boolean | `false` | Reverse trajectory component 2 before display canonicalization. |
+| Orientation | `orientation` | choice | `zyx_fy` | Shared sodiumgridding trajectory/display mapping. |
+| Reverse slice axis | `orientationflipslice` | boolean | `true` | Reverse trajectory component 2 before display canonicalization. |
 
 The scanner GUI is limited to 14 parameters. Advanced pTPI defaults remain
 fixed in the wrapper: coil compression is enabled, echo normalization is

--- a/recipes/sodiumgridding_ptpi/TPI_gridding_N256_AC_coil_compression_kb.py
+++ b/recipes/sodiumgridding_ptpi/TPI_gridding_N256_AC_coil_compression_kb.py
@@ -1,0 +1,433 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import h5py
+import numpy as np
+import scipy.ndimage as ndi
+import numba
+
+# Optional: For a significant speed-up in the FFT calculation
+try:
+    import pyfftw
+    pyfftw.interfaces.cache.enable()
+    use_pyfftw = True
+except ImportError:
+    use_pyfftw = False
+
+# --- Config ------------------------------------------------------------------
+# Some of these config values should be adjustable in the .json file!
+N           = 128
+NUM_COILS   = 16
+COIL_VARIANCE_RETENTION = 0.9 #.95 could be better, but .9 seems fine
+COIL_COMBINE_MODE = 'AC'  # 'AC' for adaptive coil combine, 'SoS' for sum of squares
+FOV_CM      = 22
+OVERSAMP    = 2
+DCF_ITER    = 5
+MAX_WORKERS = 8
+N4_SHRINK_FACTOR = 2
+N4_MAX_ITERATIONS = [50, 50, 50, 50]
+KB_KERNEL_WIDTH = 3.0 # 3 is a good trade off for 1H and 23Na
+KB_BETA = np.pi * np.sqrt((KB_KERNEL_WIDTH / OVERSAMP * (OVERSAMP - 0.5))**2 - 0.8)
+KB_I0_BETA = np.i0(KB_BETA)
+KB_LUT_SIZE = 2048
+KB_LUT_DISTANCES = np.linspace(0.0, 0.5 * KB_KERNEL_WIDTH, KB_LUT_SIZE, dtype=np.float64)
+KB_LUT = (
+    np.i0(KB_BETA * np.sqrt(np.maximum(0.0, 1.0 - (KB_LUT_DISTANCES / (0.5 * KB_KERNEL_WIDTH))**2)))
+    / KB_I0_BETA
+).astype(np.float64)
+
+# --- Sharpness Control ---
+FERMI_CUTOFF = .98 # Higher value = sharper image. (e.g., 0.9 to 1.0)
+FERMI_WIDTH  = 0.05 # Smaller value = sharper transition.
+
+# --- Memory Control ---
+MAX_SIMULTANEOUS_GRIDS = 2
+grid_semaphore = threading.Semaphore(MAX_SIMULTANEOUS_GRIDS)
+
+TRAJ_FILE = '/Users/clicht/Data_7T/23Na/Sofia_20260317/23Na_n50_trajectory.h5'
+#TRAJ_FILE = '/Users/clicht/Desktop/Python/n72_TPI_traj_new.h5'
+#TRAJ_FILE = '/Users/clicht/Desktop/Python/n28_TPI_23Na.h5'
+DATA_FILE = '/Users/clicht/Data_7T/23Na/Sofia_20260317/23Na_n50_TE50_7T_Sofia_1.h5'
+#DATA_FILE ="/Users/clicht/Data_7T/For_Chiadika/10272025/TPI_1H_TE0_14.h5"
+#DATA_FILE = '/Users/clicht/Data_3T/FIRE_sodiumNUFFT/23Na_FIRE_n28.h5'
+#DATA_FILE = "/Users/clicht/Data_7T/23Na/20260616_23Na_MESTIM_Shailja/23Na_n28_7T_Shailja_TR55_TE05.h5"
+
+def compress_coils_by_variance(coil_data, variance_retention=0.90, eps=1e-12):
+    """Compress physical coils into virtual coils retaining target signal energy."""
+    num_input_coils = coil_data.shape[0]
+    if num_input_coils <= 1:
+        return coil_data, np.array([1.0], dtype=np.float32), np.eye(num_input_coils, dtype=np.complex64)
+
+    data_2d = coil_data.reshape(num_input_coils, -1)
+    covariance = data_2d @ data_2d.conj().T
+    covariance /= max(data_2d.shape[1], 1)
+
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    sort_idx = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[sort_idx].real, 0.0)
+    eigenvectors = eigenvectors[:, sort_idx]
+
+    total_variance = eigenvalues.sum()
+    if total_variance <= eps:
+        print("Coil compression skipped: coil covariance has near-zero total variance.")
+        return coil_data, np.ones(num_input_coils, dtype=np.float32), np.eye(num_input_coils, dtype=np.complex64)
+
+    cumulative_variance = np.cumsum(eigenvalues) / total_variance
+    variance_retention = np.clip(variance_retention, 0.0, 1.0)
+    num_virtual_coils = np.searchsorted(cumulative_variance, variance_retention) + 1
+    compression_matrix = eigenvectors[:, :num_virtual_coils].astype(np.complex64)
+    compressed_data = np.einsum('cv,c...->v...', compression_matrix.conj(), coil_data, optimize=True)
+
+    print(
+        f"Coil compression: {num_input_coils} physical coils -> {num_virtual_coils} virtual coils "
+        f"({100.0 * cumulative_variance[num_virtual_coils - 1]:.2f}% variance retained)"
+    )
+    print("Cumulative coil variance:", np.array2string(cumulative_variance[:num_virtual_coils], precision=4))
+    return compressed_data.astype(np.complex64), cumulative_variance.astype(np.float32), compression_matrix
+
+# --- Load data and trajectory ------------------------------------
+print("Loading trajectory and data...")
+with h5py.File(TRAJ_FILE, 'r') as f: k_1_cm_full = f['k'][...]
+with h5py.File(DATA_FILE, 'r') as f:
+    data_dset = f['data']
+    if data_dset.ndim == 2:
+        data_shape = data_dset.shape
+        all_coil_data = data_dset[:data_shape[0], :data_shape[1]][None, ...].astype(np.complex64)
+    elif data_dset.ndim == 3:
+        actual_num_coils = min(NUM_COILS, data_dset.shape[0])
+        data_shape = data_dset[0, :, :].shape
+        all_coil_data = data_dset[:actual_num_coils, :data_shape[0], :data_shape[1]].astype(np.complex64)
+    else:
+        raise ValueError(f"Expected data to be 2D or 3D, got shape {data_dset.shape}")
+#    all_coil_data = f['data'][:NUM_COILS, :data_shape[0], 0::2].astype(np.complex64)
+NUM_COILS = all_coil_data.shape[0]
+k_1_cm = k_1_cm_full[:data_shape[0], :data_shape[1]]
+
+print("Loading trajectory and data done")
+print(f"Loaded {NUM_COILS} channel(s) with data shape {data_shape}")
+
+# --- THIS IS THE FIX ---
+k_physical = k_1_cm.reshape(-1, 3) # Changed --1 back to -1
+
+k_nyquist = 1.0 / (2.0 * FOV_CM / N)
+k_norm_pre = (k_physical / k_nyquist / 2.0).astype(np.float32)
+
+abs_k = np.linalg.norm(k_1_cm, axis=-1)
+abs_k_norm = abs_k / np.nanmax(abs_k)
+fermi_filter = 1.0 / (1.0 + np.exp((abs_k_norm - FERMI_CUTOFF) / FERMI_WIDTH))
+
+def preprocess_physical_coil_kspace(coil_data):
+    max_vals = np.abs(coil_data).max(axis=0)
+    h1 = np.histogram(ndi.gaussian_filter1d(max_vals, 5), bins=40)
+    most_common_max = h1[1][np.argmax(h1[0])]
+    high_readout_vals = max_vals[max_vals >= 0.95 * most_common_max]
+    high_readout_std = high_readout_vals.std() if high_readout_vals.size > 0 else max_vals.std()
+    threshold = most_common_max - 3 * high_readout_std
+    bad_readouts = np.where(max_vals < threshold)[0]
+
+    data_weights = np.ones(coil_data.shape, dtype=np.uint8)
+    if len(bad_readouts) > 0:
+        data_weights[:, bad_readouts] = 0
+
+    processed_data = coil_data * data_weights
+    center_idx = processed_data.shape[1] // 2
+    center_signal = np.abs(processed_data)[:, center_idx - 5:center_idx + 5].mean()
+    if center_signal > 1e-8:
+        processed_data *= 2.0 / center_signal
+
+    return (processed_data * fermi_filter).astype(np.complex64)
+
+print(f"Preprocessing {NUM_COILS} physical coils before compression...")
+all_coil_data = np.stack(
+    [preprocess_physical_coil_kspace(all_coil_data[k]) for k in range(NUM_COILS)],
+    axis=0
+).astype(np.complex64)
+
+all_coil_data, coil_variance, coil_compression_matrix = compress_coils_by_variance(
+    all_coil_data, variance_retention=COIL_VARIANCE_RETENTION
+)
+NUM_COILS = all_coil_data.shape[0]
+
+print(f"Configuration: N={N}, Oversampling={OVERSAMP}, Fermi Cutoff={FERMI_CUTOFF}")
+print(f"Kaiser-Bessel gridding: width={KB_KERNEL_WIDTH:.1f}, beta={KB_BETA:.3f}")
+print(f"Using pyFFTW for acceleration: {use_pyfftw}")
+
+# === Numba Gridding Kernels ==============================
+@numba.jit(nopython=True, fastmath=True)
+def _kaiser_bessel_weight_lut(distance, kernel_width, lut):
+    half_width = 0.5 * kernel_width
+    if distance > half_width:
+        return 0.0
+    lut_pos = distance / half_width * (len(lut) - 1)
+    idx0 = int(np.floor(lut_pos))
+    if idx0 >= len(lut) - 1:
+        return lut[len(lut) - 1]
+    frac = lut_pos - idx0
+    return lut[idx0] * (1.0 - frac) + lut[idx0 + 1] * frac
+
+@numba.jit(nopython=True)
+def _grid_kb_complex(grid, k_coords_norm, weights, grid_size, oversamp, kernel_width, lut):
+    og = grid_size * oversamp
+    num_points = len(k_coords_norm)
+    half_width = 0.5 * kernel_width
+    for i in range(num_points):
+        gx = (k_coords_norm[i, 0] + 0.5) * og - 0.5
+        gy = (k_coords_norm[i, 1] + 0.5) * og - 0.5
+        gz = (k_coords_norm[i, 2] + 0.5) * og - 0.5
+        ix_min = int(np.ceil(gx - half_width)); ix_max = int(np.floor(gx + half_width))
+        iy_min = int(np.ceil(gy - half_width)); iy_max = int(np.floor(gy + half_width))
+        iz_min = int(np.ceil(gz - half_width)); iz_max = int(np.floor(gz + half_width))
+        w = weights[i]
+        for iz in range(iz_min, iz_max + 1):
+            if 0 <= iz < og:
+                wz = _kaiser_bessel_weight_lut(abs(gz - iz), kernel_width, lut)
+                for iy in range(iy_min, iy_max + 1):
+                    if 0 <= iy < og:
+                        wy = _kaiser_bessel_weight_lut(abs(gy - iy), kernel_width, lut)
+                        for ix in range(ix_min, ix_max + 1):
+                            if 0 <= ix < og:
+                                wx = _kaiser_bessel_weight_lut(abs(gx - ix), kernel_width, lut)
+                                grid[iz, iy, ix] += w * wx * wy * wz
+
+@numba.jit(nopython=True, fastmath=True)
+def _grid_kb_real(grid, k_coords_norm, weights, grid_size, oversamp, kernel_width, lut):
+    og = grid_size * oversamp
+    num_points = len(k_coords_norm)
+    half_width = 0.5 * kernel_width
+    for i in range(num_points):
+        gx = (k_coords_norm[i, 0] + 0.5) * og - 0.5
+        gy = (k_coords_norm[i, 1] + 0.5) * og - 0.5
+        gz = (k_coords_norm[i, 2] + 0.5) * og - 0.5
+        ix_min = int(np.ceil(gx - half_width)); ix_max = int(np.floor(gx + half_width))
+        iy_min = int(np.ceil(gy - half_width)); iy_max = int(np.floor(gy + half_width))
+        iz_min = int(np.ceil(gz - half_width)); iz_max = int(np.floor(gz + half_width))
+        w = weights[i]
+        for iz in range(iz_min, iz_max + 1):
+            if 0 <= iz < og:
+                wz = _kaiser_bessel_weight_lut(abs(gz - iz), kernel_width, lut)
+                for iy in range(iy_min, iy_max + 1):
+                    if 0 <= iy < og:
+                        wy = _kaiser_bessel_weight_lut(abs(gy - iy), kernel_width, lut)
+                        for ix in range(ix_min, ix_max + 1):
+                            if 0 <= ix < og:
+                                wx = _kaiser_bessel_weight_lut(abs(gx - ix), kernel_width, lut)
+                                grid[iz, iy, ix] += w * wx * wy * wz
+
+@numba.jit(nopython=True, fastmath=True)
+def _sample_kb(values, grid, k_coords_norm, grid_size, oversamp, kernel_width, lut):
+    og = grid_size * oversamp
+    num_points = len(k_coords_norm)
+    half_width = 0.5 * kernel_width
+    for i in range(num_points):
+        gx = (k_coords_norm[i, 0] + 0.5) * og - 0.5
+        gy = (k_coords_norm[i, 1] + 0.5) * og - 0.5
+        gz = (k_coords_norm[i, 2] + 0.5) * og - 0.5
+        ix_min = int(np.ceil(gx - half_width)); ix_max = int(np.floor(gx + half_width))
+        iy_min = int(np.ceil(gy - half_width)); iy_max = int(np.floor(gy + half_width))
+        iz_min = int(np.ceil(gz - half_width)); iz_max = int(np.floor(gz + half_width))
+        val = 0.0
+        for iz in range(iz_min, iz_max + 1):
+            if 0 <= iz < og:
+                wz = _kaiser_bessel_weight_lut(abs(gz - iz), kernel_width, lut)
+                for iy in range(iy_min, iy_max + 1):
+                    if 0 <= iy < og:
+                        wy = _kaiser_bessel_weight_lut(abs(gy - iy), kernel_width, lut)
+                        for ix in range(ix_min, ix_max + 1):
+                            if 0 <= ix < og:
+                                wx = _kaiser_bessel_weight_lut(abs(gx - ix), kernel_width, lut)
+                                val += grid[iz, iy, ix] * wx * wy * wz
+        values[i] = val
+
+# === Main Functions ==============================================
+def compute_dcf_kb(k_coords_norm, grid_size, oversamp, n_iter=10):
+    og = grid_size * oversamp
+    dcf = np.ones(len(k_coords_norm), dtype=np.float64)
+    print(f"  DCF Iterations: ", end="")
+    for i in range(n_iter):
+        print(f"{i+1}...", end="", flush=True)
+        wsum = np.zeros((og, og, og), dtype=np.float64)
+        _grid_kb_real(wsum, k_coords_norm, dcf, grid_size, oversamp, KB_KERNEL_WIDTH, KB_LUT)
+        sampled_density = np.zeros_like(dcf)
+        _sample_kb(sampled_density, wsum, k_coords_norm, grid_size, oversamp, KB_KERNEL_WIDTH, KB_LUT)
+        sampled_density[sampled_density < 1e-9] = 1.0
+        dcf /= sampled_density
+        dcf /= np.median(dcf)
+    print(" Done.")
+    return dcf.astype(np.float32)
+
+def compute_deapodisation_kb(grid_size, oversamp):
+    og = grid_size * oversamp
+    kernel_1d = np.zeros(og, dtype=np.complex128)
+    g_center = 0.5 * og - 0.5
+    half_width = 0.5 * KB_KERNEL_WIDTH
+    ix_min = int(np.ceil(g_center - half_width))
+    ix_max = int(np.floor(g_center + half_width))
+    for ix in range(ix_min, ix_max + 1):
+        if 0 <= ix < og:
+            distance = abs(g_center - ix)
+            ratio = distance / half_width
+            kernel_1d[ix] = np.i0(KB_BETA * np.sqrt(max(0.0, 1.0 - ratio * ratio))) / KB_I0_BETA
+
+    response_1d = np.fft.ifftshift(np.fft.ifft(np.fft.ifftshift(kernel_1d))) * og
+    start = (og - grid_size) // 2
+    end = start + grid_size
+    deapo_1d = np.abs(response_1d[start:end])
+    deapo = np.multiply.outer(np.multiply.outer(deapo_1d, deapo_1d).ravel(), deapo_1d)
+    deapo = deapo.reshape(grid_size, grid_size, grid_size)
+    deapo /= np.nanmax(deapo)
+    deapo = np.where(deapo < 1e-8, 1e-8, deapo)
+    return deapo.astype(np.float32)
+
+def regrid_3d_kb(kspace_data, k_coords_norm, grid_size, dcf, deapo, oversamp):
+    og = grid_size * oversamp
+    data_dcf = (kspace_data * dcf).astype(np.complex128)
+    grid = np.zeros((og, og, og), dtype=np.complex128)
+    _grid_kb_complex(grid, k_coords_norm, data_dcf, grid_size, oversamp, KB_KERNEL_WIDTH, KB_LUT)
+    shifted_grid = np.fft.ifftshift(grid)
+    if use_pyfftw:
+        ifft_obj = pyfftw.builders.ifftn(shifted_grid, auto_align_input=True, auto_contiguous=True, threads=-1)
+        transformed_grid = ifft_obj()
+    else:
+        transformed_grid = np.fft.ifftn(shifted_grid)
+    img_os = np.fft.ifftshift(transformed_grid) * (og**3)
+    start = (og - grid_size) // 2
+    end = start + grid_size
+    img = img_os[start:end, start:end, start:end].copy()
+    img /= deapo
+    return img.astype(np.complex64)
+
+
+# --- Precomputation, Coil Processing, and Combination (Logic Unchanged) ---
+print('Computing DCF...')
+dcf_precomputed = compute_dcf_kb(k_norm_pre, grid_size=N, oversamp=OVERSAMP, n_iter=DCF_ITER)
+print('Computing deapodisation...')
+deapo_precomputed = compute_deapodisation_kb(N, OVERSAMP)
+print('Ready for reconstruction.')
+
+def process_coil(coil_k, coil_data):
+    with grid_semaphore:
+        img = regrid_3d_kb(
+            coil_data.ravel(), k_norm_pre,
+            grid_size=N, dcf=dcf_precomputed, deapo=deapo_precomputed,
+            oversamp=OVERSAMP
+        )
+    return coil_k, img
+
+NUFFT_all_coils = np.zeros([NUM_COILS, N, N, N], dtype=np.complex64)
+print(f"Reconstructing {NUM_COILS} coils at {N}³ with {MAX_WORKERS} workers...")
+with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+    futures = [executor.submit(process_coil, k, all_coil_data[k]) for k in range(NUM_COILS)]
+    for i, future in enumerate(futures):
+        k, img = future.result()
+        NUFFT_all_coils[k] = img
+        if (i + 1) % 4 == 0 or (i + 1) == NUM_COILS:
+            print(f"Completed {i + 1}/{NUM_COILS} coils")
+
+def estimate_sensitivities(img_coils, smooth_sigma=None, eps=1e-8):
+    C, X, Y, Z = img_coils.shape
+    if smooth_sigma is None: smooth_sigma = X / 32.0
+    print(f"Using sensitivity smoothing sigma: {smooth_sigma:.1f} voxels")
+    sens_smooth = np.zeros_like(img_coils, dtype=np.complex64)
+    for c in range(C):
+        sr = ndi.gaussian_filter(img_coils[c].real, smooth_sigma)
+        si = ndi.gaussian_filter(img_coils[c].imag, smooth_sigma)
+        sens_smooth[c] = sr + 1j * si
+    rss = np.sqrt(np.sum(np.abs(sens_smooth) ** 2, axis=0)) + eps
+    sens_smooth /= rss[None, ...]
+    return sens_smooth.astype(np.complex64)
+
+def combine_coils(img_coils, mode='AC'):
+    mode_normalized = mode.strip().upper()
+    if img_coils.shape[0] == 1:
+        print("Single-channel data: skipping coil combination.")
+        return np.abs(img_coils[0])
+
+    if mode_normalized == 'SOS':
+        print("Performing sum-of-squares coil combination...")
+        return np.sqrt(np.sum(np.abs(img_coils) ** 2, axis=0)).astype(np.float32)
+
+    if mode_normalized == 'AC':
+        print("Estimating coil sensitivities...")
+        sens_maps = estimate_sensitivities(img_coils)
+        print("Performing adaptive coil combination...")
+        img_combined = np.sum(np.conj(sens_maps) * img_coils, axis=0)
+        return np.abs(img_combined).astype(np.float32)
+
+    raise ValueError("COIL_COMBINE_MODE must be 'AC' or 'SoS'")
+
+img_combined_AC = combine_coils(NUFFT_all_coils, mode=COIL_COMBINE_MODE)
+
+print(f"\nFinal image shape: {img_combined_AC.shape}")
+print(f"Coil combination mode: {COIL_COMBINE_MODE}")
+print(f"Final voxel size: {FOV_CM/N:.3f} cm")
+print("Reconstruction complete.")
+
+# --- N4 Bias Field Correction -----------------------------------------------
+import SimpleITK as sitk
+
+
+def n4_bias_field_correct(image_xyz):
+    image_zyx = image_xyz.swapaxes(0, 2).astype(np.float32)
+    sitk_image = sitk.GetImageFromArray(image_zyx)
+
+    mask = sitk.OtsuThreshold(sitk_image, 0, 1, 512)
+    mask = sitk.BinaryMorphologicalClosing(mask, [9, 9, 9])
+    mask = sitk.BinaryFillhole(mask)
+
+    if N4_SHRINK_FACTOR > 1:
+        shrink = [int(N4_SHRINK_FACTOR)] * sitk_image.GetDimension()
+        correction_image = sitk.Shrink(sitk_image, shrink)
+        correction_mask = sitk.Shrink(mask, shrink)
+    else:
+        correction_image = sitk_image
+        correction_mask = mask
+
+    corrector = sitk.N4BiasFieldCorrectionImageFilter()
+    corrector.SetMaximumNumberOfIterations(N4_MAX_ITERATIONS)
+    corrector.SetConvergenceThreshold(0.001)
+    corrector.SetSplineOrder(3)
+    corrector.SetWienerFilterNoise(0.1)
+    corrector.SetBiasFieldFullWidthAtHalfMaximum(0.15) # this should also be in .json file to tune!
+
+    corrector.Execute(correction_image, correction_mask)
+    log_bias_field = corrector.GetLogBiasFieldAsImage(sitk_image)
+    corrected_sitk = sitk_image / sitk.Exp(log_bias_field)
+    corrected_xyz = sitk.GetArrayFromImage(corrected_sitk).swapaxes(0, 2)
+    return corrected_xyz.astype(np.float32), corrected_sitk, mask
+
+
+print(f"Running N4 bias field correction with shrink factor {N4_SHRINK_FACTOR}...")
+img_combined_AC_n4, corrected_image, n4_mask = n4_bias_field_correct(img_combined_AC)
+print("N4 bias field correction complete.")
+
+# --- Compare Original vs N4-Corrected Image ---------------------------------
+import matplotlib.pyplot as plt
+
+axial_idx = N // 2 - 20
+sagittal_idx = N // 2
+coronal_idx = N // 2 - 10
+
+img_original = np.abs(img_combined_AC).swapaxes(0, 2)
+img_n4 = np.abs(img_combined_AC_n4).swapaxes(0, 2)
+
+slice_pairs = [
+    (img_original[:, :, axial_idx], img_n4[:, :, axial_idx], f"Axial (z={axial_idx})"),
+    (img_original[sagittal_idx, :, :], img_n4[sagittal_idx, :, :], f"Sagittal (x={sagittal_idx})"),
+    (img_original[:, coronal_idx, :], img_n4[:, coronal_idx, :], f"Coronal (y={coronal_idx})"),
+]
+
+fig, axes = plt.subplots(2, 3, figsize=(12, 7))
+for col, (original_slice, n4_slice, title) in enumerate(slice_pairs):
+    original_slice = np.rot90(original_slice)
+    n4_slice = np.rot90(n4_slice)
+    vmax = np.percentile(np.concatenate([original_slice.ravel(), n4_slice.ravel()]), 99.5)
+
+    axes[0, col].imshow(original_slice, cmap='gray', vmin=0, vmax=vmax)
+    axes[0, col].set_title(f"Original {title}")
+    axes[1, col].imshow(n4_slice, cmap='gray', vmin=0, vmax=vmax)
+    axes[1, col].set_title(f"N4 Corrected {title}")
+
+for ax in axes.ravel():
+    ax.axis('off')
+
+plt.tight_layout()
+plt.show()

--- a/recipes/sodiumgridding_ptpi/build.yaml
+++ b/recipes/sodiumgridding_ptpi/build.yaml
@@ -1,0 +1,101 @@
+name: sodiumgridding_ptpi
+version: 0.1.0
+
+copyright:
+  - license: MIT
+    url: https://github.com/NeuroDesk/neurocontainers/blob/main/LICENSE
+
+architectures:
+  - x86_64
+
+files:
+  - name: sodiumgridding_ptpi.py
+    filename: sodiumgridding_ptpi.py
+  - name: ptpi_dual_echo_lowrank_core.py
+    filename: ptpi_dual_echo_lowrank_core.py
+  - name: sodiumgridding.py
+    filename: sodiumgridding.py
+  - name: twix2mrd.py
+    filename: twix2mrd.py
+  - name: siemens_twix2mrd.py
+    filename: siemens_twix2mrd.py
+  - name: mrd2nifti.py
+    filename: mrd2nifti.py
+  - name: sodiumgridding_ptpi_trajectory_n28_g50_p5
+    url: https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/build/23Na_pTPI_n28_g50_p5traj.h5
+  - name: sodiumgridding_ptpi_trajectory_n28_g70_p5
+    url: https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/build/23Na_pTPI_n28_g70_p5traj.h5
+  - name: sodiumgridding_ptpi_trajectory_n50_g70_p5
+    url: https://object-store.rc.nectar.org.au/v1/AUTH_dead991e1fa847e3afcca2d3a7041f5d/build/23Na_pTPI_n50_g70_p5traj.h5
+  - name: OpenReconLabel.json
+    filename: OpenReconLabel.json
+  - name: OpenReconREADME.md
+    filename: OpenReconREADME.md
+
+build:
+  kind: neurodocker
+  base-image: ubuntu:22.04
+  pkg-manager: apt
+
+  directives:
+    - environment:
+        DEBIAN_FRONTEND: noninteractive
+        NUMBA_CACHE_DIR: /tmp/numba-sodiumgridding
+    - install:
+        - bzip2
+        - ca-certificates
+        - git
+        - build-essential
+        - python3-pip
+        - python-is-python3
+    - include: macros/openrecon/neurodocker.yaml
+    - run:
+        - ldconfig
+    - run:
+        - pip3 install --no-cache-dir numba==0.66.0 pyFFTW==0.15.0 SimpleITK==2.5.5 twixtools==0.24 nibabel==5.3.2 scikit-image==0.25.2 matplotlib==3.10.7
+    - workdir: /opt/sodiumgridding_ptpi
+    - run:
+        - cp {{ get_file("sodiumgridding_ptpi.py") }} /opt/code/python-ismrmrd-server/sodiumgridding_ptpi.py
+        - cp {{ get_file("ptpi_dual_echo_lowrank_core.py") }} /opt/code/python-ismrmrd-server/ptpi_dual_echo_lowrank_core.py
+        - cp {{ get_file("sodiumgridding.py") }} /opt/code/python-ismrmrd-server/sodiumgridding.py
+        - cp {{ get_file("twix2mrd.py") }} /opt/code/python-ismrmrd-server/twix2mrd.py
+        - cp {{ get_file("siemens_twix2mrd.py") }} /opt/code/python-ismrmrd-server/siemens_twix2mrd.py
+        - cp {{ get_file("mrd2nifti.py") }} /opt/code/python-ismrmrd-server/mrd2nifti.py
+        - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
+    - run:
+        - mkdir -p /opt/sodiumgridding_ptpi
+        - cp {{ get_file("sodiumgridding_ptpi_trajectory_n28_g50_p5") }} /opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5
+        - cp {{ get_file("sodiumgridding_ptpi_trajectory_n28_g70_p5") }} /opt/sodiumgridding_ptpi/23Na_pTPI_n28_g70_p5traj.h5
+        - cp {{ get_file("sodiumgridding_ptpi_trajectory_n50_g70_p5") }} /opt/sodiumgridding_ptpi/23Na_pTPI_n50_g70_p5traj.h5
+
+deploy:
+  bins:
+    - python
+    - siemens_to_ismrmrd
+
+categories:
+  - image reconstruction
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABKCAYAAAAL8lK4AAAACXBIWXMAAAsTAAALEwEAmpwYAAAFF2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNy4xLWMwMDAgNzkuN2E3YTIzNiwgMjAyMS8wOC8xMi0wMDoyNToyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnBob3Rvc2hvcD0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIDIyLjUgKFdpbmRvd3MpIiB4bXA6Q3JlYXRlRGF0ZT0iMjAyMS0wOS0xNVQyMDozNDozMCsxMDowMCIgeG1wOk1vZGlmeURhdGU9IjIwMjEtMDktMjlUMDg6MzA6NDIrMTA6MDAiIHhtcDpNZXRhZGF0YURhdGU9IjIwMjEtMDktMjlUMDg6MzA6NDIrMTA6MDAiIGRjOmZvcm1hdD0iaW1hZ2UvcG5nIiBwaG90b3Nob3A6Q29sb3JNb2RlPSIzIiBwaG90b3Nob3A6SUNDUHJvZmlsZT0ic1JHQiBJRUM2MTk2Ni0yLjEiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6ZGM2MWFhMTUtNDI3MS03ZDQyLTk5Y2MtMWQ2MTA1MzQ5MTViIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOmRjNjFhYTE1LTQyNzEtN2Q0Mi05OWNjLTFkNjEwNTM0OTE1YiIgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOmRjNjFhYTE1LTQyNzEtN2Q0Mi05OWNjLTFkNjEwNTM0OTE1YiI+IDx4bXBNTTpIaXN0b3J5PiA8cmRmOlNlcT4gPHJkZjpsaSBzdEV2dDphY3Rpb249ImNyZWF0ZWQiIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6ZGM2MWFhMTUtNDI3MS03ZDQyLTk5Y2MtMWQ2MTA1MzQ5MTViIiBzdEV2dDp3aGVuPSIyMDIxLTA5LTE1VDIwOjM0OjMwKzEwOjAwIiBzdEV2dDpzb2Z0d2FyZUFnZW50PSJBZG9iZSBQaG90b3Nob3AgMjIuNSAoV2luZG93cykiLz4gPC9yZGY6U2VxPiA8L3htcE1NOkhpc3Rvcnk+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+TzdbEgAAElBJREFUeJzNW2dUlFe3fqYwDAMI4gxKUwYYRCBYiIhSVBQUjIpGVAixoEE+cy1BNNgoiRcF0cRLLJhF0ysGS4war1FMiNFEiYqiUfFDsQBKUZA4SBtm3x/CLNoM0zTfs9ZeM+ucs8vZ73n32ae8DCLCW8AgsVgcePv2bZtnz569J5FIdIRC4Z+urq7/BvAjgHI5fL4vXrwYWlhYOLSurs7SxMTkvrm5eYVIJLoM4NTbMBREpE1yvHnz5jcrVqxo5vP5BKAT2djYUGJi4t9EZN+V9/79++lTp04lAwODbnx+fn6Unp5+mYgWa9lerTmA/fTp080RERHdjO+Jzp07d7sL/6whQ4b0yufs7ExpaWk3iGj6f5IDhubk5Nzp27evUp0HQH379qX6+vqoNn7D5ORksbK8ACggIIAqKir+5z/BAVMjIyOlqhjfTikpKUVtMhabmpqqzM/n8+nChQt5RMT4pxzw/pIlS1Q2vJ3mzp0rJSJcv379S3VlAKD8/Pw//gkHcHJycso0Mdzd3Z2IaERWVtY3msgxNDSkurq6f6nrACbUw4jExEQLNXkBANXV1QDgLhaLhZrIefXqFfLy8hary6+WAx4+fLisoKBAXZ0AgNLSUgAYWF1dbaKRIAApKSkjAASrxazikBEVFBR8b2Njo/aQbacRI0YQEW27cuXKZTabrbG8yZMnU1FRURYRWb2tGLDo008/VSvidyUHBwc6dOgQSaXSLQUFBRdDQ0OJy+VqLBcAbdiwoYGIxmnbAROnT5+uFQMHDx5MMTEx5OrqSlKpdOmaNWuOjB49mhITE7UiHwDFxcUREZloywGs9PT0v5VVbmtrSxYWFj3WDRo0iLKysmjgwIHE4XCIiHyPHj26HQAtXbqUNmzYIFeuQCAge3t7pZ1QUlJyTFsOmNGnTx+l38PExERKSkqi4cOHd6rr168fZWZmkoeHBwGg999/n4jI/aeffpLlAWvXrqU1a9Z0kztkyBBKTEykLVu20JQpU5SyJSQkhIiIr6kDBPv27StWRqFIJJIZr6OjQ2lpabRkyRKaMWMGzZkzh1JTU2ncuHGy9iNHjiQiGpaXl7e2o5yYmBiKj4+nGTNm0KxZsygsLIwyMjLI2NiYANCqVavI2dlZKSecPXu2gIj6KeqjomnQNCMj4+q8efPsFLSRQSqVyv5zOBwAgKGhIfh8PgQCATIzM/Hrr7/K2ujo6ABAI4/Ha+wo54svvkBZWRkGDBiAvn37Ql9fHwDAZL4xlcVivXlySsDPz294dnb2NQB95TaS55kffvjhPlQMPgEBAbRy5UpavXo1ubq6Kmzr5eVFRCQsKipa2ptcR0dH+vzzz2nZsmUUGBioclA8e/bsXyq9AqWlpdmqKmkngUBARkZGvbYbO3YsEZFVWVlZmDJy9fX1acCAAWrZxGQyqaamJkVZB7w/ZswYtRSpQhMnTiQi4tfV1YXq6uq+dX0ffvghEZF1rw7Iz8+/8LaNAUATJkwgIuI3NzfPbg9wb5vKysr29xYErbdu3eqJdwcGk8lsYbPZ70TZnj17JgFgdCzrqnnizZs3taIsLCwM1tbWuHXrFg4fPtytvr6+HgBYLBarubGxsVs9AEybNg2urq6oqKhAampqp5lGHVy/fl0AQAigpL2sqwOa26cwTRASEgI+n4+jR4/C398fCxcuxNWrV2VTmUQiwfDhwwGgAUCrh4cHysvLwWKxALyZUl1cXCAUCvH9999j/PjxWLx4Mfbu3auRXaamphIALzuWdXXASx6Pp5ESAHBycsLx48dRWFgIHo+HqKgo8Hg8MBhvRl9LSwuGDRsGAI0ApGPGjEFFRYXMAUSEcePGITU1FYWFhWhubkZ4eLjGdtXV1QGAOYAaWWHHgFBWVrZd3qrMxMSEzM3NlQo2Li4uFBsbS6GhoRQXF0f9+vXr1sbb25uIiEdE4/v379+tXl9fn2JiYig0NJRiY2PJ3d1d4yDI5XKpqqoqRd4swFiwYEFVT4xOTk60Y8cOSkpKooCAAKWUWVhYkJ+fH8mL8FOmTGl3gLe8LXF9fX3y9fUla2trrc0Ea9eurSUinfZ+d3wFFpiYmAhmzJghe1eJCMbGxnB3d8fatWtRW1uLqKgoFBcXo7i4WNFoQ3l5OcrL5R0AQfY6AGhuS4u7ob6+Hrm5uQr1qIrMzEzjhISEJQC+ATpsiZ0/fz68pKQE+vr64PF4MjI0NASHw4FYLJZF4fZ3VRM0NzcDgAGAlg7OeOt49uwZsrKy/iUraBsKTn5+fnKHjZubG61bt45WrVpFQUFBWhmKPj4+REQWROQ8cuTId5IItZOnpycRkbcsBtTU1GzjcDgKmfr160eWlpZaM6ItEzT/JxwAgEpKStJkmeB33303tm1IysWLFy9QVlamsI2akGgrE+zTpw9EIpFSbQ8cODAeeJMHWF68eHGEVizoAgaDAaFQiJKSkh7r2iA3CKoCHx8feHp64tmzZ3Bzc8PBgwcVZo6XLl0SAhjOBuB369YtrUcha2trzJo1C2KxGBKJBAcPHmxPfwHINlCYAJiaprhcLhcjR45ESkoKamtrkZCQAG9v704bMF1x+/ZtABjPbGxsHPjo0SONDOgJixYtwvXr17Fnzx4wmUz4+Ph0qm9paQEADoDW9mm3K+bMmYNNmzYhMjISenp6cnU1NjaiqakJZmZmYDAYYLFYaGpqUmjfkydP8PTpUwv2/fv3+a9evVKxe72jtbUVXC4XAFBbWyvPIAaApp5eAW9vb9jY2ODbb7+Fj48PIiIi8NVXX/Woy9LSEo6Ojhg0aBBev36NX375BZcuXVJoHxHh7t27JmyxWKxUBLKxsUFYWBikUilSU1MVJjkAkJqaio8//hje3t7o378/FixY0Km+LQaQPH4ul4tr167h8ePHKCgowLx583psZ25ujk2bNmHr1q24c+cOzM3Ne7WtHRwOR4Kampov9PX1FU4ZJiYmFB8fTx4eHvTBBx/QqlWrlD7JEYlEFBkZSd7e3p3KR40aRUQ0hIjMfXx8uvE5OjrS6dOnKTo6mrZs2UI9pcvDhg2j1NRUGjRokMrTIIPBoLKysi1sPT295t4yu8DAQIhEIsTGxgIARCIRDAwMIG8d3xHFxcU4fPgw1q1bh4KCAojFYgCy/QAGAGZDQ0MnHpFIhPDwcHz55ZdgsVgoLi5GRUVFj/L19PTU2ido2/s0Yf/111/mf//9d4+NuFwuFi1aBFNTU9y7dw+hoaGwsLDA8+fP8fz5c6WVlZaW4siRI4iNjcW9e/fQ2traPl+zAEhmz54Ne3t76OrqgslkwsnJCWlpabhx44ZCuTdu3MDGjRsRFxeHXbt24dq1a0rb1MZvgePHj3+HHobIpEmTaNeuXfTZZ591Kus6lFUhKysrsre3Jzs7O5o6dSoR0Sgi0g8PDydbW1sSiUQ0ePDgHm+K9SY3MzOTRo8erRLfyZMn83HgwIFTHQstLS0pISGBkpOTycHB4a2loiKRiIjInYh4EyZM0FielZUVpaWldTp9UkRBQUFUWFh4ly2RSGQTbFhYGFxdXXHlyhVkZmYqHj8aoi395QCArq6uxvJKS0sRFxeHhIQEAJCbBDGZTGzevBm5ublISkrSYz58+NDQ2dkZW7duxcCBA7F+/fq33nkAqKmpAd7EAPS2DlEWpaWlWLVqFUJCQjBx4sRu9To6Oti+fTsePXqEc+fOwcTERIc9evTolurqavz44484f/68RgYYGRlh5syZePnyJRgMhizf7/orlUphYWEBvFmLkJ+fH4yNjTud+3X8bf9vbGyM33//HUVFRXJtqKqqQnR0NJKTkwEA586dAwDweDxs374d+fn5yMjIAPBmFLKlUql4586dGnUcAGxtbREdHY2rV6+ioqJCZrhUKu32XyKRoLa2FgB0ANCdO3dw9epVcDgcsNlssFgssFgsMJlMMBgM2W9raytWr16Nffv2KXxYNTU1iIyMxLZt29Da2oq8vDzs2LEDZ86cwZEjR2Tt2Gx2K/bv338MGgYgFxcX2r9/P3l6eirNY2RkREQUSEQcRZsxXcna2poyMzNp0qRJvbbl8/mUnJxM2dnZNHny5G718fHxd/Hnn39+q0nnPTw8aP/+/TR06FCV+Pr370+tra0ziMhYFQe086anp5My13aMjY3lPpidO3f+zh42bFiZoaEhlF0Q6ejoYPbs2dDT04O1tTWYTCbi4uLw4MEDpfjb0dLSAiJiAuBIJBKVeCsrKxEVFYXly5fDw8MDRUVFYDKZyMnJ6daPly9f4uLFiz3KEQqFZUwdHZ1/29vbK6185syZEAqFOHnyJPh8PoqKilTuPPAmFW5oaOACkMpbDitCTU0Nrl27BlNTU5w6dQqGhoYIDAxUmp/L5cLT0/MBE8CZ9957r0VZRktLS1y+fBmVlZU4fvw4rKysVDYeAJqamlBZWWkAwEDdadDW1hYnTpxAZWUlfv75Z/D5fKV5hw4dCkNDw8tsADWTJk36MzMz00MZxtOnT2P+/Plwd3eHrq6ubEpRB1VVVYa2trZGr1+/Vov/xIkTCA8Ph6OjI4yMjHDgwAGleb28vGoAnGqfllb3dHwlj4yMjGj69OmkyjcCPdHZs2djichT2UtPPRGPx6Pp06erfHukqKjofzsejRktX768WZPOqEPHjh3bRkQf2NravlO9beeS7p3OBqurq1OYTOY7NSQjIyONiCIEAsE71Xvx4sUL3W6I8Pn8dRs3bux9h0OLqK+v1wNgom4MUAcBAQHw8PBYLivocmfmUzMzs3f2JHbs2JFDROsMDQ3fmc6ysrIDiu4I7czJyflLff/2DDs7OwQHB0MgEHQqZzAYUgCNPd1KEYlECA4OxoABA7RmR3x8vMTCwmJZx7JuGYiXl9fMqVOnak2pnZ0dlixZAgsLC6xcubLT0RWbzZYAELdvn7fD2dkZYWFhMDc3x7Jly2BiovE3FTAyMkJMTEwkOt4OQfcrMgBQnJ6eni0QCELkCRMKhRg7dizEYjGIqOMxV7elb0BAAKKjo1FRUYGZM2di/vz52LBhAwCAyWRKAbzqeugRHByMw4cPo6CgAG5ubkhOTsapU6fA4XDAYDDw6tUriMVi3L17V+5maVckJCTUAkjpWt7jmQCfz182e/bskEOHDnWrGzduHEJCQpCbm4vKykrZgYdUKpUtdzv+CgQCBAcH48yZM3Bzc8Mff/whk6Wrq9sEoKarA+7cuQNfX180NDTA19cX58+fx6NHj2BmZia7Q6ynp4egoCDk5ubi2LFjCjuvp6eHpUuX/nePlfLu0JaWln6PLgFk2rRplJGRofKVlY8++ojCw8PJ39+/U3lWVtYeIvJ0c3PrVM5gMCgoKIg++eQThXeDBQIB7dq1ixYuXKhQf3R0dBMRMZW9KttOgzoaPGvWLNq7dy+p85GjPMrIyEglIlcvLy+N5CQlJdHSpUvl1ovF4m/k9VPRMuzx9u3bzwFvDka8vb2xfPlyVFVVKWBRDRKJhIW2fUFNsGbNGpiZmWHFihXd6ubOnQt9ff0YebwK16EODg5R27ZtA5/PR2RkpFInQaqgoaFBD0Cf3k5ylcHGjRvB5/Oxfv36TuWbNm36P3SJ/J2g4BUAEaG5uTkXbykp2bx583Eimuvi4qI1mdHR0RQbG0vAm8/u284f1fpiBADAZrOX+vn59dZMLdTV1fUBYN7x4oSm2LJlC8rLyzFv3jwkJCQcA3BXIUNvI4CIUFVVlYW3MAIiIiJuEtFudT+EUETZ2dlEvXwvpNQIAACBQLB49+7dWr9F0dTUxAPAb21t1apcoVAIf3///wLwotfGyoyANhoaFRWl1ae0aNGiIiLK0uYIsLGxoerq6l3K9ksVB4CIRqSnpz9Q5psgZSgiIuISEX1uZ2enFXmhoaHU3Nwcq0qfVHUAiIj9/Pnz5GXLlkl4PJ5GBu/evfscEdkre6IrjyZPnkwXLlw4Q0TDVO2POg5oJ5vy8vKt69atq5L3qawiCggIoObm5rlEhPz8/OOq3gkAQIGBgZSXl/cDEfmq2w9NHNBOBo2NjZ9//fXXN8aOHSvXWD6fTyNHjqSFCxe2ZGdn5xFRUAcZjCdPnny1YcOGh/7+/qRoj9DKyorCw8Mlly9fziYiT03tZxARtIgpDx488P3tt99cHj58aElEMDMze+7k5FQ8atSoe1wutxjAJQCK7tx6A3jv8ePH1jdu3LB+/PjxwNra2j4GBgavHRwcSvz9/fOZTOYRAI+0YfD/AxEFJ8mg+GSnAAAAAElFTkSuQmCC
+
+readme: |-
+  ----------------------------------
+  ## sodiumgridding_ptpi/{{ context.version }} ##
+  This container runs a dual-echo palindromic TPI Kaiser-Bessel gridding
+  reconstruction for OpenRecon. It includes variance-based coil compression,
+  TE1/TE2 field-map estimation, low-rank phase correction, adaptive or
+  sum-of-squares coil combination, and optional N4 bias correction.
+
+  Build the recipe with:
+  ```bash
+  source env/bin/activate
+  python -m builder generate sodiumgridding_ptpi --recreate --architecture x86_64
+  ```
+
+  Full build:
+  ```bash
+  source env/bin/activate
+  sf-build sodiumgridding_ptpi --architecture x86_64
+  ```
+
+  OpenRecon runtime notes are documented in `recipes/sodiumgridding_ptpi/OpenReconREADME.md`.
+  ----------------------------------

--- a/recipes/sodiumgridding_ptpi/build.yaml
+++ b/recipes/sodiumgridding_ptpi/build.yaml
@@ -1,5 +1,5 @@
 name: sodiumgridding_ptpi
-version: 0.1.0
+version: 0.1.9
 
 copyright:
   - license: MIT
@@ -80,10 +80,11 @@ icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABKCAYAAAAL8lK4AAAACXBI
 readme: |-
   ----------------------------------
   ## sodiumgridding_ptpi/{{ context.version }} ##
-  This container runs a dual-echo palindromic TPI Kaiser-Bessel gridding
+  This container runs a multi-echo palindromic TPI Kaiser-Bessel gridding
   reconstruction for OpenRecon. It includes variance-based coil compression,
   TE1/TE2 field-map estimation, low-rank phase correction, adaptive or
-  sum-of-squares coil combination, and optional N4 bias correction.
+  sum-of-squares coil combination, optional N4 bias correction, and temporal
+  SVD denoising of the final echo volumes.
 
   Build the recipe with:
   ```bash

--- a/recipes/sodiumgridding_ptpi/fulltest.yaml
+++ b/recipes/sodiumgridding_ptpi/fulltest.yaml
@@ -1,0 +1,109 @@
+# sodiumgridding_ptpi container test suite
+# Focused verification for the OpenRecon runtime, pTPI assets, and gridding dependencies.
+
+name: sodiumgridding_ptpi
+version: 0.1.0
+container: sodiumgridding_ptpi_${version}_REFERENCE.simg
+
+test_data:
+  output_dir: test_output
+
+setup:
+  script: |
+    #!/usr/bin/env bash
+    set -e
+    mkdir -p ${output_dir}
+
+tests:
+  - name: OpenRecon server help
+    description: Verify the python-ismrmrd server entrypoint starts correctly
+    script: |
+      python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
+
+  - name: pTPI trajectory and label assets
+    description: Verify the packaged pTPI trajectory and OpenRecon label are present and readable
+    script: |
+      python - <<'PY'
+      import json
+      from pathlib import Path
+      import h5py
+
+      trajectories = [
+          Path("/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5"),
+          Path("/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g70_p5traj.h5"),
+          Path("/opt/sodiumgridding_ptpi/23Na_pTPI_n50_g70_p5traj.h5"),
+      ]
+      label = Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json")
+      for trajectory in trajectories:
+          with h5py.File(trajectory, "r") as handle:
+              keys = set(handle.keys())
+              assert {"k_echo1", "k_echo2_forward_order"} <= keys or "k" in keys, sorted(keys)
+              print("trajectory", trajectory.name, sorted(keys))
+      data = json.loads(label.read_text())
+      assert data["general"]["id"] == "sodiumgridding_ptpi"
+      parameters = {item["id"]: item for item in data["parameters"]}
+      offered = {value["id"] for value in parameters["trajectoryfile"]["values"]}
+      expected = {str(path) for path in trajectories}
+      assert expected <= offered, expected - offered
+      print(label)
+      PY
+
+  - name: OpenRecon label choices match shared geometry implementation
+    description: Verify the UI mappings feed the acquisition stage before display canonicalization
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python - <<'PY'
+      import json
+      from pathlib import Path
+      import sodiumgridding
+
+      label = json.loads(
+          Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json").read_text()
+      )
+      parameters = {item["id"]: item for item in label["parameters"]}
+      offered = {value["id"] for value in parameters["orientation"]["values"]}
+      implemented = set(sodiumgridding.ORIENTATION_IN_PLANE_TRANSFORMS) | {
+          sodiumgridding.ORIENTATION_DEBUG_SELECTION
+      }
+      assert offered == implemented, offered ^ implemented
+      assert parameters["orientation"]["default"] == sodiumgridding.DEFAULT_ORIENTATION
+      assert "orientationflipslice" in parameters
+      print("orientation choices:", sorted(offered))
+      PY
+
+  - name: Emitted geometry matches the native reconstruction display frame
+    description: Verify the shared geometry helper reproduces the reference slice position
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python - <<'PY'
+      import numpy as np
+      import sodiumgridding
+
+      slices, rows, columns = (
+          np.asarray(target, dtype=float)
+          for target in sodiumgridding.DISPLAY_FRAME_TARGETS
+      )
+      handedness = float(np.dot(np.cross(columns, rows), slices))
+      assert handedness > 0.0, handedness
+
+      position = sodiumgridding._frame_position(
+          center_position=(0.0, 0.0, 0.0),
+          slice_dir=(0.0, 0.0, 1.0),
+          frame_index=47,
+          slice_count=128,
+          slice_spacing_mm=220.0 / 128.0,
+      )
+      label = sodiumgridding._slice_position_label(position)
+      assert label == "F28.4", label
+      print("display frame handedness:", handedness, "frame 48/128:", label)
+      PY
+
+  - name: pTPI gridding module imports
+    description: Verify the reconstruction module imports with its runtime dependencies
+    script: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import SimpleITK, h5py, ismrmrd, nibabel, numba, pyfftw, scipy, skimage, sodiumgridding, sodiumgridding_ptpi, ptpi_dual_echo_lowrank_core, twixtools; print(sodiumgridding_ptpi.__file__)" | grep -x '/opt/code/python-ismrmrd-server/sodiumgridding_ptpi.py'
+
+  - name: Helper scripts render help
+    description: Verify conversion helper scripts start and expose command line help
+    script: |
+      python /opt/code/python-ismrmrd-server/twix2mrd.py -h 2>&1 | grep 'usage:'
+      python /opt/code/python-ismrmrd-server/siemens_twix2mrd.py -h 2>&1 | grep 'usage:'
+      python /opt/code/python-ismrmrd-server/mrd2nifti.py -h 2>&1 | grep 'usage:'

--- a/recipes/sodiumgridding_ptpi/fulltest.yaml
+++ b/recipes/sodiumgridding_ptpi/fulltest.yaml
@@ -2,7 +2,7 @@
 # Focused verification for the OpenRecon runtime, pTPI assets, and gridding dependencies.
 
 name: sodiumgridding_ptpi
-version: 0.1.0
+version: 0.1.9
 container: sodiumgridding_ptpi_${version}_REFERENCE.simg
 
 test_data:

--- a/recipes/sodiumgridding_ptpi/mrd2nifti.py
+++ b/recipes/sodiumgridding_ptpi/mrd2nifti.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+import ismrmrd
+import nibabel as nib
+import numpy as np
+
+
+def _extract_component(image_data, component):
+    array = np.asarray(image_data)
+    if component == "complex":
+        return np.asarray(array, dtype=np.complex64)
+    if component == "real":
+        return np.asarray(np.real(array), dtype=np.float32)
+    if component == "imag":
+        return np.asarray(np.imag(array), dtype=np.float32)
+    return np.asarray(np.abs(array), dtype=np.float32)
+
+
+def _to_canonical_volume(image, component):
+    array = np.squeeze(_extract_component(image.data, component))
+
+    if array.ndim == 0:
+        return np.asarray(array.reshape((1, 1, 1)))
+
+    if array.ndim == 1:
+        return np.asarray(array[:, np.newaxis, np.newaxis])
+
+    if array.ndim == 2:
+        return np.asarray(array[:, :, np.newaxis])
+
+    if array.ndim == 3:
+        # MRD image data is always stored as (channels, z, y, x), so a squeezed
+        # 3D volume is (slice, phase, read) and must be transposed to the
+        # (read, phase, slice) order this converter and the affine below assume.
+        # Do not branch on shape: for a cubic matrix, shape equals matrix_size
+        # and its reverse, so a shape-based check silently skips the transpose
+        # and the affine then maps read_dir onto the slice axis.
+        matrix_size = tuple(int(value) for value in image.getHead().matrix_size)
+        if all(value > 0 for value in matrix_size) and array.shape != matrix_size[::-1]:
+            raise ValueError(
+                f"Image data shape {array.shape} does not match the header "
+                f"matrix_size {matrix_size} in (z, y, x) order"
+            )
+        return np.asarray(array.transpose((2, 1, 0)))
+
+    raise ValueError(
+        f"Unsupported ISMRMRD image data shape {np.asarray(image.data).shape} after squeezing to {array.shape}"
+    )
+
+
+def convert_mrd_to_nifti(input_path, output_path, group_name="dataset", image_series="image_0", component="magnitude"):
+    dataset = ismrmrd.Dataset(str(input_path), group_name)
+    try:
+        image_count = dataset.number_of_images(image_series)
+        if image_count == 0:
+            raise RuntimeError(f"No images found in group '{group_name}' series '{image_series}'")
+
+        first_image = dataset.read_image(image_series, 0)
+        volume_blocks = [_to_canonical_volume(first_image, component)]
+
+        for index in range(1, image_count):
+            volume_blocks.append(
+                _to_canonical_volume(
+                    dataset.read_image(image_series, index),
+                    component,
+                )
+            )
+
+        nx, ny = volume_blocks[0].shape[:2]
+        for block_index, block in enumerate(volume_blocks[1:], start=1):
+            if block.shape[:2] != (nx, ny):
+                raise ValueError(
+                    f"Image {block_index} in series '{image_series}' has shape {block.shape}, "
+                    f"expected matching in-plane shape {(nx, ny)}"
+                )
+        volume = np.concatenate(volume_blocks, axis=2)
+        nz = volume.shape[2]
+
+        fov = np.array([float(value) for value in first_image.field_of_view], dtype=np.float32)
+        voxel_sizes = np.array(
+            [
+                fov[0] / max(nx, 1),
+                fov[1] / max(ny, 1),
+                fov[2] / max(nz, 1),
+            ],
+            dtype=np.float32,
+        )
+
+        head = first_image.getHead()
+        read_dir = np.array([float(value) for value in head.read_dir], dtype=np.float32)
+        phase_dir = np.array([float(value) for value in head.phase_dir], dtype=np.float32)
+        slice_dir = np.array([float(value) for value in head.slice_dir], dtype=np.float32)
+        slice_pos = np.array([float(value) for value in head.position], dtype=np.float32)
+
+        affine = np.eye(4, dtype=np.float32)
+        affine[:3, 0] = read_dir * voxel_sizes[0]
+        affine[:3, 1] = phase_dir * voxel_sizes[1]
+        affine[:3, 2] = slice_dir * voxel_sizes[2]
+        affine[:3, 3] = slice_pos - 0.5 * (
+            (nx - 1) * affine[:3, 0] + (ny - 1) * affine[:3, 1] + (nz - 1) * affine[:3, 2]
+        )
+
+        nifti = nib.Nifti1Image(volume, affine)
+        nifti.header.set_data_dtype(volume.dtype)
+        nifti.header.set_zooms(tuple(float(value) for value in voxel_sizes))
+        nib.save(nifti, str(output_path))
+    finally:
+        dataset.close()
+
+    print(
+        f"Converted {input_path} [{image_series}] to {output_path} "
+        f"with shape {volume.shape} and dtype {volume.dtype}"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert ISMRMRD HDF5 image output to NIfTI.")
+    parser.add_argument("-i", "--input", required=True, help="Input ISMRMRD HDF5 file")
+    parser.add_argument("-o", "--output", required=True, help="Output NIfTI path")
+    parser.add_argument("-g", "--group", default="dataset", help="ISMRMRD group name")
+    parser.add_argument("-s", "--series", default="image_0", help="Image series name")
+    parser.add_argument(
+        "--component",
+        choices=("magnitude", "complex", "real", "imag"),
+        default="magnitude",
+        help="Image component to write to NIfTI",
+    )
+    args = parser.parse_args()
+
+    convert_mrd_to_nifti(
+        input_path=Path(args.input),
+        output_path=Path(args.output),
+        group_name=args.group,
+        image_series=args.series,
+        component=args.component,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/sodiumgridding_ptpi/ptpi_dual_echo_lowrank_core.py
+++ b/recipes/sodiumgridding_ptpi/ptpi_dual_echo_lowrank_core.py
@@ -1,0 +1,1715 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Dual-echo pTPI reconstruction with the N256 AC KB gridding pipeline.
+
+This keeps the Kaiser-Bessel gridding, variance-retention coil compression,
+adaptive coil combination, and optional N4 correction style from
+TPI_gridding_N256_AC_coil_compression_kb.py, while adding the pTPI dual-echo
+loader and low-rank phase correction used for palindromic forward/reverse
+echoes.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+
+import h5py
+import matplotlib.pyplot as plt
+import numba
+import numpy as np
+import scipy.fft as sp_fft
+import scipy.ndimage as ndi
+
+try:
+    import pyfftw
+    pyfftw.interfaces.cache.enable()
+    USE_PYFFTW = True
+except ImportError:
+    USE_PYFFTW = False
+
+try:
+    import nibabel as nib
+except ImportError as exc:
+    nib = None
+    NIBABEL_IMPORT_ERROR = exc
+
+try:
+    from skimage.restoration import unwrap_phase as skimage_unwrap_phase
+except ImportError:
+    skimage_unwrap_phase = None
+
+try:
+    import SimpleITK as sitk
+except ImportError as exc:
+    sitk = None
+    SIMPLEITK_IMPORT_ERROR = exc
+
+
+# --- Config ------------------------------------------------------------------
+# These defaults intentionally mirror TPI_gridding_N256_AC_coil_compression_kb.py.
+N = 128
+FOV_CM = 22
+OVERSAMP = 2
+DCF_ITER = 5
+
+FERMI_CUTOFF = 0.98
+FERMI_WIDTH = 0.05
+
+MAX_WORKERS = 8
+MAX_SIMULTANEOUS_GRIDS = 2
+GRID_SEMAPHORE = threading.Semaphore(MAX_SIMULTANEOUS_GRIDS)
+FFT_WORKERS = -1
+
+## 23Na
+#TRAJ_FILE = "/Users/clicht/Desktop/Python/n28_TPI_23Na.h5"
+# DATA_FILE = "/Users/clicht/Data_3T/TPI/TPI_2TE/20260604/23Na_n14_TPI_TE2_3T_Pht_20260604.h5"
+#DATA_FILE = "/Users/clicht/Data_3T/TPI/TPI_2TE/20260605/1H_n14_TPI_TE2_3T_Pht_20260605.h5"
+#DATA_FILE = "/Users/clicht/Data_7T/23Na/TPI_2TE/20260608/23Na_n28_TPI_TE2_7T_Pht_20260608.h5"
+#OUTPUT_FILE = "/Users/clicht/Data_7T/TPI_2TE/20260611_invivo/20260611_InVivo_Liliana/tpi_dual_echo_gridded_multi_coil.h5"
+
+## 1H
+#TRAJ_FILE = "/Users/clicht/Desktop/Python/1H_n14_TPI_traj_new.h5"
+# For the new dual-echo trajectory file, this script uses k_echo1 and
+# k_echo2_forward_order automatically when those datasets are present.
+#TRAJ_FILE = '/Users/clicht/Desktop/Python/n72_TPI_traj_new.h5'
+#TRAJ_FILE = '/Users/clicht/Desktop/Python/1H_n72_TPI_dual_echo_traj_new.h5'
+#TRAJ_FILE ="/Users/clicht/Desktop/Python/23Na_n28_TPI_dual_echo_traj_g90.h5"
+TRAJ_FILE = '/Users/clicht/Desktop/Python/23Na_pTPI_n28_g50_p5traj.h5'
+
+DATA_FILE ='/Users/clicht/Data_7T/TPI_2TE/pTPI_20260724/23Na_pTPI_n28_g50_p5.h5'
+#DATA_FILE = "/Users/clicht/Data_7T/TPI_2TE/20260611_invivo/20260611_InVivo_Liliana/1H_n72_TPI_TE2_7T_TR10_Rx64_Lil.h5"
+#DATA_FILE = '/Users/clicht/Data_7T/23Na/20260618/23Na_n50_7T_g90_TE05.h5'
+#'/Users/clicht/Data_7T/TPI_2TE/20260612_redHeadPhantom/1H_TPI2TE_TE007_RHP.h5'
+
+#DATA_FILE = "/Users/clicht/Data_3T/TPI/TPI_2TE/20260605/1H_n14_TPI_TE2_3T_Pht_20260605.h5"
+
+# Set to None to use all available coils. Use 16 to match the N256 AC script.
+NUM_COILS = None
+COIL_COMPRESSION = True
+COIL_VARIANCE_RETENTION = 0.9
+COIL_COMPRESSION_SOURCE = "both"  # "both", "te1", or "te2"; used to estimate the PCA basis.
+COIL_COMPRESSION_MAX_CALIB_POINTS = 2500000
+COIL_COMBINE_MODE = "AC"  # "AC" or "SoS", matching the N256 AC script.
+ADAPTIVE_COMBINE_SMOOTH_SIGMA = None  # None uses N / 32 voxels.
+PLOT_RESULTS = True
+SAVE_C0_FILES = True
+C0_ECHO1_FILE = "/Users/clicht/Data_7T/TPI_2TE/pTPI_20260724/23Na_pTPI_TE05_RHP.c0"
+C0_ECHO2_FILE = "/Users/clicht/Data_7T/TPI_2TE/pTPI_20260724/23Na_pTPI_TE50_RHP.c0"
+SAVE_NIFTI_FILES = False
+NIFTI_OUTPUT_PREFIX = "/Users/clicht/Data_7T/TPI_2TE/pTPI_20260724/PC_lowrank_recon"
+NIFTI_FIELD_MAP_NAN_VALUE = 0.0
+# Keep saved reconstructed arrays in the same native grid orientation as
+# TPI_gridding_N256_AC_coil_compression_kb.py. That script applies swapaxes(0, 2)
+# only for display.
+SAVE_OUTPUTS_IN_GRIDDING_DISPLAY_ORIENTATION = False
+DISPLAY_ROT90_K = 1
+DISPLAY_FIELD_MAP = False
+DISPLAY_VMIN_PERCENTILE = 0.0
+DISPLAY_VMAX_PERCENTILE = 99.5
+SAVE_COIL_IMAGES = False
+USE_TE1_BAD_READOUTS_FOR_TE2 = True
+ECHO_NORMALIZATION_MODE = "none"  # Use "none" for quantitative TE1/TE2 scaling; "independent" matches old behavior.
+APPLY_TRAJECTORY_DELAY_CORRECTION = False
+TRAJ_DELAY_US = [0.0, 0.0, 0.0]  # Per-axis [kx, ky, kz] delay in microseconds.
+TRAJ_DELAY_APPLY_TO = "te2"  # "te1", "te2", or "both".
+
+FIELD_MAP_DELTA_TE_S = .005 #0.0045
+FIELD_MAP_SIGN = 1.0
+FIELD_MAP_ESTIMATION_MODE = "cross_sum"  # "coilwise" or "cross_sum"
+FIELD_MAP_MAG_MASK_FRACTION = .08 #0.08
+FIELD_MAP_PHASE_SMOOTH_SIGMA = .7
+FIELD_MAP_UNWRAP_METHOD = "skimage"  # "skimage", "axis", or "none"
+FIELD_MAP_SMOOTH_SIGMA_HZ = 1.0
+FIELD_MAP_DISPLAY_CLIP_HZ = 250.0
+FIELD_MAP_COIL_WEIGHT_POWER = 0.5
+FIELD_MAP_COIL_WEIGHT_NORMALIZE = True
+FIELD_MAP_COIL_WEIGHT_CLIP_PERCENTILE = 95.0
+FIELD_MAP_COIL_WEIGHT_MIN_FRACTION = 0.02
+
+RUN_TE2_PHASE_CORRECTION = True #True
+RUN_TE1_PHASE_CORRECTION = True
+TE1_PHASE_TIME_DATASET = "t_echo1_relative_s"
+TE1_PHASE_CORRECTION_SIGN = -1.0
+TE2_PHASE_TIME_DATASET = "t_echo2_forward_relative_s"
+TE2_PHASE_SEGMENTS = 10 # Used only by the legacy hard-segment correction.
+TE2_PHASE_CORRECTION_SIGN = -1.0
+TE2_PHASE_CORRECTION_MODEL = "lowrank"  # "lowrank" or "hard_segments"
+TE2_PHASE_LOWRANK_RANK = 10
+TE2_PHASE_LOWRANK_FIELD_BINS = 256
+TE2_PHASE_LOWRANK_FIELD_CLIP_HZ = None  # None uses FIELD_MAP_DISPLAY_CLIP_HZ.
+FIELD_MODEL_RANGE_MODE = "percentile"  # "percentile", "minmax", or "symmetric_clip"
+FIELD_MODEL_RANGE_PERCENTILES = (1.0, 99.0)
+PLOT_PHASE_TABLE_ROWS = False
+PHASE_TABLE_ROW_INDICES = None  # None plots 4 evenly spaced B0 rows.
+PHASE_TABLE_ROW_COUNT = 4
+
+APPLY_N4_BIAS_CORRECTION = True
+N4_MASK_ECHO = "te1"  # "te1" or "te2"
+N4_BIAS_ECHO = "te2"  # "te1" or "te2"
+N4_APPLY_TO_ECHOES = "both"  # "both", "te1", or "te2"
+N4_MASK_THRESHOLD_FRACTION = 0.05
+N4_MASK_CLOSE_ITERATIONS = 2
+N4_MASK_ERODE_ITERATIONS = 1
+N4_BIAS_FLOOR_FRACTION = 0.05
+N4_CLIP_PERCENTILES = (1.0, 99.0)
+N4_SHRINK_FACTOR = 4
+N4_MAX_ITERATIONS = [50, 50, 50, 50]
+N4_CONVERGENCE_THRESHOLD = 1e-6
+N4_WIENER_FILTER_NOISE = 0.1
+N4_BIAS_FIELD_FWHM = 0.25
+N4_OUTPUT_MASK_DILATE_ITERATIONS = 2  # Used only when N4_BACKGROUND_MODE is "zero" or "original".
+N4_BACKGROUND_MODE = "corrected"  # "corrected" keeps the full image; "zero"/"original" mask the background.
+
+KB_WIDTH = 3.0
+KB_BETA = np.pi * np.sqrt((KB_WIDTH / OVERSAMP * (OVERSAMP - 0.5)) ** 2 - 0.8)
+KB_LUT_SIZE = 2048
+KB_DEAPODIZATION_FLOOR = 1e-8
+
+
+def default_kb_beta(width, oversamp):
+    return np.pi * np.sqrt((width / oversamp * (oversamp - 0.5)) ** 2 - 0.8)
+
+
+def make_kaiser_bessel_lut(width, beta, lut_size):
+    radius = np.linspace(0.0, width / 2.0, lut_size, dtype=np.float64)
+    arg = beta * np.sqrt(np.maximum(1.0 - (2.0 * radius / width) ** 2, 0.0))
+    lut = np.i0(arg) / np.i0(beta)
+    lut[-1] = 0.0
+    return lut.astype(np.float64)
+
+
+@numba.jit(nopython=True, fastmath=True)
+def _kb_lut_value(distance, kernel_lut, width):
+    half_width = 0.5 * width
+    if distance >= half_width:
+        return 0.0
+    pos = distance / half_width * (len(kernel_lut) - 1)
+    idx = int(np.floor(pos))
+    frac = pos - idx
+    if idx >= len(kernel_lut) - 1:
+        return kernel_lut[len(kernel_lut) - 1]
+    return kernel_lut[idx] * (1.0 - frac) + kernel_lut[idx + 1] * frac
+
+
+@numba.jit(nopython=True)
+def _grid_kb_complex(grid, k_coords_norm, weights, grid_size, oversamp, kernel_lut, width):
+    og = grid_size * oversamp
+    num_points = len(k_coords_norm)
+    half_width = 0.5 * width
+    for i in range(num_points):
+        gx = (k_coords_norm[i, 0] + 0.5) * og - 0.5
+        gy = (k_coords_norm[i, 1] + 0.5) * og - 0.5
+        gz = (k_coords_norm[i, 2] + 0.5) * og - 0.5
+        ix_min = int(np.ceil(gx - half_width))
+        ix_max = int(np.floor(gx + half_width))
+        iy_min = int(np.ceil(gy - half_width))
+        iy_max = int(np.floor(gy + half_width))
+        iz_min = int(np.ceil(gz - half_width))
+        iz_max = int(np.floor(gz + half_width))
+        w = weights[i]
+        for iz in range(iz_min, iz_max + 1):
+            if 0 <= iz < og:
+                wz = _kb_lut_value(abs(gz - iz), kernel_lut, width)
+                if wz > 0.0:
+                    for iy in range(iy_min, iy_max + 1):
+                        if 0 <= iy < og:
+                            wy = _kb_lut_value(abs(gy - iy), kernel_lut, width)
+                            if wy > 0.0:
+                                for ix in range(ix_min, ix_max + 1):
+                                    if 0 <= ix < og:
+                                        wx = _kb_lut_value(abs(gx - ix), kernel_lut, width)
+                                        if wx > 0.0:
+                                            grid[iz, iy, ix] += w * wx * wy * wz
+
+
+@numba.jit(nopython=True, fastmath=True)
+def _grid_kb_real(grid, k_coords_norm, weights, grid_size, oversamp, kernel_lut, width):
+    og = grid_size * oversamp
+    num_points = len(k_coords_norm)
+    half_width = 0.5 * width
+    for i in range(num_points):
+        gx = (k_coords_norm[i, 0] + 0.5) * og - 0.5
+        gy = (k_coords_norm[i, 1] + 0.5) * og - 0.5
+        gz = (k_coords_norm[i, 2] + 0.5) * og - 0.5
+        ix_min = int(np.ceil(gx - half_width))
+        ix_max = int(np.floor(gx + half_width))
+        iy_min = int(np.ceil(gy - half_width))
+        iy_max = int(np.floor(gy + half_width))
+        iz_min = int(np.ceil(gz - half_width))
+        iz_max = int(np.floor(gz + half_width))
+        w = weights[i]
+        for iz in range(iz_min, iz_max + 1):
+            if 0 <= iz < og:
+                wz = _kb_lut_value(abs(gz - iz), kernel_lut, width)
+                if wz > 0.0:
+                    for iy in range(iy_min, iy_max + 1):
+                        if 0 <= iy < og:
+                            wy = _kb_lut_value(abs(gy - iy), kernel_lut, width)
+                            if wy > 0.0:
+                                for ix in range(ix_min, ix_max + 1):
+                                    if 0 <= ix < og:
+                                        wx = _kb_lut_value(abs(gx - ix), kernel_lut, width)
+                                        if wx > 0.0:
+                                            grid[iz, iy, ix] += w * wx * wy * wz
+
+
+@numba.jit(nopython=True, fastmath=True)
+def _sample_kb(values, grid, k_coords_norm, grid_size, oversamp, kernel_lut, width):
+    og = grid_size * oversamp
+    num_points = len(k_coords_norm)
+    half_width = 0.5 * width
+    for i in range(num_points):
+        gx = (k_coords_norm[i, 0] + 0.5) * og - 0.5
+        gy = (k_coords_norm[i, 1] + 0.5) * og - 0.5
+        gz = (k_coords_norm[i, 2] + 0.5) * og - 0.5
+        ix_min = int(np.ceil(gx - half_width))
+        ix_max = int(np.floor(gx + half_width))
+        iy_min = int(np.ceil(gy - half_width))
+        iy_max = int(np.floor(gy + half_width))
+        iz_min = int(np.ceil(gz - half_width))
+        iz_max = int(np.floor(gz + half_width))
+        val = 0.0
+        for iz in range(iz_min, iz_max + 1):
+            if 0 <= iz < og:
+                wz = _kb_lut_value(abs(gz - iz), kernel_lut, width)
+                if wz > 0.0:
+                    for iy in range(iy_min, iy_max + 1):
+                        if 0 <= iy < og:
+                            wy = _kb_lut_value(abs(gy - iy), kernel_lut, width)
+                            if wy > 0.0:
+                                for ix in range(ix_min, ix_max + 1):
+                                    if 0 <= ix < og:
+                                        wx = _kb_lut_value(abs(gx - ix), kernel_lut, width)
+                                        if wx > 0.0:
+                                            val += grid[iz, iy, ix] * wx * wy * wz
+        values[i] = val
+
+
+def compute_dcf_kb(k_coords_norm, grid_size, oversamp, n_iter, kernel_lut, width):
+    og = grid_size * oversamp
+    dcf = np.ones(len(k_coords_norm), dtype=np.float64)
+    print("Computing KB DCF:", end=" ")
+    for i in range(n_iter):
+        print(f"{i + 1}", end=" ", flush=True)
+        wsum = np.zeros((og, og, og), dtype=np.float64)
+        _grid_kb_real(wsum, k_coords_norm, dcf, grid_size, oversamp, kernel_lut, width)
+        sampled_density = np.zeros_like(dcf)
+        _sample_kb(sampled_density, wsum, k_coords_norm, grid_size, oversamp, kernel_lut, width)
+        sampled_density[sampled_density < 1e-9] = 1.0
+        dcf /= sampled_density
+        dcf /= np.median(dcf)
+    print("done")
+    return dcf.astype(np.float32)
+
+
+def compute_deapodisation_kb(grid_size, oversamp, kernel_lut, width):
+    og = grid_size * oversamp
+    kernel_1d = np.zeros(og, dtype=np.complex128)
+    g_center = 0.5 * og - 0.5
+    half_width = 0.5 * width
+    ix_min = int(np.ceil(g_center - half_width))
+    ix_max = int(np.floor(g_center + half_width))
+    for ix in range(ix_min, ix_max + 1):
+        if 0 <= ix < og:
+            distance = abs(g_center - ix)
+            pos = distance / half_width * (len(kernel_lut) - 1)
+            idx = int(np.floor(pos))
+            frac = pos - idx
+            value = kernel_lut[idx] * (1.0 - frac) + kernel_lut[min(idx + 1, len(kernel_lut) - 1)] * frac
+            kernel_1d[ix] = value
+
+    response_1d = np.fft.ifftshift(np.fft.ifft(np.fft.ifftshift(kernel_1d))) * og
+    start = (og - grid_size) // 2
+    end = start + grid_size
+    deapo_1d = np.abs(response_1d[start:end])
+    deapo = np.multiply.outer(np.multiply.outer(deapo_1d, deapo_1d).ravel(), deapo_1d)
+    deapo = deapo.reshape(grid_size, grid_size, grid_size)
+    deapo /= np.nanmax(deapo)
+    deapo = np.where(deapo < KB_DEAPODIZATION_FLOOR, KB_DEAPODIZATION_FLOOR, deapo)
+    return deapo.astype(np.float32)
+
+
+def regrid_3d_kb(kspace_data, k_coords_norm, grid_size, dcf, deapo, oversamp, kernel_lut, width):
+    og = grid_size * oversamp
+    data_dcf = (kspace_data * dcf).astype(np.complex64, copy=False)
+    grid = np.zeros((og, og, og), dtype=np.complex64)
+    _grid_kb_complex(grid, k_coords_norm, data_dcf, grid_size, oversamp, kernel_lut, width)
+
+    shifted_grid = np.fft.ifftshift(grid)
+    if USE_PYFFTW:
+        transformed_grid = pyfftw.builders.ifftn(
+            shifted_grid,
+            auto_align_input=True,
+            auto_contiguous=True,
+            threads=FFT_WORKERS,
+        )()
+    else:
+        transformed_grid = sp_fft.ifftn(
+            shifted_grid,
+            workers=FFT_WORKERS,
+            overwrite_x=True,
+        )
+
+    img_os = np.fft.ifftshift(transformed_grid) * (og**3)
+    start = (og - grid_size) // 2
+    end = start + grid_size
+    img = img_os[start:end, start:end, start:end].copy()
+    img /= deapo
+    return img.astype(np.complex64)
+
+
+def find_bad_readouts(data):
+    max_vals = np.abs(data).max(axis=0)
+    hist_counts, hist_edges = np.histogram(ndi.gaussian_filter1d(max_vals, 5), bins=40)
+    most_common_max = hist_edges[np.argmax(hist_counts)]
+    reference = max_vals[max_vals >= 0.95 * most_common_max]
+    if reference.size == 0:
+        return np.array([], dtype=int)
+    threshold = most_common_max - 3.0 * reference.std()
+    return np.where(max_vals < threshold)[0]
+
+
+def preprocess_echo(
+    data,
+    k_cm,
+    coil_index=None,
+    echo_label="",
+    bad_readouts=None,
+    bad_readout_source="detected",
+    normalization_scale=None,
+):
+    if bad_readouts is None:
+        bad_readouts = find_bad_readouts(data)
+        bad_readout_source = "detected"
+    else:
+        bad_readouts = np.asarray(bad_readouts, dtype=int)
+    prefix = f"coil {coil_index} {echo_label}".strip()
+    print(f"  {prefix}: bad readouts {bad_readouts.size} ({bad_readout_source})")
+
+    weights = np.ones(data.shape, dtype=np.uint8)
+    if bad_readouts.size:
+        weights[:, bad_readouts] = 0
+    weights[0, :] = 0
+
+    processed = data * weights
+    if normalization_scale is None:
+        center_signal = np.abs(processed[1:11, :]).mean()
+        if center_signal > 1e-8:
+            processed *= 2.0 / center_signal
+    else:
+        processed *= np.float32(normalization_scale)
+
+    abs_k = np.linalg.norm(k_cm, axis=-1)
+    abs_k_norm = abs_k / np.nanmax(abs_k)
+    fermi_filter = 1.0 / (1.0 + np.exp((abs_k_norm - FERMI_CUTOFF) / FERMI_WIDTH))
+    processed *= fermi_filter
+
+    return processed.astype(np.complex64)
+
+
+def echo_center_normalization_scale(data, bad_readouts=None):
+    if bad_readouts is None:
+        bad_readouts = np.array([], dtype=int)
+    else:
+        bad_readouts = np.asarray(bad_readouts, dtype=int)
+
+    weights = np.ones(data.shape, dtype=np.uint8)
+    if bad_readouts.size:
+        weights[:, bad_readouts] = 0
+    #weights[0, :] = 0
+
+    center_signal = np.abs(data * weights)[1:11, :].mean()
+    if center_signal > 1e-8:
+        return np.float32(2.0 / center_signal), float(center_signal)
+    return np.float32(1.0), float(center_signal)
+
+
+def build_echo_normalization_scales(data_te1, data_te2, bad_readouts_by_coil=None):
+    mode = ECHO_NORMALIZATION_MODE.lower()
+    n_coils = data_te1.shape[0]
+
+    if mode in ("none", "off", "false"):
+        print("Echo normalization: disabled")
+        return np.ones(n_coils, dtype=np.float32), np.ones(n_coils, dtype=np.float32)
+
+    if mode not in ("te1", "shared", "independent"):
+        raise ValueError("ECHO_NORMALIZATION_MODE must be 'te1', 'independent', or 'none'")
+
+    te1_scales = np.ones(n_coils, dtype=np.float32)
+    te2_scales = np.ones(n_coils, dtype=np.float32)
+    te1_centers = np.zeros(n_coils, dtype=np.float32)
+    te2_centers = np.zeros(n_coils, dtype=np.float32)
+
+    for coil in range(n_coils):
+        bad = None if bad_readouts_by_coil is None else bad_readouts_by_coil[coil]
+        te1_scales[coil], te1_centers[coil] = echo_center_normalization_scale(data_te1[coil], bad)
+        if mode == "independent":
+            te2_scales[coil], te2_centers[coil] = echo_center_normalization_scale(data_te2[coil], bad)
+        else:
+            te2_scales[coil] = te1_scales[coil]
+            _, te2_centers[coil] = echo_center_normalization_scale(data_te2[coil], bad)
+
+    raw_ratio = np.divide(
+        te2_centers,
+        te1_centers,
+        out=np.full_like(te2_centers, np.nan, dtype=np.float32),
+        where=te1_centers > 1e-8,
+    )
+    print(
+        "Echo normalization: "
+        f"mode={ECHO_NORMALIZATION_MODE}, "
+        f"TE1 center median={np.nanmedian(te1_centers):.4g}, "
+        f"TE2 center median={np.nanmedian(te2_centers):.4g}, "
+        f"raw TE2/TE1 center median={np.nanmedian(raw_ratio):.4g}, "
+        f"TE1 scale median={np.nanmedian(te1_scales):.4g}, "
+        f"TE2 scale median={np.nanmedian(te2_scales):.4g}"
+    )
+    return te1_scales, te2_scales
+
+
+def find_bad_readouts_by_coil(data_echo, echo_label):
+    bad_readouts_by_coil = []
+    counts = []
+    for coil in range(data_echo.shape[0]):
+        bad_readouts = find_bad_readouts(data_echo[coil])
+        bad_readouts_by_coil.append(bad_readouts)
+        counts.append(bad_readouts.size)
+    print(
+        f"{echo_label} bad-readout detection summary: "
+        f"min={np.min(counts)}, median={np.median(counts):.1f}, max={np.max(counts)}"
+    )
+    return bad_readouts_by_coil
+
+
+def compress_coils_by_variance(coil_data, variance_retention=0.90, eps=1e-12):
+    """Compress coils with the variance-retention PCA method from the N256 AC recon."""
+    num_input_coils = coil_data.shape[0]
+    if num_input_coils <= 1:
+        return coil_data, np.array([1.0], dtype=np.float32), np.eye(num_input_coils, dtype=np.complex64)
+
+    data_2d = coil_data.reshape(num_input_coils, -1)
+    covariance = data_2d @ data_2d.conj().T
+    covariance /= max(data_2d.shape[1], 1)
+
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    sort_idx = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[sort_idx].real, 0.0)
+    eigenvectors = eigenvectors[:, sort_idx]
+
+    total_variance = eigenvalues.sum()
+    if total_variance <= eps:
+        print("Coil compression skipped: coil covariance has near-zero total variance.")
+        return coil_data, np.ones(num_input_coils, dtype=np.float32), np.eye(num_input_coils, dtype=np.complex64)
+
+    cumulative_variance = np.cumsum(eigenvalues) / total_variance
+    variance_retention = np.clip(variance_retention, 0.0, 1.0)
+    num_virtual_coils = np.searchsorted(cumulative_variance, variance_retention) + 1
+    compression_matrix = eigenvectors[:, :num_virtual_coils].astype(np.complex64)
+    compressed_data = np.einsum("cv,c...->v...", compression_matrix.conj(), coil_data, optimize=True)
+
+    print(
+        f"Coil compression: {num_input_coils} physical coils -> {num_virtual_coils} virtual coils "
+        f"({100.0 * cumulative_variance[num_virtual_coils - 1]:.2f}% variance retained)"
+    )
+    print("Cumulative coil variance:", np.array2string(cumulative_variance[:num_virtual_coils], precision=4))
+    return compressed_data.astype(np.complex64), cumulative_variance.astype(np.float32), compression_matrix
+
+
+def compress_coils_covariance(data_all):
+    if not COIL_COMPRESSION:
+        return data_all
+
+    n_coils, n_samples, n_acqs = data_all.shape
+    if n_coils <= 1:
+        return data_all
+
+    print(
+        f"Compressing coils by variance retention: source={COIL_COMPRESSION_SOURCE}, "
+        f"target={COIL_VARIANCE_RETENTION:.3f}"
+    )
+
+    source = COIL_COMPRESSION_SOURCE.lower()
+    if source == "te1":
+        calib = data_all[:, :, 0::2]
+    elif source == "te2":
+        calib = data_all[:, :, 1::2]
+    elif source == "both":
+        calib = data_all
+    else:
+        raise ValueError(
+            f"Unsupported COIL_COMPRESSION_SOURCE={COIL_COMPRESSION_SOURCE!r}. "
+            "Use 'both', 'te1', or 'te2'."
+        )
+
+    calib_flat = calib.reshape(n_coils, -1)
+    n_points = calib_flat.shape[1]
+    stride = max(1, int(np.ceil(n_points / COIL_COMPRESSION_MAX_CALIB_POINTS)))
+    calib_sub = calib_flat[:, ::stride].reshape(n_coils, -1, 1).astype(np.complex64, copy=False)
+    print(f"  calibration points: {calib_sub.shape[1]} of {n_points} (stride {stride})")
+
+    _, _, basis = compress_coils_by_variance(
+        calib_sub,
+        variance_retention=COIL_VARIANCE_RETENTION,
+    )
+    data_flat = data_all.reshape(n_coils, -1)
+    compressed = basis.conj().T @ data_flat
+    return compressed.reshape(basis.shape[1], n_samples, n_acqs).astype(np.complex64, copy=False)
+
+
+def load_dual_echo_multi_coil():
+    print("Loading trajectory and multi-coil dual-echo data...")
+    with h5py.File(TRAJ_FILE, "r") as f:
+        if "k_echo1" in f and "k_echo2_forward_order" in f:
+            k_cm_te1_full = f["k_echo1"][...]
+            k_cm_te2_full = f["k_echo2_forward_order"][...]
+            trajectory_mode = "dual-echo forward-order"
+        else:
+            k_cm_te1_full = f["k"][...]
+            k_cm_te2_full = k_cm_te1_full
+            trajectory_mode = "single-trajectory fallback"
+        if TE1_PHASE_TIME_DATASET in f:
+            t_te1_full = f[TE1_PHASE_TIME_DATASET][...].astype(np.float32)
+            te1_time_mode = TE1_PHASE_TIME_DATASET
+        else:
+            dt_s = float(f["k"].attrs.get("sampling_time_us", 10.0)) * 1e-6
+            t_te1_full = np.arange(k_cm_te1_full.shape[0], dtype=np.float32) * dt_s
+            te1_time_mode = f"inferred +{dt_s:.3e} s/sample"
+
+        if TE2_PHASE_TIME_DATASET in f:
+            t_te2_full = f[TE2_PHASE_TIME_DATASET][...].astype(np.float32)
+            te2_time_mode = TE2_PHASE_TIME_DATASET
+        else:
+            dt_s = float(f["k"].attrs.get("sampling_time_us", 10.0)) * 1e-6
+            t_te2_full = -np.arange(k_cm_te2_full.shape[0], dtype=np.float32) * dt_s
+            te2_time_mode = f"inferred {-dt_s:.3e} s/sample"
+
+    with h5py.File(DATA_FILE, "r") as f:
+        raw = f["data"]
+        if raw.ndim == 3:
+            available_coils = raw.shape[0]
+            n_coils = available_coils if NUM_COILS is None else min(NUM_COILS, available_coils)
+            data_all = raw[:n_coils, :, :].astype(np.complex64)
+        elif raw.ndim == 2:
+            data_all = raw[None, :, :].astype(np.complex64)
+        else:
+            raise ValueError(f"Unsupported data shape: {raw.shape}")
+
+    data_all = compress_coils_covariance(data_all)
+
+    data_echo_1 = data_all[:, :, 0::2].copy()
+    data_echo_2 = data_all[:, :, 1::2].copy()
+
+    # Echo 2 is acquired in the reverse sample order. Put it in forward order
+    # for gridding with k_echo2_forward_order when available.
+    data_echo_2 = data_echo_2[:, ::-1, :]
+
+    n_samples = min(
+        k_cm_te1_full.shape[0],
+        k_cm_te2_full.shape[0],
+        data_echo_1.shape[1],
+        data_echo_2.shape[1],
+    )
+    n_readouts = min(
+        k_cm_te1_full.shape[1],
+        k_cm_te2_full.shape[1],
+        data_echo_1.shape[2],
+        data_echo_2.shape[2],
+    )
+
+    k_cm_te1 = k_cm_te1_full[:n_samples, :n_readouts, :]
+    k_cm_te2 = k_cm_te2_full[:n_samples, :n_readouts, :]
+    t_te1 = t_te1_full[:n_samples]
+    t_te2 = t_te2_full[:n_samples]
+    data_echo_1 = data_echo_1[:, :n_samples, :n_readouts]
+    data_echo_2 = data_echo_2[:, :n_samples, :n_readouts]
+
+    print(f"  coils      : {data_echo_1.shape[0]}")
+    print(f"  traj mode  : {trajectory_mode}")
+    print(f"  TE1 time   : {te1_time_mode}")
+    print(f"  TE2 time   : {te2_time_mode}")
+    print(f"  k TE1 shape: {k_cm_te1.shape}")
+    print(f"  k TE2 shape: {k_cm_te2.shape}")
+    print(f"  t TE1 shape: {t_te1.shape}")
+    print(f"  t TE2 shape: {t_te2.shape}")
+    print(f"  TE1 shape  : {data_echo_1.shape}")
+    print(f"  TE2 shape  : {data_echo_2.shape}")
+    return k_cm_te1, k_cm_te2, t_te1, t_te2, data_echo_1, data_echo_2
+
+
+def trajectory_delay_applies(echo_label):
+    apply_to = TRAJ_DELAY_APPLY_TO.lower()
+    echo_label = echo_label.lower()
+    if apply_to == "both":
+        return True
+    if apply_to in ("te1", "echo1"):
+        return echo_label in ("te1", "echo1")
+    if apply_to in ("te2", "echo2"):
+        return echo_label in ("te2", "echo2")
+    if apply_to in ("none", "off", "false"):
+        return False
+    raise ValueError("TRAJ_DELAY_APPLY_TO must be 'te1', 'te2', 'both', or 'none'")
+
+
+def apply_trajectory_delay_correction(k_cm, sample_times_s, echo_label):
+    if not APPLY_TRAJECTORY_DELAY_CORRECTION or not trajectory_delay_applies(echo_label):
+        return k_cm
+
+    delays_s = np.asarray(TRAJ_DELAY_US, dtype=np.float32) * 1e-6
+    if delays_s.shape != (3,):
+        raise ValueError("TRAJ_DELAY_US must contain exactly three values: [kx, ky, kz]")
+    if np.allclose(delays_s, 0.0):
+        print(f"Trajectory delay correction for {echo_label}: enabled, delays are all zero")
+        return k_cm
+
+    t = np.asarray(sample_times_s, dtype=np.float32)
+    if t.ndim != 1 or t.size != k_cm.shape[0]:
+        raise ValueError(
+            f"{echo_label} trajectory delay correction needs one sample time per k-space sample"
+        )
+
+    order = np.argsort(t)
+    t_sorted = t[order]
+    k_sorted = k_cm[order, :, :]
+    corrected_sorted = np.empty_like(k_sorted, dtype=np.float32)
+
+    for axis in range(3):
+        shifted_t = t_sorted + delays_s[axis]
+        for readout in range(k_sorted.shape[1]):
+            corrected_sorted[:, readout, axis] = np.interp(
+                shifted_t,
+                t_sorted,
+                k_sorted[:, readout, axis],
+                left=k_sorted[0, readout, axis],
+                right=k_sorted[-1, readout, axis],
+            )
+
+    corrected = np.empty_like(k_cm, dtype=np.float32)
+    corrected[order, :, :] = corrected_sorted
+    print(
+        f"Applied trajectory delay correction to {echo_label}: "
+        f"[kx, ky, kz]=[{TRAJ_DELAY_US[0]:.3f}, {TRAJ_DELAY_US[1]:.3f}, {TRAJ_DELAY_US[2]:.3f}] us"
+    )
+    return corrected
+
+
+def reconstruct_one_coil(
+    coil_index,
+    echo_data,
+    k_cm,
+    k_norm,
+    dcf,
+    deapo,
+    kernel_lut,
+    echo_label,
+    bad_readouts=None,
+    bad_readout_source="detected",
+    normalization_scale=None,
+):
+    processed = preprocess_echo(
+        echo_data,
+        k_cm,
+        coil_index=coil_index,
+        echo_label=echo_label,
+        bad_readouts=bad_readouts,
+        bad_readout_source=bad_readout_source,
+        normalization_scale=normalization_scale,
+    )
+    with GRID_SEMAPHORE:
+        img = regrid_3d_kb(processed.ravel(), k_norm, N, dcf, deapo, OVERSAMP, kernel_lut, KB_WIDTH)
+    return coil_index, img
+
+
+def reconstruct_echo_all_coils(
+    data_echo,
+    k_cm,
+    k_norm,
+    dcf,
+    deapo,
+    kernel_lut,
+    echo_label,
+    bad_readouts_by_coil=None,
+    bad_readout_source="detected",
+    normalization_scales=None,
+):
+    n_coils = data_echo.shape[0]
+    imgs = np.zeros((n_coils, N, N, N), dtype=np.complex64)
+    print(f"Reconstructing {echo_label}: {n_coils} coils")
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = [
+            executor.submit(
+                reconstruct_one_coil,
+                coil,
+                data_echo[coil],
+                k_cm,
+                k_norm,
+                dcf,
+                deapo,
+                kernel_lut,
+                echo_label,
+                None if bad_readouts_by_coil is None else bad_readouts_by_coil[coil],
+                bad_readout_source,
+                None if normalization_scales is None else normalization_scales[coil],
+            )
+            for coil in range(n_coils)
+        ]
+        for i, future in enumerate(futures, start=1):
+            coil, img = future.result()
+            imgs[coil] = img
+            print(f"  completed {echo_label} coil {coil + 1}/{n_coils} ({i}/{n_coils})")
+    return imgs
+
+
+def phase_segment_bounds(num_samples, num_segments):
+    num_segments = max(1, int(num_segments))
+    edges = np.linspace(0, num_samples, num_segments + 1, dtype=int)
+    return [(int(edges[i]), int(edges[i + 1])) for i in range(num_segments) if edges[i + 1] > edges[i]]
+
+
+def determine_lowrank_field_range(field_map_hz):
+    field = np.asarray(field_map_hz, dtype=np.float32)
+    finite_field = field[np.isfinite(field)]
+    mode = FIELD_MODEL_RANGE_MODE.lower()
+
+    if finite_field.size and mode in ("percentile", "percentiles"):
+        p_low, p_high = FIELD_MODEL_RANGE_PERCENTILES
+        lo, hi = np.percentile(finite_field, [float(p_low), float(p_high)])
+        if hi > lo:
+            return float(lo), float(hi), f"percentile p{p_low:g}-p{p_high:g}"
+
+    if finite_field.size and mode in ("minmax", "min_max", "data"):
+        lo = float(np.min(finite_field))
+        hi = float(np.max(finite_field))
+        if hi > lo:
+            return lo, hi, "minmax"
+
+    if mode not in ("symmetric_clip", "clip", "display_clip", "percentile", "percentiles", "minmax", "min_max", "data"):
+        raise ValueError("FIELD_MODEL_RANGE_MODE must be 'percentile', 'minmax', or 'symmetric_clip'")
+
+    clip_hz = (
+        FIELD_MAP_DISPLAY_CLIP_HZ
+        if TE2_PHASE_LOWRANK_FIELD_CLIP_HZ is None
+        else float(TE2_PHASE_LOWRANK_FIELD_CLIP_HZ)
+    )
+    if clip_hz <= 0:
+        clip_hz = float(np.nanpercentile(np.abs(finite_field), 99.0)) if finite_field.size else 250.0
+        clip_hz = max(clip_hz, 1.0)
+    return -float(clip_hz), float(clip_hz), f"symmetric_clip +/-{clip_hz:.1f}Hz"
+
+
+def plot_phase_table_rows(freq_bins, sample_times_s, phase_table, echo_label):
+    if not PLOT_PHASE_TABLE_ROWS:
+        return
+
+    if PHASE_TABLE_ROW_INDICES is None:
+        count = max(1, int(PHASE_TABLE_ROW_COUNT))
+        row_indices = np.linspace(0, phase_table.shape[0] - 1, count, dtype=int)
+    else:
+        row_indices = np.asarray(PHASE_TABLE_ROW_INDICES, dtype=int)
+        row_indices = np.clip(row_indices, 0, phase_table.shape[0] - 1)
+
+    t_ms = np.asarray(sample_times_s, dtype=np.float32) * 1e3
+    fig, axes = plt.subplots(2, 1, figsize=(8, 6), sharex=True, constrained_layout=True)
+
+    for row in row_indices:
+        curve = phase_table[row]
+        label = f"{freq_bins[row]:.1f} Hz"
+        axes[0].plot(t_ms, np.unwrap(np.angle(curve)), label=label)
+        axes[1].plot(t_ms, curve.real, label=f"Re {label}")
+        axes[1].plot(t_ms, curve.imag, linestyle="--", label=f"Im {label}")
+
+    axes[0].set_title(f"{echo_label} phase table rows P(B0, t)")
+    axes[0].set_ylabel("unwrapped phase [rad]")
+    axes[0].legend(loc="best", fontsize=8)
+    axes[0].grid(True, alpha=0.25)
+    axes[1].set_xlabel("ADC sample time [ms]")
+    axes[1].set_ylabel("complex value")
+    axes[1].legend(loc="best", fontsize=8, ncol=2)
+    axes[1].grid(True, alpha=0.25)
+    plt.show()
+
+
+def build_lowrank_phase_model(field_map_hz, sample_times_s, correction_sign, echo_label):
+    field_hz = np.nan_to_num(field_map_hz, nan=0.0).astype(np.float32, copy=False)
+    field_min_hz, field_max_hz, field_range_label = determine_lowrank_field_range(field_map_hz)
+
+    rank = int(TE2_PHASE_LOWRANK_RANK)
+    n_bins = int(TE2_PHASE_LOWRANK_FIELD_BINS)
+    if rank < 1:
+        raise ValueError("TE2_PHASE_LOWRANK_RANK must be >= 1")
+    if n_bins < rank:
+        raise ValueError("TE2_PHASE_LOWRANK_FIELD_BINS must be >= TE2_PHASE_LOWRANK_RANK")
+
+    freq_bins = np.linspace(field_min_hz, field_max_hz, n_bins, dtype=np.float32)
+    field_hz = np.clip(field_hz, field_min_hz, field_max_hz).astype(np.float32, copy=False)
+    sample_times_s = np.asarray(sample_times_s, dtype=np.float32)
+
+    phase_table = np.exp(
+        1j
+        * float(correction_sign)
+        * 2.0
+        * np.pi
+        * freq_bins[:, None].astype(np.float32)
+        * sample_times_s[None, :]
+    ).astype(np.complex64)
+    plot_phase_table_rows(freq_bins, sample_times_s, phase_table, echo_label)
+
+    u, s, vh = np.linalg.svd(phase_table, full_matrices=False)
+    rank = min(rank, s.size)
+    coeff_table = (u[:, :rank] * s[:rank][None, :]).astype(np.complex64)
+    time_basis = vh[:rank, :].astype(np.complex64)
+
+    approx = coeff_table @ time_basis
+    rel_error = np.linalg.norm(phase_table - approx) / max(np.linalg.norm(phase_table), 1e-12)
+    print(
+        f"Built low-rank {echo_label} phase model: "
+        f"rank={rank}, field_bins={n_bins}, "
+        f"field_range=[{field_min_hz:.1f}, {field_max_hz:.1f}] Hz ({field_range_label}), "
+        f"time_range=[{1e3 * float(sample_times_s.min()):.3f}, "
+        f"{1e3 * float(sample_times_s.max()):.3f}] ms, "
+        f"sign={correction_sign}, "
+        f"relative_table_error={rel_error:.3e}"
+    )
+
+    return {
+        "field_hz": field_hz,
+        "freq_bins": freq_bins,
+        "coeff_table": coeff_table,
+        "time_basis": time_basis,
+    }
+
+
+def lowrank_spatial_coeff(phase_model, basis_index):
+    coeff = phase_model["coeff_table"][:, basis_index]
+    field_flat = phase_model["field_hz"].reshape(-1)
+    freq_bins = phase_model["freq_bins"]
+    coeff_real = np.interp(field_flat, freq_bins, coeff.real).astype(np.float32)
+    coeff_imag = np.interp(field_flat, freq_bins, coeff.imag).astype(np.float32)
+    return (coeff_real + 1j * coeff_imag).reshape(phase_model["field_hz"].shape).astype(np.complex64)
+
+
+def reconstruct_one_coil_phase_corrected(
+    coil_index,
+    echo_data,
+    k_cm,
+    k_norm,
+    dcf,
+    deapo,
+    kernel_lut,
+    field_map_hz,
+    sample_times_s,
+    correction_sign,
+    echo_label,
+    phase_model=None,
+    bad_readouts=None,
+    bad_readout_source="detected",
+    normalization_scale=None,
+):
+    processed = preprocess_echo(
+        echo_data,
+        k_cm,
+        coil_index=coil_index,
+        echo_label=f"{echo_label} phase-corrected",
+        bad_readouts=bad_readouts,
+        bad_readout_source=bad_readout_source,
+        normalization_scale=normalization_scale,
+    )
+
+    n_samples, n_readouts = processed.shape
+    field_hz = np.nan_to_num(field_map_hz, nan=0.0).astype(np.float32, copy=False)
+
+    if TE2_PHASE_CORRECTION_MODEL.lower() in ("lowrank", "low-rank", "svd"):
+        if phase_model is None:
+            phase_model = build_lowrank_phase_model(
+                field_hz,
+                sample_times_s,
+                correction_sign,
+                echo_label,
+            )
+
+        img = np.zeros((N, N, N), dtype=np.complex64)
+        time_basis = phase_model["time_basis"]
+        for basis_index in range(time_basis.shape[0]):
+            weighted = processed * time_basis[basis_index, :, None]
+            with GRID_SEMAPHORE:
+                basis_img = regrid_3d_kb(
+                    weighted.reshape(-1),
+                    k_norm,
+                    N,
+                    dcf,
+                    deapo,
+                    OVERSAMP,
+                    kernel_lut,
+                    KB_WIDTH,
+                )
+
+            spatial_coeff = lowrank_spatial_coeff(phase_model, basis_index)
+            img += basis_img * spatial_coeff
+            print(
+                f"    coil {coil_index} {echo_label} low-rank basis "
+                f"{basis_index + 1}/{time_basis.shape[0]}"
+            )
+
+        return coil_index, img
+
+    if TE2_PHASE_CORRECTION_MODEL.lower() not in ("hard_segments", "hard-segments", "segments"):
+        raise ValueError("TE2_PHASE_CORRECTION_MODEL must be 'lowrank' or 'hard_segments'")
+
+    k_norm_3d = k_norm.reshape(n_samples, n_readouts, 3)
+    dcf_2d = dcf.reshape(n_samples, n_readouts)
+
+    img = np.zeros((N, N, N), dtype=np.complex64)
+    for seg_index, (start, stop) in enumerate(phase_segment_bounds(n_samples, TE2_PHASE_SEGMENTS), start=1):
+        seg_data = processed[start:stop, :]
+        seg_k_norm = k_norm_3d[start:stop, :, :].reshape(-1, 3)
+        seg_dcf = dcf_2d[start:stop, :].reshape(-1)
+        t_mid = float(np.mean(sample_times_s[start:stop]))
+
+        with GRID_SEMAPHORE:
+            seg_img = regrid_3d_kb(
+                seg_data.reshape(-1),
+                seg_k_norm,
+                N,
+                seg_dcf,
+                deapo,
+                OVERSAMP,
+                kernel_lut,
+                KB_WIDTH,
+            )
+
+        phase = np.exp(
+            1j * float(correction_sign) * 2.0 * np.pi * field_hz * t_mid
+        ).astype(np.complex64)
+        img += seg_img * phase
+        print(
+            f"    coil {coil_index} {echo_label} segment {seg_index}: "
+            f"samples {start}:{stop}, t_mid={1e3 * t_mid:.3f} ms"
+        )
+
+    return coil_index, img
+
+
+def reconstruct_phase_corrected_all_coils(
+    data_echo,
+    k_cm,
+    k_norm,
+    dcf,
+    deapo,
+    kernel_lut,
+    field_map_hz,
+    sample_times_s,
+    correction_sign,
+    echo_label,
+    bad_readouts_by_coil=None,
+    bad_readout_source="detected",
+    normalization_scales=None,
+):
+    n_coils = data_echo.shape[0]
+    imgs = np.zeros((n_coils, N, N, N), dtype=np.complex64)
+    correction_model = TE2_PHASE_CORRECTION_MODEL.lower()
+    phase_model = None
+    if correction_model in ("lowrank", "low-rank", "svd"):
+        phase_model = build_lowrank_phase_model(
+            field_map_hz,
+            sample_times_s,
+            correction_sign,
+            echo_label,
+        )
+    print(
+        f"Reconstructing {echo_label} with phase correction: "
+        f"{n_coils} coils, model={TE2_PHASE_CORRECTION_MODEL}, "
+        f"segments={TE2_PHASE_SEGMENTS}, lowrank_rank={TE2_PHASE_LOWRANK_RANK}, "
+        f"sign={correction_sign}"
+    )
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = [
+            executor.submit(
+                reconstruct_one_coil_phase_corrected,
+                coil,
+                data_echo[coil],
+                k_cm,
+                k_norm,
+                dcf,
+                deapo,
+                kernel_lut,
+                field_map_hz,
+                sample_times_s,
+                correction_sign,
+                echo_label,
+                phase_model,
+                None if bad_readouts_by_coil is None else bad_readouts_by_coil[coil],
+                bad_readout_source,
+                None if normalization_scales is None else normalization_scales[coil],
+            )
+            for coil in range(n_coils)
+        ]
+        for i, future in enumerate(futures, start=1):
+            coil, img = future.result()
+            imgs[coil] = img
+            print(f"  completed corrected {echo_label} coil {coil + 1}/{n_coils} ({i}/{n_coils})")
+    return imgs
+
+
+def estimate_sensitivities(img_coils, smooth_sigma=None, eps=1e-8):
+    n_coils, nx, _, _ = img_coils.shape
+    if smooth_sigma is None:
+        smooth_sigma = nx / 32.0
+    print(f"Using sensitivity smoothing sigma: {smooth_sigma:.1f} voxels")
+    sens_smooth = np.zeros_like(img_coils, dtype=np.complex64)
+    for coil in range(n_coils):
+        real = ndi.gaussian_filter(img_coils[coil].real, smooth_sigma)
+        imag = ndi.gaussian_filter(img_coils[coil].imag, smooth_sigma)
+        sens_smooth[coil] = real + 1j * imag
+    rss = np.sqrt(np.sum(np.abs(sens_smooth) ** 2, axis=0)) + eps
+    sens_smooth /= rss[None, ...]
+    return sens_smooth.astype(np.complex64)
+
+
+def combine_sum_of_squares(img_coils):
+    return np.sqrt(np.sum(np.abs(img_coils) ** 2, axis=0)).astype(np.float32)
+
+
+def combine_single_echo_coils(img_coils, mode="AC"):
+    mode_normalized = mode.strip().upper()
+    if img_coils.shape[0] == 1:
+        print("Single-channel data: skipping coil combination.")
+        return np.abs(img_coils[0])
+
+    if mode_normalized == "SOS":
+        print("Performing sum-of-squares coil combination...")
+        return combine_sum_of_squares(img_coils)
+
+    if mode_normalized == "AC":
+        print("Estimating coil sensitivities...")
+        sens_maps = estimate_sensitivities(
+            img_coils,
+            smooth_sigma=ADAPTIVE_COMBINE_SMOOTH_SIGMA,
+        )
+        print("Performing adaptive coil combination...")
+        img_combined = np.sum(np.conj(sens_maps) * img_coils, axis=0)
+        return np.abs(img_combined).astype(np.float32)
+
+    raise ValueError("COIL_COMBINE_MODE must be 'AC' or 'SoS'")
+
+
+def combine_coils(imgs_te1, imgs_te2):
+    print(f"Combining TE1/TE2 coils with N256 AC mode={COIL_COMBINE_MODE}")
+    return (
+        combine_single_echo_coils(imgs_te1, mode=COIL_COMBINE_MODE),
+        combine_single_echo_coils(imgs_te2, mode=COIL_COMBINE_MODE),
+        None,
+    )
+
+
+def unwrap_field_map_phase(phase, mask):
+    method = FIELD_MAP_UNWRAP_METHOD.lower()
+    if method in ("none", "off", "false"):
+        return phase.astype(np.float32, copy=False)
+
+    if not np.any(mask):
+        return phase.astype(np.float32, copy=False)
+
+    if method == "skimage":
+        if skimage_unwrap_phase is None:
+            print("Field-map warning: scikit-image unavailable; falling back to axis unwrap")
+        else:
+            masked_phase = np.ma.array(phase, mask=~mask)
+            unwrapped = skimage_unwrap_phase(masked_phase)
+            return np.asarray(unwrapped.filled(np.nan), dtype=np.float32)
+
+    if method == "axis" or (method == "skimage" and skimage_unwrap_phase is None):
+        phase = np.unwrap(phase, axis=0)
+        phase = np.unwrap(phase, axis=1)
+        phase = np.unwrap(phase, axis=2)
+        return phase.astype(np.float32, copy=False)
+
+    raise ValueError("FIELD_MAP_UNWRAP_METHOD must be 'skimage', 'axis', or 'none'")
+
+
+def compute_cross_sum_phase_reference(imgs_te1, imgs_te2):
+    cross = np.sum(imgs_te2 * np.conj(imgs_te1), axis=0).astype(np.complex64, copy=False)
+    return cross, None
+
+
+def compute_coilwise_phase_reference(imgs_te1, imgs_te2):
+    n_coils = imgs_te1.shape[0]
+    phase_sum = np.zeros(imgs_te1.shape[1:], dtype=np.complex64)
+    weight_sum = np.zeros(imgs_te1.shape[1:], dtype=np.float32)
+    eps = np.float32(1e-8)
+
+    for coil in range(n_coils):
+        cross = (imgs_te2[coil] * np.conj(imgs_te1[coil])).astype(np.complex64, copy=False)
+        abs_cross = np.abs(cross).astype(np.float32, copy=False)
+        phase_unit = np.divide(
+            cross,
+            abs_cross + eps,
+            out=np.zeros_like(cross, dtype=np.complex64),
+            where=abs_cross > eps,
+        )
+
+        if FIELD_MAP_COIL_WEIGHT_NORMALIZE:
+            valid = abs_cross[np.isfinite(abs_cross) & (abs_cross > eps)]
+            if valid.size:
+                scale = np.percentile(valid, FIELD_MAP_COIL_WEIGHT_CLIP_PERCENTILE)
+            else:
+                scale = 1.0
+            weight = np.clip(abs_cross / max(float(scale), 1e-8), 0.0, 1.0).astype(np.float32)
+        else:
+            weight = abs_cross
+
+        if FIELD_MAP_COIL_WEIGHT_POWER != 1.0:
+            weight = np.power(weight, float(FIELD_MAP_COIL_WEIGHT_POWER)).astype(np.float32)
+
+        phase_sum += phase_unit * weight
+        weight_sum += weight
+
+    phase_ref = np.divide(
+        phase_sum,
+        weight_sum + eps,
+        out=np.zeros_like(phase_sum, dtype=np.complex64),
+        where=weight_sum > eps,
+    )
+    return phase_ref.astype(np.complex64, copy=False), weight_sum
+
+
+def compute_field_map_from_coils(imgs_te1, imgs_te2):
+    if FIELD_MAP_DELTA_TE_S <= 0:
+        raise ValueError("FIELD_MAP_DELTA_TE_S must be positive")
+
+    mode = FIELD_MAP_ESTIMATION_MODE.lower()
+    if mode in ("coilwise", "coil-wise", "weighted"):
+        cross, coil_weight_sum = compute_coilwise_phase_reference(imgs_te1, imgs_te2)
+    elif mode in ("cross_sum", "cross-sum", "sum"):
+        cross, coil_weight_sum = compute_cross_sum_phase_reference(imgs_te1, imgs_te2)
+    else:
+        raise ValueError("FIELD_MAP_ESTIMATION_MODE must be 'coilwise' or 'cross_sum'")
+
+    if FIELD_MAP_PHASE_SMOOTH_SIGMA > 0:
+        sigma = float(FIELD_MAP_PHASE_SMOOTH_SIGMA)
+        cross = (
+            ndi.gaussian_filter(cross.real, sigma)
+            + 1j * ndi.gaussian_filter(cross.imag, sigma)
+        ).astype(np.complex64)
+
+    mag_te1 = np.sqrt(np.sum(np.abs(imgs_te1) ** 2, axis=0))
+    mag_te2 = np.sqrt(np.sum(np.abs(imgs_te2) ** 2, axis=0))
+    mag_ref = np.sqrt(mag_te1 * mag_te2)
+    threshold = FIELD_MAP_MAG_MASK_FRACTION * np.nanmax(mag_ref)
+    mask = mag_ref > threshold
+    if coil_weight_sum is not None and FIELD_MAP_COIL_WEIGHT_MIN_FRACTION > 0:
+        weight_threshold = FIELD_MAP_COIL_WEIGHT_MIN_FRACTION * np.nanmax(coil_weight_sum)
+        mask &= coil_weight_sum > weight_threshold
+
+    phase = np.angle(cross).astype(np.float32, copy=False)
+    phase = unwrap_field_map_phase(phase, mask)
+
+    field_map_hz = FIELD_MAP_SIGN * phase / (2.0 * np.pi * FIELD_MAP_DELTA_TE_S)
+    mask &= np.isfinite(field_map_hz)
+
+    field_map_hz = field_map_hz.astype(np.float32, copy=False)
+    if FIELD_MAP_SMOOTH_SIGMA_HZ > 0:
+        sigma = float(FIELD_MAP_SMOOTH_SIGMA_HZ)
+        mask_float = mask.astype(np.float32)
+        field_filled = np.where(mask, field_map_hz, 0.0).astype(np.float32, copy=False)
+        smooth_num = ndi.gaussian_filter(field_filled * mask_float, sigma)
+        smooth_den = ndi.gaussian_filter(mask_float, sigma)
+        field_map_hz = np.divide(
+            smooth_num,
+            smooth_den,
+            out=np.zeros_like(smooth_num, dtype=np.float32),
+            where=smooth_den > 1e-6,
+        )
+        mask &= smooth_den > 1e-6
+
+    field_map_hz[~mask] = np.nan
+    print(
+        "Computed TE1/TE2 field map: "
+        f"mode={FIELD_MAP_ESTIMATION_MODE}, "
+        f"delta_te={FIELD_MAP_DELTA_TE_S * 1e3:.3f} ms, "
+        f"unwrap={FIELD_MAP_UNWRAP_METHOD}, "
+        f"smooth_sigma_hz={FIELD_MAP_SMOOTH_SIGMA_HZ}, "
+        f"mask_voxels={int(mask.sum())}"
+    )
+    return field_map_hz
+
+
+def make_bias_mask(reference_mag):
+    threshold = N4_MASK_THRESHOLD_FRACTION * np.nanmax(reference_mag)
+    mask = np.isfinite(reference_mag) & (reference_mag > threshold)
+    if N4_MASK_CLOSE_ITERATIONS > 0:
+        mask = ndi.binary_closing(mask, iterations=N4_MASK_CLOSE_ITERATIONS)
+    mask = ndi.binary_fill_holes(mask)
+    if N4_MASK_ERODE_ITERATIONS > 0:
+        mask = ndi.binary_erosion(mask, iterations=N4_MASK_ERODE_ITERATIONS)
+    return mask
+
+
+def get_echo_magnitude(img_te1, img_te2, echo_name):
+    echo_name = echo_name.lower()
+    if echo_name == "te1":
+        return np.abs(img_te1)
+    if echo_name == "te2":
+        return np.abs(img_te2)
+    raise ValueError("Echo selector must be 'te1' or 'te2'")
+
+
+def estimate_bias_field_sitk_n4(reference_mag, mask):
+    if sitk is None:
+        raise ImportError(
+            "SimpleITK is required for this script. Install it with:\n"
+            "  /opt/anaconda3/bin/python3 -m pip install SimpleITK"
+        ) from SIMPLEITK_IMPORT_ERROR
+
+    reference_mag = np.asarray(reference_mag, dtype=np.float32)
+    if not np.any(mask):
+        print("N4 warning: empty object mask; skipping correction")
+        return np.ones_like(reference_mag, dtype=np.float32), mask
+
+    p_low, p_high = N4_CLIP_PERCENTILES
+    lo, hi = np.percentile(reference_mag[mask], [p_low, p_high])
+    reference_clip = np.clip(reference_mag, max(lo, 1e-8), max(hi, lo + 1e-8)).astype(np.float32)
+    scale = np.percentile(reference_clip[mask], 99)
+    reference_norm = reference_clip / max(float(scale), 1e-8)
+
+    reference_norm_zyx = reference_norm.swapaxes(0, 2).astype(np.float32)
+    mask_zyx = mask.swapaxes(0, 2).astype(np.uint8)
+    image = sitk.GetImageFromArray(reference_norm_zyx)
+    mask_image = sitk.GetImageFromArray(mask_zyx)
+
+    if N4_SHRINK_FACTOR > 1:
+        shrink = [int(N4_SHRINK_FACTOR)] * 3
+        n4_image = sitk.Shrink(image, shrink)
+        n4_mask = sitk.Shrink(mask_image, shrink)
+    else:
+        n4_image = image
+        n4_mask = mask_image
+
+    corrector = sitk.N4BiasFieldCorrectionImageFilter()
+    corrector.SetMaximumNumberOfIterations([int(v) for v in N4_MAX_ITERATIONS])
+    corrector.SetConvergenceThreshold(float(N4_CONVERGENCE_THRESHOLD))
+    if N4_WIENER_FILTER_NOISE is not None:
+        corrector.SetWienerFilterNoise(float(N4_WIENER_FILTER_NOISE))
+    if N4_BIAS_FIELD_FWHM is not None:
+        corrector.SetBiasFieldFullWidthAtHalfMaximum(float(N4_BIAS_FIELD_FWHM))
+
+    print(
+        "Running SimpleITK N4 bias correction: "
+        f"shrink={N4_SHRINK_FACTOR}, iterations={N4_MAX_ITERATIONS}, "
+        f"wiener_noise={N4_WIENER_FILTER_NOISE}, "
+        f"bias_fwhm={N4_BIAS_FIELD_FWHM}, "
+        f"mask_voxels={int(mask.sum())}"
+    )
+    corrector.Execute(n4_image, n4_mask)
+
+    log_bias = corrector.GetLogBiasFieldAsImage(image)
+    bias = np.exp(sitk.GetArrayFromImage(log_bias)).swapaxes(0, 2).astype(np.float32)
+    if np.any(mask):
+        bias /= np.median(bias[mask])
+
+    bias_floor = N4_BIAS_FLOOR_FRACTION * np.nanmax(bias)
+    bias = np.maximum(bias, bias_floor).astype(np.float32)
+    print(
+        "SimpleITK N4 bias field: "
+        f"median={np.median(bias[mask]):.3f}, "
+        f"p05={np.percentile(bias[mask], 5):.3f}, "
+        f"p95={np.percentile(bias[mask], 95):.3f}"
+    )
+    return bias, mask
+
+
+def apply_bias_field_to_image(img, bias, mask, should_correct):
+    if N4_OUTPUT_MASK_DILATE_ITERATIONS > 0:
+        output_mask = ndi.binary_dilation(mask, iterations=N4_OUTPUT_MASK_DILATE_ITERATIONS)
+    else:
+        output_mask = mask
+
+    if should_correct:
+        corrected = img / bias
+    else:
+        corrected = img.copy()
+
+    background_mode = N4_BACKGROUND_MODE.lower()
+    if background_mode == "zero":
+        corrected = np.where(output_mask, corrected, 0.0)
+    elif background_mode == "original":
+        corrected = np.where(output_mask, corrected, img)
+    elif background_mode == "corrected":
+        pass
+    else:
+        raise ValueError("N4_BACKGROUND_MODE must be 'zero', 'original', or 'corrected'")
+
+    return corrected, output_mask
+
+
+def apply_n4_bias_correction(img_te1, img_te2):
+    if not APPLY_N4_BIAS_CORRECTION:
+        return img_te1, img_te2, None, None
+
+    mask_echo = N4_MASK_ECHO.lower()
+    bias_echo = N4_BIAS_ECHO.lower()
+    mask_reference = get_echo_magnitude(img_te1, img_te2, mask_echo)
+    bias_reference = get_echo_magnitude(img_te1, img_te2, bias_echo)
+    mask = make_bias_mask(mask_reference)
+
+    print(
+        "Preparing SimpleITK N4 bias correction: "
+        f"mask_echo={mask_echo}, bias_echo={bias_echo}, "
+        f"mask_voxels={int(mask.sum())}"
+    )
+    bias, mask = estimate_bias_field_sitk_n4(bias_reference, mask)
+    apply_to = N4_APPLY_TO_ECHOES.lower()
+    if apply_to not in ("both", "te1", "te2"):
+        raise ValueError("N4_APPLY_TO_ECHOES must be 'both', 'te1', or 'te2'")
+    img_te1, output_mask = apply_bias_field_to_image(img_te1, bias, mask, apply_to in ("both", "te1"))
+    img_te2, output_mask = apply_bias_field_to_image(img_te2, bias, mask, apply_to in ("both", "te2"))
+
+    return img_te1, img_te2, bias, output_mask
+
+
+def orient_like_gridding_script(volume):
+    """Match the display orientation used by TPI_gridding_N256_AC_coil_compression_kb.py."""
+    return np.asarray(volume).swapaxes(0, 2)
+
+
+def save_echoes_as_c0(echo1, echo2):
+    if not SAVE_C0_FILES:
+        return
+    if SAVE_OUTPUTS_IN_GRIDDING_DISPLAY_ORIENTATION:
+        echo1 = orient_like_gridding_script(echo1)
+        echo2 = orient_like_gridding_script(echo2)
+    echo1.astype(np.complex64).tofile(C0_ECHO1_FILE)
+    echo2.astype(np.complex64).tofile(C0_ECHO2_FILE)
+    print(f"Saved {C0_ECHO1_FILE}: shape={echo1.shape}, dtype=complex64")
+    print(f"Saved {C0_ECHO2_FILE}: shape={echo2.shape}, dtype=complex64")
+
+
+def nifti_affine():
+    voxel_mm = float(FOV_CM) * 10.0 / float(N)
+    return np.diag([voxel_mm, voxel_mm, voxel_mm, 1.0]).astype(np.float32)
+
+
+def save_nifti_volume(volume, filename, is_field_map=False):
+    if nib is None:
+        raise ImportError(
+            "nibabel is required to write NIfTI files. Install it with:\n"
+            "  /opt/anaconda3/bin/python3 -m pip install nibabel"
+        ) from NIBABEL_IMPORT_ERROR
+
+    if np.iscomplexobj(volume):
+        data = np.abs(volume)
+    else:
+        data = np.asarray(volume)
+    if SAVE_OUTPUTS_IN_GRIDDING_DISPLAY_ORIENTATION:
+        data = orient_like_gridding_script(data)
+    data = data.astype(np.float32, copy=False)
+    if is_field_map:
+        data = np.nan_to_num(data, nan=float(NIFTI_FIELD_MAP_NAN_VALUE)).astype(np.float32)
+
+    img = nib.Nifti1Image(data, nifti_affine())
+    img.header.set_xyzt_units("mm", "sec")
+    img.header["descrip"] = f"FOV={FOV_CM}cm, N={N}".encode("ascii")[:80]
+    nib.save(img, filename)
+    print(f"Saved {filename}: shape={data.shape}, dtype=float32")
+
+
+def save_nifti_outputs(
+    te1_uncorrected_n4,
+    te2_uncorrected_n4,
+    te1_final,
+    te2_final,
+    field_map_hz,
+):
+    if not SAVE_NIFTI_FILES:
+        return
+
+    prefix = NIFTI_OUTPUT_PREFIX
+    save_nifti_volume(te1_uncorrected_n4, f"{prefix}_te1_phaseuncorrected_n4.nii.gz")
+    save_nifti_volume(te2_uncorrected_n4, f"{prefix}_te2_phaseuncorrected_n4.nii.gz")
+    save_nifti_volume(te1_final, f"{prefix}_te1_phasecorrected_n4.nii.gz")
+    save_nifti_volume(te2_final, f"{prefix}_te2_phasecorrected_n4.nii.gz")
+    save_nifti_volume(field_map_hz, f"{prefix}_b0_map_hz.nii.gz", is_field_map=True)
+
+
+def plot_te1_te2_n4_corrected(te1_n4_corrected, te2_n4_corrected):
+    axial_idx = N // 2 - 20
+    sagittal_idx = N // 2
+    coronal_idx = N // 2 - 10
+
+    def display_slice(slice_2d):
+        return np.rot90(slice_2d, k=DISPLAY_ROT90_K)
+
+    te1_img = orient_like_gridding_script(np.abs(te1_n4_corrected))
+    te2_img = orient_like_gridding_script(np.abs(te2_n4_corrected))
+    panels = [
+        ("TE1 N4 Corrected", te1_img),
+        ("TE2 N4 Corrected", te2_img),
+    ]
+    slice_getters = [
+        (lambda img: img[:, :, axial_idx], f"Axial (z={axial_idx})"),
+        (lambda img: img[sagittal_idx, :, :], f"Sagittal (x={sagittal_idx})"),
+        (lambda img: img[:, coronal_idx, :], f"Coronal (y={coronal_idx})"),
+    ]
+
+    fig, axes = plt.subplots(2, 3, figsize=(12, 7))
+    for row, (row_label, img) in enumerate(panels):
+        row_slices = [display_slice(get_slice(img)) for get_slice, _ in slice_getters]
+        values = np.concatenate([slc.ravel() for slc in row_slices])
+        values = values[np.isfinite(values)]
+        vmax = np.percentile(values, DISPLAY_VMAX_PERCENTILE) if values.size else 1.0
+        vmin = np.percentile(values, DISPLAY_VMIN_PERCENTILE) if values.size else 0.0
+        if vmax <= vmin:
+            vmax = vmin + 1.0
+
+        for col, (slice_2d, (_, col_title)) in enumerate(zip(row_slices, slice_getters)):
+            axes[row, col].imshow(slice_2d, cmap="gray", vmin=vmin, vmax=vmax)
+            axes[row, col].set_title(f"{row_label} {col_title}")
+
+    for ax in axes.ravel():
+        ax.axis("off")
+    plt.tight_layout()
+    plt.show()
+
+
+def plot_field_map(field_map_hz):
+    if not DISPLAY_FIELD_MAP:
+        return
+    axial_idx = N // 2 - 20
+    sagittal_idx = N // 2
+    coronal_idx = N // 2 - 10
+    field = field_map_hz
+    field = orient_like_gridding_script(field)
+
+    values = field[np.isfinite(field)]
+    if values.size == 0:
+        vmin, vmax = -1.0, 1.0
+    elif FIELD_MAP_DISPLAY_CLIP_HZ is not None:
+        vmax = float(FIELD_MAP_DISPLAY_CLIP_HZ)
+        vmin = -vmax
+    else:
+        vmax = float(np.percentile(np.abs(values), 98.0))
+        vmax = max(vmax, 1e-6)
+        vmin = -vmax
+
+    slices = [
+        (field[:, :, axial_idx], f"Field map Axial (z={axial_idx})"),
+        (field[sagittal_idx, :, :], f"Field map Sagittal (x={sagittal_idx})"),
+        (field[:, coronal_idx, :], f"Field map Coronal (y={coronal_idx})"),
+    ]
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
+    im = None
+    for ax, (slc, title) in zip(axes, slices):
+        im = ax.imshow(np.rot90(slc, k=DISPLAY_ROT90_K), cmap="coolwarm", vmin=vmin, vmax=vmax)
+        ax.set_title(title)
+        ax.axis("off")
+    fig.colorbar(im, ax=axes.ravel().tolist(), shrink=0.85, label="Hz")
+    plt.show()
+
+
+def plot_results(
+    te1_final,
+    te2_final,
+    field_map_hz,
+):
+    plot_te1_te2_n4_corrected(te1_final, te2_final)
+    plot_field_map(field_map_hz)
+
+
+def main():
+    print(
+        f"Configuration: N={N}, oversampling={OVERSAMP}, DCF_ITER={DCF_ITER}, "
+        f"kernel=kaiser-bessel, kb_width={KB_WIDTH}, "
+        f"fft={'pyfftw' if USE_PYFFTW else 'scipy'}, fft_workers={FFT_WORKERS}, max_workers={MAX_WORKERS}, "
+        f"coil_combine={COIL_COMBINE_MODE}, "
+        f"coil_compression={COIL_COMPRESSION}, variance_retention={COIL_VARIANCE_RETENTION}, "
+        f"save_nifti={SAVE_NIFTI_FILES}, nifti_prefix={NIFTI_OUTPUT_PREFIX}, "
+        f"save_gridding_display_orientation={SAVE_OUTPUTS_IN_GRIDDING_DISPLAY_ORIENTATION}, "
+        f"simpleitk_n4_bias={APPLY_N4_BIAS_CORRECTION}, "
+        f"n4_mask_echo={N4_MASK_ECHO}, n4_bias_echo={N4_BIAS_ECHO}, "
+        f"n4_background={N4_BACKGROUND_MODE}, "
+        f"te2_bad_readouts_from_te1={USE_TE1_BAD_READOUTS_FOR_TE2}, "
+        f"echo_normalization={ECHO_NORMALIZATION_MODE}, "
+        f"traj_delay_correction={APPLY_TRAJECTORY_DELAY_CORRECTION}, "
+        f"traj_delay_apply_to={TRAJ_DELAY_APPLY_TO}, "
+        f"traj_delay_us={TRAJ_DELAY_US}, "
+        f"field_map_mode={FIELD_MAP_ESTIMATION_MODE}, "
+        f"field_map_delta_te_ms={FIELD_MAP_DELTA_TE_S * 1e3:.3f}, "
+        f"te1_phase_correction={RUN_TE1_PHASE_CORRECTION}, "
+        f"te1_phase_sign={TE1_PHASE_CORRECTION_SIGN}, "
+        f"te2_phase_correction={RUN_TE2_PHASE_CORRECTION}, "
+        f"te2_phase_model={TE2_PHASE_CORRECTION_MODEL}, "
+        f"te2_phase_segments={TE2_PHASE_SEGMENTS}, "
+        f"te2_lowrank_rank={TE2_PHASE_LOWRANK_RANK}, "
+        f"field_model_range={FIELD_MODEL_RANGE_MODE}, "
+        f"te2_phase_sign={TE2_PHASE_CORRECTION_SIGN}"
+    )
+    k_cm_te1, k_cm_te2, t_te1_s, t_te2_s, data_te1_raw, data_te2_raw = load_dual_echo_multi_coil()
+
+    k_cm_te1 = apply_trajectory_delay_correction(k_cm_te1, t_te1_s, "TE1")
+    k_cm_te2 = apply_trajectory_delay_correction(k_cm_te2, t_te2_s, "TE2")
+
+    k_nyquist = 1.0 / (2.0 * FOV_CM / N)
+    k_norm_te1 = (k_cm_te1.reshape(-1, 3) / k_nyquist / 2.0).astype(np.float32)
+    k_norm_te2 = (k_cm_te2.reshape(-1, 3) / k_nyquist / 2.0).astype(np.float32)
+
+    kb_beta = default_kb_beta(KB_WIDTH, OVERSAMP) if KB_BETA is None else float(KB_BETA)
+    print(f"Kaiser-Bessel beta={kb_beta:.4f}, LUT size={KB_LUT_SIZE}")
+    kernel_lut = make_kaiser_bessel_lut(KB_WIDTH, kb_beta, KB_LUT_SIZE)
+
+    print("Preparing TE1 trajectory weights")
+    dcf_te1 = compute_dcf_kb(
+        k_norm_te1,
+        grid_size=N,
+        oversamp=OVERSAMP,
+        n_iter=DCF_ITER,
+        kernel_lut=kernel_lut,
+        width=KB_WIDTH,
+    )
+    print("Preparing TE2 trajectory weights")
+    dcf_te2 = compute_dcf_kb(
+        k_norm_te2,
+        grid_size=N,
+        oversamp=OVERSAMP,
+        n_iter=DCF_ITER,
+        kernel_lut=kernel_lut,
+        width=KB_WIDTH,
+    )
+    deapo = compute_deapodisation_kb(N, OVERSAMP, kernel_lut, KB_WIDTH)
+
+    te1_bad_readouts_by_coil = None
+    if USE_TE1_BAD_READOUTS_FOR_TE2:
+        te1_bad_readouts_by_coil = find_bad_readouts_by_coil(data_te1_raw, "TE1")
+
+    te1_normalization_scales, te2_normalization_scales = build_echo_normalization_scales(
+        data_te1_raw,
+        data_te2_raw,
+        te1_bad_readouts_by_coil,
+    )
+
+    imgs_te1 = reconstruct_echo_all_coils(
+        data_te1_raw,
+        k_cm_te1,
+        k_norm_te1,
+        dcf_te1,
+        deapo,
+        kernel_lut,
+        "TE1",
+        bad_readouts_by_coil=te1_bad_readouts_by_coil,
+        bad_readout_source="TE1 precomputed",
+        normalization_scales=te1_normalization_scales,
+    )
+    imgs_te2 = reconstruct_echo_all_coils(
+        data_te2_raw,
+        k_cm_te2,
+        k_norm_te2,
+        dcf_te2,
+        deapo,
+        kernel_lut,
+        "TE2",
+        bad_readouts_by_coil=te1_bad_readouts_by_coil,
+        bad_readout_source="TE1 precomputed",
+        normalization_scales=te2_normalization_scales,
+    )
+    field_map_hz = compute_field_map_from_coils(imgs_te1, imgs_te2)
+    img_te1_uncorrected_combined, img_te2_uncorrected_combined, _ = combine_coils(imgs_te1, imgs_te2)
+
+    if RUN_TE1_PHASE_CORRECTION:
+        imgs_te1_for_output = reconstruct_phase_corrected_all_coils(
+            data_te1_raw,
+            k_cm_te1,
+            k_norm_te1,
+            dcf_te1,
+            deapo,
+            kernel_lut,
+            field_map_hz,
+            t_te1_s,
+            TE1_PHASE_CORRECTION_SIGN,
+            "TE1",
+            bad_readouts_by_coil=te1_bad_readouts_by_coil,
+            bad_readout_source="TE1 precomputed",
+            normalization_scales=te1_normalization_scales,
+        )
+    else:
+        imgs_te1_for_output = imgs_te1
+
+    if RUN_TE2_PHASE_CORRECTION:
+        imgs_te2_for_output = reconstruct_phase_corrected_all_coils(
+            data_te2_raw,
+            k_cm_te2,
+            k_norm_te2,
+            dcf_te2,
+            deapo,
+            kernel_lut,
+            field_map_hz,
+            t_te2_s,
+            TE2_PHASE_CORRECTION_SIGN,
+            "TE2",
+            bad_readouts_by_coil=te1_bad_readouts_by_coil,
+            bad_readout_source="TE1 precomputed",
+            normalization_scales=te2_normalization_scales,
+        )
+    else:
+        imgs_te2_for_output = imgs_te2
+
+    img_te1_phasecorr_combined, img_te2_phasecorr_combined, combine_weights = combine_coils(
+        imgs_te1_for_output,
+        imgs_te2_for_output,
+    )
+    img_te1_combined, img_te2_combined, bias_field, bias_mask = apply_n4_bias_correction(
+        img_te1_phasecorr_combined,
+        img_te2_phasecorr_combined,
+    )
+    if APPLY_N4_BIAS_CORRECTION and bias_field is not None and bias_mask is not None:
+        apply_to = N4_APPLY_TO_ECHOES.lower()
+        img_te1_uncorrected_n4, _ = apply_bias_field_to_image(
+            img_te1_uncorrected_combined,
+            bias_field,
+            bias_mask,
+            apply_to in ("both", "te1"),
+        )
+        img_te2_uncorrected_n4, _ = apply_bias_field_to_image(
+            img_te2_uncorrected_combined,
+            bias_field,
+            bias_mask,
+            apply_to in ("both", "te2"),
+        )
+    else:
+        img_te1_uncorrected_n4 = img_te1_uncorrected_combined
+        img_te2_uncorrected_n4 = img_te2_uncorrected_combined
+
+    save_echoes_as_c0(img_te1_combined, img_te2_combined)
+    save_nifti_outputs(
+        img_te1_uncorrected_n4,
+        img_te2_uncorrected_n4,
+        img_te1_combined,
+        img_te2_combined,
+        field_map_hz,
+    )
+
+    # with h5py.File(OUTPUT_FILE, "w") as f:
+    #     if np.iscomplexobj(img_te1_combined):
+    #         f.create_dataset("img_te1_complex", data=img_te1_combined, compression="gzip")
+    #         f.create_dataset("img_te2_complex", data=img_te2_combined, compression="gzip")
+    #     f.create_dataset("img_te1_abs", data=np.abs(img_te1_combined).astype(np.float32), compression="gzip")
+    #     f.create_dataset("img_te2_abs", data=np.abs(img_te2_combined).astype(np.float32), compression="gzip")
+    #     if combine_weights is not None:
+    #         f.create_dataset("combine_weights", data=combine_weights, compression="gzip")
+    #     if SAVE_COIL_IMAGES:
+    #         f.create_dataset("coil_imgs_te1", data=imgs_te1, compression="gzip")
+    #         f.create_dataset("coil_imgs_te2", data=imgs_te2, compression="gzip")
+    #     f.attrs["fov_cm"] = FOV_CM
+    #     f.attrs["matrix_size"] = N
+    #     f.attrs["oversampling"] = OVERSAMP
+    #     f.attrs["num_coils"] = data_te1_raw.shape[0]
+    #     f.attrs["coil_combine_method"] = COIL_COMBINE_MODE
+
+    # print(f"Saved: {OUTPUT_FILE}")
+    # print(f"Voxel size: {FOV_CM / N:.4f} cm")
+
+    if PLOT_RESULTS:
+        plot_results(
+            img_te1_combined,
+            img_te2_combined,
+            field_map_hz,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/sodiumgridding_ptpi/siemens_twix2mrd.py
+++ b/recipes/sodiumgridding_ptpi/siemens_twix2mrd.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PYTHON_ISMRMRD_SERVER_DIR = Path("/opt/code/python-ismrmrd-server")
+for candidate in (SCRIPT_DIR, PYTHON_ISMRMRD_SERVER_DIR):
+    if candidate.exists() and str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+import connection
+
+
+class FileSocket:
+    def __init__(self, path: Path):
+        self._file = path.open("rb")
+
+    def recv(self, nbytes: int, flags: int = 0) -> bytes:
+        if flags == socket.MSG_PEEK:
+            position = self._file.tell()
+            data = self._file.read(nbytes)
+            self._file.seek(position)
+            return data
+        return self._file.read(nbytes)
+
+    def shutdown(self, how):
+        del how
+
+    def close(self):
+        self._file.close()
+
+
+def _stream_to_hdf5(stream_path: Path, output_path: Path, group_name: str):
+    file_socket = FileSocket(stream_path)
+    conn = connection.Connection(
+        file_socket,
+        savedata=True,
+        savedataFile=str(output_path),
+        savedataFolder="",
+        savedataGroup=group_name,
+    )
+
+    try:
+        for _ in conn:
+            pass
+    finally:
+        if conn.dset is not None:
+            conn.dset.close()
+        file_socket.close()
+
+
+def convert_twix_to_mrd(input_file: Path, output_file: Path, group_name: str, attach_trajectory: bool):
+    with tempfile.TemporaryDirectory(prefix="siemens_twix2mrd_") as temp_dir:
+        stream_path = Path(temp_dir) / "converter.stream"
+        command = [
+            "siemens_to_ismrmrd",
+            "--skipSyncData",
+            "-f",
+            str(input_file),
+            "-o",
+            str(stream_path),
+        ]
+        if attach_trajectory:
+            command.insert(1, "--attachTrajectory")
+
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                "siemens_to_ismrmrd failed with exit code "
+                f"{result.returncode}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            )
+        if not stream_path.exists() or stream_path.stat().st_size == 0:
+            raise RuntimeError(
+                "siemens_to_ismrmrd did not produce a stream file.\n"
+                f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            )
+
+        _stream_to_hdf5(stream_path, output_file, group_name)
+
+        print(result.stderr.strip())
+        print(
+            "Converted Siemens Twix data to MRD via siemens_to_ismrmrd stream:",
+            output_file,
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Siemens Twix data to ISMRMRD HDF5 using siemens_to_ismrmrd."
+    )
+    parser.add_argument("-f", "--file", required=True, help="Input Siemens .dat file")
+    parser.add_argument("-o", "--output", required=True, help="Output ISMRMRD HDF5 file")
+    parser.add_argument("-g", "--group", default="dataset", help="ISMRMRD group name")
+    parser.add_argument(
+        "--attach-trajectory",
+        action="store_true",
+        help="Request trajectory attachment from siemens_to_ismrmrd before materializing the stream.",
+    )
+    args = parser.parse_args()
+
+    convert_twix_to_mrd(
+        input_file=Path(args.file),
+        output_file=Path(args.output),
+        group_name=args.group,
+        attach_trajectory=bool(args.attach_trajectory),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/sodiumgridding_ptpi/sodiumgridding.py
+++ b/recipes/sodiumgridding_ptpi/sodiumgridding.py
@@ -1,0 +1,2134 @@
+#!/usr/bin/env python3
+
+from concurrent.futures import ThreadPoolExecutor
+import ctypes
+from itertools import permutations
+import logging
+import os
+from pathlib import Path
+import threading
+from time import perf_counter
+import traceback
+import uuid
+
+import h5py
+import ismrmrd
+import numba
+import numpy as np
+import scipy.ndimage as ndi
+
+import constants
+import mrdhelper
+
+
+try:
+    import pyfftw
+
+    pyfftw.interfaces.cache.enable()
+    USE_PYFFTW = True
+except ImportError:
+    pyfftw = None
+    USE_PYFFTW = False
+
+
+debugFolder = "/tmp/share/debug"
+BUNDLED_TRAJECTORIES = {
+    "sodiumn50": "/opt/sodiumgridding/23Na_n50_trajectory.h5",
+    "sodiumn28": "/opt/sodiumgridding/23Na_n28_trajectory.h5",
+    "23Na_n50": "/opt/sodiumgridding/23Na_n50_trajectory.h5",
+    "23Na_n28": "/opt/sodiumgridding/23Na_n28_trajectory.h5",
+}
+OPENRECON_DEFAULTS = {
+    "config": "sodiumgridding",
+    "matrixsize": 128,
+    "fovcm": 22.0,
+    "trajectorypreset": "23Na_n28",
+    "trajectoryfile": "",
+    "trajectorydataset": "k",
+    "trajectorysampleoffset": 0,
+    "rejectbadreadouts": True,
+    "badreadoutsigma": 3.0,
+    "centerwindow": 5,
+    "applyfermifilter": True,
+    "fermiwidth": 0.05,
+    "fermicutoff": 0.98,
+    "dcfiterations": 5,
+    "maxcoils": 16,
+    "maxworkers": 8,
+    "coilvarianceretention": 0.9,
+    "coilcombinemode": "AC",
+    "applyn4biascorrection": True,
+    "orientation": "zyx",
+    "orientationflipslice": False,
+    "orientationdebugseries": False,
+}
+OUTPUT_SERIES_DESCRIPTION = "sodiumgridding"
+OUTPUT_IMAGE_COMMENT = "23Na Kaiser-Bessel Gridding"
+OUTPUT_IMAGE_SERIES_INDEX = 1
+
+# Trajectory-to-acquisition orientation is the first geometry stage.
+#
+# The gridding kernel writes grid[iz, iy, ix] with ix taken from trajectory
+# component 0, so the reconstructed volume is (component 2, component 1,
+# component 0). Which trajectory component maps to the acquisition's read and
+# phase axes is not encoded by the trajectory file. The orientation setting
+# selects that mapping and any component-sign corrections.
+ORIENTATION_IN_PLANE_TRANSFORMS = {
+    # key: (transpose_in_plane, reverse_rows, reverse_columns)
+    "zyx": (False, False, False),
+    "zyx_fx": (False, False, True),
+    "zyx_fy": (False, True, False),
+    "zyx_fxy": (False, True, True),
+    "zxy": (True, False, False),
+    "zxy_fx": (True, False, True),
+    "zxy_fy": (True, True, False),
+    "zxy_fxy": (True, True, True),
+}
+DEFAULT_ORIENTATION = "zyx"
+ORIENTATION_DEBUG_SELECTION = "debug"
+ORIENTATION_DEBUG_ORDER = tuple(ORIENTATION_IN_PLANE_TRANSFORMS)
+#
+# ISMRMRD direction vectors are in the DICOM/Siemens patient coordinate system
+# (+x left, +y posterior, +z head). Labels below are (negative, positive).
+PATIENT_AXIS_LABELS = (("R", "L"), ("A", "P"), ("F", "H"))
+
+# The FIRE Configurator disables NormOrientation, so nothing downstream rotates
+# our images into the DICOM standard display view. The native ICE reconstruction
+# is emitted in that view, so this app has to produce it itself, otherwise the
+# two series are mirrored relative to each other on screen.
+#
+# The standard view is the right-handed frame
+#   columns increase toward the patient's Left      (+x)
+#   rows    increase toward the patient's Posterior (+y)
+#   slices  increase toward the patient's Head      (+z)
+#
+# The slice sign is measured from the native reference series in
+# sodiumgridding_v0.1.3.PNG. That volume is centred at isocenter -- the scanner
+# logfile records "dSag, dCor, Tra = 0; 0; 0" for the native reconstruction --
+# and holds 128 slices over 220 mm, so frame 48 of 128 lies at
+#   (47 - 63.5) * 220/128 = -28.36 mm
+# along the slice axis. The reference displays that frame at SP F28.4, that is
+# at z = -28.4, which is only possible if the slice axis points toward the Head.
+#
+# Version 0.1.3 targeted the Feet instead and displayed the same frame at H29.
+# Because reversing one axis of a right-handed frame also swaps the side the
+# viewer looks from, that single sign error is what produced the apparent 180
+# degree rotation about the anterior-posterior axis: R/L exchanged on the left
+# edge, the view-from marker flipped H/F, and slice 48 showing what the
+# reference shows at slice 81.
+#
+# Targets are ordered (slices, rows, columns) to match the emitted array.
+DISPLAY_FRAME_TARGETS = (
+    (0.0, 0.0, 1.0),
+    (0.0, 1.0, 0.0),
+    (1.0, 0.0, 0.0),
+)
+DISPLAY_FRAME_AXIS_NAMES = ("slices", "rows", "columns")
+
+
+def _validate_display_frame_targets(targets):
+    """Return the handedness of the display targets, refusing a left-handed set.
+
+    Every physical acquisition frame is right-handed. Reaching the targets by
+    permuting and reversing its axes keeps that property only if the targets are
+    right-handed too, so a left-handed target set can only be a sign mistake: it
+    reverses one axis too many and silently emits a volume the scanner draws
+    from the opposite side. That is exactly how 0.1.3 shipped.
+    """
+    slices, rows, columns = (np.asarray(target, dtype=float) for target in targets)
+    handedness = float(np.dot(np.cross(columns, rows), slices))
+    if handedness <= 0.0:
+        raise ValueError(
+            "DISPLAY_FRAME_TARGETS must form a right-handed (columns, rows, "
+            f"slices) frame, but columns x rows . slices = {handedness:+.3f}"
+        )
+    return handedness
+
+
+DISPLAY_FRAME_HANDEDNESS = _validate_display_frame_targets(DISPLAY_FRAME_TARGETS)
+SCANNER_DISPLAY_MIN = 0
+SCANNER_DISPLAY_MAX = 4096
+OVERSAMPLING = 2
+KB_KERNEL_WIDTH = 3.0
+KB_LUT_SIZE = 2048
+MAX_SIMULTANEOUS_GRIDS = 2
+N4_SHRINK_FACTOR = 2
+N4_MAX_ITERATIONS = [50, 50, 50, 50]
+GRID_SEMAPHORE = threading.Semaphore(MAX_SIMULTANEOUS_GRIDS)
+
+
+def _kaiser_bessel_parameters(kernel_width=KB_KERNEL_WIDTH, oversampling=OVERSAMPLING):
+    radicand = (kernel_width / oversampling * (oversampling - 0.5)) ** 2 - 0.8
+    if radicand <= 0:
+        raise ValueError(
+            "Kaiser-Bessel parameters require a positive beta radicand; "
+            f"got kernel_width={kernel_width} oversampling={oversampling}"
+        )
+    beta = float(np.pi * np.sqrt(radicand))
+    distances = np.linspace(
+        0.0,
+        0.5 * kernel_width,
+        KB_LUT_SIZE,
+        dtype=np.float64,
+    )
+    lut = np.i0(
+        beta
+        * np.sqrt(
+            np.maximum(
+                0.0,
+                1.0 - (distances / (0.5 * kernel_width)) ** 2,
+            )
+        )
+    ) / np.i0(beta)
+    return beta, np.asarray(lut, dtype=np.float64)
+
+
+KB_BETA, KB_LUT = _kaiser_bessel_parameters()
+
+
+def _get_config_value(config, key, default, value_type):
+    try:
+        return mrdhelper.get_json_config_param(config, key, default=default, type=value_type)
+    except Exception:
+        return default
+
+
+def _config_bool(config, key, default):
+    value = _get_config_value(config, key, default, "bool")
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _config_int(config, key, default):
+    value = _get_config_value(config, key, default, "int")
+    try:
+        return int(value)
+    except Exception:
+        return int(default)
+
+
+def _config_float(config, key, default):
+    value = _get_config_value(config, key, default, "float")
+    try:
+        return float(value)
+    except Exception:
+        return float(default)
+
+
+def _config_str(config, key, default):
+    value = _get_config_value(config, key, default, "str")
+    if value is None:
+        return default
+    return str(value)
+
+
+def _ensure_debug_folder():
+    os.makedirs(debugFolder, exist_ok=True)
+
+
+def _read_runtime_file(*paths):
+    for path_text in paths:
+        try:
+            value = Path(path_text).read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if value:
+            return value
+    return "unavailable"
+
+
+def _cgroup_cpu_limit():
+    cpu_max = _read_runtime_file("/sys/fs/cgroup/cpu.max")
+    if cpu_max != "unavailable":
+        return cpu_max
+
+    quota = _read_runtime_file("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    period = _read_runtime_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    if quota == "unavailable" and period == "unavailable":
+        return "unavailable"
+    return f"quota={quota} period={period}"
+
+
+def _cgroup_cpuset():
+    return _read_runtime_file(
+        "/sys/fs/cgroup/cpuset.cpus.effective",
+        "/sys/fs/cgroup/cpuset/cpuset.cpus",
+    )
+
+
+def _log_cpu_resources(configured_max_workers, effective_coil_workers):
+    logical_cpu_count = os.cpu_count()
+    try:
+        affinity = sorted(os.sched_getaffinity(0))
+        affinity_count = len(affinity)
+        affinity_cpus = ",".join(str(cpu) for cpu in affinity)
+    except (AttributeError, OSError):
+        affinity_count = "unavailable"
+        affinity_cpus = "unavailable"
+
+    logging.info(
+        "FIRE CPU resources: os_cpu_count=%s affinity_count=%s "
+        "affinity_cpus=%s cgroup_cpu_limit='%s' cgroup_cpuset='%s' "
+        "configured_maxworkers=%d effective_coil_workers=%d",
+        logical_cpu_count,
+        affinity_count,
+        affinity_cpus,
+        _cgroup_cpu_limit(),
+        _cgroup_cpuset(),
+        configured_max_workers,
+        effective_coil_workers,
+    )
+
+
+def _safe_protocol_name(metadata):
+    try:
+        protocol_name = getattr(metadata.measurementInformation, "protocolName", "")
+        if protocol_name:
+            return str(protocol_name)
+    except Exception:
+        pass
+    return OUTPUT_SERIES_DESCRIPTION
+
+
+@numba.njit(fastmath=True)
+def _kaiser_bessel_weight_lut(distance, kernel_width, lut):
+    half_width = 0.5 * kernel_width
+    if distance > half_width:
+        return 0.0
+
+    lut_position = distance / half_width * (len(lut) - 1)
+    index = int(np.floor(lut_position))
+    if index >= len(lut) - 1:
+        return lut[len(lut) - 1]
+
+    fraction = lut_position - index
+    return lut[index] * (1.0 - fraction) + lut[index + 1] * fraction
+
+
+@numba.njit
+def _grid_kb_complex(
+    grid,
+    normalized_coordinates,
+    weights,
+    grid_size,
+    oversampling,
+    kernel_width,
+    lut,
+):
+    oversampled_size = grid_size * oversampling
+    half_width = 0.5 * kernel_width
+
+    for point_index in range(len(normalized_coordinates)):
+        grid_x = (normalized_coordinates[point_index, 0] + 0.5) * oversampled_size - 0.5
+        grid_y = (normalized_coordinates[point_index, 1] + 0.5) * oversampled_size - 0.5
+        grid_z = (normalized_coordinates[point_index, 2] + 0.5) * oversampled_size - 0.5
+        x_min = int(np.ceil(grid_x - half_width))
+        x_max = int(np.floor(grid_x + half_width))
+        y_min = int(np.ceil(grid_y - half_width))
+        y_max = int(np.floor(grid_y + half_width))
+        z_min = int(np.ceil(grid_z - half_width))
+        z_max = int(np.floor(grid_z + half_width))
+        value = weights[point_index]
+
+        for z_index in range(z_min, z_max + 1):
+            if 0 <= z_index < oversampled_size:
+                z_weight = _kaiser_bessel_weight_lut(
+                    abs(grid_z - z_index), kernel_width, lut
+                )
+                for y_index in range(y_min, y_max + 1):
+                    if 0 <= y_index < oversampled_size:
+                        y_weight = _kaiser_bessel_weight_lut(
+                            abs(grid_y - y_index), kernel_width, lut
+                        )
+                        for x_index in range(x_min, x_max + 1):
+                            if 0 <= x_index < oversampled_size:
+                                x_weight = _kaiser_bessel_weight_lut(
+                                    abs(grid_x - x_index), kernel_width, lut
+                                )
+                                grid[z_index, y_index, x_index] += (
+                                    value * x_weight * y_weight * z_weight
+                                )
+
+
+@numba.njit(fastmath=True)
+def _grid_kb_real(
+    grid,
+    normalized_coordinates,
+    weights,
+    grid_size,
+    oversampling,
+    kernel_width,
+    lut,
+):
+    oversampled_size = grid_size * oversampling
+    half_width = 0.5 * kernel_width
+
+    for point_index in range(len(normalized_coordinates)):
+        grid_x = (normalized_coordinates[point_index, 0] + 0.5) * oversampled_size - 0.5
+        grid_y = (normalized_coordinates[point_index, 1] + 0.5) * oversampled_size - 0.5
+        grid_z = (normalized_coordinates[point_index, 2] + 0.5) * oversampled_size - 0.5
+        x_min = int(np.ceil(grid_x - half_width))
+        x_max = int(np.floor(grid_x + half_width))
+        y_min = int(np.ceil(grid_y - half_width))
+        y_max = int(np.floor(grid_y + half_width))
+        z_min = int(np.ceil(grid_z - half_width))
+        z_max = int(np.floor(grid_z + half_width))
+        value = weights[point_index]
+
+        for z_index in range(z_min, z_max + 1):
+            if 0 <= z_index < oversampled_size:
+                z_weight = _kaiser_bessel_weight_lut(
+                    abs(grid_z - z_index), kernel_width, lut
+                )
+                for y_index in range(y_min, y_max + 1):
+                    if 0 <= y_index < oversampled_size:
+                        y_weight = _kaiser_bessel_weight_lut(
+                            abs(grid_y - y_index), kernel_width, lut
+                        )
+                        for x_index in range(x_min, x_max + 1):
+                            if 0 <= x_index < oversampled_size:
+                                x_weight = _kaiser_bessel_weight_lut(
+                                    abs(grid_x - x_index), kernel_width, lut
+                                )
+                                grid[z_index, y_index, x_index] += (
+                                    value * x_weight * y_weight * z_weight
+                                )
+
+
+@numba.njit(fastmath=True)
+def _sample_kb(
+    values,
+    grid,
+    normalized_coordinates,
+    grid_size,
+    oversampling,
+    kernel_width,
+    lut,
+):
+    oversampled_size = grid_size * oversampling
+    half_width = 0.5 * kernel_width
+
+    for point_index in range(len(normalized_coordinates)):
+        grid_x = (normalized_coordinates[point_index, 0] + 0.5) * oversampled_size - 0.5
+        grid_y = (normalized_coordinates[point_index, 1] + 0.5) * oversampled_size - 0.5
+        grid_z = (normalized_coordinates[point_index, 2] + 0.5) * oversampled_size - 0.5
+        x_min = int(np.ceil(grid_x - half_width))
+        x_max = int(np.floor(grid_x + half_width))
+        y_min = int(np.ceil(grid_y - half_width))
+        y_max = int(np.floor(grid_y + half_width))
+        z_min = int(np.ceil(grid_z - half_width))
+        z_max = int(np.floor(grid_z + half_width))
+        value = 0.0
+
+        for z_index in range(z_min, z_max + 1):
+            if 0 <= z_index < oversampled_size:
+                z_weight = _kaiser_bessel_weight_lut(
+                    abs(grid_z - z_index), kernel_width, lut
+                )
+                for y_index in range(y_min, y_max + 1):
+                    if 0 <= y_index < oversampled_size:
+                        y_weight = _kaiser_bessel_weight_lut(
+                            abs(grid_y - y_index), kernel_width, lut
+                        )
+                        for x_index in range(x_min, x_max + 1):
+                            if 0 <= x_index < oversampled_size:
+                                x_weight = _kaiser_bessel_weight_lut(
+                                    abs(grid_x - x_index), kernel_width, lut
+                                )
+                                value += (
+                                    grid[z_index, y_index, x_index]
+                                    * x_weight
+                                    * y_weight
+                                    * z_weight
+                                )
+        values[point_index] = value
+
+
+def _normalize_grid_coordinates(trajectory, matrix_size, fov_cm):
+    physical_coordinates = np.asarray(trajectory, dtype=np.float32).reshape(-1, 3)
+    normalized = physical_coordinates * (float(fov_cm) / float(matrix_size))
+    max_coordinate = float(np.max(np.abs(normalized))) if normalized.size else 0.0
+    if max_coordinate > 0.5 + 1e-5:
+        logging.warning(
+            "Normalized trajectory extends beyond the gridding FOV: max_abs=%.6f",
+            max_coordinate,
+        )
+    return np.asarray(normalized, dtype=np.float32)
+
+
+def _compute_dcf_kb(
+    normalized_coordinates,
+    grid_size,
+    oversampling=OVERSAMPLING,
+    num_iterations=5,
+):
+    oversampled_size = grid_size * oversampling
+    dcf = np.ones(len(normalized_coordinates), dtype=np.float64)
+
+    for iteration in range(num_iterations):
+        logging.info("Computing Kaiser-Bessel DCF iteration %d/%d", iteration + 1, num_iterations)
+        density_grid = np.zeros(
+            (oversampled_size, oversampled_size, oversampled_size),
+            dtype=np.float64,
+        )
+        _grid_kb_real(
+            density_grid,
+            normalized_coordinates,
+            dcf,
+            grid_size,
+            oversampling,
+            KB_KERNEL_WIDTH,
+            KB_LUT,
+        )
+        sampled_density = np.zeros_like(dcf)
+        _sample_kb(
+            sampled_density,
+            density_grid,
+            normalized_coordinates,
+            grid_size,
+            oversampling,
+            KB_KERNEL_WIDTH,
+            KB_LUT,
+        )
+        sampled_density[sampled_density < 1e-9] = 1.0
+        dcf /= sampled_density
+        median = float(np.median(dcf))
+        if median > 0.0 and np.isfinite(median):
+            dcf /= median
+
+    return np.asarray(dcf, dtype=np.float32)
+
+
+def _compute_deapodization_kb(grid_size, oversampling=OVERSAMPLING):
+    oversampled_size = grid_size * oversampling
+    kernel_1d = np.zeros(oversampled_size, dtype=np.complex128)
+    grid_center = 0.5 * oversampled_size - 0.5
+    half_width = 0.5 * KB_KERNEL_WIDTH
+    index_min = int(np.ceil(grid_center - half_width))
+    index_max = int(np.floor(grid_center + half_width))
+
+    for index in range(index_min, index_max + 1):
+        if 0 <= index < oversampled_size:
+            distance = abs(grid_center - index)
+            ratio = distance / half_width
+            kernel_1d[index] = np.i0(
+                KB_BETA * np.sqrt(max(0.0, 1.0 - ratio * ratio))
+            ) / np.i0(KB_BETA)
+
+    response_1d = (
+        np.fft.ifftshift(np.fft.ifft(np.fft.ifftshift(kernel_1d)))
+        * oversampled_size
+    )
+    start = (oversampled_size - grid_size) // 2
+    stop = start + grid_size
+    deapodization_1d = np.abs(response_1d[start:stop])
+    deapodization = np.multiply.outer(
+        np.multiply.outer(deapodization_1d, deapodization_1d).ravel(),
+        deapodization_1d,
+    ).reshape(grid_size, grid_size, grid_size)
+    deapodization /= np.nanmax(deapodization)
+    deapodization = np.where(deapodization < 1e-8, 1e-8, deapodization)
+    return np.asarray(deapodization, dtype=np.float32)
+
+
+def _regrid_3d_kb(
+    kspace_data,
+    normalized_coordinates,
+    grid_size,
+    dcf,
+    deapodization,
+    oversampling=OVERSAMPLING,
+):
+    oversampled_size = grid_size * oversampling
+    weighted_data = (
+        np.asarray(kspace_data).ravel() * np.asarray(dcf).ravel()
+    ).astype(np.complex128)
+    grid = np.zeros(
+        (oversampled_size, oversampled_size, oversampled_size),
+        dtype=np.complex128,
+    )
+    _grid_kb_complex(
+        grid,
+        normalized_coordinates,
+        weighted_data,
+        grid_size,
+        oversampling,
+        KB_KERNEL_WIDTH,
+        KB_LUT,
+    )
+
+    shifted_grid = np.fft.ifftshift(grid)
+    if USE_PYFFTW:
+        inverse_fft = pyfftw.builders.ifftn(
+            shifted_grid,
+            auto_align_input=True,
+            auto_contiguous=True,
+            threads=-1,
+        )
+        transformed_grid = inverse_fft()
+    else:
+        transformed_grid = np.fft.ifftn(shifted_grid)
+
+    oversampled_image = np.fft.ifftshift(transformed_grid) * (oversampled_size**3)
+    start = (oversampled_size - grid_size) // 2
+    stop = start + grid_size
+    image = oversampled_image[start:stop, start:stop, start:stop].copy()
+    image /= deapodization
+    return np.asarray(image, dtype=np.complex64)
+
+
+def _normalize_trajectory_array(traj):
+    array = np.asarray(traj)
+    if array.size == 0:
+        raise ValueError("Trajectory array is empty")
+
+    if array.ndim == 2:
+        if array.shape[-1] in (2, 3):
+            array = array[None, :, :]
+        elif array.shape[0] in (2, 3):
+            array = array.T[None, :, :]
+        else:
+            raise ValueError(f"Unsupported 2D trajectory shape: {array.shape}")
+    elif array.ndim == 3:
+        if array.shape[-1] in (2, 3):
+            pass
+        elif array.shape[0] in (2, 3):
+            array = np.moveaxis(array, 0, -1)
+        elif array.shape[1] in (2, 3):
+            array = np.moveaxis(array, 1, -1)
+        else:
+            raise ValueError(f"Unsupported 3D trajectory shape: {array.shape}")
+    else:
+        raise ValueError(f"Unsupported trajectory shape: {array.shape}")
+
+    if array.shape[-1] == 2:
+        array = np.concatenate(
+            [array, np.zeros(array.shape[:-1] + (1,), dtype=array.dtype)],
+            axis=-1,
+        )
+
+    return np.asarray(array, dtype=np.float32)
+
+
+def _load_trajectory_from_file(path_text, dataset_name):
+    path = Path(path_text).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Trajectory file does not exist: {path}")
+
+    with h5py.File(path, "r") as h5_file:
+        if dataset_name not in h5_file:
+            raise KeyError(
+                f"Trajectory dataset '{dataset_name}' not found in {path}. "
+                f"Available datasets: {list(h5_file.keys())}"
+            )
+        trajectory = h5_file[dataset_name][...]
+
+    logging.info("Loaded trajectory from %s[%s] with shape %s", path, dataset_name, trajectory.shape)
+    return _normalize_trajectory_array(trajectory)
+
+
+def _resolve_trajectory_file(config):
+    explicit_file = _config_str(
+        config,
+        "trajectoryfile",
+        OPENRECON_DEFAULTS["trajectoryfile"],
+    ).strip()
+    if explicit_file:
+        if explicit_file in BUNDLED_TRAJECTORIES:
+            trajectory_file = BUNDLED_TRAJECTORIES[explicit_file]
+            logging.info("Using bundled trajectory %s: %s", explicit_file, trajectory_file)
+            return trajectory_file
+        logging.info("Using trajectory file override: %s", explicit_file)
+        return explicit_file
+
+    preset = _config_str(
+        config,
+        "trajectorypreset",
+        OPENRECON_DEFAULTS["trajectorypreset"],
+    ).strip() or OPENRECON_DEFAULTS["trajectorypreset"]
+
+    if preset in BUNDLED_TRAJECTORIES:
+        trajectory_file = BUNDLED_TRAJECTORIES[preset]
+        logging.info("Using bundled trajectory preset %s: %s", preset, trajectory_file)
+        return trajectory_file
+
+    valid_presets = ", ".join(sorted(BUNDLED_TRAJECTORIES))
+    raise ValueError(
+        f"Unknown trajectory preset '{preset}'. "
+        f"Expected one of: {valid_presets}. "
+        "Use 'trajectoryfile' to provide an explicit external HDF5 path."
+    )
+
+
+def _load_trajectory(acquisitions, config):
+    embedded_trajectory = []
+    for acquisition in acquisitions:
+        traj = getattr(acquisition, "traj", None)
+        if traj is None:
+            continue
+        traj_array = np.asarray(traj)
+        if traj_array.size == 0:
+            continue
+        embedded_trajectory.append(_normalize_trajectory_array(traj_array)[0])
+
+    if embedded_trajectory:
+        trajectory = np.stack(embedded_trajectory, axis=0)
+        logging.info("Using embedded ISMRMRD trajectory with shape %s", trajectory.shape)
+        return trajectory
+
+    trajectory_file = _resolve_trajectory_file(config)
+    if not trajectory_file:
+        raise ValueError(
+            "No embedded trajectory found in the MRD acquisitions and no "
+            "'trajectorypreset' or 'trajectoryfile' parameter was provided."
+        )
+
+    trajectory_dataset = _config_str(
+        config,
+        "trajectorydataset",
+        OPENRECON_DEFAULTS["trajectorydataset"],
+    ).strip() or OPENRECON_DEFAULTS["trajectorydataset"]
+    return _load_trajectory_from_file(trajectory_file, trajectory_dataset)
+
+
+def _build_data_array(acquisitions):
+    num_readouts = len(acquisitions)
+    num_coils = int(acquisitions[0].data.shape[0])
+    num_samples = min(int(acq.data.shape[1]) for acq in acquisitions)
+
+    data = np.zeros((num_coils, num_readouts, num_samples), dtype=np.complex64)
+    for readout_index, acquisition in enumerate(acquisitions):
+        acquisition_data = np.asarray(acquisition.data, dtype=np.complex64)
+        if acquisition_data.shape[0] != num_coils:
+            raise ValueError(
+                "All acquisitions must contain the same number of coils. "
+                f"Expected {num_coils}, got {acquisition_data.shape[0]}"
+            )
+        data[:, readout_index, :] = acquisition_data[:, :num_samples]
+
+    return data
+
+
+def _compute_default_fov_cm(metadata):
+    try:
+        fov_cm = float(metadata.encoding[0].reconSpace.fieldOfView_mm.x) / 10.0
+        if fov_cm <= 0:
+            raise ValueError(f"Invalid reconSpace FOV from metadata: {fov_cm}")
+        return fov_cm
+    except Exception:
+        return OPENRECON_DEFAULTS["fovcm"]
+
+
+def _compute_default_matrix_size(metadata):
+    try:
+        matrix_size = int(metadata.encoding[0].reconSpace.matrixSize.x)
+        if matrix_size <= 1:
+            raise ValueError(f"Invalid reconSpace matrix size from metadata: {matrix_size}")
+        return matrix_size
+    except Exception:
+        return OPENRECON_DEFAULTS["matrixsize"]
+
+
+def _clip_data_to_trajectory(data, trajectory, sample_offset):
+    data_readouts = data.shape[1]
+    data_samples = data.shape[2]
+
+    if trajectory.ndim == 3:
+        direct_score = abs(trajectory.shape[0] - data_samples) + abs(trajectory.shape[1] - data_readouts)
+        swapped_score = abs(trajectory.shape[1] - data_samples) + abs(trajectory.shape[0] - data_readouts)
+
+        if swapped_score < direct_score:
+            logging.warning(
+                "Swapping trajectory axes to match standalone dimensions: trajectory=%s data=(samples=%d, readouts=%d)",
+                trajectory.shape,
+                data_samples,
+                data_readouts,
+            )
+            trajectory = np.swapaxes(trajectory, 0, 1)
+
+    available_sample_offset = max(0, trajectory.shape[0] - data_samples)
+    applied_sample_offset = max(0, min(sample_offset, available_sample_offset))
+    if applied_sample_offset > 0:
+        logging.info(
+            "Applying trajectory sample offset %d to align %d trajectory samples with %d raw samples",
+            applied_sample_offset,
+            trajectory.shape[0],
+            data_samples,
+        )
+
+    samples = min(data.shape[2], trajectory.shape[0] - applied_sample_offset)
+    readouts = min(data.shape[1], trajectory.shape[1])
+    if readouts != data.shape[1] or samples != data.shape[2]:
+        logging.warning(
+            "Cropping raw data to match trajectory dimensions: data=%s trajectory=%s offset=%d -> (%d, %d)",
+            data.shape,
+            trajectory.shape,
+            applied_sample_offset,
+            readouts,
+            samples,
+        )
+    return (
+        data[:, :readouts, :samples],
+        trajectory[applied_sample_offset:applied_sample_offset + samples, :readouts, :],
+    )
+
+
+def _compute_sample_mask_and_scale(coil_data, sigma):
+    column_max = np.abs(coil_data).max(axis=0)
+    smoothed = ndi.gaussian_filter1d(column_max.astype(np.float32), 5)
+    histogram, edges = np.histogram(smoothed, bins=40)
+    modal_edge = float(edges[int(np.argmax(histogram))])
+
+    nearby = column_max[column_max >= 0.95 * modal_edge]
+    if nearby.size == 0:
+        bad_columns = np.array([], dtype=np.int64)
+    else:
+        threshold = modal_edge - sigma * float(nearby.std())
+        bad_columns = np.where(column_max < threshold)[0]
+
+    filtered = np.array(coil_data, copy=True)
+    if bad_columns.size > 0:
+        filtered[:, bad_columns] = 0
+
+    return filtered, bad_columns
+
+
+def _build_fermi_filter(
+    trajectory,
+    apply_fermi_filter,
+    fermi_width,
+    fermi_cutoff,
+):
+    if not apply_fermi_filter:
+        return np.ones(trajectory.shape[:2], dtype=np.float32)
+
+    abs_k = np.linalg.norm(trajectory, axis=-1)
+    abs_k_max = float(np.max(abs_k)) if abs_k.size else 0.0
+    if abs_k_max <= 0.0:
+        return np.ones(trajectory.shape[:2], dtype=np.float32)
+
+    normalized_radius = abs_k / abs_k_max
+    fermi_filter = 1.0 / (
+        1.0
+        + np.exp(
+            (normalized_radius - float(fermi_cutoff))
+            / max(float(fermi_width), 1e-6)
+        )
+    )
+    return np.asarray(fermi_filter, dtype=np.float32)
+
+
+def _prepare_single_coil_data(
+    coil_index,
+    coil_data,
+    reject_bad_readouts,
+    bad_readout_sigma,
+    center_window,
+    fermi_filter,
+):
+    working_data = np.asarray(coil_data.T, dtype=np.complex64)
+
+    if reject_bad_readouts:
+        working_data, bad_columns = _compute_sample_mask_and_scale(
+            working_data,
+            sigma=bad_readout_sigma,
+        )
+        logging.info(
+            "Coil %d: rejected %d low-signal sample columns",
+            coil_index,
+            bad_columns.size,
+        )
+    else:
+        bad_columns = np.array([], dtype=np.int64)
+        working_data = np.array(working_data, copy=True)
+
+    center = working_data.shape[1] // 2
+    start = max(0, center - center_window)
+    stop = min(working_data.shape[1], center + center_window)
+    reference_mean = float(np.abs(working_data[:, start:stop]).mean())
+    if reference_mean > 0:
+        working_data *= 2.0 / reference_mean
+
+    return np.asarray(working_data * fermi_filter, dtype=np.complex64)
+
+
+def _compress_coils_by_variance(coil_data, variance_retention=0.9, epsilon=1e-12):
+    num_input_coils = int(coil_data.shape[0])
+    if num_input_coils <= 1:
+        return (
+            np.asarray(coil_data, dtype=np.complex64),
+            np.array([1.0], dtype=np.float32),
+            np.eye(num_input_coils, dtype=np.complex64),
+        )
+
+    data_2d = np.asarray(coil_data).reshape(num_input_coils, -1)
+    covariance = data_2d @ data_2d.conj().T
+    covariance /= max(data_2d.shape[1], 1)
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    order = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[order].real, 0.0)
+    eigenvectors = eigenvectors[:, order]
+
+    total_variance = float(eigenvalues.sum())
+    if total_variance <= epsilon:
+        logging.warning(
+            "Coil compression skipped because covariance has near-zero variance"
+        )
+        return (
+            np.asarray(coil_data, dtype=np.complex64),
+            np.ones(num_input_coils, dtype=np.float32),
+            np.eye(num_input_coils, dtype=np.complex64),
+        )
+
+    cumulative_variance = np.cumsum(eigenvalues) / total_variance
+    retention = float(np.clip(variance_retention, 0.0, 1.0))
+    num_virtual_coils = min(
+        num_input_coils,
+        int(np.searchsorted(cumulative_variance, retention) + 1),
+    )
+    compression_matrix = np.asarray(
+        eigenvectors[:, :num_virtual_coils],
+        dtype=np.complex64,
+    )
+    compressed_data = np.einsum(
+        "cv,c...->v...",
+        compression_matrix.conj(),
+        coil_data,
+        optimize=True,
+    )
+
+    logging.info(
+        "Coil compression: %d physical coils -> %d virtual coils "
+        "(%.2f%% variance retained)",
+        num_input_coils,
+        num_virtual_coils,
+        100.0 * cumulative_variance[num_virtual_coils - 1],
+    )
+    logging.info(
+        "Cumulative coil variance: %s",
+        np.array2string(cumulative_variance[:num_virtual_coils], precision=4),
+    )
+    return (
+        np.asarray(compressed_data, dtype=np.complex64),
+        np.asarray(cumulative_variance, dtype=np.float32),
+        compression_matrix,
+    )
+
+
+def _reconstruct_single_virtual_coil(
+    coil_index,
+    coil_data,
+    normalized_coordinates,
+    dcf,
+    deapodization,
+    matrix_size,
+):
+    logging.info("Starting Kaiser-Bessel gridding for virtual coil %d", coil_index)
+    with GRID_SEMAPHORE:
+        reconstructed = _regrid_3d_kb(
+            coil_data.ravel(),
+            normalized_coordinates,
+            grid_size=matrix_size,
+            dcf=dcf,
+            deapodization=deapodization,
+            oversampling=OVERSAMPLING,
+        )
+    logging.info("Finished Kaiser-Bessel gridding for virtual coil %d", coil_index)
+    return coil_index, reconstructed
+
+
+def _estimate_sensitivities(coil_images, smooth_sigma=None, epsilon=1e-8):
+    num_coils, matrix_x, _, _ = coil_images.shape
+    if smooth_sigma is None:
+        smooth_sigma = matrix_x / 32.0
+    logging.info(
+        "Estimating sensitivities for %d virtual coils with sigma %.2f voxels",
+        num_coils,
+        smooth_sigma,
+    )
+
+    smoothed = np.zeros_like(coil_images, dtype=np.complex64)
+    for coil_index in range(num_coils):
+        real = ndi.gaussian_filter(coil_images[coil_index].real, smooth_sigma)
+        imaginary = ndi.gaussian_filter(coil_images[coil_index].imag, smooth_sigma)
+        smoothed[coil_index] = real + 1j * imaginary
+
+    root_sum_of_squares = np.sqrt(np.sum(np.abs(smoothed) ** 2, axis=0)) + epsilon
+    smoothed /= root_sum_of_squares[None, ...]
+    return np.asarray(smoothed, dtype=np.complex64)
+
+
+def _combine_coils(coil_images, mode="AC"):
+    normalized_mode = str(mode).strip().upper()
+    if coil_images.shape[0] == 1:
+        logging.info("Single virtual coil: skipping coil combination")
+        return np.asarray(np.abs(coil_images[0]), dtype=np.float32)
+
+    if normalized_mode == "SOS":
+        logging.info("Combining virtual coils with root-sum-of-squares")
+        return np.asarray(
+            np.sqrt(np.sum(np.abs(coil_images) ** 2, axis=0)),
+            dtype=np.float32,
+        )
+
+    if normalized_mode == "AC":
+        sensitivity_maps = _estimate_sensitivities(coil_images)
+        logging.info("Combining virtual coils adaptively")
+        combined = np.sum(np.conj(sensitivity_maps) * coil_images, axis=0)
+        return np.asarray(np.abs(combined), dtype=np.float32)
+
+    raise ValueError("coilcombinemode must be 'AC' or 'SoS'")
+
+
+def _n4_bias_field_correct(volume):
+    try:
+        import SimpleITK as sitk
+    except ImportError as error:
+        raise RuntimeError(
+            "N4 bias correction requires the SimpleITK runtime dependency"
+        ) from error
+
+    values = np.asarray(volume, dtype=np.float32)
+    if not values.size or float(np.max(values)) <= 0.0:
+        logging.warning("Skipping N4 bias correction for an empty image")
+        return values
+
+    image_zyx = values.swapaxes(0, 2)
+    sitk_image = sitk.GetImageFromArray(image_zyx)
+    mask = sitk.OtsuThreshold(sitk_image, 0, 1, 512)
+    mask = sitk.BinaryMorphologicalClosing(mask, [9, 9, 9])
+    mask = sitk.BinaryFillhole(mask)
+
+    if N4_SHRINK_FACTOR > 1:
+        shrink = [int(N4_SHRINK_FACTOR)] * sitk_image.GetDimension()
+        correction_image = sitk.Shrink(sitk_image, shrink)
+        correction_mask = sitk.Shrink(mask, shrink)
+    else:
+        correction_image = sitk_image
+        correction_mask = mask
+
+    corrector = sitk.N4BiasFieldCorrectionImageFilter()
+    corrector.SetMaximumNumberOfIterations(N4_MAX_ITERATIONS)
+    corrector.SetConvergenceThreshold(0.001)
+    corrector.SetSplineOrder(3)
+    corrector.SetWienerFilterNoise(0.1)
+    corrector.SetBiasFieldFullWidthAtHalfMaximum(0.15)
+    corrector.Execute(correction_image, correction_mask)
+    log_bias_field = corrector.GetLogBiasFieldAsImage(sitk_image)
+    corrected = sitk_image / sitk.Exp(log_bias_field)
+    return np.asarray(
+        sitk.GetArrayFromImage(corrected).swapaxes(0, 2),
+        dtype=np.float32,
+    )
+
+
+def _format_display_number(value):
+    number = float(value)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.6g}"
+
+
+def _scale_volume_to_display_range(volume):
+    values = np.asarray(volume, dtype=np.float32)
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        display = np.zeros(values.shape, dtype=np.uint16)
+        return display, {
+            "input_min": 0.0,
+            "input_max": 0.0,
+            "scale": 1.0,
+            "display_min": 0,
+            "display_max": 0,
+            "formula": "value = display",
+        }
+
+    input_min = float(np.min(finite))
+    input_max = float(np.max(finite))
+    input_range = input_max - input_min
+    if input_range <= 0.0 or not np.isfinite(input_range):
+        display = np.zeros(values.shape, dtype=np.uint16)
+        return display, {
+            "input_min": input_min,
+            "input_max": input_max,
+            "scale": 1.0,
+            "display_min": 0,
+            "display_max": 0,
+            "formula": f"value = display + {_format_display_number(input_min)}",
+        }
+
+    scale = float(SCANNER_DISPLAY_MAX - SCANNER_DISPLAY_MIN) / input_range
+    cleaned = np.nan_to_num(values, nan=input_min, posinf=input_max, neginf=input_min)
+    display = np.rint((cleaned - input_min) * scale + SCANNER_DISPLAY_MIN)
+    display = np.clip(display, SCANNER_DISPLAY_MIN, SCANNER_DISPLAY_MAX)
+    display = display.astype(np.uint16, copy=False)
+    scale_text = _format_display_number(scale)
+    min_text = _format_display_number(input_min)
+    return display, {
+        "input_min": input_min,
+        "input_max": input_max,
+        "scale": scale,
+        "display_min": int(np.min(display)) if display.size else 0,
+        "display_max": int(np.max(display)) if display.size else 0,
+        "formula": f"value = display / {scale_text} + {min_text}",
+    }
+
+
+def _scanner_display_comment(display_meta):
+    return (
+        f"{OUTPUT_IMAGE_COMMENT}; scanner display uint16 "
+        f"{SCANNER_DISPLAY_MIN}-{SCANNER_DISPLAY_MAX}; {display_meta['formula']}"
+    )
+
+
+def _new_dicom_uid():
+    return f"2.25.{uuid.uuid4().int}"
+
+
+def _log_trajectory_extent(trajectory):
+    """Log per-component k-space extent.
+
+    An asymmetric or unequal extent between components is the main offline clue
+    that the trajectory component order is not (read, phase, slice).
+    """
+    coordinates = np.asarray(trajectory, dtype=np.float64).reshape(-1, 3)
+    if not coordinates.size:
+        logging.warning("Trajectory is empty; cannot report k-space extent")
+        return
+
+    for component in range(3):
+        values = coordinates[:, component]
+        logging.info(
+            "Trajectory component %d: min=%+.6f max=%+.6f mean=%+.6f "
+            "abs_max=%.6f center_offset=%+.6f",
+            component,
+            float(values.min()),
+            float(values.max()),
+            float(values.mean()),
+            float(np.abs(values).max()),
+            float(values.min() + values.max()),
+        )
+
+
+def _direction_letters(vector):
+    """Return the anatomical letters at the start and end of a direction vector.
+
+    ``(-x, +x)`` yields ``("L", "R")`` because the vector begins on the
+    patient's left and ends on the right. The scanner labels the edges of a
+    displayed image with exactly these two letters.
+    """
+    values = np.asarray(vector, dtype=float)
+    norm = float(np.linalg.norm(values))
+    if norm < 1e-6:
+        return ("?", "?")
+    unit = values / norm
+    axis = int(np.argmax(np.abs(unit)))
+    start, end = PATIENT_AXIS_LABELS[axis]
+    if unit[axis] < 0:
+        start, end = end, start
+    return (start, end)
+
+
+def _direction_label(vector):
+    """Describe a patient-space direction vector as, for example, 'R->L'."""
+    start, end = _direction_letters(vector)
+    if start == "?":
+        return "undefined"
+    return f"{start}->{end}"
+
+
+def _format_direction(vector):
+    values = np.asarray(vector, dtype=float)
+    components = ",".join(f"{float(value):+.4f}" for value in values)
+    obliquity = float(np.max(np.abs(values))) if values.size else 0.0
+    return f"{_direction_label(values)} [{components}] alignment={obliquity:.4f}"
+
+
+def _position_label(position):
+    """Format a patient-space position the way the scanner prints one, 'R6.3 P2.3 H35.4'."""
+    values = np.asarray(position, dtype=float)
+    parts = []
+    for axis in range(3):
+        value = float(values[axis])
+        negative, positive = PATIENT_AXIS_LABELS[axis]
+        parts.append(f"{positive if value >= 0.0 else negative}{abs(value):.1f}")
+    return " ".join(parts)
+
+
+def _slice_position_label(position):
+    """Format the dominant component of a position, matching the scanner 'SP' field."""
+    values = np.asarray(position, dtype=float)
+    axis = int(np.argmax(np.abs(values)))
+    value = float(values[axis])
+    negative, positive = PATIENT_AXIS_LABELS[axis]
+    return f"{positive if value >= 0.0 else negative}{abs(value):.1f}"
+
+
+def _unit_vector(vector, fallback=(0.0, 0.0, 1.0)):
+    values = np.asarray(vector, dtype=float)
+    norm = float(np.linalg.norm(values))
+    if norm < 1e-6:
+        return np.asarray(fallback, dtype=float)
+    return values / norm
+
+
+def _frame_position(center_position, slice_dir, frame_index, slice_count, slice_spacing_mm):
+    """Patient-space centre of one emitted frame.
+
+    ``center_position`` is the centre of the whole volume, which is what the MRD
+    header carries, so frame ``frame_index`` of ``slice_count`` sits half a
+    volume away from it minus its own offset. ``frame_index`` is zero based;
+    the scanner numbers the same frame ``frame_index + 1``.
+    """
+    offset = (float(frame_index) - (float(slice_count) - 1.0) / 2.0) * float(
+        slice_spacing_mm
+    )
+    return np.asarray(center_position, dtype=float) + offset * _unit_vector(slice_dir)
+
+
+def _resolve_orientation(orientation):
+    key = str(orientation).strip().lower()
+    if key not in ORIENTATION_IN_PLANE_TRANSFORMS:
+        logging.warning(
+            "Unknown orientation '%s'; falling back to '%s'. Valid values: %s",
+            orientation,
+            DEFAULT_ORIENTATION,
+            ", ".join(sorted(ORIENTATION_IN_PLANE_TRANSFORMS)),
+        )
+        key = DEFAULT_ORIENTATION
+    return key
+
+
+def _resolve_orientation_selection(selection):
+    """Split a UI orientation value into (orientation, emit_debug_series).
+
+    ``ORIENTATION_DEBUG_SELECTION`` is one of the values the scanner UI offers,
+    so every entry point that accepts an orientation has to understand it. This
+    is the single place that mapping is made.
+    """
+    if str(selection).strip().lower() == ORIENTATION_DEBUG_SELECTION:
+        return DEFAULT_ORIENTATION, True
+    return _resolve_orientation(selection), False
+
+
+def _resolve_orientation_config(config):
+    selection = _config_str(config, "orientation", OPENRECON_DEFAULTS["orientation"])
+    orientation, emit_debug_series = _resolve_orientation_selection(selection)
+    # Continue accepting the older boolean in manually supplied JSON configs.
+    if _config_bool(
+        config,
+        "orientationdebugseries",
+        OPENRECON_DEFAULTS["orientationdebugseries"],
+    ):
+        orientation, emit_debug_series = DEFAULT_ORIENTATION, True
+    return orientation, emit_debug_series
+
+
+def _orient_volume(volume, orientation, flip_slice=False):
+    """Map trajectory components into acquisition (slice, phase, read) axes."""
+    key = _resolve_orientation(orientation)
+    transpose_in_plane, reverse_rows, reverse_columns = (
+        ORIENTATION_IN_PLANE_TRANSFORMS[key]
+    )
+
+    oriented = np.asarray(volume)
+    if transpose_in_plane:
+        oriented = oriented.transpose(0, 2, 1)
+    if reverse_rows:
+        oriented = oriented[:, ::-1, :]
+    if reverse_columns:
+        oriented = oriented[:, :, ::-1]
+    if flip_slice:
+        oriented = oriented[::-1, :, :]
+
+    return np.ascontiguousarray(oriented), key
+
+
+def _canonicalize_to_display_frame(volume, axis_directions):
+    """Rotate a (slices, rows, columns) volume into the DICOM standard display view.
+
+    ``axis_directions`` are the patient-space directions of the volume's own
+    axes, in the same (slices, rows, columns) order. The returned directions
+    describe the returned volume, so the header stays exactly as honest as it
+    was on input: this is a change of display convention, not a correction
+    layered on top of one.
+
+    The permutation and signs are derived from the acquisition's own vectors
+    rather than hardcoded, so obliquity and a non-HFS patient position are
+    handled without a second code path.
+    """
+    directions = [np.asarray(vector, dtype=float) for vector in axis_directions]
+    unit_directions = []
+    for vector in directions:
+        norm = float(np.linalg.norm(vector))
+        unit_directions.append(vector / norm if norm > 1e-6 else vector)
+
+    targets = [np.asarray(target, dtype=float) for target in DISPLAY_FRAME_TARGETS]
+
+    # Choose all three axes as one assignment. Greedy target-by-target matching
+    # can consume the second-best axis early and force a wrong mapping for a
+    # valid oblique rotation.
+    permutation = max(
+        permutations(range(3)),
+        key=lambda candidate: sum(
+            abs(float(np.dot(unit_directions[candidate[index]], targets[index])))
+            for index in range(3)
+        ),
+    )
+    signs = [
+        -1.0
+        if float(np.dot(unit_directions[permutation[index]], targets[index])) < 0.0
+        else 1.0
+        for index in range(3)
+    ]
+
+    canonical = np.asarray(volume).transpose(*permutation)
+    for output_axis, sign in enumerate(signs):
+        if sign < 0.0:
+            canonical = np.flip(canonical, axis=output_axis)
+
+    canonical_directions = [
+        signs[output_axis] * directions[permutation[output_axis]]
+        for output_axis in range(3)
+    ]
+    return np.ascontiguousarray(canonical), canonical_directions, permutation, signs
+
+
+def _log_display_frame(permutation, signs, canonical_directions, shape):
+    logging.info(
+        "DICOM display frame: NormOrientation is disabled on the scanner, so the "
+        "volume is rotated into the standard view here (columns to L, rows to P, "
+        "slices to H). Direction metadata is transformed with the pixels."
+    )
+    for output_axis, name in enumerate(DISPLAY_FRAME_AXIS_NAMES):
+        logging.info(
+            "Display frame axis %d (%s): source axis %d %s -> %s",
+            output_axis,
+            name,
+            permutation[output_axis],
+            "reversed" if signs[output_axis] < 0.0 else "kept",
+            _format_direction(canonical_directions[output_axis]),
+        )
+    logging.info("Display frame shape: %s", tuple(int(size) for size in shape))
+
+    slices, rows, columns = canonical_directions
+    handedness = float(np.dot(np.cross(_unit_vector(columns), _unit_vector(rows)),
+                              _unit_vector(slices)))
+    if handedness > 0.0:
+        logging.info(
+            "Display frame handedness: right-handed (columns x rows . slices = "
+            "%+.3f), matching the native reconstruction.",
+            handedness,
+        )
+    else:
+        logging.error(
+            "Display frame handedness: LEFT-handed (columns x rows . slices = "
+            "%+.3f). The scanner will draw this volume from the opposite side of "
+            "the native reconstruction. An acquisition frame is always "
+            "right-handed, so this means an axis was reversed without its "
+            "direction vector, or DISPLAY_FRAME_TARGETS is inconsistent.",
+            handedness,
+        )
+
+
+def _log_emitted_geometry(center_position, read_dir, phase_dir, slice_dir, shape, fov_mm):
+    """Log what the scanner should display, so one screenshot can confirm or refute it.
+
+    Everything here is derived from the header this app is about to emit. If the
+    scanner shows something different, the header was overridden downstream
+    rather than computed wrongly here, and that distinction is the whole reason
+    this block exists: 0.1.3 could not be diagnosed from its own log.
+    """
+    slice_count = int(shape[0])
+    spacing = float(fov_mm) / float(slice_count) if slice_count else 0.0
+
+    left, right = _direction_letters(read_dir)
+    top, bottom = _direction_letters(phase_dir)
+    view_from, _ = _direction_letters(slice_dir)
+
+    logging.info(
+        "Predicted scanner display: left edge '%s', right edge '%s', top edge "
+        "'%s', bottom edge '%s', viewed from '%s' (the boxed marker). The native "
+        "transversal reconstruction shows R, L, A, P and F.",
+        left,
+        right,
+        top,
+        bottom,
+        view_from,
+    )
+    logging.info(
+        "Emitted volume centre: %s [%s], slice spacing %.5f mm over %d slices",
+        _position_label(center_position),
+        ",".join(f"{float(value):+.3f}" for value in center_position),
+        spacing,
+        slice_count,
+    )
+
+    if slice_count:
+        sample_indices = sorted(
+            {0, slice_count // 4, slice_count // 2, (3 * slice_count) // 4, slice_count - 1}
+        )
+        for index in sample_indices:
+            position = _frame_position(
+                center_position, slice_dir, index, slice_count, spacing
+            )
+            logging.info(
+                "Predicted frame %d/%d (scanner numbering): SP %s, full position %s",
+                index + 1,
+                slice_count,
+                _slice_position_label(position),
+                _position_label(position),
+            )
+        logging.info(
+            "Compare any one of those against the scanner's SP field for the same "
+            "frame number. A match confirms the emitted geometry is honoured; a "
+            "sign difference means the slice axis is reversed relative to the "
+            "native series; a different magnitude means the volume centre or the "
+            "field of view disagrees."
+        )
+
+
+def _log_patient_space_localisation(label, volume, center_position, axis_directions, fov_mm):
+    """Log where the signal actually sits in patient coordinates.
+
+    Voxel-index centroids cannot be compared against a scanner screenshot, but
+    these positions can. They are what distinguishes a volume that is merely
+    stored back to front from one whose content is genuinely in the wrong place.
+    """
+    values = np.asarray(volume, dtype=np.float64)
+    if values.ndim != 3 or not values.size:
+        logging.info("Patient-space localisation [%s]: unavailable", label)
+        return
+
+    total = float(values.sum())
+    if total <= 0.0:
+        logging.info("Patient-space localisation [%s]: no signal", label)
+        return
+
+    centroid_position = np.asarray(center_position, dtype=float).copy()
+    for axis, name in enumerate(DISPLAY_FRAME_AXIS_NAMES):
+        profile = values.sum(
+            axis=tuple(other for other in range(3) if other != axis)
+        )
+        count = int(profile.size)
+        spacing = float(fov_mm) / float(count)
+        indices = np.arange(count, dtype=np.float64)
+        centroid_index = float((profile * indices).sum() / profile.sum())
+        peak_index = int(np.argmax(profile))
+
+        above = np.flatnonzero(profile >= 0.1 * float(profile.max()))
+        extent_mm = (float(above[-1] - above[0]) + 1.0) * spacing if above.size else 0.0
+
+        offset_mm = (centroid_index - (count - 1) / 2.0) * spacing
+        direction = _unit_vector(axis_directions[axis])
+        centroid_position = centroid_position + offset_mm * direction
+
+        logging.info(
+            "Patient-space localisation [%s] %s (%s): centroid index %.2f/%d "
+            "(%+.2f mm from centre), peak index %d, signal extent %.1f mm",
+            label,
+            name,
+            _direction_label(direction),
+            centroid_index,
+            count,
+            offset_mm,
+            peak_index,
+            extent_mm,
+        )
+
+    logging.info(
+        "Patient-space localisation [%s]: intensity centroid at %s [%s]",
+        label,
+        _position_label(centroid_position),
+        ",".join(f"{float(value):+.3f}" for value in centroid_position),
+    )
+
+
+def _log_volume_statistics(label, volume):
+    values = np.asarray(volume, dtype=np.float64)
+    if not values.size:
+        logging.info("Volume statistics [%s]: empty", label)
+        return
+
+    total = float(values.sum())
+    if total > 0.0:
+        centroid = [
+            float(
+                (values.sum(axis=tuple(other for other in range(values.ndim) if other != axis))
+                 * np.arange(values.shape[axis])).sum()
+                / total
+            )
+            for axis in range(values.ndim)
+        ]
+        centroid_text = ",".join(
+            f"{value:.2f}/{values.shape[axis]}" for axis, value in enumerate(centroid)
+        )
+    else:
+        centroid_text = "undefined"
+
+    logging.info(
+        "Volume statistics [%s]: shape=%s dtype=%s min=%.6g max=%.6g mean=%.6g "
+        "intensity_centroid_per_axis=%s",
+        label,
+        tuple(int(size) for size in values.shape),
+        np.asarray(volume).dtype,
+        float(values.min()),
+        float(values.max()),
+        float(values.mean()),
+        centroid_text,
+    )
+
+
+def _log_reference_geometry(reference_head, metadata):
+    try:
+        patient_position = str(metadata.measurementInformation.patientPosition)
+    except Exception:
+        patient_position = "unavailable"
+
+    logging.info(
+        "Acquisition geometry: patient_position=%s position=(%s) "
+        "patient_table_position=(%s)",
+        patient_position,
+        ",".join(f"{float(value):+.3f}" for value in reference_head.position),
+        ",".join(
+            f"{float(value):+.3f}"
+            for value in getattr(reference_head, "patient_table_position", ())
+        ),
+    )
+    logging.info("Acquisition read_dir  (MRD x, columns): %s", _format_direction(reference_head.read_dir))
+    logging.info("Acquisition phase_dir (MRD y, rows):    %s", _format_direction(reference_head.phase_dir))
+    logging.info("Acquisition slice_dir (MRD z, slices):  %s", _format_direction(reference_head.slice_dir))
+    logging.info(
+        "Acquisition volume centre: %s",
+        _position_label(reference_head.position),
+    )
+    acquisition_handedness = float(
+        np.dot(
+            np.cross(
+                _unit_vector(reference_head.read_dir),
+                _unit_vector(reference_head.phase_dir),
+            ),
+            _unit_vector(reference_head.slice_dir),
+        )
+    )
+    logging.info(
+        "Acquisition frame handedness: %+.3f (%s). A physical acquisition is "
+        "always right-handed; anything else means the incoming vectors are "
+        "inconsistent and no downstream mapping can be trusted.",
+        acquisition_handedness,
+        "right-handed" if acquisition_handedness > 0.0 else "LEFT-handed",
+    )
+    logging.info(
+        "Direction vectors are only ever transformed together with the pixels. "
+        "Under this FIRE configuration (UseIceFillingMiniHeader, "
+        "IsFlipAndShiftImages, NormOrientation disabled) a lone sign change "
+        "relabels markers without moving a pixel."
+    )
+
+
+def _log_acquisition_axes(packed_shape, reference_head, orientation_key, flip_slice):
+    transpose_in_plane, reverse_rows, reverse_columns = (
+        ORIENTATION_IN_PLANE_TRANSFORMS[orientation_key]
+    )
+    logging.info(
+        "Trajectory orientation '%s': transpose_in_plane=%s reverse_rows=%s "
+        "reverse_columns=%s reverse_slices=%s",
+        orientation_key,
+        transpose_in_plane,
+        reverse_rows,
+        reverse_columns,
+        flip_slice,
+    )
+    logging.info(
+        "Acquisition-frame volume: shape=%s, slices along %s, rows along %s, "
+        "columns along %s",
+        tuple(int(size) for size in packed_shape),
+        _direction_label(reference_head.slice_dir),
+        _direction_label(reference_head.phase_dir),
+        _direction_label(reference_head.read_dir),
+    )
+
+
+def _build_output_images(
+    volume,
+    reference_head,
+    metadata,
+    output_fov_mm,
+    orientation=DEFAULT_ORIENTATION,
+    flip_slice=False,
+    emit_debug_series=False,
+):
+    volume = np.asarray(volume, dtype=np.float32)
+    if volume.ndim != 3:
+        raise ValueError(f"Reconstructed volume must be 3D, got shape {volume.shape}")
+
+    _log_reference_geometry(reference_head, metadata)
+    _log_volume_statistics("reconstructed volume (z, y, x)", volume)
+
+    display_volume, display_meta = _scale_volume_to_display_range(volume)
+    logging.info(
+        "Scanner display scaling: input_min=%.6g input_max=%.6g scale=%s formula='%s'",
+        display_meta["input_min"],
+        display_meta["input_max"],
+        _format_display_number(display_meta["scale"]),
+        display_meta["formula"],
+    )
+
+    # Accept every value the scanner UI offers, including the debug selection,
+    # so passing a configured orientation straight through cannot silently fall
+    # back to the default.
+    orientation, selects_debug_series = _resolve_orientation_selection(orientation)
+    emit_debug_series = emit_debug_series or selects_debug_series
+
+    if emit_debug_series:
+        # Sweep the slice reversal as well as the in-plane mappings. The eight
+        # in-plane keys leave the through-plane axis untouched, so a sweep over
+        # them alone cannot reach a volume whose slice order is wrong -- which is
+        # precisely the failure 0.1.3 had, and precisely the one its debug sweep
+        # could not have surfaced.
+        sweep = [
+            (key, slice_flip)
+            for key in ORIENTATION_DEBUG_ORDER
+            for slice_flip in (False, True)
+        ]
+        logging.warning(
+            "Orientation debug sweep enabled: emitting %d canonicalized series, "
+            "every combination of the %d trajectory mappings (%s) with the slice "
+            "axis kept and reversed. Series are suffixed '_ori_<key>_fz<0|1>'. "
+            "Identify the anatomically correct one against an asymmetric object "
+            "or a marker on a known side, then set 'orientation' to its key and "
+            "'orientationflipslice' to its fz digit. The four 'zxy' mappings are "
+            "already excluded by the phantom aspect ratio measured in "
+            "sodiumgridding_v0.1.3.PNG and are emitted only as a cross-check.",
+            len(sweep),
+            len(ORIENTATION_DEBUG_ORDER),
+            ", ".join(ORIENTATION_DEBUG_ORDER),
+        )
+    else:
+        sweep = [(orientation, flip_slice)]
+
+    return [
+        _build_single_output_image(
+            display_volume,
+            display_meta,
+            reference_head,
+            metadata,
+            output_fov_mm=output_fov_mm,
+            orientation_key=orientation_key,
+            flip_slice=slice_flip,
+            series_index=OUTPUT_IMAGE_SERIES_INDEX + offset,
+            label_series=emit_debug_series,
+        )
+        for offset, (orientation_key, slice_flip) in enumerate(sweep)
+    ]
+
+
+def _build_single_output_image(
+    display_volume,
+    display_meta,
+    reference_head,
+    metadata,
+    output_fov_mm,
+    orientation_key,
+    flip_slice,
+    series_index,
+    label_series,
+):
+    # Stage 1 resolves the trajectory components against the acquisition axes.
+    # Stage 2 transforms the acquisition vectors together with the pixels in
+    # _canonicalize_to_display_frame; no display correction changes metadata
+    # without changing the corresponding pixels.
+    read_dir = np.asarray(reference_head.read_dir, dtype=float)
+    phase_dir = np.asarray(reference_head.phase_dir, dtype=float)
+    slice_dir = np.asarray(reference_head.slice_dir, dtype=float)
+    slice_dir_norm = float(np.linalg.norm(slice_dir))
+    if slice_dir_norm < 1e-6:
+        logging.warning("Acquisition slice_dir is degenerate; substituting +z (head)")
+        slice_dir = np.array([0.0, 0.0, 1.0], dtype=float)
+    else:
+        slice_dir = slice_dir / slice_dir_norm
+
+    center_position = np.asarray(reference_head.position, dtype=float)
+
+    series_description = f"{_safe_protocol_name(metadata)}_{OUTPUT_SERIES_DESCRIPTION}"
+    if label_series:
+        series_description = (
+            f"{series_description}_ori_{orientation_key}_fz{int(bool(flip_slice))}"
+        )
+    series_grouping = f"{series_description}_{series_index}"
+    series_uid = _new_dicom_uid()
+    output_fov_mm = float(output_fov_mm)
+    image_comment = _scanner_display_comment(display_meta)
+
+    # Pack the complete matrix as one explicit 3D MRD image. Sending 64 separate
+    # 2D messages lets ICE refill each mini-header from the source protocol's
+    # NoImagesPerSlab=32 and causes the DICOM writer to flush two 32-frame
+    # volumes. One [z, y, x] image gives the writer one 64-frame volume,
+    # matching the native ICE reconstruction contract.
+    #
+    # Stage 1 maps trajectory components into the acquisition's slice, phase
+    # and read axes. Stage 2 rotates that acquisition frame into the standard
+    # display view while transforming its direction vectors with the pixels.
+    packed_volume, orientation_key = _orient_volume(
+        display_volume,
+        orientation_key,
+        flip_slice=flip_slice,
+    )
+    _log_acquisition_axes(
+        packed_volume.shape,
+        reference_head,
+        orientation_key,
+        flip_slice,
+    )
+
+    packed_volume, canonical_directions, permutation, signs = (
+        _canonicalize_to_display_frame(
+            packed_volume,
+            (slice_dir, phase_dir, read_dir),
+        )
+    )
+    slice_dir, phase_dir, read_dir = canonical_directions
+    _log_display_frame(permutation, signs, canonical_directions, packed_volume.shape)
+    _log_emitted_geometry(
+        center_position,
+        read_dir,
+        phase_dir,
+        slice_dir,
+        packed_volume.shape,
+        output_fov_mm,
+    )
+
+    slice_count = int(packed_volume.shape[0])
+    _log_volume_statistics("packed output", packed_volume)
+    _log_patient_space_localisation(
+        "packed output",
+        packed_volume,
+        center_position,
+        canonical_directions,
+        output_fov_mm,
+    )
+    image = ismrmrd.Image.from_array(packed_volume, transpose=False)
+
+    new_header = mrdhelper.update_img_header_from_raw(image.getHead(), reference_head)
+    new_header.data_type = image.data_type
+    new_header.image_type = ismrmrd.IMTYPE_MAGNITUDE
+    new_header.image_series_index = series_index
+    new_header.image_index = 1
+    new_header.slice = 0
+    new_header.matrix_size = tuple(int(value) for value in image.getHead().matrix_size)
+    new_header.position = tuple(float(value) for value in center_position)
+    new_header.read_dir = tuple(float(value) for value in read_dir)
+    new_header.phase_dir = tuple(float(value) for value in phase_dir)
+    new_header.slice_dir = tuple(float(value) for value in slice_dir)
+    new_header.field_of_view = (
+        output_fov_mm,
+        output_fov_mm,
+        output_fov_mm,
+    )
+    image.setHead(new_header)
+    image.image_series_index = series_index
+    image.field_of_view = (
+        ctypes.c_float(output_fov_mm),
+        ctypes.c_float(output_fov_mm),
+        ctypes.c_float(output_fov_mm),
+    )
+
+    meta = ismrmrd.Meta()
+    meta["DataRole"] = "Image"
+    meta["ImageProcessingHistory"] = ["PYTHON", "NUMBA", "KAISERBESSEL", "GRIDDING"]
+    meta["ImageType"] = "DERIVED\\PRIMARY\\M\\SODIUMGRIDDING"
+    meta["DicomImageType"] = "DERIVED\\PRIMARY\\M\\SODIUMGRIDDING"
+    meta["ImageTypeValue4"] = "SODIUMGRIDDING"
+    meta["ComplexImageComponent"] = "MAGNITUDE"
+    meta["SequenceDescriptionAdditional"] = OUTPUT_IMAGE_COMMENT
+    meta["SeriesDescription"] = series_description
+    meta["SequenceDescription"] = series_description
+    meta["ProtocolName"] = series_description
+    meta["SeriesNumberRangeNameUID"] = series_grouping
+    meta["SeriesInstanceUID"] = series_uid
+    meta["SOPInstanceUID"] = _new_dicom_uid()
+    meta["ImageComment"] = image_comment
+    meta["ImageComments"] = image_comment
+    # 1 tells ICE to keep the geometry described in this header instead of
+    # rebuilding it and applying its own flip/shift. The vectors above describe
+    # the canonicalized pixels, so geometry has exactly one owner.
+    meta["Keep_image_geometry"] = 1
+    meta["partition_count"] = 1
+    meta["slice_count"] = slice_count
+    meta["NumberOfSlices"] = slice_count
+    meta["ImagesInAcquisition"] = slice_count
+    meta["NumberInSeries"] = 1
+    meta["SliceNo"] = 0
+    meta["IsmrmrdSliceNo"] = 0
+    meta["AnatomicalSliceNo"] = 0
+    meta["ChronSliceNo"] = 0
+    meta["ProtocolSliceNumber"] = 0
+    meta["Actual3DImagePartNumber"] = 0
+    meta["Actual3DImaPartNumber"] = 0
+    meta["AnatomicalPartitionNo"] = 0
+    meta["ImageRowDir"] = [f"{float(value):.18f}" for value in read_dir]
+    meta["ImageColumnDir"] = [f"{float(value):.18f}" for value in phase_dir]
+    meta["ImageSliceNormDir"] = [f"{float(value):.18f}" for value in slice_dir]
+    meta["SlicePosLightMarker"] = [
+        f"{float(value):.18f}" for value in new_header.position
+    ]
+    meta["SodiumGriddingDisplayScale"] = _format_display_number(display_meta["scale"])
+    meta["SodiumGriddingDisplayInputMin"] = f"{float(display_meta['input_min']):.6g}"
+    meta["SodiumGriddingDisplayInputMax"] = f"{float(display_meta['input_max']):.6g}"
+    meta["SodiumGriddingDisplayMin"] = str(int(display_meta["display_min"]))
+    meta["SodiumGriddingDisplayMax"] = str(int(display_meta["display_max"]))
+    meta["SodiumGriddingDisplayFormula"] = display_meta["formula"]
+    meta["SodiumGriddingOrientation"] = orientation_key
+    meta["SodiumGriddingOrientationFlipSlice"] = str(int(bool(flip_slice)))
+    image.attribute_string = meta.serialize()
+
+    logging.info(
+        "Emitting image: series_index=%d series_description='%s' matrix_size=%s "
+        "slice_count=%d fov_mm=%.3f orientation='%s' flip_slice=%s "
+        "columns=%s rows=%s slices=%s "
+        "Keep_image_geometry=%s series_uid=%s",
+        series_index,
+        series_description,
+        tuple(int(value) for value in new_header.matrix_size),
+        slice_count,
+        output_fov_mm,
+        orientation_key,
+        flip_slice,
+        _direction_label(read_dir),
+        _direction_label(phase_dir),
+        _direction_label(slice_dir),
+        meta["Keep_image_geometry"],
+        series_uid,
+    )
+
+    return image
+
+
+def process(connection, config, metadata):
+    logging.info("Config:\n%s", config)
+
+    try:
+        logging.info("Incoming dataset contains %d encodings", len(metadata.encoding))
+        logging.info(
+            "First encoding trajectory=%s matrix=(%s x %s x %s) fov=(%s x %s x %s)mm^3",
+            metadata.encoding[0].trajectory,
+            metadata.encoding[0].encodedSpace.matrixSize.x,
+            metadata.encoding[0].encodedSpace.matrixSize.y,
+            metadata.encoding[0].encodedSpace.matrixSize.z,
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.x,
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.y,
+            metadata.encoding[0].encodedSpace.fieldOfView_mm.z,
+        )
+    except Exception:
+        logging.info("Improperly formatted metadata: %s", metadata)
+
+    acquisitions = []
+    passthrough_images = []
+
+    try:
+        for item in connection:
+            if isinstance(item, ismrmrd.Acquisition):
+                if (
+                    not item.is_flag_set(ismrmrd.ACQ_IS_NOISE_MEASUREMENT)
+                    and not item.is_flag_set(ismrmrd.ACQ_IS_PARALLEL_CALIBRATION)
+                    and not item.is_flag_set(ismrmrd.ACQ_IS_PHASECORR_DATA)
+                    and not item.is_flag_set(ismrmrd.ACQ_IS_NAVIGATION_DATA)
+                ):
+                    acquisitions.append(item)
+
+                if item.is_flag_set(ismrmrd.ACQ_LAST_IN_MEASUREMENT):
+                    logging.info("Processing %d acquired readouts", len(acquisitions))
+                    images = process_raw(acquisitions, connection, config, metadata)
+                    connection.send_image(images)
+                    acquisitions = []
+
+            elif isinstance(item, ismrmrd.Image):
+                passthrough_images.append(item)
+
+            elif item is None:
+                break
+
+            else:
+                logging.error("Unsupported data type %s", type(item).__name__)
+
+        if acquisitions:
+            logging.info("Processing %d acquired readouts (end of stream)", len(acquisitions))
+            images = process_raw(acquisitions, connection, config, metadata)
+            connection.send_image(images)
+
+        if passthrough_images:
+            logging.warning(
+                "Received %d images instead of raw data; returning them unchanged",
+                len(passthrough_images),
+            )
+            connection.send_image(process_image(passthrough_images, connection, config, metadata))
+
+    except Exception:
+        logging.error(traceback.format_exc())
+        connection.send_logging(constants.MRD_LOGGING_ERROR, traceback.format_exc())
+
+    finally:
+        connection.send_close()
+
+
+def process_raw(group, connection, config, metadata):
+    if not group:
+        return []
+
+    tic = perf_counter()
+    _ensure_debug_folder()
+
+    matrix_size = max(1, _config_int(config, "matrixsize", _compute_default_matrix_size(metadata)))
+    fov_cm = _config_float(config, "fovcm", _compute_default_fov_cm(metadata))
+    reject_bad_readouts = _config_bool(
+        config,
+        "rejectbadreadouts",
+        OPENRECON_DEFAULTS["rejectbadreadouts"],
+    )
+    bad_readout_sigma = _config_float(
+        config,
+        "badreadoutsigma",
+        OPENRECON_DEFAULTS["badreadoutsigma"],
+    )
+    center_window = max(1, _config_int(config, "centerwindow", OPENRECON_DEFAULTS["centerwindow"]))
+    apply_fermi_filter = _config_bool(
+        config,
+        "applyfermifilter",
+        OPENRECON_DEFAULTS["applyfermifilter"],
+    )
+    fermi_width = _config_float(config, "fermiwidth", OPENRECON_DEFAULTS["fermiwidth"])
+    fermi_cutoff = _config_float(config, "fermicutoff", OPENRECON_DEFAULTS["fermicutoff"])
+    dcf_iterations = max(0, _config_int(config, "dcfiterations", OPENRECON_DEFAULTS["dcfiterations"]))
+    trajectory_sample_offset = max(
+        0,
+        _config_int(
+            config,
+            "trajectorysampleoffset",
+            OPENRECON_DEFAULTS["trajectorysampleoffset"],
+        ),
+    )
+    max_coils = max(0, _config_int(config, "maxcoils", OPENRECON_DEFAULTS["maxcoils"]))
+    configured_max_workers = max(
+        1,
+        _config_int(config, "maxworkers", OPENRECON_DEFAULTS["maxworkers"]),
+    )
+    coil_variance_retention = float(
+        np.clip(
+            _config_float(
+                config,
+                "coilvarianceretention",
+                OPENRECON_DEFAULTS["coilvarianceretention"],
+            ),
+            0.0,
+            1.0,
+        )
+    )
+    coil_combine_mode = _config_str(
+        config,
+        "coilcombinemode",
+        OPENRECON_DEFAULTS["coilcombinemode"],
+    )
+    apply_n4_bias_correction = _config_bool(
+        config,
+        "applyn4biascorrection",
+        OPENRECON_DEFAULTS["applyn4biascorrection"],
+    )
+    orientation, orientation_debug_series = _resolve_orientation_config(config)
+    orientation_flip_slice = _config_bool(
+        config,
+        "orientationflipslice",
+        OPENRECON_DEFAULTS["orientationflipslice"],
+    )
+    logging.info(
+        "Resolved configuration: matrixsize=%d fovcm=%.3f trajectorysampleoffset=%d "
+        "rejectbadreadouts=%s badreadoutsigma=%.3f centerwindow=%d "
+        "applyfermifilter=%s fermiwidth=%.4f fermicutoff=%.4f dcfiterations=%d "
+        "maxcoils=%d maxworkers=%d coilvarianceretention=%.3f coilcombinemode=%s "
+        "applyn4biascorrection=%s orientation=%s orientationflipslice=%s "
+        "orientationdebugseries=%s",
+        matrix_size,
+        fov_cm,
+        trajectory_sample_offset,
+        reject_bad_readouts,
+        bad_readout_sigma,
+        center_window,
+        apply_fermi_filter,
+        fermi_width,
+        fermi_cutoff,
+        dcf_iterations,
+        max_coils,
+        configured_max_workers,
+        coil_variance_retention,
+        coil_combine_mode,
+        apply_n4_bias_correction,
+        orientation,
+        orientation_flip_slice,
+        orientation_debug_series,
+    )
+
+    data = _build_data_array(group)
+    trajectory = _load_trajectory(group, config)
+    data, trajectory = _clip_data_to_trajectory(
+        data,
+        trajectory,
+        sample_offset=trajectory_sample_offset,
+    )
+    if 0 < max_coils < data.shape[0]:
+        logging.warning(
+            "Limiting reconstruction to first %d of %d coils",
+            max_coils,
+            data.shape[0],
+        )
+        data = data[:max_coils]
+
+    logging.info(
+        "Running sodium Kaiser-Bessel gridding with physical_coils=%d "
+        "readouts=%d samples=%d matrix=%d oversampling=%d fov_cm=%.3f",
+        data.shape[0],
+        data.shape[1],
+        data.shape[2],
+        matrix_size,
+        OVERSAMPLING,
+        fov_cm,
+    )
+    logging.info("Trajectory shape after clipping: %s", trajectory.shape)
+    _log_trajectory_extent(trajectory)
+    logging.info(
+        "Gridding configuration: kernel_width=%.1f beta=%.6f dcf_iterations=%d "
+        "coil_variance_retention=%.3f coil_combine_mode=%s n4=%s pyfftw=%s",
+        KB_KERNEL_WIDTH,
+        KB_BETA,
+        dcf_iterations,
+        coil_variance_retention,
+        coil_combine_mode,
+        apply_n4_bias_correction,
+        USE_PYFFTW,
+    )
+    reference_head = group[len(group) // 2].getHead()
+    fermi_filter = _build_fermi_filter(
+        trajectory,
+        apply_fermi_filter=apply_fermi_filter,
+        fermi_width=fermi_width,
+        fermi_cutoff=fermi_cutoff,
+    )
+
+    prepared_data = []
+    logging.info("Preparing %d physical coils before compression", data.shape[0])
+    for coil_index in range(data.shape[0]):
+        prepared_data.append(
+            _prepare_single_coil_data(
+                coil_index,
+                data[coil_index],
+                reject_bad_readouts=reject_bad_readouts,
+                bad_readout_sigma=bad_readout_sigma,
+                center_window=center_window,
+                fermi_filter=fermi_filter,
+            )
+        )
+    logging.info("Finished coil data preparation")
+    prepared_data = np.asarray(prepared_data, dtype=np.complex64)
+    virtual_coil_data, cumulative_variance, compression_matrix = (
+        _compress_coils_by_variance(
+            prepared_data,
+            variance_retention=coil_variance_retention,
+        )
+    )
+
+    normalized_coordinates = _normalize_grid_coordinates(
+        trajectory,
+        matrix_size=matrix_size,
+        fov_cm=fov_cm,
+    )
+    logging.info("Computing Kaiser-Bessel density compensation")
+    dcf = _compute_dcf_kb(
+        normalized_coordinates,
+        grid_size=matrix_size,
+        oversampling=OVERSAMPLING,
+        num_iterations=dcf_iterations,
+    )
+    logging.info("Computing Kaiser-Bessel deapodization")
+    deapodization = _compute_deapodization_kb(
+        matrix_size,
+        oversampling=OVERSAMPLING,
+    )
+
+    max_workers = min(configured_max_workers, virtual_coil_data.shape[0])
+    _log_cpu_resources(configured_max_workers, max_workers)
+
+    coil_images = np.zeros(
+        (virtual_coil_data.shape[0], matrix_size, matrix_size, matrix_size),
+        dtype=np.complex64,
+    )
+
+    logging.info(
+        "Launching full-resolution gridding for %d virtual coils with up to "
+        "%d workers and %d simultaneous grids",
+        virtual_coil_data.shape[0],
+        max_workers,
+        MAX_SIMULTANEOUS_GRIDS,
+    )
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(
+                _reconstruct_single_virtual_coil,
+                coil_index,
+                virtual_coil_data[coil_index],
+                normalized_coordinates,
+                dcf,
+                deapodization,
+                matrix_size,
+            )
+            for coil_index in range(virtual_coil_data.shape[0])
+        ]
+        for future in futures:
+            coil_index, reconstructed = future.result()
+            coil_images[coil_index] = reconstructed
+            logging.info(
+                "Collected full-resolution reconstruction for virtual coil %d",
+                coil_index,
+            )
+
+    combined_magnitude_volume = _combine_coils(coil_images, mode=coil_combine_mode)
+    output_volume = combined_magnitude_volume
+    if apply_n4_bias_correction:
+        logging.info("Running N4 bias field correction")
+        output_volume = _n4_bias_field_correct(combined_magnitude_volume)
+        logging.info("Finished N4 bias field correction")
+
+    np.save(os.path.join(debugFolder, "sodiumgridding_virtual_coil_data.npy"), virtual_coil_data)
+    np.save(os.path.join(debugFolder, "sodiumgridding_coil_variance.npy"), cumulative_variance)
+    np.save(os.path.join(debugFolder, "sodiumgridding_compression_matrix.npy"), compression_matrix)
+    np.save(os.path.join(debugFolder, "sodiumgridding_coil_images.npy"), coil_images)
+    np.save(
+        os.path.join(debugFolder, "sodiumgridding_magnitude_volume.npy"),
+        combined_magnitude_volume,
+    )
+    np.save(os.path.join(debugFolder, "sodiumgridding_output_volume.npy"), output_volume)
+
+    process_time_ms = (perf_counter() - tic) * 1000.0
+    message = f"Sodium gridding processing time: {process_time_ms:.2f} ms"
+    logging.info(message)
+    connection.send_logging(constants.MRD_LOGGING_INFO, message)
+
+    return _build_output_images(
+        output_volume,
+        reference_head,
+        metadata,
+        output_fov_mm=float(fov_cm) * 10.0,
+        orientation=orientation,
+        flip_slice=orientation_flip_slice,
+        emit_debug_series=orientation_debug_series,
+    )
+
+
+def process_image(images, connection, config, metadata):
+    del connection, config, metadata
+
+    images_out = []
+    for image in images:
+        meta = ismrmrd.Meta.deserialize(image.attribute_string)
+        meta["Keep_image_geometry"] = 1
+        image.attribute_string = meta.serialize()
+        images_out.append(image)
+    return images_out

--- a/recipes/sodiumgridding_ptpi/sodiumgridding.py
+++ b/recipes/sodiumgridding_ptpi/sodiumgridding.py
@@ -63,6 +63,7 @@ OPENRECON_DEFAULTS = {
     "orientationdebugseries": False,
 }
 OUTPUT_SERIES_DESCRIPTION = "sodiumgridding"
+OUTPUT_SERIES_PREFIX_PROTOCOL = True
 OUTPUT_IMAGE_COMMENT = "23Na Kaiser-Bessel Gridding"
 OUTPUT_IMAGE_SERIES_INDEX = 1
 
@@ -1030,7 +1031,7 @@ def _format_display_number(value):
     return f"{number:.6g}"
 
 
-def _scale_volume_to_display_range(volume):
+def _scale_volume_to_display_range(volume, input_min=None, input_max=None):
     values = np.asarray(volume, dtype=np.float32)
     finite = values[np.isfinite(values)]
     if finite.size == 0:
@@ -1044,8 +1045,8 @@ def _scale_volume_to_display_range(volume):
             "formula": "value = display",
         }
 
-    input_min = float(np.min(finite))
-    input_max = float(np.max(finite))
+    input_min = float(np.min(finite)) if input_min is None else float(input_min)
+    input_max = float(np.max(finite)) if input_max is None else float(input_max)
     input_range = input_max - input_min
     if input_range <= 0.0 or not np.isfinite(input_range):
         display = np.zeros(values.shape, dtype=np.uint16)
@@ -1558,6 +1559,14 @@ def _build_output_images(
     orientation=DEFAULT_ORIENTATION,
     flip_slice=False,
     emit_debug_series=False,
+    echo_index=0,
+    total_echoes=1,
+    repetition_index=0,
+    output_repetition_index=0,
+    total_repetitions=1,
+    echo_time_s=None,
+    display_input_min=None,
+    display_input_max=None,
 ):
     volume = np.asarray(volume, dtype=np.float32)
     if volume.ndim != 3:
@@ -1566,7 +1575,11 @@ def _build_output_images(
     _log_reference_geometry(reference_head, metadata)
     _log_volume_statistics("reconstructed volume (z, y, x)", volume)
 
-    display_volume, display_meta = _scale_volume_to_display_range(volume)
+    display_volume, display_meta = _scale_volume_to_display_range(
+        volume,
+        input_min=display_input_min,
+        input_max=display_input_max,
+    )
     logging.info(
         "Scanner display scaling: input_min=%.6g input_max=%.6g scale=%s formula='%s'",
         display_meta["input_min"],
@@ -1619,6 +1632,12 @@ def _build_output_images(
             flip_slice=slice_flip,
             series_index=OUTPUT_IMAGE_SERIES_INDEX + offset,
             label_series=emit_debug_series,
+            image_index=offset + 1,
+            echo_index=echo_index,
+            total_echoes=total_echoes,
+            repetition_index=repetition_index,
+            total_repetitions=total_repetitions,
+            echo_time_s=echo_time_s,
         )
         for offset, (orientation_key, slice_flip) in enumerate(sweep)
     ]
@@ -1634,6 +1653,12 @@ def _build_single_output_image(
     flip_slice,
     series_index,
     label_series,
+    image_index,
+    echo_index,
+    total_echoes,
+    repetition_index,
+    total_repetitions,
+    echo_time_s,
 ):
     # Stage 1 resolves the trajectory components against the acquisition axes.
     # Stage 2 transforms the acquisition vectors together with the pixels in
@@ -1651,7 +1676,10 @@ def _build_single_output_image(
 
     center_position = np.asarray(reference_head.position, dtype=float)
 
-    series_description = f"{_safe_protocol_name(metadata)}_{OUTPUT_SERIES_DESCRIPTION}"
+    if OUTPUT_SERIES_PREFIX_PROTOCOL:
+        series_description = f"{_safe_protocol_name(metadata)}_{OUTPUT_SERIES_DESCRIPTION}"
+    else:
+        series_description = OUTPUT_SERIES_DESCRIPTION
     if label_series:
         series_description = (
             f"{series_description}_ori_{orientation_key}_fz{int(bool(flip_slice))}"
@@ -1714,8 +1742,13 @@ def _build_single_output_image(
     new_header.data_type = image.data_type
     new_header.image_type = ismrmrd.IMTYPE_MAGNITUDE
     new_header.image_series_index = series_index
-    new_header.image_index = 1
+    new_header.image_index = int(image_index)
+    new_header.average = 0
     new_header.slice = 0
+    new_header.contrast = int(echo_index)
+    new_header.phase = 0
+    new_header.repetition = int(repetition_index)
+    new_header.set = 0
     new_header.matrix_size = tuple(int(value) for value in image.getHead().matrix_size)
     new_header.position = tuple(float(value) for value in center_position)
     new_header.read_dir = tuple(float(value) for value in read_dir)
@@ -1741,15 +1774,26 @@ def _build_single_output_image(
     meta["DicomImageType"] = "DERIVED\\PRIMARY\\M\\SODIUMGRIDDING"
     meta["ImageTypeValue4"] = "SODIUMGRIDDING"
     meta["ComplexImageComponent"] = "MAGNITUDE"
-    meta["SequenceDescriptionAdditional"] = OUTPUT_IMAGE_COMMENT
+    echo_number = int(echo_index) + 1
+    echo_label = f"TE{echo_number}"
+    image_comment_with_echo = (
+        f"{series_description}; {image_comment}"
+        if int(total_echoes) > 1 or int(total_repetitions) > 1
+        else image_comment
+    )
+
+    meta["SequenceDescriptionAdditional"] = series_description
     meta["SeriesDescription"] = series_description
+    meta["ImageSeriesDescription"] = series_description
     meta["SequenceDescription"] = series_description
     meta["ProtocolName"] = series_description
+    meta["SeriesLabel"] = series_description
+    meta["LUTLabel"] = series_description
     meta["SeriesNumberRangeNameUID"] = series_grouping
     meta["SeriesInstanceUID"] = series_uid
     meta["SOPInstanceUID"] = _new_dicom_uid()
-    meta["ImageComment"] = image_comment
-    meta["ImageComments"] = image_comment
+    meta["ImageComment"] = image_comment_with_echo
+    meta["ImageComments"] = image_comment_with_echo
     # 1 tells ICE to keep the geometry described in this header instead of
     # rebuilding it and applying its own flip/shift. The vectors above describe
     # the canonicalized pixels, so geometry has exactly one owner.
@@ -1759,11 +1803,32 @@ def _build_single_output_image(
     meta["NumberOfSlices"] = slice_count
     meta["ImagesInAcquisition"] = slice_count
     meta["NumberInSeries"] = 1
+    meta["ImageIndex"] = int(image_index)
     meta["SliceNo"] = 0
     meta["IsmrmrdSliceNo"] = 0
     meta["AnatomicalSliceNo"] = 0
     meta["ChronSliceNo"] = 0
     meta["ProtocolSliceNumber"] = 0
+    meta["Average"] = 0
+    meta["Phase"] = 0
+    meta["Repetition"] = int(repetition_index)
+    meta["RepetitionNo"] = int(repetition_index)
+    meta["IsmrmrdRepetition"] = int(repetition_index)
+    meta["NumberOfRepetitions"] = int(total_repetitions)
+    meta["Set"] = 0
+    meta["Contrast"] = int(echo_index)
+    meta["ContrastNo"] = int(echo_index)
+    meta["IsmrmrdContrast"] = int(echo_index)
+    meta["ImageContrast"] = int(echo_index)
+    meta["EchoNo"] = echo_number
+    meta["EchoNumber"] = echo_number
+    meta["EchoNumbers"] = echo_number
+    meta["EchoLabel"] = echo_label
+    meta["NumberOfEchoes"] = int(total_echoes)
+    if echo_time_s is not None:
+        echo_time_ms = float(echo_time_s) * 1e3
+        meta["EchoTime"] = echo_time_ms
+        meta["EffectiveEchoTime"] = echo_time_ms
     meta["Actual3DImagePartNumber"] = 0
     meta["Actual3DImaPartNumber"] = 0
     meta["AnatomicalPartitionNo"] = 0

--- a/recipes/sodiumgridding_ptpi/sodiumgridding_ptpi.py
+++ b/recipes/sodiumgridding_ptpi/sodiumgridding_ptpi.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""OpenRecon entrypoint for dual-echo palindromic TPI gridding.
+"""OpenRecon entrypoint for multi-echo palindromic TPI gridding.
 
 This module adapts ``ptpi_dual_echo_lowrank_core.py`` from its standalone
 file-based workflow into the same MRD streaming contract used by
 ``sodiumgridding``. The reconstruction math stays in the core module; this file
 only resolves OpenRecon config, converts incoming acquisitions into the
-dual-echo array layout, and emits TE1/TE2 magnitude volumes.
+interleaved echo array layout, and emits one magnitude volume per echo.
 """
 
 import logging
@@ -24,7 +24,7 @@ import ptpi_dual_echo_lowrank_core as core
 
 
 DEFAULT_TRAJECTORY_FILE = "/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5"
-OUTPUT_SERIES_BASE = "sodiumgridding_pTPI"
+OUTPUT_SERIES_BASE = "pTPI"
 debugFolder = "/tmp/share/debug"
 
 OPENRECON_DEFAULTS = {
@@ -33,6 +33,7 @@ OPENRECON_DEFAULTS = {
     "fovcm": 22.0,
     "trajectoryfile": DEFAULT_TRAJECTORY_FILE,
     "trajectorydataset": "k",
+    "numechoes": 2,
     "dcfiterations": 5,
     "maxcoils": 0,
     "maxworkers": 8,
@@ -46,6 +47,11 @@ OPENRECON_DEFAULTS = {
     "runphasecorrection": True,
     "phaselowrankrank": 10,
     "applyn4biascorrection": True,
+    "denoisetemporalsvd": True,
+    "svdpatchsize": 7,
+    "svdstride": 4,
+    "svdretainfraction": 0.2,
+    "sharedechodisplayscale": True,
     "orientation": "zyx",
     "orientationflipslice": False,
     "orientationdebugseries": False,
@@ -72,7 +78,7 @@ def _config_str(config, key):
     return openrecon_base._config_str(config, key, OPENRECON_DEFAULTS[key])
 
 
-def _load_dual_trajectory(config):
+def _load_base_trajectories(config):
     trajectory_file = _config_str(config, "trajectoryfile").strip()
     if not trajectory_file:
         trajectory_file = DEFAULT_TRAJECTORY_FILE
@@ -86,7 +92,7 @@ def _load_dual_trajectory(config):
         if "k_echo1" in h5_file and "k_echo2_forward_order" in h5_file:
             k_cm_te1 = h5_file["k_echo1"][...]
             k_cm_te2 = h5_file["k_echo2_forward_order"][...]
-            trajectory_mode = "dual-echo forward-order"
+            trajectory_mode = "forward/reverse echo trajectories"
         elif trajectory_dataset in h5_file:
             k_cm_te1 = h5_file[trajectory_dataset][...]
             k_cm_te2 = k_cm_te1
@@ -135,50 +141,313 @@ def _load_dual_trajectory(config):
     )
 
 
+def _metadata_contrast_count(metadata):
+    try:
+        contrast = metadata.encoding[0].encodingLimits.contrast
+        return int(contrast.maximum) - int(contrast.minimum) + 1
+    except Exception:
+        return 0
+
+
+def _acquisition_contrast(acquisition):
+    try:
+        return int(acquisition.getHead().idx.contrast)
+    except Exception:
+        return 0
+
+
+def _detect_echo_count(acquisitions, metadata, config):
+    header_contrasts = [_acquisition_contrast(item) for item in acquisitions]
+    if header_contrasts:
+        header_count = max(header_contrasts) + 1
+        if header_count > 1:
+            return header_count, "acquisition contrast index"
+
+    metadata_count = _metadata_contrast_count(metadata)
+    if metadata_count > 0:
+        return metadata_count, "MRD encodingLimits.contrast"
+
+    configured_count = max(1, _config_int(config, "numechoes"))
+    return configured_count, "config/default numechoes"
+
+
 def _build_interleaved_data_array(acquisitions):
     """Return raw data as (coils, samples, acquisitions)."""
     base_data = openrecon_base._build_data_array(acquisitions)
     return np.ascontiguousarray(base_data.transpose(0, 2, 1))
 
 
-def _split_dual_echo_data(data_all):
-    if data_all.shape[2] < 2:
+def _split_echo_data(data_all, echo_count):
+    echo_count = int(echo_count)
+    if echo_count < 1:
+        raise ValueError(f"numechoes must be at least 1, got {echo_count}")
+    if data_all.shape[2] < echo_count:
         raise ValueError(
-            "Dual-echo pTPI reconstruction needs alternating TE1/TE2 acquisitions; "
-            f"got only {data_all.shape[2]} acquisition(s)."
+            "Multi-echo pTPI reconstruction needs at least one acquisition per echo; "
+            f"got {data_all.shape[2]} acquisition(s) for {echo_count} echoes."
         )
-    data_te1 = data_all[:, :, 0::2].copy()
-    data_te2 = data_all[:, :, 1::2].copy()
-    # TE2 is acquired in reverse sample order in the standalone pTPI workflow.
-    data_te2 = data_te2[:, ::-1, :]
-    return data_te1, data_te2
+    if data_all.shape[2] % echo_count:
+        logging.warning(
+            "Incoming pTPI readout count %d is not divisible by detected echo count %d; "
+            "later echoes may have one fewer readout after interleaved splitting.",
+            data_all.shape[2],
+            echo_count,
+        )
+
+    echo_data = []
+    for echo_index in range(echo_count):
+        data_echo = data_all[:, :, echo_index::echo_count].copy()
+        # Echoes 2, 4, 6, ... are acquired in reverse sample order.
+        if echo_index % 2 == 1:
+            data_echo = data_echo[:, ::-1, :]
+        echo_data.append(data_echo)
+    return echo_data
 
 
-def _clip_to_common_shape(k_te1, k_te2, t_te1, t_te2, data_te1, data_te2):
+def _split_dual_echo_data(data_all):
+    echo_data = _split_echo_data(data_all, 2)
+    return echo_data[0], echo_data[1]
+
+
+def _echo_label(echo_index):
+    return f"TE{int(echo_index) + 1}"
+
+
+def _series_index_for_echo(echo_index, output_repetition_index, total_repetitions):
+    series_offset = int(output_repetition_index) if int(total_repetitions) > 1 else 0
+    if int(echo_index) == 0:
+        return 1 + series_offset
+    return 1000 * int(echo_index) + 1 + series_offset
+
+
+def _echo_sample_times(base_times, echo_index):
+    base_times = np.asarray(base_times, dtype=np.float32)
+    pair_offset = 2 * (int(echo_index) // 2) * float(core.FIELD_MAP_DELTA_TE_S)
+    if pair_offset == 0:
+        return base_times.copy()
+    return (base_times + np.float32(pair_offset)).astype(np.float32, copy=False)
+
+
+def _sequence_parameter_values(metadata, name):
+    try:
+        values = getattr(metadata.sequenceParameters, name)
+    except Exception:
+        return []
+    if values is None:
+        return []
+    if isinstance(values, (str, bytes)):
+        values = [values]
+    try:
+        return [float(value) for value in values]
+    except TypeError:
+        return [float(values)]
+    except ValueError:
+        return []
+
+
+def _metadata_echo_times_s(metadata, echo_count, delta_te_s):
+    values = _sequence_parameter_values(metadata, "TE")
+    values = [value for value in values if np.isfinite(value) and value >= 0.0]
+    if not values:
+        echo_times = np.arange(echo_count, dtype=np.float32) * np.float32(delta_te_s)
+        return echo_times, "fallback delta TE offsets"
+
+    # ISMRMRD sequenceParameters.TE is normally in milliseconds. Some Siemens
+    # mappings expose alTE-style microseconds, and some tools pass seconds.
+    max_value = max(values)
+    if max_value > 100.0:
+        scale = 1e-6
+    elif max_value >= 0.1:
+        scale = 1e-3
+    else:
+        scale = 1.0
+    values_s = np.asarray(values, dtype=np.float32) * np.float32(scale)
+    if values_s.size >= echo_count:
+        return values_s[:echo_count], "MRD sequenceParameters.TE"
+
+    echo_times = values_s[0] + np.arange(echo_count, dtype=np.float32) * np.float32(delta_te_s)
+    return echo_times, "MRD first TE plus configured delta TE"
+
+
+def _patch_starts(n, patch_size, stride):
+    n = int(n)
+    patch_size = int(patch_size)
+    stride = int(stride)
+    if n <= patch_size:
+        return [0]
+    starts = list(range(0, n - patch_size + 1, stride))
+    final_start = n - patch_size
+    if starts[-1] != final_start:
+        starts.append(final_start)
+    return starts
+
+
+def _denoise_temporal_svd_final_images(
+    echo_images,
+    patch_size,
+    stride,
+    retain_fraction,
+):
+    if len(echo_images) < 2:
+        logging.info("Temporal SVD denoising skipped: need at least two echoes")
+        return list(echo_images)
+
+    combined_echoes = np.asarray(echo_images, dtype=np.float32)
+    n_echoes, nx, ny, nz = combined_echoes.shape
+    patch_size = int(patch_size)
+    stride = int(stride)
+    retain_fraction = float(retain_fraction)
+    if patch_size < 2:
+        raise ValueError("svdpatchsize must be >= 2")
+    if stride < 1:
+        raise ValueError("svdstride must be >= 1")
+    if not (0.0 < retain_fraction <= 1.0):
+        raise ValueError("svdretainfraction must be > 0 and <= 1")
+
+    patch_size = min(patch_size, nx, ny, nz)
+    xs = _patch_starts(nx, patch_size, stride)
+    ys = _patch_starts(ny, patch_size, stride)
+    zs = _patch_starts(nz, patch_size, stride)
+    total_patches = len(xs) * len(ys) * len(zs)
+    logging.info(
+        "Temporal SVD denoising final magnitude images: patch=%d^3 stride=%d "
+        "contrasts=%d patches=%d singular_value_threshold_fraction=%.3g",
+        patch_size,
+        stride,
+        n_echoes,
+        total_patches,
+        retain_fraction,
+    )
+
+    accum = np.zeros_like(combined_echoes, dtype=np.float32)
+    weights = np.zeros((nx, ny, nz), dtype=np.float32)
+    rank_sum = 0.0
+    patch_counter = 0
+
+    for ix in xs:
+        for iy in ys:
+            for iz in zs:
+                patch = combined_echoes[
+                    :,
+                    ix : ix + patch_size,
+                    iy : iy + patch_size,
+                    iz : iz + patch_size,
+                ]
+                x = patch.reshape(n_echoes, -1).T.astype(np.float32, copy=False)
+                if not np.all(np.isfinite(x)):
+                    x = np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
+                try:
+                    u, s, vt = np.linalg.svd(x, full_matrices=False)
+                except np.linalg.LinAlgError:
+                    x_denoised = x
+                    rank = n_echoes
+                else:
+                    if s.size:
+                        threshold = retain_fraction * float(s[0])
+                        rank = max(1, int(np.count_nonzero(s >= threshold)))
+                    else:
+                        rank = 0
+                    if rank >= s.size:
+                        x_denoised = x
+                    else:
+                        x_denoised = (u[:, :rank] * s[:rank]) @ vt[:rank, :]
+
+                accum[
+                    :,
+                    ix : ix + patch_size,
+                    iy : iy + patch_size,
+                    iz : iz + patch_size,
+                ] += x_denoised.T.reshape(
+                    n_echoes,
+                    patch_size,
+                    patch_size,
+                    patch_size,
+                ).astype(np.float32, copy=False)
+                weights[
+                    ix : ix + patch_size,
+                    iy : iy + patch_size,
+                    iz : iz + patch_size,
+                ] += 1.0
+
+                rank_sum += float(rank)
+                patch_counter += 1
+                if patch_counter == 1 or patch_counter % 5000 == 0 or patch_counter == total_patches:
+                    logging.info(
+                        "Temporal SVD patches %d/%d, mean retained rank=%.2f",
+                        patch_counter,
+                        total_patches,
+                        rank_sum / patch_counter,
+                    )
+
+    denoised = accum / np.maximum(weights[None, ...], 1.0)
+    denoised = np.maximum(denoised, 0.0).astype(np.float32, copy=False)
+    finite_signal = combined_echoes[np.isfinite(combined_echoes)]
+    signal_scale = float(np.percentile(finite_signal, 99.0)) if finite_signal.size else 1.0
+    abs_diff = np.abs(denoised - combined_echoes)
+    logging.info(
+        "Temporal SVD denoising complete; mean retained rank=%.2f, "
+        "mean_abs_change=%.4g, p95_abs_change=%.4g, change_vs_p99_signal=%.3f%%",
+        rank_sum / max(patch_counter, 1),
+        float(np.mean(abs_diff)),
+        float(np.percentile(abs_diff, 95.0)),
+        100.0 * float(np.mean(abs_diff)) / max(signal_scale, 1e-12),
+    )
+    return [denoised[index] for index in range(n_echoes)]
+
+
+def _shared_echo_display_range(echo_images):
+    finite_values = [
+        np.asarray(image, dtype=np.float32)[np.isfinite(image)]
+        for image in echo_images
+    ]
+    finite_values = [values for values in finite_values if values.size]
+    if not finite_values:
+        return None, None
+    finite = np.concatenate(finite_values)
+    input_min = float(np.min(finite))
+    input_max = float(np.max(finite))
+    if not np.isfinite(input_max - input_min) or input_max <= input_min:
+        return None, None
+    return input_min, input_max
+
+
+def _clip_echo_inputs(echo_inputs):
     samples = min(
-        k_te1.shape[0],
-        k_te2.shape[0],
-        t_te1.shape[0],
-        t_te2.shape[0],
-        data_te1.shape[1],
-        data_te2.shape[1],
+        min(echo_input["k"].shape[0], echo_input["t"].shape[0], echo_input["data"].shape[1])
+        for echo_input in echo_inputs
     )
     readouts = min(
-        k_te1.shape[1],
-        k_te2.shape[1],
-        data_te1.shape[2],
-        data_te2.shape[2],
+        min(echo_input["k"].shape[1], echo_input["data"].shape[2])
+        for echo_input in echo_inputs
     )
     if samples <= 0 or readouts <= 0:
         raise ValueError("No overlapping pTPI samples/readouts between data and trajectory")
 
+    clipped = []
+    for echo_input in echo_inputs:
+        item = dict(echo_input)
+        item["k"] = echo_input["k"][:samples, :readouts, :]
+        item["t"] = echo_input["t"][:samples]
+        item["data"] = echo_input["data"][:, :samples, :readouts]
+        clipped.append(item)
+    return clipped
+
+
+def _clip_to_common_shape(k_te1, k_te2, t_te1, t_te2, data_te1, data_te2):
+    clipped = _clip_echo_inputs(
+        [
+            {"k": k_te1, "t": t_te1, "data": data_te1},
+            {"k": k_te2, "t": t_te2, "data": data_te2},
+        ]
+    )
+
     return (
-        k_te1[:samples, :readouts, :],
-        k_te2[:samples, :readouts, :],
-        t_te1[:samples],
-        t_te2[:samples],
-        data_te1[:, :samples, :readouts],
-        data_te2[:, :samples, :readouts],
+        clipped[0]["k"],
+        clipped[1]["k"],
+        clipped[0]["t"],
+        clipped[1]["t"],
+        clipped[0]["data"],
+        clipped[1]["data"],
     )
 
 
@@ -208,19 +477,36 @@ def _configure_core(config, matrix_size, fov_cm):
 def _build_echo_images(
     volume,
     echo_label,
+    echo_time_s,
     series_index,
+    echo_index,
+    total_echoes,
+    repetition_index,
+    total_repetitions,
+    output_repetition_index,
     reference_head,
     metadata,
     output_fov_mm,
     orientation,
     orientation_flip_slice,
     orientation_debug_series,
+    display_input_min=None,
+    display_input_max=None,
 ):
     old_description = openrecon_base.OUTPUT_SERIES_DESCRIPTION
     old_index = openrecon_base.OUTPUT_IMAGE_SERIES_INDEX
+    old_prefix_protocol = getattr(openrecon_base, "OUTPUT_SERIES_PREFIX_PROTOCOL", True)
     try:
-        openrecon_base.OUTPUT_SERIES_DESCRIPTION = f"{OUTPUT_SERIES_BASE}_{echo_label.lower()}"
+        repetition_suffix = (
+            f"_rep{int(output_repetition_index) + 1}"
+            if int(total_repetitions) > 1
+            else ""
+        )
+        openrecon_base.OUTPUT_SERIES_DESCRIPTION = (
+            f"{OUTPUT_SERIES_BASE}_{echo_label}{repetition_suffix}"
+        )
         openrecon_base.OUTPUT_IMAGE_SERIES_INDEX = int(series_index)
+        openrecon_base.OUTPUT_SERIES_PREFIX_PROTOCOL = False
         return openrecon_base._build_output_images(
             np.abs(volume).astype(np.float32, copy=False),
             reference_head,
@@ -229,10 +515,171 @@ def _build_echo_images(
             orientation=orientation,
             flip_slice=orientation_flip_slice,
             emit_debug_series=orientation_debug_series,
+            echo_index=echo_index,
+            total_echoes=total_echoes,
+            repetition_index=repetition_index,
+            total_repetitions=total_repetitions,
+            echo_time_s=echo_time_s,
+            display_input_min=display_input_min,
+            display_input_max=display_input_max,
         )
     finally:
         openrecon_base.OUTPUT_SERIES_DESCRIPTION = old_description
         openrecon_base.OUTPUT_IMAGE_SERIES_INDEX = old_index
+        openrecon_base.OUTPUT_SERIES_PREFIX_PROTOCOL = old_prefix_protocol
+
+
+def _build_echo_normalization_scales(echo_data, bad_readouts_by_coil=None):
+    if len(echo_data) == 2:
+        return list(
+            core.build_echo_normalization_scales(
+                echo_data[0],
+                echo_data[1],
+                bad_readouts_by_coil,
+            )
+        )
+
+    mode = core.ECHO_NORMALIZATION_MODE.lower()
+    n_coils = echo_data[0].shape[0]
+    if mode in ("none", "off", "false"):
+        logging.info("Echo normalization: disabled")
+        return [np.ones(n_coils, dtype=np.float32) for _echo in echo_data]
+
+    if mode not in ("te1", "shared", "independent"):
+        raise ValueError("ECHO_NORMALIZATION_MODE must be 'te1', 'independent', or 'none'")
+
+    scales = []
+    reference_scales = np.ones(n_coils, dtype=np.float32)
+    center_medians = []
+    for echo_index, data_echo in enumerate(echo_data):
+        echo_scales = np.ones(n_coils, dtype=np.float32)
+        echo_centers = np.zeros(n_coils, dtype=np.float32)
+        for coil in range(n_coils):
+            bad = None if bad_readouts_by_coil is None else bad_readouts_by_coil[coil]
+            scale, center = core.echo_center_normalization_scale(data_echo[coil], bad)
+            echo_centers[coil] = center
+            if echo_index == 0:
+                reference_scales[coil] = scale
+                echo_scales[coil] = scale
+            elif mode == "independent":
+                echo_scales[coil] = scale
+            else:
+                echo_scales[coil] = reference_scales[coil]
+        scales.append(echo_scales)
+        center_medians.append(float(np.nanmedian(echo_centers)))
+
+    logging.info(
+        "Echo normalization: mode=%s center_medians=%s scale_medians=%s",
+        core.ECHO_NORMALIZATION_MODE,
+        ", ".join(f"{value:.4g}" for value in center_medians),
+        ", ".join(f"{float(np.nanmedian(value)):.4g}" for value in scales),
+    )
+    return scales
+
+
+def _phase_correction_sign(echo_index):
+    if int(echo_index) == 0:
+        return core.TE1_PHASE_CORRECTION_SIGN
+    return core.TE2_PHASE_CORRECTION_SIGN
+
+
+def _phase_correction_enabled(echo_index):
+    if int(echo_index) == 0:
+        return bool(core.RUN_TE1_PHASE_CORRECTION)
+    return bool(core.RUN_TE2_PHASE_CORRECTION)
+
+
+def _apply_n4_bias_correction_to_echoes(echo_images):
+    if not core.APPLY_N4_BIAS_CORRECTION:
+        return list(echo_images), None, None
+    if len(echo_images) < 2:
+        image = np.asarray(echo_images[0])
+        reference_mag = np.abs(image).astype(np.float32, copy=False)
+        mask = core.make_bias_mask(reference_mag)
+        logging.info(
+            "Preparing single-echo SimpleITK N4 bias correction: mask_voxels=%d",
+            int(mask.sum()),
+        )
+        bias_field, mask = core.estimate_bias_field_sitk_n4(reference_mag, mask)
+        corrected_image, output_mask = core.apply_bias_field_to_image(
+            image,
+            bias_field,
+            mask,
+            True,
+        )
+        return [corrected_image], bias_field, output_mask
+
+    corrected_te1, corrected_te2, bias_field, output_mask = core.apply_n4_bias_correction(
+        echo_images[0],
+        echo_images[1],
+    )
+    corrected = [corrected_te1, corrected_te2]
+    if len(echo_images) == 2:
+        return corrected, bias_field, output_mask
+
+    apply_to = core.N4_APPLY_TO_ECHOES.lower()
+    correct_later_echoes = apply_to == "both"
+    for image in echo_images[2:]:
+        corrected_image, output_mask = core.apply_bias_field_to_image(
+            image,
+            bias_field,
+            output_mask,
+            correct_later_echoes,
+        )
+        corrected.append(corrected_image)
+    return corrected, bias_field, output_mask
+
+
+def _acquisition_repetition(acquisition):
+    try:
+        return int(acquisition.getHead().idx.repetition)
+    except Exception:
+        return 0
+
+
+def _split_acquisitions_by_repetition(acquisitions):
+    groups = {}
+    for acquisition in acquisitions:
+        groups.setdefault(_acquisition_repetition(acquisition), []).append(acquisition)
+    return list(groups.items())
+
+
+def _process_acquisitions(acquisitions, connection, config, metadata):
+    repetition_groups = _split_acquisitions_by_repetition(acquisitions)
+    if len(repetition_groups) > 1:
+        logging.info(
+            "Detected %d repetitions in incoming pTPI measurement: %s",
+            len(repetition_groups),
+            ", ".join(
+                f"rep{repetition_index}={len(group)} readouts"
+                for repetition_index, group in repetition_groups
+            ),
+        )
+
+    images = []
+    total_repetitions = len(repetition_groups)
+    for output_repetition_index, (repetition_index, repetition_group) in enumerate(
+        repetition_groups
+    ):
+        logging.info(
+            "Processing repetition %d/%d (MRD repetition=%d, %d readouts)",
+            output_repetition_index + 1,
+            total_repetitions,
+            repetition_index,
+            len(repetition_group),
+        )
+        images.extend(
+            process_raw(
+                repetition_group,
+                connection,
+                config,
+                metadata,
+                repetition_index=repetition_index,
+                total_repetitions=total_repetitions,
+                output_repetition_index=output_repetition_index,
+            )
+        )
+    return images
 
 
 def process(connection, config, metadata):
@@ -252,7 +699,9 @@ def process(connection, config, metadata):
 
                 if item.is_flag_set(ismrmrd.ACQ_LAST_IN_MEASUREMENT):
                     logging.info("Processing %d acquired readouts", len(acquisitions))
-                    connection.send_image(process_raw(acquisitions, connection, config, metadata))
+                    connection.send_image(
+                        _process_acquisitions(acquisitions, connection, config, metadata)
+                    )
                     acquisitions = []
             elif isinstance(item, ismrmrd.Image):
                 passthrough_images.append(item)
@@ -263,7 +712,9 @@ def process(connection, config, metadata):
 
         if acquisitions:
             logging.info("Processing %d acquired readouts (end of stream)", len(acquisitions))
-            connection.send_image(process_raw(acquisitions, connection, config, metadata))
+            connection.send_image(
+                _process_acquisitions(acquisitions, connection, config, metadata)
+            )
 
         if passthrough_images:
             logging.warning(
@@ -280,7 +731,15 @@ def process(connection, config, metadata):
         connection.send_close()
 
 
-def process_raw(group, connection, config, metadata):
+def process_raw(
+    group,
+    connection,
+    config,
+    metadata,
+    repetition_index=0,
+    total_repetitions=1,
+    output_repetition_index=0,
+):
     if not group:
         return []
 
@@ -301,6 +760,11 @@ def process_raw(group, connection, config, metadata):
         raise ValueError(f"fovcm must be positive, got {fov_cm}")
 
     _configure_core(config, matrix_size, fov_cm)
+    denoise_temporal_svd = _config_bool(config, "denoisetemporalsvd")
+    svd_patch_size = _config_int(config, "svdpatchsize")
+    svd_stride = _config_int(config, "svdstride")
+    svd_retain_fraction = _config_float(config, "svdretainfraction")
+    shared_echo_display_scale = _config_bool(config, "sharedechodisplayscale")
     orientation, orientation_debug_series = openrecon_base._resolve_orientation_config(config)
     orientation_flip_slice = openrecon_base._config_bool(
         config,
@@ -313,7 +777,9 @@ def process_raw(group, connection, config, metadata):
         "maxworkers=%d coilcompression=%s coilvarianceretention=%.3f "
         "coilcompressionsource=%s coilcombinemode=%s echonormalizationmode=%s "
         "fieldmapdeltates=%.6f fieldmapunwrapmethod=%s runphasecorrection=%s "
-        "phaselowrankrank=%d applyn4biascorrection=%s orientation=%s "
+        "phaselowrankrank=%d applyn4biascorrection=%s denoisetemporalsvd=%s "
+        "svdpatchsize=%d svdstride=%d svdretainfraction=%.3g "
+        "sharedechodisplayscale=%s orientation=%s "
         "orientationflipslice=%s orientationdebugseries=%s",
         core.N,
         core.FOV_CM,
@@ -329,6 +795,11 @@ def process_raw(group, connection, config, metadata):
         core.RUN_TE2_PHASE_CORRECTION,
         core.TE2_PHASE_LOWRANK_RANK,
         core.APPLY_N4_BIAS_CORRECTION,
+        denoise_temporal_svd,
+        svd_patch_size,
+        svd_stride,
+        svd_retain_fraction,
+        shared_echo_display_scale,
         orientation,
         orientation_flip_slice,
         orientation_debug_series,
@@ -341,179 +812,265 @@ def process_raw(group, connection, config, metadata):
         data_all = data_all[:max_coils]
 
     data_all = core.compress_coils_covariance(data_all)
-    data_te1_raw, data_te2_raw = _split_dual_echo_data(data_all)
-    k_cm_te1, k_cm_te2, t_te1_s, t_te2_s = _load_dual_trajectory(config)
-    (
-        k_cm_te1,
-        k_cm_te2,
-        t_te1_s,
-        t_te2_s,
-        data_te1_raw,
-        data_te2_raw,
-    ) = _clip_to_common_shape(
-        k_cm_te1,
-        k_cm_te2,
-        t_te1_s,
-        t_te2_s,
-        data_te1_raw,
-        data_te2_raw,
+    echo_count, echo_count_source = _detect_echo_count(group, metadata, config)
+    single_echo_mode = echo_count < 2
+    if single_echo_mode:
+        logging.info(
+            "Single-echo pTPI input detected; field-map phase correction, "
+            "and temporal SVD denoising require at least two echoes and will "
+            "be skipped. N4 bias correction can still run from TE1."
+        )
+    effective_denoise_temporal_svd = denoise_temporal_svd and not single_echo_mode
+    echo_times_s, echo_time_source = _metadata_echo_times_s(
+        metadata,
+        echo_count,
+        core.FIELD_MAP_DELTA_TE_S,
     )
+    echo_data_raw = _split_echo_data(data_all, echo_count)
+    k_cm_forward, k_cm_reverse, t_forward_s, t_reverse_s = _load_base_trajectories(config)
+    echo_inputs = []
+    for echo_index, data_echo in enumerate(echo_data_raw):
+        is_reverse = echo_index % 2 == 1
+        echo_inputs.append(
+            {
+                "echo_index": echo_index,
+                "label": _echo_label(echo_index),
+                "echo_time_s": float(echo_times_s[echo_index]),
+                "data": data_echo,
+                "k": k_cm_reverse if is_reverse else k_cm_forward,
+                "t": _echo_sample_times(t_reverse_s if is_reverse else t_forward_s, echo_index),
+                "trajectory_parity": "reverse" if is_reverse else "forward",
+            }
+        )
+    echo_inputs = _clip_echo_inputs(echo_inputs)
 
     logging.info(
-        "pTPI input after clipping: coils=%d samples=%d readouts=%d "
-        "k_te1=%s k_te2=%s",
-        data_te1_raw.shape[0],
-        data_te1_raw.shape[1],
-        data_te1_raw.shape[2],
-        k_cm_te1.shape,
-        k_cm_te2.shape,
+        "Detected %d pTPI echoes from %s; echo times from %s: %s; "
+        "input after clipping: coils=%d samples=%d readouts=%d trajectories=%s",
+        echo_count,
+        echo_count_source,
+        echo_time_source,
+        ", ".join(f"{value * 1e3:.3f} ms" for value in echo_times_s),
+        echo_inputs[0]["data"].shape[0],
+        echo_inputs[0]["data"].shape[1],
+        echo_inputs[0]["data"].shape[2],
+        ", ".join(
+            f"{item['label']}:{item['trajectory_parity']} k={item['k'].shape} "
+            f"t={item['t'].shape} data={item['data'].shape}"
+            for item in echo_inputs
+        ),
     )
-    openrecon_base._log_trajectory_extent(k_cm_te1)
-    openrecon_base._log_trajectory_extent(k_cm_te2)
-
-    k_cm_te1 = core.apply_trajectory_delay_correction(k_cm_te1, t_te1_s, "TE1")
-    k_cm_te2 = core.apply_trajectory_delay_correction(k_cm_te2, t_te2_s, "TE2")
+    openrecon_base._log_trajectory_extent(echo_inputs[0]["k"])
+    if len(echo_inputs) > 1:
+        openrecon_base._log_trajectory_extent(echo_inputs[1]["k"])
 
     k_nyquist = 1.0 / (2.0 * fov_cm / matrix_size)
-    k_norm_te1 = (k_cm_te1.reshape(-1, 3) / k_nyquist / 2.0).astype(np.float32)
-    k_norm_te2 = (k_cm_te2.reshape(-1, 3) / k_nyquist / 2.0).astype(np.float32)
-
     kb_beta = core.default_kb_beta(core.KB_WIDTH, core.OVERSAMP) if core.KB_BETA is None else float(core.KB_BETA)
     logging.info("Kaiser-Bessel beta=%.4f LUT size=%d", kb_beta, core.KB_LUT_SIZE)
     kernel_lut = core.make_kaiser_bessel_lut(core.KB_WIDTH, kb_beta, core.KB_LUT_SIZE)
-
-    logging.info("Preparing TE1 trajectory weights")
-    dcf_te1 = core.compute_dcf_kb(k_norm_te1, matrix_size, core.OVERSAMP, core.DCF_ITER, kernel_lut, core.KB_WIDTH)
-    logging.info("Preparing TE2 trajectory weights")
-    dcf_te2 = core.compute_dcf_kb(k_norm_te2, matrix_size, core.OVERSAMP, core.DCF_ITER, kernel_lut, core.KB_WIDTH)
     deapo = core.compute_deapodisation_kb(matrix_size, core.OVERSAMP, kernel_lut, core.KB_WIDTH)
 
-    te1_bad_readouts_by_coil = None
+    dcf_cache = {}
+    for echo_input in echo_inputs:
+        echo_input["k"] = core.apply_trajectory_delay_correction(
+            echo_input["k"],
+            echo_input["t"],
+            echo_input["label"],
+        )
+        echo_input["k_norm"] = (
+            echo_input["k"].reshape(-1, 3) / k_nyquist / 2.0
+        ).astype(np.float32)
+        cache_key = (echo_input["trajectory_parity"], echo_input["k"].shape)
+        if cache_key not in dcf_cache:
+            logging.info(
+                "Preparing %s trajectory weights from %s",
+                echo_input["trajectory_parity"],
+                echo_input["label"],
+            )
+            dcf_cache[cache_key] = core.compute_dcf_kb(
+                echo_input["k_norm"],
+                matrix_size,
+                core.OVERSAMP,
+                core.DCF_ITER,
+                kernel_lut,
+                core.KB_WIDTH,
+            )
+        echo_input["dcf"] = dcf_cache[cache_key]
+
+    first_echo_bad_readouts_by_coil = None
     if core.USE_TE1_BAD_READOUTS_FOR_TE2:
-        te1_bad_readouts_by_coil = core.find_bad_readouts_by_coil(data_te1_raw, "TE1")
+        first_echo_bad_readouts_by_coil = core.find_bad_readouts_by_coil(
+            echo_inputs[0]["data"],
+            echo_inputs[0]["label"],
+        )
 
-    te1_normalization_scales, te2_normalization_scales = core.build_echo_normalization_scales(
-        data_te1_raw,
-        data_te2_raw,
-        te1_bad_readouts_by_coil,
+    normalization_scales = _build_echo_normalization_scales(
+        [item["data"] for item in echo_inputs],
+        first_echo_bad_readouts_by_coil,
     )
 
-    imgs_te1 = core.reconstruct_echo_all_coils(
-        data_te1_raw,
-        k_cm_te1,
-        k_norm_te1,
-        dcf_te1,
-        deapo,
-        kernel_lut,
-        "TE1",
-        bad_readouts_by_coil=te1_bad_readouts_by_coil,
-        bad_readout_source="TE1 precomputed",
-        normalization_scales=te1_normalization_scales,
-    )
-    imgs_te2 = core.reconstruct_echo_all_coils(
-        data_te2_raw,
-        k_cm_te2,
-        k_norm_te2,
-        dcf_te2,
-        deapo,
-        kernel_lut,
-        "TE2",
-        bad_readouts_by_coil=te1_bad_readouts_by_coil,
-        bad_readout_source="TE1 precomputed",
-        normalization_scales=te2_normalization_scales,
-    )
+    uncorrected_coil_images = []
+    for echo_input, scales in zip(echo_inputs, normalization_scales):
+        uncorrected_coil_images.append(
+            core.reconstruct_echo_all_coils(
+                echo_input["data"],
+                echo_input["k"],
+                echo_input["k_norm"],
+                echo_input["dcf"],
+                deapo,
+                kernel_lut,
+                echo_input["label"],
+                bad_readouts_by_coil=first_echo_bad_readouts_by_coil,
+                bad_readout_source="TE1 precomputed",
+                normalization_scales=scales,
+            )
+        )
 
-    field_map_hz = core.compute_field_map_from_coils(imgs_te1, imgs_te2)
-    img_te1_uncorrected, img_te2_uncorrected, _ = core.combine_coils(imgs_te1, imgs_te2)
+    field_map_hz = None
+    if len(uncorrected_coil_images) >= 2:
+        field_map_hz = core.compute_field_map_from_coils(
+            uncorrected_coil_images[0],
+            uncorrected_coil_images[1],
+        )
+    elif core.RUN_TE1_PHASE_CORRECTION or core.RUN_TE2_PHASE_CORRECTION:
+        logging.info("Phase correction skipped: at least two echoes are required")
 
-    if core.RUN_TE1_PHASE_CORRECTION:
-        imgs_te1_output = core.reconstruct_phase_corrected_all_coils(
-            data_te1_raw,
-            k_cm_te1,
-            k_norm_te1,
-            dcf_te1,
-            deapo,
-            kernel_lut,
-            field_map_hz,
-            t_te1_s,
-            core.TE1_PHASE_CORRECTION_SIGN,
-            "TE1",
-            bad_readouts_by_coil=te1_bad_readouts_by_coil,
-            bad_readout_source="TE1 precomputed",
-            normalization_scales=te1_normalization_scales,
+    output_coil_images = []
+    for echo_input, coil_images, scales in zip(
+        echo_inputs,
+        uncorrected_coil_images,
+        normalization_scales,
+    ):
+        if field_map_hz is not None and _phase_correction_enabled(echo_input["echo_index"]):
+            output_coil_images.append(
+                core.reconstruct_phase_corrected_all_coils(
+                    echo_input["data"],
+                    echo_input["k"],
+                    echo_input["k_norm"],
+                    echo_input["dcf"],
+                    deapo,
+                    kernel_lut,
+                    field_map_hz,
+                    echo_input["t"],
+                    _phase_correction_sign(echo_input["echo_index"]),
+                    echo_input["label"],
+                    bad_readouts_by_coil=first_echo_bad_readouts_by_coil,
+                    bad_readout_source="TE1 precomputed",
+                    normalization_scales=scales,
+                )
+            )
+        else:
+            output_coil_images.append(coil_images)
+
+    uncorrected_echo_images = [
+        core.combine_single_echo_coils(coil_images, mode=core.COIL_COMBINE_MODE)
+        for coil_images in uncorrected_coil_images
+    ]
+    phase_corrected_echo_images = [
+        core.combine_single_echo_coils(coil_images, mode=core.COIL_COMBINE_MODE)
+        for coil_images in output_coil_images
+    ]
+    final_echo_images, bias_field, bias_mask = _apply_n4_bias_correction_to_echoes(
+        phase_corrected_echo_images
+    )
+    if effective_denoise_temporal_svd:
+        pre_denoise_echo_images = [image.copy() for image in final_echo_images]
+        final_echo_images = _denoise_temporal_svd_final_images(
+            final_echo_images,
+            patch_size=svd_patch_size,
+            stride=svd_stride,
+            retain_fraction=svd_retain_fraction,
         )
     else:
-        imgs_te1_output = imgs_te1
+        pre_denoise_echo_images = None
+        if denoise_temporal_svd and single_echo_mode:
+            logging.info("Temporal SVD denoising skipped: at least two echoes are required")
+        else:
+            logging.info("Temporal SVD denoising: disabled")
 
-    if core.RUN_TE2_PHASE_CORRECTION:
-        imgs_te2_output = core.reconstruct_phase_corrected_all_coils(
-            data_te2_raw,
-            k_cm_te2,
-            k_norm_te2,
-            dcf_te2,
-            deapo,
-            kernel_lut,
-            field_map_hz,
-            t_te2_s,
-            core.TE2_PHASE_CORRECTION_SIGN,
-            "TE2",
-            bad_readouts_by_coil=te1_bad_readouts_by_coil,
-            bad_readout_source="TE1 precomputed",
-            normalization_scales=te2_normalization_scales,
-        )
-    else:
-        imgs_te2_output = imgs_te2
-
-    img_te1_phasecorr, img_te2_phasecorr, _ = core.combine_coils(imgs_te1_output, imgs_te2_output)
-    img_te1_final, img_te2_final, bias_field, bias_mask = core.apply_n4_bias_correction(
-        img_te1_phasecorr,
-        img_te2_phasecorr,
+    debug_suffix = (
+        f"_rep{int(output_repetition_index) + 1}"
+        if int(total_repetitions) > 1
+        else ""
     )
-
-    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te1_uncorrected.npy"), img_te1_uncorrected)
-    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te2_uncorrected.npy"), img_te2_uncorrected)
-    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te1_final.npy"), img_te1_final)
-    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te2_final.npy"), img_te2_final)
-    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_field_map_hz.npy"), field_map_hz)
+    for echo_input, uncorrected_image, final_image in zip(
+        echo_inputs,
+        uncorrected_echo_images,
+        final_echo_images,
+    ):
+        label = echo_input["label"].lower()
+        np.save(
+            os.path.join(debugFolder, f"sodiumgridding_ptpi_{label}_uncorrected{debug_suffix}.npy"),
+            uncorrected_image,
+        )
+        np.save(
+            os.path.join(debugFolder, f"sodiumgridding_ptpi_{label}_final{debug_suffix}.npy"),
+            final_image,
+        )
+    if pre_denoise_echo_images is not None:
+        for echo_input, pre_denoise_image in zip(echo_inputs, pre_denoise_echo_images):
+            label = echo_input["label"].lower()
+            np.save(
+                os.path.join(debugFolder, f"sodiumgridding_ptpi_{label}_pre_svd{debug_suffix}.npy"),
+                pre_denoise_image,
+            )
+    if field_map_hz is not None:
+        np.save(os.path.join(debugFolder, f"sodiumgridding_ptpi_field_map_hz{debug_suffix}.npy"), field_map_hz)
     if bias_field is not None:
-        np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_n4_bias_field.npy"), bias_field)
+        np.save(os.path.join(debugFolder, f"sodiumgridding_ptpi_n4_bias_field{debug_suffix}.npy"), bias_field)
     if bias_mask is not None:
-        np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_n4_bias_mask.npy"), bias_mask)
+        np.save(os.path.join(debugFolder, f"sodiumgridding_ptpi_n4_bias_mask{debug_suffix}.npy"), bias_mask)
 
     elapsed_ms = (perf_counter() - tic) * 1000.0
-    message = f"pTPI dual-echo low-rank reconstruction time: {elapsed_ms:.2f} ms"
+    recon_mode = "single-echo" if single_echo_mode else f"{echo_count}-echo low-rank"
+    message = f"pTPI {recon_mode} reconstruction time: {elapsed_ms:.2f} ms"
     logging.info(message)
     connection.send_logging(constants.MRD_LOGGING_INFO, message)
 
     reference_head = group[len(group) // 2].getHead()
     output_fov_mm = float(fov_cm) * 10.0
+    if shared_echo_display_scale:
+        display_input_min, display_input_max = _shared_echo_display_range(final_echo_images)
+        if display_input_min is not None:
+            logging.info(
+                "Using shared echo display scale across %d final echoes: input_min=%.6g input_max=%.6g",
+                len(final_echo_images),
+                display_input_min,
+                display_input_max,
+            )
+        else:
+            logging.info("Shared echo display scale requested but no finite common range was available")
+    else:
+        display_input_min = display_input_max = None
+        logging.info("Shared echo display scale: disabled")
+
     images = []
-    images.extend(
-        _build_echo_images(
-            img_te1_final,
-            "TE1",
-            1,
-            reference_head,
-            metadata,
-            output_fov_mm,
-            orientation,
-            orientation_flip_slice,
-            orientation_debug_series,
+    for echo_input, final_image in zip(echo_inputs, final_echo_images):
+        images.extend(
+            _build_echo_images(
+                final_image,
+                echo_input["label"],
+                echo_input["echo_time_s"],
+                _series_index_for_echo(
+                    echo_input["echo_index"],
+                    output_repetition_index,
+                    total_repetitions,
+                ),
+                echo_input["echo_index"],
+                echo_count,
+                repetition_index,
+                total_repetitions,
+                output_repetition_index,
+                reference_head,
+                metadata,
+                output_fov_mm,
+                orientation,
+                orientation_flip_slice,
+                orientation_debug_series,
+                display_input_min=display_input_min,
+                display_input_max=display_input_max,
+            )
         )
-    )
-    images.extend(
-        _build_echo_images(
-            img_te2_final,
-            "TE2",
-            1001,
-            reference_head,
-            metadata,
-            output_fov_mm,
-            orientation,
-            orientation_flip_slice,
-            orientation_debug_series,
-        )
-    )
     return images
 
 

--- a/recipes/sodiumgridding_ptpi/sodiumgridding_ptpi.py
+++ b/recipes/sodiumgridding_ptpi/sodiumgridding_ptpi.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""OpenRecon entrypoint for dual-echo palindromic TPI gridding.
+
+This module adapts ``ptpi_dual_echo_lowrank_core.py`` from its standalone
+file-based workflow into the same MRD streaming contract used by
+``sodiumgridding``. The reconstruction math stays in the core module; this file
+only resolves OpenRecon config, converts incoming acquisitions into the
+dual-echo array layout, and emits TE1/TE2 magnitude volumes.
+"""
+
+import logging
+import os
+from pathlib import Path
+from time import perf_counter
+import traceback
+
+import h5py
+import ismrmrd
+import numpy as np
+
+import constants
+import sodiumgridding as openrecon_base
+import ptpi_dual_echo_lowrank_core as core
+
+
+DEFAULT_TRAJECTORY_FILE = "/opt/sodiumgridding_ptpi/23Na_pTPI_n28_g50_p5traj.h5"
+OUTPUT_SERIES_BASE = "sodiumgridding_pTPI"
+debugFolder = "/tmp/share/debug"
+
+OPENRECON_DEFAULTS = {
+    "config": "sodiumgridding_ptpi",
+    "matrixsize": 128,
+    "fovcm": 22.0,
+    "trajectoryfile": DEFAULT_TRAJECTORY_FILE,
+    "trajectorydataset": "k",
+    "dcfiterations": 5,
+    "maxcoils": 0,
+    "maxworkers": 8,
+    "coilcompression": True,
+    "coilvarianceretention": 0.9,
+    "coilcompressionsource": "both",
+    "coilcombinemode": "AC",
+    "echonormalizationmode": "none",
+    "fieldmapdeltates": 0.005,
+    "fieldmapunwrapmethod": "skimage",
+    "runphasecorrection": True,
+    "phaselowrankrank": 10,
+    "applyn4biascorrection": True,
+    "orientation": "zyx",
+    "orientationflipslice": False,
+    "orientationdebugseries": False,
+}
+
+
+def _ensure_debug_folder():
+    os.makedirs(debugFolder, exist_ok=True)
+
+
+def _config_bool(config, key):
+    return openrecon_base._config_bool(config, key, OPENRECON_DEFAULTS[key])
+
+
+def _config_int(config, key):
+    return openrecon_base._config_int(config, key, OPENRECON_DEFAULTS[key])
+
+
+def _config_float(config, key):
+    return openrecon_base._config_float(config, key, OPENRECON_DEFAULTS[key])
+
+
+def _config_str(config, key):
+    return openrecon_base._config_str(config, key, OPENRECON_DEFAULTS[key])
+
+
+def _load_dual_trajectory(config):
+    trajectory_file = _config_str(config, "trajectoryfile").strip()
+    if not trajectory_file:
+        trajectory_file = DEFAULT_TRAJECTORY_FILE
+    trajectory_dataset = _config_str(config, "trajectorydataset").strip() or "k"
+
+    path = Path(trajectory_file).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"pTPI trajectory file does not exist: {path}")
+
+    with h5py.File(path, "r") as h5_file:
+        if "k_echo1" in h5_file and "k_echo2_forward_order" in h5_file:
+            k_cm_te1 = h5_file["k_echo1"][...]
+            k_cm_te2 = h5_file["k_echo2_forward_order"][...]
+            trajectory_mode = "dual-echo forward-order"
+        elif trajectory_dataset in h5_file:
+            k_cm_te1 = h5_file[trajectory_dataset][...]
+            k_cm_te2 = k_cm_te1
+            trajectory_mode = f"single-trajectory fallback [{trajectory_dataset}]"
+        else:
+            raise KeyError(
+                f"Trajectory dataset '{trajectory_dataset}' not found in {path}. "
+                f"Available datasets: {list(h5_file.keys())}"
+            )
+
+        if core.TE1_PHASE_TIME_DATASET in h5_file:
+            t_te1 = h5_file[core.TE1_PHASE_TIME_DATASET][...].astype(np.float32)
+            te1_time_mode = core.TE1_PHASE_TIME_DATASET
+        else:
+            sample_source = trajectory_dataset if trajectory_dataset in h5_file else next(iter(h5_file.keys()))
+            dt_s = float(h5_file[sample_source].attrs.get("sampling_time_us", 10.0)) * 1e-6
+            t_te1 = np.arange(k_cm_te1.shape[0], dtype=np.float32) * dt_s
+            te1_time_mode = f"inferred +{dt_s:.3e} s/sample"
+
+        if core.TE2_PHASE_TIME_DATASET in h5_file:
+            t_te2 = h5_file[core.TE2_PHASE_TIME_DATASET][...].astype(np.float32)
+            te2_time_mode = core.TE2_PHASE_TIME_DATASET
+        else:
+            sample_source = trajectory_dataset if trajectory_dataset in h5_file else next(iter(h5_file.keys()))
+            dt_s = float(h5_file[sample_source].attrs.get("sampling_time_us", 10.0)) * 1e-6
+            t_te2 = -np.arange(k_cm_te2.shape[0], dtype=np.float32) * dt_s
+            te2_time_mode = f"inferred {-dt_s:.3e} s/sample"
+
+    logging.info(
+        "Loaded pTPI trajectory from %s: mode=%s te1_time=%s te2_time=%s "
+        "k_te1=%s k_te2=%s t_te1=%s t_te2=%s",
+        path,
+        trajectory_mode,
+        te1_time_mode,
+        te2_time_mode,
+        k_cm_te1.shape,
+        k_cm_te2.shape,
+        t_te1.shape,
+        t_te2.shape,
+    )
+    return (
+        openrecon_base._normalize_trajectory_array(k_cm_te1),
+        openrecon_base._normalize_trajectory_array(k_cm_te2),
+        np.asarray(t_te1, dtype=np.float32),
+        np.asarray(t_te2, dtype=np.float32),
+    )
+
+
+def _build_interleaved_data_array(acquisitions):
+    """Return raw data as (coils, samples, acquisitions)."""
+    base_data = openrecon_base._build_data_array(acquisitions)
+    return np.ascontiguousarray(base_data.transpose(0, 2, 1))
+
+
+def _split_dual_echo_data(data_all):
+    if data_all.shape[2] < 2:
+        raise ValueError(
+            "Dual-echo pTPI reconstruction needs alternating TE1/TE2 acquisitions; "
+            f"got only {data_all.shape[2]} acquisition(s)."
+        )
+    data_te1 = data_all[:, :, 0::2].copy()
+    data_te2 = data_all[:, :, 1::2].copy()
+    # TE2 is acquired in reverse sample order in the standalone pTPI workflow.
+    data_te2 = data_te2[:, ::-1, :]
+    return data_te1, data_te2
+
+
+def _clip_to_common_shape(k_te1, k_te2, t_te1, t_te2, data_te1, data_te2):
+    samples = min(
+        k_te1.shape[0],
+        k_te2.shape[0],
+        t_te1.shape[0],
+        t_te2.shape[0],
+        data_te1.shape[1],
+        data_te2.shape[1],
+    )
+    readouts = min(
+        k_te1.shape[1],
+        k_te2.shape[1],
+        data_te1.shape[2],
+        data_te2.shape[2],
+    )
+    if samples <= 0 or readouts <= 0:
+        raise ValueError("No overlapping pTPI samples/readouts between data and trajectory")
+
+    return (
+        k_te1[:samples, :readouts, :],
+        k_te2[:samples, :readouts, :],
+        t_te1[:samples],
+        t_te2[:samples],
+        data_te1[:, :samples, :readouts],
+        data_te2[:, :samples, :readouts],
+    )
+
+
+def _configure_core(config, matrix_size, fov_cm):
+    core.N = int(matrix_size)
+    core.FOV_CM = float(fov_cm)
+    core.DCF_ITER = max(0, _config_int(config, "dcfiterations"))
+    core.MAX_WORKERS = max(1, _config_int(config, "maxworkers"))
+    core.COIL_COMPRESSION = _config_bool(config, "coilcompression")
+    core.COIL_VARIANCE_RETENTION = float(
+        np.clip(_config_float(config, "coilvarianceretention"), 0.0, 1.0)
+    )
+    core.COIL_COMPRESSION_SOURCE = _config_str(config, "coilcompressionsource")
+    core.COIL_COMBINE_MODE = _config_str(config, "coilcombinemode")
+    core.ECHO_NORMALIZATION_MODE = _config_str(config, "echonormalizationmode")
+    core.FIELD_MAP_DELTA_TE_S = _config_float(config, "fieldmapdeltates")
+    core.FIELD_MAP_UNWRAP_METHOD = _config_str(config, "fieldmapunwrapmethod")
+    core.RUN_TE1_PHASE_CORRECTION = _config_bool(config, "runphasecorrection")
+    core.RUN_TE2_PHASE_CORRECTION = _config_bool(config, "runphasecorrection")
+    core.TE2_PHASE_LOWRANK_RANK = max(1, _config_int(config, "phaselowrankrank"))
+    core.APPLY_N4_BIAS_CORRECTION = _config_bool(config, "applyn4biascorrection")
+    core.PLOT_RESULTS = False
+    core.SAVE_C0_FILES = False
+    core.SAVE_NIFTI_FILES = False
+
+
+def _build_echo_images(
+    volume,
+    echo_label,
+    series_index,
+    reference_head,
+    metadata,
+    output_fov_mm,
+    orientation,
+    orientation_flip_slice,
+    orientation_debug_series,
+):
+    old_description = openrecon_base.OUTPUT_SERIES_DESCRIPTION
+    old_index = openrecon_base.OUTPUT_IMAGE_SERIES_INDEX
+    try:
+        openrecon_base.OUTPUT_SERIES_DESCRIPTION = f"{OUTPUT_SERIES_BASE}_{echo_label.lower()}"
+        openrecon_base.OUTPUT_IMAGE_SERIES_INDEX = int(series_index)
+        return openrecon_base._build_output_images(
+            np.abs(volume).astype(np.float32, copy=False),
+            reference_head,
+            metadata,
+            output_fov_mm=output_fov_mm,
+            orientation=orientation,
+            flip_slice=orientation_flip_slice,
+            emit_debug_series=orientation_debug_series,
+        )
+    finally:
+        openrecon_base.OUTPUT_SERIES_DESCRIPTION = old_description
+        openrecon_base.OUTPUT_IMAGE_SERIES_INDEX = old_index
+
+
+def process(connection, config, metadata):
+    logging.info("Config:\n%s", config)
+    acquisitions = []
+    passthrough_images = []
+    try:
+        for item in connection:
+            if isinstance(item, ismrmrd.Acquisition):
+                if (
+                    not item.is_flag_set(ismrmrd.ACQ_IS_NOISE_MEASUREMENT)
+                    and not item.is_flag_set(ismrmrd.ACQ_IS_PARALLEL_CALIBRATION)
+                    and not item.is_flag_set(ismrmrd.ACQ_IS_PHASECORR_DATA)
+                    and not item.is_flag_set(ismrmrd.ACQ_IS_NAVIGATION_DATA)
+                ):
+                    acquisitions.append(item)
+
+                if item.is_flag_set(ismrmrd.ACQ_LAST_IN_MEASUREMENT):
+                    logging.info("Processing %d acquired readouts", len(acquisitions))
+                    connection.send_image(process_raw(acquisitions, connection, config, metadata))
+                    acquisitions = []
+            elif isinstance(item, ismrmrd.Image):
+                passthrough_images.append(item)
+            elif item is None:
+                break
+            else:
+                logging.error("Unsupported data type %s", type(item).__name__)
+
+        if acquisitions:
+            logging.info("Processing %d acquired readouts (end of stream)", len(acquisitions))
+            connection.send_image(process_raw(acquisitions, connection, config, metadata))
+
+        if passthrough_images:
+            logging.warning(
+                "Received %d images instead of raw data; returning them unchanged",
+                len(passthrough_images),
+            )
+            connection.send_image(
+                openrecon_base.process_image(passthrough_images, connection, config, metadata)
+            )
+    except Exception:
+        logging.error(traceback.format_exc())
+        connection.send_logging(constants.MRD_LOGGING_ERROR, traceback.format_exc())
+    finally:
+        connection.send_close()
+
+
+def process_raw(group, connection, config, metadata):
+    if not group:
+        return []
+
+    tic = perf_counter()
+    _ensure_debug_folder()
+
+    matrix_size = max(1, openrecon_base._config_int(
+        config,
+        "matrixsize",
+        openrecon_base._compute_default_matrix_size(metadata),
+    ))
+    fov_cm = openrecon_base._config_float(
+        config,
+        "fovcm",
+        openrecon_base._compute_default_fov_cm(metadata),
+    )
+    if fov_cm <= 0:
+        raise ValueError(f"fovcm must be positive, got {fov_cm}")
+
+    _configure_core(config, matrix_size, fov_cm)
+    orientation, orientation_debug_series = openrecon_base._resolve_orientation_config(config)
+    orientation_flip_slice = openrecon_base._config_bool(
+        config,
+        "orientationflipslice",
+        OPENRECON_DEFAULTS["orientationflipslice"],
+    )
+
+    logging.info(
+        "Resolved pTPI configuration: matrixsize=%d fovcm=%.3f dcfiterations=%d "
+        "maxworkers=%d coilcompression=%s coilvarianceretention=%.3f "
+        "coilcompressionsource=%s coilcombinemode=%s echonormalizationmode=%s "
+        "fieldmapdeltates=%.6f fieldmapunwrapmethod=%s runphasecorrection=%s "
+        "phaselowrankrank=%d applyn4biascorrection=%s orientation=%s "
+        "orientationflipslice=%s orientationdebugseries=%s",
+        core.N,
+        core.FOV_CM,
+        core.DCF_ITER,
+        core.MAX_WORKERS,
+        core.COIL_COMPRESSION,
+        core.COIL_VARIANCE_RETENTION,
+        core.COIL_COMPRESSION_SOURCE,
+        core.COIL_COMBINE_MODE,
+        core.ECHO_NORMALIZATION_MODE,
+        core.FIELD_MAP_DELTA_TE_S,
+        core.FIELD_MAP_UNWRAP_METHOD,
+        core.RUN_TE2_PHASE_CORRECTION,
+        core.TE2_PHASE_LOWRANK_RANK,
+        core.APPLY_N4_BIAS_CORRECTION,
+        orientation,
+        orientation_flip_slice,
+        orientation_debug_series,
+    )
+
+    data_all = _build_interleaved_data_array(group)
+    max_coils = max(0, _config_int(config, "maxcoils"))
+    if 0 < max_coils < data_all.shape[0]:
+        logging.warning("Limiting reconstruction to first %d of %d coils", max_coils, data_all.shape[0])
+        data_all = data_all[:max_coils]
+
+    data_all = core.compress_coils_covariance(data_all)
+    data_te1_raw, data_te2_raw = _split_dual_echo_data(data_all)
+    k_cm_te1, k_cm_te2, t_te1_s, t_te2_s = _load_dual_trajectory(config)
+    (
+        k_cm_te1,
+        k_cm_te2,
+        t_te1_s,
+        t_te2_s,
+        data_te1_raw,
+        data_te2_raw,
+    ) = _clip_to_common_shape(
+        k_cm_te1,
+        k_cm_te2,
+        t_te1_s,
+        t_te2_s,
+        data_te1_raw,
+        data_te2_raw,
+    )
+
+    logging.info(
+        "pTPI input after clipping: coils=%d samples=%d readouts=%d "
+        "k_te1=%s k_te2=%s",
+        data_te1_raw.shape[0],
+        data_te1_raw.shape[1],
+        data_te1_raw.shape[2],
+        k_cm_te1.shape,
+        k_cm_te2.shape,
+    )
+    openrecon_base._log_trajectory_extent(k_cm_te1)
+    openrecon_base._log_trajectory_extent(k_cm_te2)
+
+    k_cm_te1 = core.apply_trajectory_delay_correction(k_cm_te1, t_te1_s, "TE1")
+    k_cm_te2 = core.apply_trajectory_delay_correction(k_cm_te2, t_te2_s, "TE2")
+
+    k_nyquist = 1.0 / (2.0 * fov_cm / matrix_size)
+    k_norm_te1 = (k_cm_te1.reshape(-1, 3) / k_nyquist / 2.0).astype(np.float32)
+    k_norm_te2 = (k_cm_te2.reshape(-1, 3) / k_nyquist / 2.0).astype(np.float32)
+
+    kb_beta = core.default_kb_beta(core.KB_WIDTH, core.OVERSAMP) if core.KB_BETA is None else float(core.KB_BETA)
+    logging.info("Kaiser-Bessel beta=%.4f LUT size=%d", kb_beta, core.KB_LUT_SIZE)
+    kernel_lut = core.make_kaiser_bessel_lut(core.KB_WIDTH, kb_beta, core.KB_LUT_SIZE)
+
+    logging.info("Preparing TE1 trajectory weights")
+    dcf_te1 = core.compute_dcf_kb(k_norm_te1, matrix_size, core.OVERSAMP, core.DCF_ITER, kernel_lut, core.KB_WIDTH)
+    logging.info("Preparing TE2 trajectory weights")
+    dcf_te2 = core.compute_dcf_kb(k_norm_te2, matrix_size, core.OVERSAMP, core.DCF_ITER, kernel_lut, core.KB_WIDTH)
+    deapo = core.compute_deapodisation_kb(matrix_size, core.OVERSAMP, kernel_lut, core.KB_WIDTH)
+
+    te1_bad_readouts_by_coil = None
+    if core.USE_TE1_BAD_READOUTS_FOR_TE2:
+        te1_bad_readouts_by_coil = core.find_bad_readouts_by_coil(data_te1_raw, "TE1")
+
+    te1_normalization_scales, te2_normalization_scales = core.build_echo_normalization_scales(
+        data_te1_raw,
+        data_te2_raw,
+        te1_bad_readouts_by_coil,
+    )
+
+    imgs_te1 = core.reconstruct_echo_all_coils(
+        data_te1_raw,
+        k_cm_te1,
+        k_norm_te1,
+        dcf_te1,
+        deapo,
+        kernel_lut,
+        "TE1",
+        bad_readouts_by_coil=te1_bad_readouts_by_coil,
+        bad_readout_source="TE1 precomputed",
+        normalization_scales=te1_normalization_scales,
+    )
+    imgs_te2 = core.reconstruct_echo_all_coils(
+        data_te2_raw,
+        k_cm_te2,
+        k_norm_te2,
+        dcf_te2,
+        deapo,
+        kernel_lut,
+        "TE2",
+        bad_readouts_by_coil=te1_bad_readouts_by_coil,
+        bad_readout_source="TE1 precomputed",
+        normalization_scales=te2_normalization_scales,
+    )
+
+    field_map_hz = core.compute_field_map_from_coils(imgs_te1, imgs_te2)
+    img_te1_uncorrected, img_te2_uncorrected, _ = core.combine_coils(imgs_te1, imgs_te2)
+
+    if core.RUN_TE1_PHASE_CORRECTION:
+        imgs_te1_output = core.reconstruct_phase_corrected_all_coils(
+            data_te1_raw,
+            k_cm_te1,
+            k_norm_te1,
+            dcf_te1,
+            deapo,
+            kernel_lut,
+            field_map_hz,
+            t_te1_s,
+            core.TE1_PHASE_CORRECTION_SIGN,
+            "TE1",
+            bad_readouts_by_coil=te1_bad_readouts_by_coil,
+            bad_readout_source="TE1 precomputed",
+            normalization_scales=te1_normalization_scales,
+        )
+    else:
+        imgs_te1_output = imgs_te1
+
+    if core.RUN_TE2_PHASE_CORRECTION:
+        imgs_te2_output = core.reconstruct_phase_corrected_all_coils(
+            data_te2_raw,
+            k_cm_te2,
+            k_norm_te2,
+            dcf_te2,
+            deapo,
+            kernel_lut,
+            field_map_hz,
+            t_te2_s,
+            core.TE2_PHASE_CORRECTION_SIGN,
+            "TE2",
+            bad_readouts_by_coil=te1_bad_readouts_by_coil,
+            bad_readout_source="TE1 precomputed",
+            normalization_scales=te2_normalization_scales,
+        )
+    else:
+        imgs_te2_output = imgs_te2
+
+    img_te1_phasecorr, img_te2_phasecorr, _ = core.combine_coils(imgs_te1_output, imgs_te2_output)
+    img_te1_final, img_te2_final, bias_field, bias_mask = core.apply_n4_bias_correction(
+        img_te1_phasecorr,
+        img_te2_phasecorr,
+    )
+
+    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te1_uncorrected.npy"), img_te1_uncorrected)
+    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te2_uncorrected.npy"), img_te2_uncorrected)
+    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te1_final.npy"), img_te1_final)
+    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_te2_final.npy"), img_te2_final)
+    np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_field_map_hz.npy"), field_map_hz)
+    if bias_field is not None:
+        np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_n4_bias_field.npy"), bias_field)
+    if bias_mask is not None:
+        np.save(os.path.join(debugFolder, "sodiumgridding_ptpi_n4_bias_mask.npy"), bias_mask)
+
+    elapsed_ms = (perf_counter() - tic) * 1000.0
+    message = f"pTPI dual-echo low-rank reconstruction time: {elapsed_ms:.2f} ms"
+    logging.info(message)
+    connection.send_logging(constants.MRD_LOGGING_INFO, message)
+
+    reference_head = group[len(group) // 2].getHead()
+    output_fov_mm = float(fov_cm) * 10.0
+    images = []
+    images.extend(
+        _build_echo_images(
+            img_te1_final,
+            "TE1",
+            1,
+            reference_head,
+            metadata,
+            output_fov_mm,
+            orientation,
+            orientation_flip_slice,
+            orientation_debug_series,
+        )
+    )
+    images.extend(
+        _build_echo_images(
+            img_te2_final,
+            "TE2",
+            1001,
+            reference_head,
+            metadata,
+            output_fov_mm,
+            orientation,
+            orientation_flip_slice,
+            orientation_debug_series,
+        )
+    )
+    return images
+
+
+def process_image(images, connection, config, metadata):
+    return openrecon_base.process_image(images, connection, config, metadata)

--- a/recipes/sodiumgridding_ptpi/test_sodiumgridding_ptpi.py
+++ b/recipes/sodiumgridding_ptpi/test_sodiumgridding_ptpi.py
@@ -1,0 +1,106 @@
+import importlib
+from pathlib import Path
+import sys
+import types
+
+import numpy as np
+
+
+RECIPE_DIR = Path(__file__).resolve().parent
+
+
+def _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch):
+    constants = types.ModuleType("constants")
+    constants.MRD_LOGGING_INFO = 1
+    constants.MRD_LOGGING_ERROR = 2
+    mrdhelper = types.ModuleType("mrdhelper")
+
+    def update_img_header_from_raw(image_header, reference_head):
+        del reference_head
+        return image_header
+
+    def get_json_config_param(config, key, default=None, type=None):
+        del type
+        return config.get(key, default)
+
+    mrdhelper.update_img_header_from_raw = update_img_header_from_raw
+    mrdhelper.get_json_config_param = get_json_config_param
+
+    monkeypatch.syspath_prepend(str(RECIPE_DIR))
+    monkeypatch.setitem(sys.modules, "constants", constants)
+    monkeypatch.setitem(sys.modules, "mrdhelper", mrdhelper)
+    monkeypatch.delitem(sys.modules, "sodiumgridding", raising=False)
+    monkeypatch.delitem(sys.modules, "ptpi_dual_echo_lowrank_core", raising=False)
+    monkeypatch.delitem(sys.modules, "sodiumgridding_ptpi", raising=False)
+    return importlib.import_module("sodiumgridding_ptpi")
+
+
+def test_split_dual_echo_data_reverses_second_echo(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    data = np.arange(2 * 4 * 6, dtype=np.complex64).reshape(2, 4, 6)
+
+    te1, te2 = sodiumgridding_ptpi._split_dual_echo_data(data)
+
+    np.testing.assert_array_equal(te1, data[:, :, 0::2])
+    np.testing.assert_array_equal(te2, data[:, ::-1, 1::2])
+
+
+def test_clip_to_common_shape_uses_shared_sample_and_readout_extent(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    k1 = np.zeros((5, 4, 3), dtype=np.float32)
+    k2 = np.zeros((6, 3, 3), dtype=np.float32)
+    t1 = np.arange(7, dtype=np.float32)
+    t2 = np.arange(5, dtype=np.float32)
+    d1 = np.zeros((2, 4, 5), dtype=np.complex64)
+    d2 = np.zeros((2, 8, 3), dtype=np.complex64)
+
+    clipped = sodiumgridding_ptpi._clip_to_common_shape(k1, k2, t1, t2, d1, d2)
+
+    assert clipped[0].shape == (4, 3, 3)
+    assert clipped[1].shape == (4, 3, 3)
+    assert clipped[2].shape == (4,)
+    assert clipped[3].shape == (4,)
+    assert clipped[4].shape == (2, 4, 3)
+    assert clipped[5].shape == (2, 4, 3)
+
+
+def test_configure_core_disables_standalone_outputs(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    sodiumgridding_ptpi._configure_core(
+        {
+            "dcfiterations": 2,
+            "maxworkers": 3,
+            "coilcompression": True,
+            "coilvarianceretention": "0.95",
+            "coilcompressionsource": "te1",
+            "coilcombinemode": "SoS",
+            "echonormalizationmode": "te1",
+            "fieldmapdeltates": "0.0045",
+            "fieldmapunwrapmethod": "axis",
+            "runphasecorrection": False,
+            "phaselowrankrank": 4,
+            "applyn4biascorrection": False,
+        },
+        matrix_size=64,
+        fov_cm=20.0,
+    )
+
+    core = sodiumgridding_ptpi.core
+    assert core.N == 64
+    assert core.FOV_CM == 20.0
+    assert core.DCF_ITER == 2
+    assert core.MAX_WORKERS == 3
+    assert core.COIL_VARIANCE_RETENTION == 0.95
+    assert core.COIL_COMPRESSION_SOURCE == "te1"
+    assert core.COIL_COMBINE_MODE == "SoS"
+    assert core.ECHO_NORMALIZATION_MODE == "te1"
+    assert core.FIELD_MAP_DELTA_TE_S == 0.0045
+    assert core.FIELD_MAP_UNWRAP_METHOD == "axis"
+    assert core.RUN_TE1_PHASE_CORRECTION is False
+    assert core.RUN_TE2_PHASE_CORRECTION is False
+    assert core.TE2_PHASE_LOWRANK_RANK == 4
+    assert core.APPLY_N4_BIAS_CORRECTION is False
+    assert core.PLOT_RESULTS is False
+    assert core.SAVE_C0_FILES is False
+    assert core.SAVE_NIFTI_FILES is False

--- a/recipes/sodiumgridding_ptpi/test_sodiumgridding_ptpi.py
+++ b/recipes/sodiumgridding_ptpi/test_sodiumgridding_ptpi.py
@@ -45,6 +45,51 @@ def test_split_dual_echo_data_reverses_second_echo(monkeypatch):
     np.testing.assert_array_equal(te2, data[:, ::-1, 1::2])
 
 
+def test_split_multi_echo_data_reverses_even_numbered_echoes(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    data = np.arange(1 * 4 * 16, dtype=np.complex64).reshape(1, 4, 16)
+
+    echoes = sodiumgridding_ptpi._split_echo_data(data, 4)
+
+    assert len(echoes) == 4
+    np.testing.assert_array_equal(echoes[0], data[:, :, 0::4])
+    np.testing.assert_array_equal(echoes[1], data[:, ::-1, 1::4])
+    np.testing.assert_array_equal(echoes[2], data[:, :, 2::4])
+    np.testing.assert_array_equal(echoes[3], data[:, ::-1, 3::4])
+
+
+def test_echo_sample_times_use_forward_reverse_pair_delta_te(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    sodiumgridding_ptpi.core.FIELD_MAP_DELTA_TE_S = 0.005
+    base_times = np.asarray([0.0, 0.001], dtype=np.float32)
+
+    np.testing.assert_allclose(
+        sodiumgridding_ptpi._echo_sample_times(base_times, 0),
+        [0.0, 0.001],
+    )
+    np.testing.assert_allclose(
+        sodiumgridding_ptpi._echo_sample_times(base_times, 1),
+        [0.0, 0.001],
+    )
+    np.testing.assert_allclose(
+        sodiumgridding_ptpi._echo_sample_times(base_times, 2),
+        [0.010, 0.011],
+    )
+    np.testing.assert_allclose(
+        sodiumgridding_ptpi._echo_sample_times(base_times, 3),
+        [0.010, 0.011],
+    )
+
+
+def test_series_index_is_unique_by_echo_and_repetition(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    assert sodiumgridding_ptpi._series_index_for_echo(0, 0, 2) == 1
+    assert sodiumgridding_ptpi._series_index_for_echo(0, 1, 2) == 2
+    assert sodiumgridding_ptpi._series_index_for_echo(1, 0, 2) == 1001
+    assert sodiumgridding_ptpi._series_index_for_echo(1, 1, 2) == 1002
+
+
 def test_clip_to_common_shape_uses_shared_sample_and_readout_extent(monkeypatch):
     sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
     k1 = np.zeros((5, 4, 3), dtype=np.float32)
@@ -62,6 +107,33 @@ def test_clip_to_common_shape_uses_shared_sample_and_readout_extent(monkeypatch)
     assert clipped[3].shape == (4,)
     assert clipped[4].shape == (2, 4, 3)
     assert clipped[5].shape == (2, 4, 3)
+
+
+def test_clip_echo_inputs_uses_common_extent_across_all_echoes(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    echo_inputs = [
+        {
+            "k": np.zeros((5, 4, 3), dtype=np.float32),
+            "t": np.arange(6, dtype=np.float32),
+            "data": np.zeros((2, 5, 4), dtype=np.complex64),
+        },
+        {
+            "k": np.zeros((4, 3, 3), dtype=np.float32),
+            "t": np.arange(4, dtype=np.float32),
+            "data": np.zeros((2, 6, 3), dtype=np.complex64),
+        },
+        {
+            "k": np.zeros((7, 5, 3), dtype=np.float32),
+            "t": np.arange(8, dtype=np.float32),
+            "data": np.zeros((2, 4, 5), dtype=np.complex64),
+        },
+    ]
+
+    clipped = sodiumgridding_ptpi._clip_echo_inputs(echo_inputs)
+
+    assert [item["k"].shape for item in clipped] == [(4, 3, 3)] * 3
+    assert [item["t"].shape for item in clipped] == [(4,)] * 3
+    assert [item["data"].shape for item in clipped] == [(2, 4, 3)] * 3
 
 
 def test_configure_core_disables_standalone_outputs(monkeypatch):
@@ -104,3 +176,287 @@ def test_configure_core_disables_standalone_outputs(monkeypatch):
     assert core.PLOT_RESULTS is False
     assert core.SAVE_C0_FILES is False
     assert core.SAVE_NIFTI_FILES is False
+
+
+def test_build_echo_images_passes_echo_identity_to_output_builder(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    captured = {}
+
+    def fake_build_output_images(volume, reference_head, metadata, **kwargs):
+        del volume, reference_head, metadata
+        captured.update(kwargs)
+        captured["series_description"] = (
+            sodiumgridding_ptpi.openrecon_base.OUTPUT_SERIES_DESCRIPTION
+        )
+        return ["te2-image"]
+
+    monkeypatch.setattr(
+        sodiumgridding_ptpi.openrecon_base,
+        "_build_output_images",
+        fake_build_output_images,
+    )
+    old_description = sodiumgridding_ptpi.openrecon_base.OUTPUT_SERIES_DESCRIPTION
+    old_index = sodiumgridding_ptpi.openrecon_base.OUTPUT_IMAGE_SERIES_INDEX
+    old_prefix_protocol = sodiumgridding_ptpi.openrecon_base.OUTPUT_SERIES_PREFIX_PROTOCOL
+
+    images = sodiumgridding_ptpi._build_echo_images(
+        np.ones((2, 2, 2), dtype=np.float32),
+        "TE2",
+        0.004,
+        1001,
+        1,
+        2,
+        4,
+        3,
+        1,
+        object(),
+        object(),
+        220.0,
+        "zyx",
+        True,
+        False,
+        display_input_min=0.0,
+        display_input_max=42.0,
+    )
+
+    assert images == ["te2-image"]
+    assert captured["echo_index"] == 1
+    assert captured["total_echoes"] == 2
+    assert captured["repetition_index"] == 4
+    assert captured["total_repetitions"] == 3
+    assert captured["echo_time_s"] == 0.004
+    assert captured["display_input_min"] == 0.0
+    assert captured["display_input_max"] == 42.0
+    assert captured["output_fov_mm"] == 220.0
+    assert captured["orientation"] == "zyx"
+    assert captured["flip_slice"] is True
+    assert captured["series_description"] == "pTPI_TE2_rep2"
+    assert sodiumgridding_ptpi.openrecon_base.OUTPUT_SERIES_PREFIX_PROTOCOL == old_prefix_protocol
+    assert sodiumgridding_ptpi.openrecon_base.OUTPUT_SERIES_DESCRIPTION == old_description
+    assert sodiumgridding_ptpi.openrecon_base.OUTPUT_IMAGE_SERIES_INDEX == old_index
+
+
+def test_metadata_echo_times_uses_sequence_parameters_te(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    class SequenceParameters:
+        TE = [0.3, 4.3, 8.3, 12.3]
+
+    class Metadata:
+        sequenceParameters = SequenceParameters()
+
+    echo_times_s, source = sodiumgridding_ptpi._metadata_echo_times_s(
+        Metadata(),
+        4,
+        0.004,
+    )
+
+    np.testing.assert_allclose(
+        echo_times_s,
+        [0.0003, 0.0043, 0.0083, 0.0123],
+        rtol=1e-6,
+    )
+    assert source == "MRD sequenceParameters.TE"
+
+
+def test_metadata_echo_times_falls_back_to_delta_te(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    echo_times_s, source = sodiumgridding_ptpi._metadata_echo_times_s(
+        object(),
+        4,
+        0.004,
+    )
+
+    np.testing.assert_allclose(echo_times_s, [0.0, 0.004, 0.008, 0.012], rtol=1e-6)
+    assert source == "fallback delta TE offsets"
+
+
+def test_temporal_svd_denoising_preserves_shape_and_finite_values(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    rng = np.random.default_rng(1234)
+    base = np.linspace(1.0, 2.0, 3, dtype=np.float32)[:, None, None, None]
+    volumes = [
+        (base[index] * np.ones((5, 5, 5), dtype=np.float32))
+        + rng.normal(0.0, 0.01, size=(5, 5, 5)).astype(np.float32)
+        for index in range(3)
+    ]
+
+    denoised = sodiumgridding_ptpi._denoise_temporal_svd_final_images(
+        volumes,
+        patch_size=3,
+        stride=2,
+        retain_fraction=0.5,
+    )
+
+    assert len(denoised) == 3
+    assert [item.shape for item in denoised] == [(5, 5, 5)] * 3
+    assert all(np.all(np.isfinite(item)) for item in denoised)
+    assert all(item.dtype == np.float32 for item in denoised)
+
+
+def test_single_echo_n4_correction_uses_te1_image(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+    image = np.arange(8, dtype=np.float32).reshape(2, 2, 2) + 1.0
+    mask = image > 2.0
+    bias = np.full(image.shape, 2.0, dtype=np.float32)
+    calls = []
+
+    sodiumgridding_ptpi.core.APPLY_N4_BIAS_CORRECTION = True
+
+    def fake_make_bias_mask(reference_mag):
+        calls.append(("mask", reference_mag.copy()))
+        return mask
+
+    def fake_estimate_bias_field(reference_mag, input_mask):
+        calls.append(("estimate", reference_mag.copy(), input_mask.copy()))
+        return bias, input_mask
+
+    def fake_apply_bias_field(input_image, input_bias, input_mask, should_correct):
+        calls.append(("apply", input_image.copy(), input_bias.copy(), input_mask.copy(), should_correct))
+        return input_image / input_bias, input_mask
+
+    monkeypatch.setattr(sodiumgridding_ptpi.core, "make_bias_mask", fake_make_bias_mask)
+    monkeypatch.setattr(
+        sodiumgridding_ptpi.core,
+        "estimate_bias_field_sitk_n4",
+        fake_estimate_bias_field,
+    )
+    monkeypatch.setattr(
+        sodiumgridding_ptpi.core,
+        "apply_bias_field_to_image",
+        fake_apply_bias_field,
+    )
+
+    corrected, bias_field, output_mask = sodiumgridding_ptpi._apply_n4_bias_correction_to_echoes(
+        [image]
+    )
+
+    assert len(corrected) == 1
+    np.testing.assert_allclose(corrected[0], image / 2.0)
+    np.testing.assert_allclose(bias_field, bias)
+    np.testing.assert_array_equal(output_mask, mask)
+    assert [call[0] for call in calls] == ["mask", "estimate", "apply"]
+    assert calls[-1][-1] is True
+
+
+def test_shared_echo_display_range_uses_all_echoes(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    input_min, input_max = sodiumgridding_ptpi._shared_echo_display_range(
+        [
+            np.asarray([[[0.0, 1.0]]], dtype=np.float32),
+            np.asarray([[[2.0, 7.0]]], dtype=np.float32),
+        ]
+    )
+
+    assert input_min == 0.0
+    assert input_max == 7.0
+
+
+def test_detect_echo_count_prefers_acquisition_contrast(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    class Idx:
+        def __init__(self, contrast):
+            self.contrast = contrast
+
+    class Head:
+        def __init__(self, contrast):
+            self.idx = Idx(contrast)
+
+    class Acquisition:
+        def __init__(self, contrast):
+            self._head = Head(contrast)
+
+        def getHead(self):
+            return self._head
+
+    count, source = sodiumgridding_ptpi._detect_echo_count(
+        [Acquisition(0), Acquisition(1), Acquisition(2), Acquisition(3)],
+        object(),
+        {"numechoes": 2},
+    )
+
+    assert count == 4
+    assert source == "acquisition contrast index"
+
+
+def test_detect_echo_count_uses_metadata_contrast_limits(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    class Contrast:
+        minimum = 0
+        maximum = 7
+
+    class EncodingLimits:
+        contrast = Contrast()
+
+    class Encoding:
+        encodingLimits = EncodingLimits()
+
+    class Metadata:
+        encoding = [Encoding()]
+
+    count, source = sodiumgridding_ptpi._detect_echo_count([], Metadata(), {"numechoes": 2})
+
+    assert count == 8
+    assert source == "MRD encodingLimits.contrast"
+
+
+def test_detect_echo_count_uses_single_metadata_contrast(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    class Contrast:
+        minimum = 0
+        maximum = 0
+
+    class EncodingLimits:
+        contrast = Contrast()
+
+    class Encoding:
+        encodingLimits = EncodingLimits()
+
+    class Metadata:
+        encoding = [Encoding()]
+
+    count, source = sodiumgridding_ptpi._detect_echo_count([], Metadata(), {})
+
+    assert count == 1
+    assert source == "MRD encodingLimits.contrast"
+
+
+def test_split_acquisitions_by_repetition_preserves_receive_order(monkeypatch):
+    sodiumgridding_ptpi = _import_sodiumgridding_ptpi_with_runtime_stubs(monkeypatch)
+
+    class Idx:
+        def __init__(self, repetition):
+            self.repetition = repetition
+
+    class Head:
+        def __init__(self, repetition):
+            self.idx = Idx(repetition)
+
+    class Acquisition:
+        def __init__(self, label, repetition):
+            self.label = label
+            self._head = Head(repetition)
+
+        def getHead(self):
+            return self._head
+
+    acquisitions = [
+        Acquisition("rep2-a", 2),
+        Acquisition("rep2-b", 2),
+        Acquisition("rep5-a", 5),
+        Acquisition("rep2-c", 2),
+        Acquisition("rep5-b", 5),
+    ]
+
+    groups = sodiumgridding_ptpi._split_acquisitions_by_repetition(acquisitions)
+
+    assert [repetition for repetition, _group in groups] == [2, 5]
+    assert [[item.label for item in group] for _repetition, group in groups] == [
+        ["rep2-a", "rep2-b", "rep2-c"],
+        ["rep5-a", "rep5-b"],
+    ]

--- a/recipes/sodiumgridding_ptpi/twix2mrd.py
+++ b/recipes/sodiumgridding_ptpi/twix2mrd.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+import ismrmrd
+import ismrmrd.xsd
+import numpy as np
+import twixtools
+
+
+DEFAULT_MATRIX_SIZE = 128
+DEFAULT_FOV_MM = 220.0
+
+
+def _clean_scalar(value, default=""):
+    if value is None:
+        return default
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="ignore")
+    if isinstance(value, np.generic):
+        value = value.item()
+    text = str(value).strip()
+    return text if text else default
+
+
+def _float_or_default(value, default):
+    try:
+        return float(value)
+    except Exception:
+        return float(default)
+
+
+def _int_or_default(value, default):
+    try:
+        return int(float(value))
+    except Exception:
+        return int(default)
+
+
+def _build_header(twix_header, matrix_size, fov_mm, protocol_name, measurement_id, num_readouts):
+    mrd_header = ismrmrd.xsd.ismrmrdHeader()
+
+    measurement_information = ismrmrd.xsd.measurementInformationType()
+    measurement_information.measurementID = measurement_id
+    measurement_information.protocolName = protocol_name
+    measurement_information.patientPosition = "HFS"
+    mrd_header.measurementInformation = measurement_information
+
+    acquisition_system_information = ismrmrd.xsd.acquisitionSystemInformationType()
+    dicom_header = twix_header.get("Dicom", {})
+    acquisition_system_information.systemVendor = _clean_scalar(
+        dicom_header.get("Manufacturer"),
+        "Siemens",
+    )
+    acquisition_system_information.systemModel = _clean_scalar(
+        dicom_header.get("ManufacturersModelName"),
+        "Unknown Siemens",
+    )
+    acquisition_system_information.systemFieldStrength_T = _float_or_default(
+        dicom_header.get("MagneticFieldStrength"),
+        7.0,
+    )
+    mrd_header.acquisitionSystemInformation = acquisition_system_information
+
+    experimental_conditions = ismrmrd.xsd.experimentalConditionsType()
+    experimental_conditions.H1resonanceFrequency_Hz = int(
+        round(42.577478518e6 * acquisition_system_information.systemFieldStrength_T)
+    )
+    mrd_header.experimentalConditions = experimental_conditions
+
+    encoding = ismrmrd.xsd.encodingType()
+    encoding.trajectory = ismrmrd.xsd.trajectoryType.OTHER
+
+    encoded_space = ismrmrd.xsd.encodingSpaceType()
+    encoded_space.matrixSize = ismrmrd.xsd.matrixSizeType()
+    encoded_space.matrixSize.x = matrix_size
+    encoded_space.matrixSize.y = matrix_size
+    encoded_space.matrixSize.z = matrix_size
+    encoded_space.fieldOfView_mm = ismrmrd.xsd.fieldOfViewMm()
+    encoded_space.fieldOfView_mm.x = fov_mm
+    encoded_space.fieldOfView_mm.y = fov_mm
+    encoded_space.fieldOfView_mm.z = fov_mm
+    encoding.encodedSpace = encoded_space
+
+    recon_space = ismrmrd.xsd.encodingSpaceType()
+    recon_space.matrixSize = ismrmrd.xsd.matrixSizeType()
+    recon_space.matrixSize.x = matrix_size
+    recon_space.matrixSize.y = matrix_size
+    recon_space.matrixSize.z = matrix_size
+    recon_space.fieldOfView_mm = ismrmrd.xsd.fieldOfViewMm()
+    recon_space.fieldOfView_mm.x = fov_mm
+    recon_space.fieldOfView_mm.y = fov_mm
+    recon_space.fieldOfView_mm.z = fov_mm
+    encoding.reconSpace = recon_space
+
+    encoding_limits = ismrmrd.xsd.encodingLimitsType()
+    encoding_limits.kspace_encoding_step_1 = ismrmrd.xsd.limitType()
+    encoding_limits.kspace_encoding_step_1.minimum = 0
+    encoding_limits.kspace_encoding_step_1.maximum = max(num_readouts - 1, 0)
+    encoding_limits.kspace_encoding_step_1.center = max(num_readouts // 2, 0)
+    encoding_limits.slice = ismrmrd.xsd.limitType()
+    encoding_limits.slice.minimum = 0
+    encoding_limits.slice.maximum = 0
+    encoding_limits.slice.center = 0
+    encoding.encodingLimits = encoding_limits
+
+    mrd_header.encoding.append(encoding)
+    return mrd_header
+
+
+def _populate_acquisition_header(acquisition, readout_index, measurement_uid):
+    header = acquisition.getHead()
+    header.measurement_uid = measurement_uid
+    header.scan_counter = readout_index
+    header.center_sample = acquisition.number_of_samples // 2
+    header.encoding_space_ref = 0
+    header.sample_time_us = 1.0
+    header.position = (0.0, 0.0, 0.0)
+    header.patient_table_position = (0.0, 0.0, 0.0)
+    header.read_dir = (1.0, 0.0, 0.0)
+    header.phase_dir = (0.0, 1.0, 0.0)
+    header.slice_dir = (0.0, 0.0, 1.0)
+    header.idx.kspace_encode_step_1 = readout_index
+    header.idx.kspace_encode_step_2 = 0
+    header.idx.slice = 0
+    acquisition.setHead(header)
+
+
+def convert_twix_to_mrd(input_file, output_file, group_name, matrix_size, fov_mm):
+    twix = twixtools.read_twix(input_file, parse_pmu=False)
+    measurement = twix[-1]
+    twix_header = measurement["hdr"]
+    protocol_name = _clean_scalar(
+        twix_header.get("MeasYaps", {}).get("tProtocolName"),
+        Path(input_file).stem,
+    )
+    measurement_uid = _int_or_default(twix_header.get("Meas", {}).get("MeasUID"), 0)
+
+    image_mdbs = [mdb for mdb in measurement["mdb"] if mdb.is_image_scan()]
+    if not image_mdbs:
+        raise RuntimeError(f"No imaging scans found in {input_file}")
+
+    mrd_dataset = ismrmrd.Dataset(output_file, group_name, create_if_needed=True)
+    try:
+        mrd_header = _build_header(
+            twix_header,
+            matrix_size=matrix_size,
+            fov_mm=fov_mm,
+            protocol_name=protocol_name,
+            measurement_id=Path(input_file).stem,
+            num_readouts=len(image_mdbs),
+        )
+        mrd_dataset.write_xml_header(bytes(mrd_header.toXML(), "utf-8"))
+
+        for readout_index, mdb in enumerate(image_mdbs):
+            acquisition_data = np.asarray(mdb.data, dtype=np.complex64)
+            acquisition = ismrmrd.Acquisition(data=acquisition_data)
+            _populate_acquisition_header(acquisition, readout_index, measurement_uid)
+            if readout_index == len(image_mdbs) - 1:
+                acquisition.setFlag(ismrmrd.ACQ_LAST_IN_MEASUREMENT)
+            mrd_dataset.append_acquisition(acquisition)
+    finally:
+        mrd_dataset.close()
+
+    print(
+        "Converted Twix imaging data to MRD:",
+        output_file,
+        f"(readouts={len(image_mdbs)}, coils={image_mdbs[0].data.shape[0]}, samples={image_mdbs[0].data.shape[1]})",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert Siemens Twix imaging scans to ISMRMRD HDF5.")
+    parser.add_argument("-f", "--file", required=True, help="Input Siemens .dat file")
+    parser.add_argument("-o", "--output", required=True, help="Output ISMRMRD HDF5 file")
+    parser.add_argument("-g", "--group", default="dataset", help="ISMRMRD group name")
+    parser.add_argument("--matrix-size", type=int, default=DEFAULT_MATRIX_SIZE, help="Reconstruction matrix size")
+    parser.add_argument("--fov-mm", type=float, default=DEFAULT_FOV_MM, help="Field of view in mm")
+    args = parser.parse_args()
+
+    convert_twix_to_mrd(
+        input_file=args.file,
+        output_file=args.output,
+        group_name=args.group,
+        matrix_size=max(1, int(args.matrix_size)),
+        fov_mm=float(args.fov_mm),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR updates `sodiumgridding_ptpi` from the initial v0.1.0 dual-echo prototype to the scanner-tested v0.1.9 pTPI OpenRecon container recipe.

The updated recipe supports multi-echo pTPI sodium reconstruction, single-echo fallback behavior, scanner-tested trajectory defaults, temporal SVD denoising, N4 bias correction, and updated FIRE/OpenRecon metadata defaults.

## Main Changes

- Updated recipe version from `0.1.0` to `0.1.9`.
- Generalized the reconstruction from fixed dual-echo input to variable multi-echo input.
- Added support for single-echo acquisitions.
  - Single-echo mode skips phase correction and temporal SVD denoising.
  - N4 bias correction can still run for single-echo data.
- Added support for multiple repetitions.
- Added bundled trajectory choices:
  - `23Na_pTPI_n28_g50_p5traj.h5`
  - `23Na_pTPI_n28_g70_p5traj.h5`
  - `23Na_pTPI_n50_g70_p5traj.h5`
- Set `23Na_pTPI_n28_g50_p5traj.h5` as the default trajectory.
- Added temporal SVD denoising along the echo dimension.
- Replaced the scanner-facing `maxcoils` parameter with `svdretainfraction`.
- Added shared echo display scaling so relative echo intensities are preserved on the scanner.
- Added echo-time handling from MRD metadata, with fallback to configured `fieldmapdeltates`.
- Added per-echo image metadata including echo index, contrast index, and echo time.
- Added repetition-aware metadata fields.
- Updated default scanner orientation settings:
  - `orientation = zyx_fy`
  - `orientationflipslice = true`
- Updated OpenRecon documentation for the multi-echo workflow and scanner parameters.
- Added tests covering multi-echo splitting, echo timing, SVD denoising, N4 behavior, display scaling, and repetition handling.

## Scanner Testing

The v0.1.9 behavior was tested on the scanner and was the best-performing version before later experimental metadata/name changes. This PR keeps v0.1.9 as the reference version going forward.