### PR TITLE
Fix candidate verification after squash merges

### DIFF
--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -183,13 +183,11 @@ def test_verify_candidate_binds_artifacts_to_pr_and_recipe(
     recipe_dir = write_recipe(tmp_path)
     monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
 
-    def build_date_for_head(recipe: str, revision: str = "HEAD") -> str:
-        """Return the deterministic fixture date for the expected PR head."""
-        assert recipe == "demo"
-        assert revision == "abc123"
-        return "20260721"
+    def unexpected_build_date(*args: object, **kwargs: object) -> str:
+        """Promotion must not require a squash-merged PR head in local Git."""
+        raise AssertionError("promotion tried to inspect the missing PR commit")
 
-    monkeypatch.setattr(one_pr_release, "build_date", build_date_for_head)
+    monkeypatch.setattr(one_pr_release, "build_date", unexpected_build_date)
     candidate_dir = tmp_path / "bundle" / "demo"
     candidate_dir.mkdir(parents=True)
     docker_archive = candidate_dir / "demo_1.2.3_20260721.docker.tar"
@@ -247,6 +245,18 @@ def test_verify_candidate_binds_artifacts_to_pr_and_recipe(
         raise AssertionError("tampered candidate tag was accepted")
     manifest["candidate_tag"] = "nd-candidate-demo:abc123"
 
+    manifest["build_date"] = "2026-07-21"
+    (candidate_dir / "manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    try:
+        one_pr_release.verify_candidate(candidate_dir, "abc123", 42)
+    except RuntimeError as error:
+        assert "Invalid build date" in str(error)
+    else:
+        raise AssertionError("unsafe candidate build date was accepted")
+    manifest["build_date"] = "20260721"
+
     manifest["docker_archive"] = "../outside.docker.tar"
     (candidate_dir / "manifest.json").write_text(
         json.dumps(manifest), encoding="utf-8"
@@ -296,9 +306,6 @@ def test_verify_candidate_rejects_a_variant_the_recipe_does_not_declare(
     """A candidate cannot invent a container identity to promote itself into."""
     write_recipe(tmp_path)
     monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(
-        one_pr_release, "build_date", lambda recipe, revision="HEAD": "20260721"
-    )
     candidate_dir = tmp_path / "bundle" / "demo_gpu"
     candidate_dir.mkdir(parents=True)
     manifest = {

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -26,6 +26,7 @@ from builder.variants import concrete_variant_specs
 
 REPO_ROOT = SCRIPT_REPO_ROOT
 VERSION_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+BUILD_DATE_PATTERN = re.compile(r"^[0-9]{8}$")
 RECIPE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 CANDIDATE_MANIFEST_FIELDS = (
     "recipe",
@@ -174,7 +175,12 @@ def resolve_variant(recipe: str, variant: str) -> dict[str, Any]:
     )
 
 
-def inspect_recipe(recipe: str, head_sha: str, variant: str = "") -> dict[str, str]:
+def inspect_recipe(
+    recipe: str,
+    head_sha: str,
+    variant: str = "",
+    candidate_build_date: str | None = None,
+) -> dict[str, str]:
     """Derive safe candidate names and release identifiers for a recipe variant."""
     data = load_recipe(recipe)
     if "version" not in data:
@@ -187,7 +193,13 @@ def inspect_recipe(recipe: str, head_sha: str, variant: str = "") -> dict[str, s
         )
     spec = resolve_variant(recipe, variant)
     container = validate_recipe_identifier(str(spec["name"]))
-    date = build_date(recipe, head_sha)
+    date = (
+        candidate_build_date
+        if candidate_build_date is not None
+        else build_date(recipe, head_sha)
+    )
+    if not isinstance(date, str) or not BUILD_DATE_PATTERN.fullmatch(date):
+        raise RuntimeError(f"Invalid build date for {container}: {date!r}")
     image_name = f"{container}_{version}"
     return {
         "recipe": recipe,
@@ -333,7 +345,18 @@ def verify_candidate(
     # Resolving the selector against the merged recipe is what stops a candidate
     # from inventing a container identity and promoting itself into an
     # unrelated releases/ directory.
-    expected_info = inspect_recipe(recipe, expected_head_sha, variant)
+    # A squash merge deliberately leaves the PR head outside main's history.
+    # The candidate job derived this date from that exact head before packaging;
+    # promotion binds the manifest back to the event head, PR, merged recipe
+    # fingerprint, artifact names, release JSON, and artifact checksums below.
+    # Reusing the validated candidate date avoids fetching PR-authored Git
+    # objects into this privileged pull_request_target job.
+    expected_info = inspect_recipe(
+        recipe,
+        expected_head_sha,
+        variant,
+        manifest.get("build_date"),
+    )
     container = expected_info["container"]
     if candidate_dir.name != container:
         raise RuntimeError(f"Candidate directory does not match container {container}")


### PR DESCRIPTION
## Summary
- verify candidate build dates from the exact-head manifest instead of requiring the squash-merged PR commit in the privileged checkout
- retain merged recipe fingerprint, PR/head identity, release JSON, artifact naming, and checksum validation
- add a regression test that fails if promotion tries to inspect the absent PR Git object

## Validation
- `pytest builder/tests` (229 passed)
- `codespell tools/one_pr_release.py builder/tests/test_one_pr_release.py`
- `git diff --check`

Fixes the failed SodiumGriddingPTPI promotion run 30872917082.