### PR TITLE
Install AWS CLI for candidate promotion

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -125,6 +125,16 @@ jobs:
           pip install -r requirements.txt python-swiftclient python-keystoneclient
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gh jq unzip
+          if ! command -v aws >/dev/null 2>&1; then
+            aws_archive="${RUNNER_TEMP}/awscliv2.zip"
+            aws_install_dir="${RUNNER_TEMP}/aws-cli"
+            curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+              -o "${aws_archive}"
+            unzip -q "${aws_archive}" -d "${aws_install_dir}"
+            sudo "${aws_install_dir}/aws/install"
+            rm -rf "${aws_archive}" "${aws_install_dir}"
+          fi
+          aws --version
       - name: Locate the successful run for the exact PR head
         id: candidate
         uses: actions/github-script@v7

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -91,6 +91,19 @@ def test_candidate_promotion_uses_trusted_main_oidc_identity() -> None:
     assert "PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}" in workflow
 
 
+def test_candidate_promotion_installs_aws_cli_before_s3_upload() -> None:
+    workflow = Path(
+        ".github/workflows/promote-container-candidate.yml"
+    ).read_text()
+
+    install_step = workflow.split("      - name: Install promotion dependencies", 1)[1]
+    install_step = install_step.split(
+        "      - name: Locate the successful run for the exact PR head", 1
+    )[0]
+    assert "awscli-exe-linux-x86_64.zip" in install_step
+    assert "aws --version" in install_step
+
+
 def test_manual_and_candidate_release_paths_share_openrecon_sync_helper() -> None:
     build_workflow = Path(".github/workflows/build-app.yml").read_text()
     promote_workflow = Path(


### PR DESCRIPTION
## Summary
- install AWS CLI v2 when it is absent from the self-hosted promotion runner
- verify the CLI before the blocking S3 upload step
- add a workflow contract test for the required dependency

## Validation
- `pytest builder/tests` (231 passed)
- focused workflow tests (25 passed)
- `codespell` on changed files
- `actionlint` (ignoring only the repository custom-runner label and pre-existing SC2295 diagnostic)
- `git diff --check`

Fixes `aws: command not found` in recovery run 30875301613. AWS OIDC assumption already passed in that run.