### PR TITLE
Refresh promotion credentials before metadata push

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -206,21 +206,12 @@ jobs:
       packages: write
       pull-requests: read
     steps:
-      - name: Create narrowly scoped release token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.NEUROCONTAINERS_RELEASE_APP_ID }}
-          private-key: ${{ secrets.NEUROCONTAINERS_RELEASE_APP_PRIVATE_KEY }}
-          permission-contents: write
       - name: Checkout trusted main
         uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-          # Intentionally retained for the final ruleset-authorized metadata push.
-          persist-credentials: true
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -425,10 +416,21 @@ jobs:
               echo "::warning::Optional Quay SIF attach failed for ${container}"
             cd "${GITHUB_WORKSPACE}"
           done
+      # Candidate downloads and multi-registry publication can take longer than
+      # a GitHub App installation token's one-hour lifetime. Mint the
+      # ruleset-authorized token only when the metadata is ready to be pushed.
+      - name: Create fresh release token for metadata push
+        id: metadata-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.NEUROCONTAINERS_RELEASE_APP_ID }}
+          private-key: ${{ secrets.NEUROCONTAINERS_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Commit generated release metadata directly to main
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          RELEASE_TOKEN: ${{ steps.metadata-token.outputs.token }}
         run: |
           python tools/one_pr_release.py materialize --bundle promotion-bundle \
             --manifests verified-manifests.json
@@ -439,8 +441,12 @@ jobs:
             exit 0
           fi
           git commit -m "Publish tested container release metadata [skipci]"
+          basic_auth="$(printf 'x-access-token:%s' "${RELEASE_TOKEN}" | base64 | tr -d '\n')"
+          git_auth_header="AUTHORIZATION: basic ${basic_auth}"
+          unset basic_auth
           for attempt in 1 2 3; do
-            if ! git pull --rebase origin main; then
+            if ! git -c http.https://github.com/.extraheader="${git_auth_header}" \
+                pull --rebase origin main; then
               git rebase --abort || true
               sleep $((attempt * 5))
               continue
@@ -448,7 +454,8 @@ jobs:
             python tools/one_pr_release.py verify --bundle promotion-bundle \
               --head-sha "${HEAD_SHA}" --pr-number "${PR_NUMBER}" \
               --output verified-manifests.json
-            if git push origin HEAD:main; then
+            if git -c http.https://github.com/.extraheader="${git_auth_header}" \
+                push origin HEAD:main; then
               exit 0
             fi
             sleep $((attempt * 5))

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -233,6 +233,29 @@ def test_candidate_promotion_preserves_optional_publish_behaviour() -> None:
     assert workflow.count('org.opencontainers.image.version=${version}_${build_date}') == 2
 
 
+def test_candidate_promotion_refreshes_auth_after_long_publication() -> None:
+    workflow = Path(
+        ".github/workflows/promote-container-candidate.yml"
+    ).read_text()
+
+    checkout = workflow.split("      - name: Checkout trusted main", 1)[1].split(
+        "      - uses: actions/setup-python@v6", 1
+    )[0]
+    token_step = "      - name: Create fresh release token for metadata push"
+    metadata_step = "      - name: Commit generated release metadata directly to main"
+
+    assert "persist-credentials: false" in checkout
+    assert workflow.index("      - name: Attach tested SIFs to OCI images") < workflow.index(
+        token_step
+    )
+    assert workflow.index(token_step) < workflow.index(metadata_step)
+    metadata = workflow.split(metadata_step, 1)[1].split(
+        "      - name: Sync OpenRecon metadata", 1
+    )[0]
+    assert "RELEASE_TOKEN: ${{ steps.metadata-token.outputs.token }}" in metadata
+    assert metadata.count('http.https://github.com/.extraheader="${git_auth_header}"') == 2
+
+
 def test_manual_and_candidate_release_paths_share_openrecon_sync_helper() -> None:
     build_workflow = Path(".github/workflows/build-app.yml").read_text()
     promote_workflow = Path(


### PR DESCRIPTION
## What

- checkout trusted main without retaining an authentication token
- mint the ruleset-authorized GitHub App token immediately before release metadata publication
- pass the fresh credential only to the rebase and push commands
- add a workflow contract that protects token creation ordering

## Why

Container promotion can take longer than the one-hour lifetime of a GitHub App installation token. Run 31164066589 created its token at 09:01 and attempted the metadata push at 10:25, after the token had expired. Images and SIFs published successfully, but the release metadata commit could not authenticate.

## Validation

- builder workflow contract tests: 32 passed
- complete builder suite: 250 passed
- workflow YAML parsed successfully
- git diff --check passed
