### PR TITLE
Build sodiumgriddingptpi 0.1.10

### DIFF
--- a/recipes/sodiumgriddingptpi/build.yaml
+++ b/recipes/sodiumgriddingptpi/build.yaml
@@ -1,5 +1,5 @@
 name: sodiumgriddingptpi
-version: 0.1.9
+version: 0.1.10
 
 copyright:
   - license: MIT

--- a/recipes/sodiumgriddingptpi/fulltest.yaml
+++ b/recipes/sodiumgriddingptpi/fulltest.yaml
@@ -2,7 +2,7 @@
 # Focused verification for the OpenRecon runtime, pTPI assets, and gridding dependencies.
 
 name: sodiumgriddingptpi
-version: 0.1.9
+version: 0.1.10
 
 test_data:
   output_dir: test_output


### PR DESCRIPTION
## Summary

- bump `sodiumgriddingptpi` from 0.1.9 to 0.1.10
- keep `fulltest.yaml` aligned with the recipe version

## Why

Build and publish the current SodiumGriddingPTPI recipe through the updated immutable PR candidate workflow.

## Validation

- `env/bin/python builder/validation.py recipes/sodiumgriddingptpi/build.yaml`
- `env/bin/python workflows/validate_openrecon_labels.py`
- `env/bin/python -m pytest recipes/sodiumgriddingptpi/test_sodiumgridding_ptpi.py -q` (18 passed)
- `env/bin/python -m builder generate sodiumgriddingptpi --recreate --architecture x86_64 --ignore-architectures`

## Post-merge automation check

The new candidate promotion workflow publishes the tested container and release metadata, but it does not invoke the legacy `build-app.yml` OpenRecon synchronization step. OpenRecon metadata synchronization therefore requires a follow-up unless that trigger is restored.