### PR TITLE
Use release planner for candidate promotion

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -24,6 +24,8 @@ jobs:
     outputs:
       recipes: ${{ steps.detect.outputs.recipes }}
       targets: ${{ steps.detect.outputs.targets }}
+      changed_recipes: ${{ steps.detect.outputs.changed_recipes }}
+      source_only_recipes: ${{ steps.detect.outputs.source_only_recipes }}
     steps:
       # Run detection from the trusted base revision. A fork cannot change the
       # policy script before it decides that the PR is recipe-only.
@@ -59,10 +61,10 @@ jobs:
           python ../trusted/tools/one_pr_release.py --repo-root . detect \
             --base "${BASE_SHA}" --head "${HEAD_SHA}"
       - name: Validate changed recipes and OpenRecon metadata
-        if: steps.detect.outputs.recipes != '[]'
+        if: steps.detect.outputs.changed_recipes != '[]'
         working-directory: source
         env:
-          RECIPES: ${{ steps.detect.outputs.recipes }}
+          RECIPES: ${{ steps.detect.outputs.changed_recipes }}
         run: |
           python workflows/validate_openrecon_labels.py
           python - <<'PY'
@@ -267,7 +269,7 @@ jobs:
         run: |
           test "${DETECT_RESULT}" = success
           if [ "${RECIPES}" = "[]" ]; then
-            echo "No recipe changes in this pull request; nothing to build."
+            echo "The release planner requires no candidate builds for this pull request."
             exit 0
           fi
           test "${CANDIDATE_RESULT}" = success

--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -61,7 +61,12 @@ jobs:
           python ../trusted/tools/one_pr_release.py --repo-root . detect \
             --base "${BASE_SHA}" --head "${HEAD_SHA}"
       - name: Validate changed recipes and OpenRecon metadata
-        if: steps.detect.outputs.changed_recipes != '[]'
+        # During the rollout PR, trusted base code does not emit the new output
+        # yet. Treat a missing output as no work so this workflow can land before
+        # later PRs start relying on the planner from main.
+        if: >-
+          steps.detect.outputs.changed_recipes != '' &&
+          steps.detect.outputs.changed_recipes != '[]'
         working-directory: source
         env:
           RECIPES: ${{ steps.detect.outputs.changed_recipes }}

--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -14,15 +14,10 @@ on:
   push:
     branches: [main]
     paths:
-      # Must stay aligned with detect_recipes() in tools/one_pr_release.py, which
-      # only treats a PR as a candidate PR when a recipes/*/build.yaml changed.
-      # On "recipes/**" this fired for fulltest-, icon- and README-only PRs, which
-      # build no candidate: detect returns [], the candidate job is skipped, the
-      # gate short-circuits to success, and promote then threw "No unexpired
-      # candidate artifacts found" on a PR that was never supposed to publish.
-      # PR #2990 is the worked example. Every build.yaml sits at exactly this
-      # depth, and GitHub's `*` does not cross `/`, so this matches all of them.
-      - "recipes/*/build.yaml"
+      # The trusted resolve job runs the same release planner as the PR gate and
+      # schedules artifact promotion only when that plan contains candidates.
+      # This broad trigger also catches recipe-local build inputs such as scripts.
+      - "recipes/**"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,12 +25,7 @@ on:
         required: true
         type: number
 
-permissions:
-  actions: read
-  contents: write
-  id-token: write
-  packages: write
-  pull-requests: read
+permissions: {}
 
 concurrency:
   group: promote-container-and-metadata
@@ -51,6 +41,12 @@ jobs:
       should_promote: ${{ steps.pr.outputs.should_promote }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
+      merge_sha: ${{ steps.pr.outputs.merge_sha }}
+      recipes: ${{ steps.plan.outputs.recipes }}
+      release_plan: ${{ steps.plan.outputs.release_plan }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Resolve trusted main event to a merged recipe PR
         id: pr
@@ -92,14 +88,49 @@ jobs:
             if (!pr.merged_at || pr.base.ref !== 'main') {
               throw new Error(`PR #${pr.number} is not merged into main`);
             }
+            const mergeSha = context.eventName === 'workflow_dispatch'
+              ? pr.merge_commit_sha
+              : context.sha;
+            if (!mergeSha) {
+              throw new Error(`PR #${pr.number} has no merge commit SHA`);
+            }
             core.setOutput('should_promote', 'true');
             core.setOutput('pr_number', String(pr.number));
             core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('merge_sha', mergeSha);
+      - name: Checkout trusted main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install release planner dependencies
+        run: pip install pyyaml
+      - name: Plan merged recipe changes
+        id: plan
+        if: steps.pr.outputs.should_promote == 'true'
+        env:
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+        run: |
+          base_sha="$(git rev-parse "${MERGE_SHA}^1")"
+          python tools/one_pr_release.py --repo-root . detect \
+            --base "${base_sha}" --head "${MERGE_SHA}"
 
   promote:
     needs: resolve
-    if: needs.resolve.outputs.should_promote == 'true'
+    if: >-
+      needs.resolve.outputs.should_promote == 'true' &&
+      needs.resolve.outputs.recipes != '[]'
     runs-on: neurodesk-syd-arcrunner-neurocontainers
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      packages: write
+      pull-requests: read
     steps:
       - name: Create narrowly scoped release token
         id: app-token

--- a/.github/workflows/report-container-candidate.yml
+++ b/.github/workflows/report-container-candidate.yml
@@ -61,14 +61,14 @@ jobs:
               per_page: 100,
             });
             const changedRecipes = [...new Set(changedFiles
-              .map(file => file.filename.match(/^recipes\/([^/]+)\/build\.yaml$/))
+              .map(file => file.filename.match(/^recipes\/([^/]+)\//))
               .filter(Boolean)
               .map(match => match[1]))].sort();
 
             // The release gate runs on every PR because it is a required check.
             // Ordinary non-recipe PRs should not receive a container-build email.
             if (changedRecipes.length === 0) {
-              core.info('No build.yaml changes; no container approval comment is needed.');
+              core.info('No recipe build candidates; no container approval comment is needed.');
               return;
             }
 
@@ -88,6 +88,11 @@ jobs:
                 !artifact.name.startsWith('candidate-report-')
               )
               .map(artifact => artifact.name);
+            const candidateJobs = jobs.filter(job => job.name.startsWith('candidate ('));
+            if (candidateJobs.length === 0 && run.conclusion === 'success') {
+              core.info('The trusted release planner classified the recipe changes as source-only.');
+              return;
+            }
 
             const reportFiles = [];
             const walk = directory => {
@@ -174,7 +179,6 @@ jobs:
             const validation = stepConclusion(
               detectJob, 'Validate changed recipes and OpenRecon metadata'
             );
-            const candidateJobs = jobs.filter(job => job.name.startsWith('candidate ('));
             const parsedJobs = new Map();
             for (const job of candidateJobs) {
               const match = job.name.match(

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -88,12 +88,21 @@ def test_load_recipe_wraps_read_and_yaml_errors(tmp_path: Path, monkeypatch) -> 
 
 def test_detect_recipes_accepts_recipe_only_change(tmp_path: Path, monkeypatch) -> None:
     """Recipe-only changes are eligible for candidate builds."""
-    write_recipe(tmp_path)
+    recipe_dir = write_recipe(tmp_path)
     monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(
         one_pr_release,
         "changed_files",
         lambda base, head: ["recipes/demo/build.yaml", "recipes/demo/fulltest.yaml"],
+    )
+    head_recipe = yaml.safe_load(
+        (recipe_dir / "build.yaml").read_text(encoding="utf-8")
+    )
+    base_recipe = {**head_recipe, "version": "1.2.2"}
+    monkeypatch.setattr(
+        one_pr_release,
+        "load_recipe_at",
+        lambda revision, recipe: base_recipe if revision == "base" else head_recipe,
     )
 
     assert one_pr_release.detect_recipes("base", "head") == ["demo"]
@@ -114,12 +123,21 @@ def test_detect_recipes_allows_pr_without_recipes(tmp_path: Path, monkeypatch) -
 
 def test_detect_recipes_rejects_mixed_pr(tmp_path: Path, monkeypatch) -> None:
     """Mixed automation and recipe changes cannot cross the trust boundary."""
-    write_recipe(tmp_path)
+    recipe_dir = write_recipe(tmp_path)
     monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(
         one_pr_release,
         "changed_files",
         lambda base, head: ["recipes/demo/build.yaml", ".github/workflows/unsafe.yml"],
+    )
+    head_recipe = yaml.safe_load(
+        (recipe_dir / "build.yaml").read_text(encoding="utf-8")
+    )
+    base_recipe = {**head_recipe, "version": "1.2.2"}
+    monkeypatch.setattr(
+        one_pr_release,
+        "load_recipe_at",
+        lambda revision, recipe: base_recipe if revision == "base" else head_recipe,
     )
 
     try:
@@ -140,6 +158,15 @@ def test_detect_recipes_requires_fulltest(tmp_path: Path, monkeypatch) -> None:
         "changed_files",
         lambda base, head: ["recipes/demo/build.yaml"],
     )
+    head_recipe = yaml.safe_load(
+        (recipe_dir / "build.yaml").read_text(encoding="utf-8")
+    )
+    base_recipe = {**head_recipe, "version": "1.2.2"}
+    monkeypatch.setattr(
+        one_pr_release,
+        "load_recipe_at",
+        lambda revision, recipe: base_recipe if revision == "base" else head_recipe,
+    )
 
     try:
         one_pr_release.detect_recipes("base", "head")
@@ -147,6 +174,24 @@ def test_detect_recipes_requires_fulltest(tmp_path: Path, monkeypatch) -> None:
         assert "fulltest.yaml is required" in str(error)
     else:
         raise AssertionError("recipe without fulltest was accepted")
+
+
+def test_detect_recipes_catches_recipe_helper_without_build_yaml(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A changed build input cannot silently bypass the candidate gate."""
+    recipe_dir = write_recipe(tmp_path)
+    (recipe_dir / "install.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        one_pr_release,
+        "changed_files",
+        lambda base, head: ["recipes/demo/install.sh"],
+    )
+    data = yaml.safe_load((recipe_dir / "build.yaml").read_text(encoding="utf-8"))
+    monkeypatch.setattr(one_pr_release, "load_recipe_at", lambda revision, recipe: data)
+
+    assert one_pr_release.detect_recipes("base", "head") == ["demo"]
 
 
 def test_inspect_recipe_rejects_missing_or_unsafe_version(

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -54,7 +54,9 @@ def test_candidate_workflow_reports_every_premerge_check_in_one_comment() -> Non
     assert "Container build approval" in reporter
     assert "Deploy + fulltest" in reporter
     assert "What happens after merge" in reporter
-    assert "No build.yaml changes; no container approval comment is needed" in reporter
+    assert "No recipe build candidates; no container approval comment is needed" in reporter
+    assert "classified the recipe changes as source-only" in reporter
+    assert "file.filename.match(/^recipes\\/([^/]+)\\//)" in reporter
     assert reporter.count("github.rest.issues.createComment") == 1
     assert "github.rest.issues.updateComment" in reporter
     assert "createComment" not in validator
@@ -108,9 +110,26 @@ def test_candidate_promotion_uses_trusted_main_oidc_identity() -> None:
     assert "pull_request_target:" not in workflow
     assert "listPullRequestsAssociatedWithCommit" in workflow
     assert "item.merge_commit_sha === context.sha" in workflow
-    assert "if: needs.resolve.outputs.should_promote == 'true'" in workflow
+    assert "needs.resolve.outputs.should_promote == 'true' &&" in workflow
+    assert "needs.resolve.outputs.recipes != '[]'" in workflow
     assert "HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}" in workflow
     assert "PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}" in workflow
+
+
+def test_pr_and_postmerge_workflows_share_the_release_planner() -> None:
+    candidate = Path(".github/workflows/pr-container-candidate.yml").read_text()
+    promotion = Path(
+        ".github/workflows/promote-container-candidate.yml"
+    ).read_text()
+
+    planner = "python tools/one_pr_release.py --repo-root . detect"
+    assert "../trusted/tools/one_pr_release.py --repo-root . detect" in candidate
+    assert planner in promotion
+    assert 'steps.detect.outputs.changed_recipes != \'[]\'' in candidate
+    assert 'RECIPES: ${{ steps.detect.outputs.changed_recipes }}' in candidate
+    assert '- "recipes/**"' in promotion
+    assert 'needs.resolve.outputs.recipes != \'[]\'' in promotion
+    assert "permissions: {}" in promotion
 
 
 def test_candidate_promotion_installs_aws_cli_before_s3_upload() -> None:

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -125,6 +125,7 @@ def test_pr_and_postmerge_workflows_share_the_release_planner() -> None:
     planner = "python tools/one_pr_release.py --repo-root . detect"
     assert "../trusted/tools/one_pr_release.py --repo-root . detect" in candidate
     assert planner in promotion
+    assert "steps.detect.outputs.changed_recipes != ''" in candidate
     assert 'steps.detect.outputs.changed_recipes != \'[]\'' in candidate
     assert 'RECIPES: ${{ steps.detect.outputs.changed_recipes }}' in candidate
     assert '- "recipes/**"' in promotion

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -22,6 +22,11 @@ if str(SCRIPT_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPT_REPO_ROOT))
 
 from builder.release import release_data
+from builder.release_plan import (
+    ReleasePlan,
+    plan_recipe_changes,
+    recipe_names_from_paths,
+)
 from builder.variants import concrete_variant_specs
 
 REPO_ROOT = SCRIPT_REPO_ROOT
@@ -99,33 +104,51 @@ def changed_files(base: str, head: str) -> list[str]:
     return [line for line in output.splitlines() if line]
 
 
-def detect_recipes(base: str, head: str) -> list[str]:
-    """Return changed recipes after enforcing the recipe-only PR boundary."""
-    paths = changed_files(base, head)
-    recipes = {
-        parts[1]
-        for path in paths
-        if len(parts := Path(path).parts) >= 3
-        and parts[0] == "recipes"
-        and parts[2] == "build.yaml"
-    }
-    if not recipes:
-        # Not an error: the release gate is a required status check, so it also
-        # runs on pull requests that touch no recipe. An empty list tells the
-        # workflow there is nothing to build.
-        return []
+def load_recipe_at(revision: str, recipe: str) -> dict[str, Any] | None:
+    """Load build.yaml from a Git tree without rendering PR-authored templates."""
+    relative = f"recipes/{recipe}/build.yaml"
+    present = run_git("ls-tree", "--name-only", revision, "--", relative)
+    if present != relative:
+        return None
+    try:
+        data = yaml.safe_load(run_git("show", f"{revision}:{relative}"))
+    except yaml.YAMLError as error:
+        raise RuntimeError(
+            f"Unable to parse {relative} at {revision}: {error}"
+        ) from error
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Recipe {relative} at {revision} must be a YAML mapping")
+    return data
 
-    allowed = tuple(f"recipes/{recipe}/" for recipe in recipes)
+
+def release_plan(base: str, head: str) -> ReleasePlan:
+    """Plan recipe work from Git trees using trusted, non-rendering policy."""
+    paths = changed_files(base, head)
+    names = recipe_names_from_paths(paths)
+    plan = plan_recipe_changes(
+        paths,
+        {recipe: load_recipe_at(base, recipe) for recipe in names},
+        {recipe: load_recipe_at(head, recipe) for recipe in names},
+    )
+    if not plan.candidate_recipes:
+        return plan
+
+    allowed = tuple(f"recipes/{recipe}/" for recipe in plan.changed_recipes)
     unrelated = [path for path in paths if not path.startswith(allowed)]
     if unrelated:
         raise RuntimeError(
             "Automated releases require a recipe-only PR. Unrelated paths: "
             + ", ".join(unrelated)
         )
-    for recipe in recipes:
+    for recipe in plan.candidate_recipes:
         if not (REPO_ROOT / "recipes" / recipe / "fulltest.yaml").is_file():
             raise RuntimeError(f"recipes/{recipe}/fulltest.yaml is required")
-    return sorted(recipes)
+    return plan
+
+
+def detect_recipes(base: str, head: str) -> list[str]:
+    """Return only recipes whose planned change requires a candidate build."""
+    return release_plan(base, head).candidate_recipes
 
 
 def build_date(recipe: str, revision: str = "HEAD") -> str:
@@ -253,11 +276,15 @@ def detect_targets(recipes: list[str]) -> list[dict[str, str]]:
 
 def command_detect(args: argparse.Namespace) -> None:
     """Implement the detect CLI command."""
-    recipes = detect_recipes(args.base, args.head)
+    plan = release_plan(args.base, args.head)
+    recipes = plan.candidate_recipes
     write_output(
         {
             "recipes": json.dumps(recipes),
             "targets": json.dumps(detect_targets(recipes)),
+            "changed_recipes": json.dumps(plan.changed_recipes),
+            "source_only_recipes": json.dumps(plan.source_only_recipes),
+            "release_plan": json.dumps(plan.as_dict(), separators=(",", ":")),
         }
     )
 

--- a/workflows/ONE_PR_RELEASES.md
+++ b/workflows/ONE_PR_RELEASES.md
@@ -20,7 +20,9 @@ artifacts after merge. They no longer create a second release-metadata PR.
    only compact, schema-checked JSON summaries; it never opens candidate images
    or test logs.
 4. `Container release gate` is the stable required check for branch rules.
-5. After merge, `Promote merged container candidate` selects the successful run
+5. After merge, `Promote merged container candidate` runs the same trusted
+   release planner over the merge commit. It exits successfully when no
+   candidate was required; otherwise it selects the successful run
    for the exact PR head SHA. It verifies the PR number, recipe fingerprint,
    artifact hashes, and release metadata before publishing the tested files.
    The variant a candidate claims is re-resolved against the merged recipe, so a
@@ -49,6 +51,22 @@ second build.
   token to preserve anonymous pulls after the first push.
 - Keep ARC runners ephemeral. Fork approval remains the point where maintainers
   decide whether untrusted recipe build commands may run.
+
+## Release planning
+
+The planner reads the base and head `build.yaml` files as YAML data. It does not
+render Jinja or execute any code from the pull request. Changes that affect only
+`auto_update`, semantically unchanged YAML, or `fulltest.yaml` are currently
+classified as source-only: they are validated, but the existing container is
+preserved and no candidate is built or promoted. This is a behavioural release
+projection, not a claim that rebuilding would produce byte-identical images;
+the current image still embeds the raw `build.yaml` and README.
+
+Every other recipe definition change is deliberately fail-closed and requires
+a candidate. A changed recipe-local file such as `install.sh` also requires a
+candidate even when `build.yaml` itself is unchanged. The explicit top-level
+field policy is checked against the accepted recipe schema so adding a field
+cannot silently broaden the source-only tier.
 
 Registry and object-storage credentials are the same secrets used by the legacy
 build workflow. GHCR and S3 are release-critical; Docker Hub, Nectar, and Quay


### PR DESCRIPTION
## What changed

- use the trusted release planner when detecting PR candidate builds
- validate all changed recipes even when the planner preserves the existing image
- detect recipe-local build inputs such as helper scripts when `build.yaml` is unchanged
- run the same planner in the trusted post-merge resolver and skip promotion when it returns no candidates
- broaden the promotion trigger to `recipes/**` now that the resolver can distinguish source-only changes
- avoid container-approval comments when a successful run has no candidate jobs
- document the behavioural-projection tradeoff and fail-closed policy

## Why

The previous detector only noticed `recipes/*/build.yaml`, so helper-script changes silently built nothing. Conversely, comparing staged contexts would classify every `auto_update` edit as different because the raw recipe is copied into the image. The shared planner fixes both sides and keeps PR and post-merge decisions aligned.

## Container-build safety for this rollout

This PR contains no `recipes/**` changes. Running the trusted planner against `main...HEAD` returns `recipes=[]` and `targets=[]`, so the candidate matrix is skipped and no container is built. The post-merge promotion workflow also is not triggered by merging this PR because its push filter remains recipe-path scoped.

## Checks

- `env/bin/python -m pytest builder/tests -q` — 244 passed
- `python tools/one_pr_release.py ... --base origin/main --head HEAD` — `recipes=[]`, `targets=[]`
- exact replay of PR #2989 — 0 candidates, 63 source-only recipes
- codespell and `git diff --check`