### PR TITLE
Add VirGL bridge support to Neurodesktop

### DIFF
--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -147,6 +147,7 @@ build:
         - unzip
         - uuid-dev
         - vim
+        - virgl-server
         - wget
         - xdg-utils
         - xz-utils

--- a/recipes/neurodesktop-lite/fulltest.yaml
+++ b/recipes/neurodesktop-lite/fulltest.yaml
@@ -46,6 +46,7 @@ tests:
         command -v jupyter
         command -v code-server
         command -v apptainer
+        command -v virgl_test_server
         test -x /usr/lib/xorg/Xorg
         ! command -v guacd
         ! command -v Xvnc


### PR DESCRIPTION
## What changed

- install Ubuntu's `virgl-server` package in `neurodesktop-lite`
- require `virgl_test_server` in the existing core-runtime image smoke test

## Why

NeurodeskAppX runs amd64 CVMFS applications under QEMU linux-user on ARM64 hosts. DRM file descriptors from GLX DRI2 cannot cross that emulation boundary, so Mesa falls back to llvmpipe. NeurodeskAppX's opt-in GPU mode uses the vtest/virpipe transport instead; the image needs the small native ARM64 vtest server for that bridge.

The service remains disabled by default and is only started by NeurodeskAppX after a user enables experimental GPU acceleration.

## Validation

- `uv run --with attrs --with pyyaml python builder/validation.py recipes/neurodesktop-lite/build.yaml`
- `python -m builder generate neurodesktop-lite --architecture aarch64 --recreate`
- confirmed the generated Dockerfile installs `virgl-server`
- built the resulting package layer on ARM64 and verified MRView reports `virgl (vmsh Darwin VirGL)`, OpenGL 4.1 core, GLSL 4.10
