### PR TITLE
Add fail-closed recipe release planner

### DIFF
--- a/builder/release_plan.py
+++ b/builder/release_plan.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Mapping
+
+
+# Every top-level field accepted by ContainerRecipe must be assigned a role here.
+# The focused completeness test makes schema growth an explicit release-policy
+# decision instead of silently treating a new field as metadata-only.
+TOP_LEVEL_FIELD_TIERS: dict[str, frozenset[str]] = {
+    "name": frozenset({"candidate"}),
+    "version": frozenset({"candidate"}),
+    "architectures": frozenset({"candidate"}),
+    "build": frozenset({"candidate"}),
+    "variants": frozenset({"candidate"}),
+    "auto_update": frozenset({"source_only"}),
+    "icon": frozenset({"catalog"}),
+    "copyright": frozenset({"source_only"}),
+    "readme": frozenset({"source_only"}),
+    "readme_url": frozenset({"source_only"}),
+    "structured_readme": frozenset({"source_only"}),
+    "files": frozenset({"candidate"}),
+    "deploy": frozenset({"candidate", "catalog"}),
+    "tests": frozenset({"candidate"}),
+    "categories": frozenset({"metadata"}),
+    "show_in_menu": frozenset({"metadata"}),
+    "show_in_applist": frozenset({"metadata"}),
+    "gui_apps": frozenset({"metadata"}),
+    "apptainer_args": frozenset({"metadata"}),
+    "draft": frozenset({"source_only"}),
+    "description": frozenset({"source_only"}),
+    "options": frozenset({"candidate"}),
+    "variables": frozenset({"candidate"}),
+    "epoch": frozenset({"candidate"}),
+}
+
+# This first release-planner milestone intentionally enables only the proven,
+# hermetic case from #2994. Other roles are recorded above for completeness but
+# remain candidate-required until their post-merge publication paths exist.
+ENABLED_SOURCE_ONLY_FIELDS = frozenset({"auto_update"})
+KNOWN_NON_IMAGE_FILES = frozenset({"fulltest.yaml"})
+
+
+@dataclass(frozen=True)
+class RecipeDecision:
+    recipe: str
+    action: str
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReleasePlan:
+    decisions: tuple[RecipeDecision, ...]
+
+    @property
+    def changed_recipes(self) -> list[str]:
+        return [decision.recipe for decision in self.decisions]
+
+    @property
+    def candidate_recipes(self) -> list[str]:
+        return [
+            decision.recipe
+            for decision in self.decisions
+            if decision.action == "candidate"
+        ]
+
+    @property
+    def source_only_recipes(self) -> list[str]:
+        return [
+            decision.recipe
+            for decision in self.decisions
+            if decision.action == "source_only"
+        ]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "changed_recipes": self.changed_recipes,
+            "candidate_recipes": self.candidate_recipes,
+            "source_only_recipes": self.source_only_recipes,
+            "decisions": [
+                {
+                    "recipe": decision.recipe,
+                    "action": decision.action,
+                    "reasons": list(decision.reasons),
+                }
+                for decision in self.decisions
+            ],
+        }
+
+
+def recipe_names_from_paths(paths: list[str]) -> list[str]:
+    recipes = {
+        parts[1]
+        for path in paths
+        if len(parts := PurePosixPath(path).parts) >= 3
+        and parts[0] == "recipes"
+    }
+    return sorted(recipes)
+
+
+def _changed_top_level_fields(
+    base: Mapping[str, object], head: Mapping[str, object]
+) -> set[str]:
+    return {
+        key
+        for key in set(base) | set(head)
+        if key not in base or key not in head or base[key] != head[key]
+    }
+
+
+def plan_recipe_changes(
+    changed_paths: list[str],
+    base_recipes: Mapping[str, Mapping[str, object] | None],
+    head_recipes: Mapping[str, Mapping[str, object] | None],
+) -> ReleasePlan:
+    """Classify recipe changes without rendering or executing head-authored data.
+
+    Projection equality here means behavioural equivalence for release policy,
+    not byte equality of a hypothetical rebuilt image. The current image embeds
+    raw build.yaml and README.md; a source-only verdict deliberately preserves
+    the already-published artifact instead of rebuilding those provenance files.
+    """
+    decisions: list[RecipeDecision] = []
+    for recipe in recipe_names_from_paths(changed_paths):
+        recipe_prefix = f"recipes/{recipe}/"
+        relative_paths = {
+            path.removeprefix(recipe_prefix)
+            for path in changed_paths
+            if path.startswith(recipe_prefix)
+        }
+        base = base_recipes.get(recipe)
+        head = head_recipes.get(recipe)
+        if head is None:
+            raise ValueError(
+                f"Recipe removal or a missing recipes/{recipe}/build.yaml "
+                "requires an explicit migration"
+            )
+
+        candidate_reasons: list[str] = []
+        source_reasons: list[str] = []
+        build_yaml_changed = "build.yaml" in relative_paths
+        other_paths = relative_paths - {"build.yaml"} - KNOWN_NON_IMAGE_FILES
+
+        if other_paths:
+            candidate_reasons.append("recipe-file-changed")
+
+        if build_yaml_changed:
+            if base is None:
+                candidate_reasons.append("new-recipe")
+            else:
+                changed_fields = _changed_top_level_fields(base, head)
+                unknown = changed_fields - TOP_LEVEL_FIELD_TIERS.keys()
+                if unknown:
+                    candidate_reasons.append("unclassified-field")
+                elif not changed_fields:
+                    source_reasons.append("yaml-only-change")
+                elif changed_fields <= ENABLED_SOURCE_ONLY_FIELDS:
+                    source_reasons.append("auto-update-only")
+                else:
+                    candidate_reasons.append("recipe-definition-changed")
+
+        if candidate_reasons:
+            decisions.append(
+                RecipeDecision(recipe, "candidate", tuple(sorted(candidate_reasons)))
+            )
+        else:
+            if relative_paths <= KNOWN_NON_IMAGE_FILES:
+                source_reasons.append("test-only")
+            decisions.append(
+                RecipeDecision(
+                    recipe,
+                    "source_only",
+                    tuple(sorted(set(source_reasons) or {"non-image-change"})),
+                )
+            )
+
+    return ReleasePlan(tuple(decisions))

--- a/builder/tests/test_release_plan.py
+++ b/builder/tests/test_release_plan.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import attrs
+
+from builder.release_plan import TOP_LEVEL_FIELD_TIERS, plan_recipe_changes
+from builder.validation import ContainerRecipe
+
+
+def recipe(**updates: object) -> dict[str, object]:
+    data: dict[str, object] = {
+        "name": "demo",
+        "version": "1.2.3",
+        "architectures": ["x86_64"],
+        "build": {
+            "kind": "neurodocker",
+            "base-image": "ubuntu:24.04",
+            "pkg-manager": "apt",
+            "directives": [],
+        },
+        "categories": ["programming"],
+    }
+    data.update(updates)
+    return data
+
+
+def test_every_validated_top_level_field_has_a_release_tier() -> None:
+    accepted = {field.name for field in attrs.fields(ContainerRecipe)}
+
+    assert set(TOP_LEVEL_FIELD_TIERS) == accepted
+
+
+def test_auto_update_only_change_is_source_only() -> None:
+    base = recipe()
+    head = recipe(
+        auto_update={"method": "github_release", "repo": "example/demo"}
+    )
+
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml"], {"demo": base}, {"demo": head}
+    )
+
+    assert plan.candidate_recipes == []
+    assert plan.source_only_recipes == ["demo"]
+    assert plan.decisions[0].reasons == ("auto-update-only",)
+
+
+def test_semantically_unchanged_yaml_is_source_only() -> None:
+    data = recipe()
+
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml"], {"demo": data}, {"demo": dict(data)}
+    )
+
+    assert plan.candidate_recipes == []
+    assert plan.decisions[0].reasons == ("yaml-only-change",)
+
+
+def test_runtime_recipe_field_change_requires_candidate() -> None:
+    base = recipe()
+    head = recipe(version="1.2.4")
+
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml"], {"demo": base}, {"demo": head}
+    )
+
+    assert plan.candidate_recipes == ["demo"]
+    assert plan.decisions[0].reasons == ("recipe-definition-changed",)
+
+
+def test_recipe_local_helper_change_requires_candidate_without_build_yaml() -> None:
+    data = recipe()
+
+    plan = plan_recipe_changes(
+        ["recipes/demo/install.sh"], {"demo": data}, {"demo": data}
+    )
+
+    assert plan.candidate_recipes == ["demo"]
+    assert plan.decisions[0].reasons == ("recipe-file-changed",)
+
+
+def test_fulltest_only_change_does_not_rebuild_image() -> None:
+    data = recipe()
+
+    plan = plan_recipe_changes(
+        ["recipes/demo/fulltest.yaml"], {"demo": data}, {"demo": data}
+    )
+
+    assert plan.candidate_recipes == []
+    assert plan.decisions[0].reasons == ("test-only",)
+
+
+def test_unclassified_field_fails_closed_to_candidate() -> None:
+    base = recipe()
+    # A null-valued addition must still count as a field change; comparing
+    # Mapping.get() values would incorrectly equate it with an absent key.
+    head = recipe(future_runtime_field=None)
+
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml"], {"demo": base}, {"demo": head}
+    )
+
+    assert plan.candidate_recipes == ["demo"]
+    assert plan.decisions[0].reasons == ("unclassified-field",)


### PR DESCRIPTION
## What changed

- add a trusted release-planning module that classifies recipe changes without rendering Jinja
- enable only the proven `auto_update`-only, semantic-YAML-only, and `fulltest.yaml`-only source-only cases
- fail closed for runtime fields, unknown fields, new recipes, removals, and recipe-local build inputs
- assert that every validated top-level recipe field has an explicit release tier

## Why

Issue #2994 cannot be solved by comparing staged build contexts because every image embeds the raw `build.yaml` and README. This planner instead records a behavioural release projection while preserving the existing published artifact for source-only changes.

This is the first rollout step only. It does not wire the planner into Actions yet, so the required gate continues to use trusted code already on `main`.

## Container-build safety

This PR changes only `builder/release_plan.py` and its unit tests. It does not touch `recipes/**`, so the container candidate workflow receives no build targets and no container is built.

## Checks

- `env/bin/python -m pytest builder/tests -q` — 244 passed
- exact replay of PR #2989 — 0 candidates, 63 source-only recipes
- codespell, YAML parsing, and `git diff --check`