### PR TITLE
Harden Neurodesktop Glass and accelerated app compatibility

### DIFF
--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -293,6 +293,7 @@ build:
         - install -m 0755 /tmp/config/jupyter/deferred_startup.sh /opt/neurodesktop/deferred_startup.sh
         - install -m 0755 /tmp/config/jupyter/nested_container_runtime.sh /opt/neurodesktop/nested_container_runtime.sh
         - install -m 0755 /tmp/config/jupyter/environment_variables.sh /opt/neurodesktop/environment_variables.sh
+        - install -m 0755 /tmp/config/jupyter/cpuinfo_compat.sh /usr/local/sbin/neurodesktop-cpuinfo-compat
         - install -m 0755 /tmp/config/jupyter/kernel_wrapper.sh /opt/neurodesktop/kernel_wrapper.sh
         - install -m 0755 /tmp/config/jupyter/jupyterlmod_modulepath.py /opt/neurodesktop/jupyterlmod_modulepath.py
         - install -m 0755 /tmp/config/slurm/setup_and_start_slurm.sh /opt/neurodesktop/setup_and_start_slurm.sh
@@ -407,6 +408,7 @@ build:
         - install -m 0755 {{ get_file("glass_jupyter_launcher") }} /usr/local/bin/neurodesktop-start-jupyter
         - install -m 0755 {{ get_file("glass_prepare") }} /usr/local/sbin/neurodesktop-glass-prepare
         - install -m 0644 {{ get_file("glass_service") }} /etc/systemd/system/neurodesktop-glass.service
+        - install -m 0644 {{ get_file("glass_virgl_service") }} /etc/systemd/system/neurodesktop-virgl.service
         - install -m 0644 {{ get_file("glass_jupyter_service") }} /etc/systemd/system/neurodesktop-jupyter.service
         - install -m 0644 {{ get_file("glass_target") }} /etc/systemd/system/glass.target
         - install -m 0644 {{ get_file("glass_xorg_config") }} /etc/X11/xorg.conf
@@ -417,6 +419,7 @@ build:
         - if [ -x /usr/bin/systemctl.orig ]; then mv -f /usr/bin/systemctl.orig /usr/bin/systemctl; fi
         - mkdir -p /etc/systemd/system/glass.target.wants
         - ln -sf /etc/systemd/system/neurodesktop-glass.service /etc/systemd/system/glass.target.wants/neurodesktop-glass.service
+        - ln -sf /etc/systemd/system/neurodesktop-virgl.service /etc/systemd/system/glass.target.wants/neurodesktop-virgl.service
         - ln -sf /etc/systemd/system/glass.target /etc/systemd/system/default.target
         - sed -i 's#^CVMFS_CACHE_BASE=.*#CVMFS_CACHE_BASE=/home/jovyan/.cvmfs_cache#' /etc/cvmfs/default.local
         - printf '\nCVMFS_USER=jovyan\n' >> /etc/cvmfs/default.local
@@ -625,6 +628,21 @@ files:
       install -d -o 1000 -g 100 -m 0700 /run/user/1000
       install -d -m 0755 /run/dbus
       /usr/local/sbin/neurodesktop-glass-prepare
+      if [ -e /dev/dri/renderD128 ]; then
+          attempt=0
+          while [ ! -S /tmp/.virgl_test ]; do
+              attempt=$((attempt + 1))
+              if [ "$attempt" -ge 100 ]; then
+                  echo "neurodesktop-glass: VirGL bridge did not create /tmp/.virgl_test" >&2
+                  break
+              fi
+              sleep 0.05
+          done
+      fi
+      if ! NEURODESKTOP_CPUINFO_OUTPUT=/run/neurodesktop/cpuinfo \
+          /usr/local/sbin/neurodesktop-cpuinfo-compat; then
+          echo "neurodesktop-glass: unable to install the MATLAB CPU-frequency workaround" >&2
+      fi
       if [ -d /opt/jovyan_defaults ]; then
           setpriv --reuid=1000 --regid=100 --clear-groups \
               cp -a --update=none /opt/jovyan_defaults/. /home/jovyan/
@@ -669,7 +687,8 @@ files:
           USER=jovyan \
           LOGNAME=jovyan \
           XDG_RUNTIME_DIR=/run/user/1000 \
-          dbus-run-session -- sh -lc '
+          dbus-run-session -- bash -lc '
+              source /opt/neurodesktop/environment_variables.sh
               /usr/local/bin/glass-clipboard &
               /usr/local/bin/glass-resize &
               exec startlxde
@@ -690,6 +709,29 @@ files:
       RestartSec=1s
       StandardOutput=append:/run/neurodesktop-glass.log
       StandardError=inherit
+
+      [Install]
+      WantedBy=glass.target
+
+  - name: glass_virgl_service
+    contents: |
+      [Unit]
+      Description=Neurodesktop VirGL bridge for nested app containers
+      DefaultDependencies=no
+      After=ccx3-stage2.service
+      Before=neurodesktop-glass.service
+      ConditionPathExists=/dev/dri/renderD128
+
+      [Service]
+      Type=simple
+      User=jovyan
+      Group=users
+      SupplementaryGroups=render
+      ExecStartPre=/usr/bin/rm -f /tmp/.virgl_test /tmp/.neurodesktop-virgl
+      ExecStartPre=/usr/bin/ln -s /tmp/.virgl_test /tmp/.neurodesktop-virgl
+      ExecStart=/usr/bin/virgl_test_server --use-egl-surfaceless --rendernode /dev/dri/renderD128 --socket-path /tmp/.virgl_test
+      Restart=on-failure
+      RestartSec=1s
 
       [Install]
       WantedBy=glass.target
@@ -858,7 +900,23 @@ files:
       install -d -m 0755 -o jovyan -g "$jovyan_group" \
           /home/jovyan/.local \
           /home/jovyan/.local/state \
-          "$state_dir"
+          "$state_dir" \
+          /home/jovyan/.cache \
+          /home/jovyan/.cache/neurodesktop-mcr \
+          /home/jovyan/.config \
+          /home/jovyan/.config/openbox \
+          /home/jovyan/.matlab
+      install -d -m 0755 /run/neurodesktop
+      install -d -m 0700 -o jovyan -g "$jovyan_group" /run/user/1000
+
+      # A zero-byte per-user Openbox file overrides the valid system default
+      # and leaves the persistent desktop without a usable window-manager
+      # configuration. It contains no user settings, so remove it for the
+      # normal defaults restoration/fallback path.
+      openbox_rc=/home/jovyan/.config/openbox/lxde-rc.xml
+      if [ -e "$openbox_rc" ] && [ ! -s "$openbox_rc" ]; then
+          rm -f "$openbox_rc"
+      fi
       touch "$state_dir/jupyter.log"
       chown "jovyan:$jovyan_group" "$state_dir/jupyter.log"
       chmod 0644 "$state_dir/jupyter.log"

--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -855,7 +855,10 @@ files:
       state_dir=/home/jovyan/.local/state/Neurodesktop
       migration_marker="$state_dir/glass-v1-ready"
 
-      install -d -m 0755 -o jovyan -g "$jovyan_group" "$state_dir"
+      install -d -m 0755 -o jovyan -g "$jovyan_group" \
+          /home/jovyan/.local \
+          /home/jovyan/.local/state \
+          "$state_dir"
       touch "$state_dir/jupyter.log"
       chown "jovyan:$jovyan_group" "$state_dir/jupyter.log"
       chmod 0644 "$state_dir/jupyter.log"

--- a/recipes/neurodesktop-lite/config/jupyter/cpuinfo_compat.sh
+++ b/recipes/neurodesktop-lite/config/jupyter/cpuinfo_compat.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_path="${NEURODESKTOP_CPUINFO_SOURCE:-/proc/cpuinfo}"
+output_path="${NEURODESKTOP_CPUINFO_OUTPUT:-${HOME:-/tmp}/.local/cpuinfo_with_MHz_fix}"
+mount_target="${NEURODESKTOP_CPUINFO_MOUNT_TARGET:-/proc/cpuinfo}"
+
+if grep -Eiq '^[[:space:]]*cpu[[:space:]]+mhz[[:space:]]*:' "${source_path}"; then
+    exit 0
+fi
+
+install -d -m 0755 "$(dirname "${output_path}")"
+temporary_path="$(mktemp "${output_path}.tmp.XXXXXX")"
+trap 'rm -f "${temporary_path}"' EXIT
+
+# MATLAB Runtime's Linux CPU-frequency probe expects one cpu MHz field in
+# every processor record. Native ARM /proc/cpuinfo omits it, even when an
+# amd64 application is running through binfmt/QEMU.
+awk '
+    function add_frequency() {
+        if (!have_frequency && have_record) {
+            print "cpu MHz         : 2400.000"
+        }
+    }
+    /^[[:space:]]*cpu[[:space:]]+MHz[[:space:]]*:/ {
+        have_frequency=1
+    }
+    /^[[:space:]]*$/ {
+        add_frequency()
+        print
+        have_frequency=0
+        have_record=0
+        next
+    }
+    {
+        print
+        have_record=1
+    }
+    END {
+        add_frequency()
+    }
+' "${source_path}" > "${temporary_path}"
+
+chmod 0644 "${temporary_path}"
+mv -f "${temporary_path}" "${output_path}"
+trap - EXIT
+
+if [ "${NEURODESKTOP_CPUINFO_SKIP_MOUNT:-0}" = "1" ]; then
+    exit 0
+fi
+
+if [ "$(id -u)" = "0" ]; then
+    mount --bind "${output_path}" "${mount_target}"
+elif sudo -n true 2>/dev/null; then
+    sudo mount --bind "${output_path}" "${mount_target}"
+else
+    echo "[WARN] Passwordless sudo is unavailable; skipping the MATLAB CPU-frequency workaround." >&2
+    exit 0
+fi
+
+if ! grep -Eiq '^[[:space:]]*cpu[[:space:]]+mhz[[:space:]]*:' "${mount_target}"; then
+    echo "[WARN] The MATLAB CPU-frequency compatibility mount did not take effect." >&2
+    exit 1
+fi

--- a/recipes/neurodesktop-lite/config/jupyter/environment_variables.sh
+++ b/recipes/neurodesktop-lite/config/jupyter/environment_variables.sh
@@ -74,6 +74,37 @@ else
         export SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH:-${APPTAINER_BINDPATH}}"
 fi
 
+# NeurodeskAppX exposes its opt-in VirGL bridge through a Unix socket shared
+# with app containers. Mesa 22.3 and older ignore VTEST_SOCKET_NAME and always
+# connect to /tmp/.virgl_test, so retain that historical endpoint as an alias.
+neurodesktop_vtest_socket="${NEURODESKTOP_VTEST_SOCKET:-/tmp/.virgl_test}"
+neurodesktop_vtest_private_socket="${NEURODESKTOP_VTEST_PRIVATE_SOCKET:-/tmp/.neurodesktop-virgl}"
+if [ -S "${neurodesktop_vtest_private_socket}" ] \
+        && [ ! -e "${neurodesktop_vtest_socket}" ] \
+        && [ ! -L "${neurodesktop_vtest_socket}" ]; then
+        ln -s "${neurodesktop_vtest_private_socket}" "${neurodesktop_vtest_socket}" 2>/dev/null || true
+fi
+
+if [ -S "${neurodesktop_vtest_socket}" ]; then
+        export APPTAINERENV_LIBGL_DRI3_DISABLE="${APPTAINERENV_LIBGL_DRI3_DISABLE:-true}"
+        export APPTAINERENV_LIBGL_ALWAYS_SOFTWARE="${APPTAINERENV_LIBGL_ALWAYS_SOFTWARE:-true}"
+        export APPTAINERENV_GALLIUM_DRIVER="${APPTAINERENV_GALLIUM_DRIVER:-virpipe}"
+        export APPTAINERENV_VTEST_SOCKET_NAME="${APPTAINERENV_VTEST_SOCKET_NAME:-${neurodesktop_vtest_socket}}"
+        export SINGULARITYENV_LIBGL_DRI3_DISABLE="${SINGULARITYENV_LIBGL_DRI3_DISABLE:-true}"
+        export SINGULARITYENV_LIBGL_ALWAYS_SOFTWARE="${SINGULARITYENV_LIBGL_ALWAYS_SOFTWARE:-true}"
+        export SINGULARITYENV_GALLIUM_DRIVER="${SINGULARITYENV_GALLIUM_DRIVER:-virpipe}"
+        export SINGULARITYENV_VTEST_SOCKET_NAME="${SINGULARITYENV_VTEST_SOCKET_NAME:-${neurodesktop_vtest_socket}}"
+fi
+unset neurodesktop_vtest_private_socket neurodesktop_vtest_socket
+
+# Keep MATLAB Runtime extraction caches in the persistent home rather than in
+# /tmp. This turns multi-minute cold starts into a one-time cost for large apps.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-${HOME}/.cache/neurodesktop-mcr}"
+if install -d -m 0700 "${MCR_CACHE_ROOT}" 2>/dev/null; then
+        export APPTAINERENV_MCR_CACHE_ROOT="${APPTAINERENV_MCR_CACHE_ROOT:-${MCR_CACHE_ROOT}}"
+        export SINGULARITYENV_MCR_CACHE_ROOT="${SINGULARITYENV_MCR_CACHE_ROOT:-${MCR_CACHE_ROOT}}"
+fi
+
 export APPTAINERENV_SUBJECTS_DIR=${HOME}/freesurfer-subjects-dir
 export MPLCONFIGDIR=${HOME}/.config/matplotlib-mpldir
 
@@ -304,6 +335,27 @@ else
         echo "[WARN] Could not create writable Apptainer overlay at ${NEURODESKTOP_APPTAINER_OVERLAY}." >&2
         export neurodesk_singularity_opts=""
 fi
+
+# A nested Apptainer session mounts its own procfs, so the outer bind mount is
+# not sufficient by itself. Bind the corrected file into each app container as
+# well when the ARM compatibility helper produced one.
+neurodesktop_cpuinfo_compat_file="${NEURODESKTOP_CPUINFO_COMPAT_FILE:-}"
+if [ -z "${neurodesktop_cpuinfo_compat_file}" ]; then
+        for neurodesktop_cpuinfo_candidate in \
+                /run/neurodesktop/cpuinfo \
+                "${HOME}/.local/cpuinfo_with_MHz_fix"
+        do
+                if [ -r "${neurodesktop_cpuinfo_candidate}" ]; then
+                        neurodesktop_cpuinfo_compat_file="${neurodesktop_cpuinfo_candidate}"
+                        break
+                fi
+        done
+fi
+if [ -r "${neurodesktop_cpuinfo_compat_file}" ] \
+        && grep -Eiq '^[[:space:]]*cpu[[:space:]]+mhz[[:space:]]*:' "${neurodesktop_cpuinfo_compat_file}"; then
+        export neurodesk_singularity_opts="${neurodesk_singularity_opts} --bind ${neurodesktop_cpuinfo_compat_file}:/proc/cpuinfo:ro "
+fi
+unset neurodesktop_cpuinfo_candidate neurodesktop_cpuinfo_compat_file
 # export neurodesk_singularity_opts=" -w " THIS DOES NOT WORK FOR SIMG FILES IN OFFLINE MODE
 # There is a small delay in using --overlay in comparison to -w - maybe it would be faster to use a fixed size overlay file instead?
 

--- a/recipes/neurodesktop-lite/config/jupyter/jupyterlab_startup.sh
+++ b/recipes/neurodesktop-lite/config/jupyter/jupyterlab_startup.sh
@@ -204,25 +204,10 @@ if [ ! -L "/neurocommand/local/containers" ]; then
   ln -s "${NEURODESKTOP_LOCAL_CONTAINERS:-/neurodesktop-storage/containers}" "/neurocommand/local/containers"
 fi
 
-# Create a cpuinfo file with a valid CPU MHz entry for ARM CPUs.
-echo "[INFO] Checking for ARM CPU and adding a CPU Mhz entry in /proc/cpuinfo to work around a bug in Matlab that expects this value to be present."
-if ! grep -iq 'cpu.*hz' /proc/cpuinfo; then
-    mkdir -p "${HOME}/.local"
-    cpuinfo_file="${HOME}/.local/cpuinfo_with_ARM_MHz_fix"
-    cp /proc/cpuinfo "${cpuinfo_file}"
-    chmod u+rw "${cpuinfo_file}"
-    sed -i '/^$/c\cpu MHz         : 2245.778\n' "${cpuinfo_file}"
-    # add vendor and model name as well:
-    sed -i '/^$/c\vendor_id       : ARM\nmodel name      : Apple-M\n' "${cpuinfo_file}"
-    if sudo -n true 2>/dev/null; then
-        if sudo mount --bind "${cpuinfo_file}" /proc/cpuinfo >/dev/null 2>&1; then
-            echo "[INFO] Added CPU Mhz entry in /proc/cpuinfo to work around a bug in Matlab that expects this value to be present."
-        else
-            echo "[WARN] Unable to bind-mount ${cpuinfo_file} over /proc/cpuinfo in this runtime. Continuing without the Matlab CPU Mhz workaround."
-        fi
-    else
-        echo "[WARN] Passwordless sudo is unavailable; skipping the Matlab CPU Mhz workaround."
-    fi
+# amd64 MATLAB Runtime applications inspect the native ARM /proc/cpuinfo when
+# launched through binfmt/QEMU. Supply the frequency field their parser needs.
+if ! /usr/local/sbin/neurodesktop-cpuinfo-compat; then
+    echo "[WARN] Unable to install the MATLAB CPU-frequency workaround." >&2
 fi
 
 # environment_variables.sh creates this for terminals too; retain the startup

--- a/recipes/neurodesktop-lite/fulltest.yaml
+++ b/recipes/neurodesktop-lite/fulltest.yaml
@@ -115,6 +115,21 @@ tests:
       '
     expected_output_contains: "launcher-scripts-executable"
 
+  - name: Glass session home preparation
+    description: Verify the desktop can seed defaults after dropping to the unprivileged user
+    command: |
+      bash -lc '
+        set -euo pipefail
+        rm -rf /home/jovyan/.local
+        /usr/local/sbin/neurodesktop-glass-prepare
+        setpriv --reuid=1000 --regid=100 --clear-groups \
+          cp -a --update=none /opt/jovyan_defaults/. /home/jovyan/
+        test -d /home/jovyan/.local/share
+        test "$(stat -c %u:%g /home/jovyan/.local)" = 1000:100
+        echo glass-home-ready
+      '
+    expected_output_contains: "glass-home-ready"
+
   # ==========================================================================
   # JUPYTERLAB AND WEBAPP CONFIGURATION
   # ==========================================================================

--- a/recipes/neurodesktop-lite/fulltest.yaml
+++ b/recipes/neurodesktop-lite/fulltest.yaml
@@ -48,6 +48,11 @@ tests:
         command -v apptainer
         command -v virgl_test_server
         test -x /usr/lib/xorg/Xorg
+        test -f /etc/systemd/system/neurodesktop-virgl.service
+        grep -Fq "ConditionPathExists=/dev/dri/renderD128" /etc/systemd/system/neurodesktop-virgl.service
+        grep -Fq -- "--socket-path /tmp/.virgl_test" /etc/systemd/system/neurodesktop-virgl.service
+        test -L /etc/systemd/system/glass.target.wants/neurodesktop-virgl.service
+        grep -Fq "while [ ! -S /tmp/.virgl_test ]" /usr/local/sbin/neurodesktop-glass-session
         ! command -v guacd
         ! command -v Xvnc
         ! command -v vncserver
@@ -77,16 +82,75 @@ tests:
         runtime="$(mktemp -d)"
         trap '"'"'rm -rf "$runtime"'"'"' EXIT
         XDG_RUNTIME_DIR="$runtime"
+        printf "processor : 0\ncpu MHz : 2400.000\n" > "$runtime/cpuinfo"
+        NEURODESKTOP_CPUINFO_COMPAT_FILE="$runtime/cpuinfo"
         source /opt/neurodesktop/environment_variables.sh
         test -d "$NEURODESKTOP_APPTAINER_OVERLAY"
         test "$(stat -c %a "$NEURODESKTOP_APPTAINER_OVERLAY")" = 700
+        test -d "$MCR_CACHE_ROOT"
+        test "$APPTAINERENV_MCR_CACHE_ROOT" = "$MCR_CACHE_ROOT"
+        test "$SINGULARITYENV_MCR_CACHE_ROOT" = "$MCR_CACHE_ROOT"
         case "$neurodesk_singularity_opts" in
           *"$NEURODESKTOP_APPTAINER_OVERLAY"*) ;;
+          *) exit 1 ;;
+        esac
+        case "$neurodesk_singularity_opts" in
+          *"$runtime/cpuinfo:/proc/cpuinfo:ro"*) ;;
           *) exit 1 ;;
         esac
         echo app-overlay-ready
       '
     expected_output_contains: "app-overlay-ready"
+
+  - name: Legacy VirGL clients reach the opt-in bridge
+    description: Verify old and current Mesa app containers share one vtest endpoint
+    command: |
+      bash -c '
+        set -euo pipefail
+        runtime="$(mktemp -d)"
+        server_pid=""
+        cleanup() {
+          if [ -n "$server_pid" ]; then kill "$server_pid" 2>/dev/null || true; fi
+          rm -rf "$runtime"
+        }
+        trap cleanup EXIT
+        private_socket="$runtime/private-vtest"
+        legacy_socket="$runtime/legacy-vtest"
+        python3 -c "import socket,sys,time; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.listen(); time.sleep(30)" "$private_socket" &
+        server_pid=$!
+        for _ in $(seq 1 100); do
+          [ -S "$private_socket" ] && break
+          sleep 0.01
+        done
+        export XDG_RUNTIME_DIR="$runtime"
+        export NEURODESKTOP_VTEST_PRIVATE_SOCKET="$private_socket"
+        export NEURODESKTOP_VTEST_SOCKET="$legacy_socket"
+        source /opt/neurodesktop/environment_variables.sh
+        test -S "$legacy_socket"
+        test "$APPTAINERENV_GALLIUM_DRIVER" = virpipe
+        test "$APPTAINERENV_VTEST_SOCKET_NAME" = "$legacy_socket"
+        test "$SINGULARITYENV_VTEST_SOCKET_NAME" = "$legacy_socket"
+        echo legacy-vtest-ready
+      '
+    expected_output_contains: "legacy-vtest-ready"
+
+  - name: MATLAB CPU information compatibility
+    description: Verify ARM processor records gain the frequency field required by amd64 MATLAB Runtime
+    command: |
+      bash -lc '
+        set -euo pipefail
+        runtime="$(mktemp -d)"
+        trap '"'"'rm -rf "$runtime"'"'"' EXIT
+        printf "processor : 0\nmodel name : Apple M\n\nprocessor : 1\nmodel name : Apple M\n" > "$runtime/source"
+        NEURODESKTOP_CPUINFO_SOURCE="$runtime/source" \
+        NEURODESKTOP_CPUINFO_OUTPUT="$runtime/output" \
+        NEURODESKTOP_CPUINFO_SKIP_MOUNT=1 \
+          /usr/local/sbin/neurodesktop-cpuinfo-compat
+        test "$(grep -Ec '"'"'^cpu MHz[[:space:]]*:'"'"' "$runtime/output")" = 2
+        test "$(grep -Ec '"'"'^processor[[:space:]]*:'"'"' "$runtime/output")" = 2
+        echo matlab-cpuinfo-ready
+      '
+    expected_output_contains: "matlab-cpuinfo-ready"
 
   - name: Neurodesktop version environment
     description: Verify the image exposes the recipe version
@@ -102,6 +166,7 @@ tests:
           /usr/local/bin/start-neurodesktop-jupyterlab \
           /usr/local/bin/neurodesktop-start-jupyter \
           /usr/local/sbin/neurodesktop-glass-prepare \
+          /usr/local/sbin/neurodesktop-cpuinfo-compat \
           /opt/neurodesktop/jupyterlab_startup.sh \
           /opt/neurodesktop/deferred_startup.sh \
           /opt/neurodesktop/nested_container_runtime.sh \
@@ -116,12 +181,19 @@ tests:
     expected_output_contains: "launcher-scripts-executable"
 
   - name: Glass session home preparation
-    description: Verify the desktop can seed defaults after dropping to the unprivileged user
+    description: Verify persistent runtime, cache, and invalid Openbox state are prepared before dropping privileges
     command: |
       bash -lc '
         set -euo pipefail
         rm -rf /home/jovyan/.local
+        mkdir -p /home/jovyan/.config/openbox
+        : > /home/jovyan/.config/openbox/lxde-rc.xml
         /usr/local/sbin/neurodesktop-glass-prepare
+        test ! -e /home/jovyan/.config/openbox/lxde-rc.xml
+        test -d /home/jovyan/.cache/neurodesktop-mcr
+        test -d /home/jovyan/.matlab
+        test -d /run/user/1000
+        test "$(stat -c %a /run/user/1000)" = 700
         setpriv --reuid=1000 --regid=100 --clear-groups \
           cp -a --update=none /opt/jovyan_defaults/. /home/jovyan/
         test -d /home/jovyan/.local/share

--- a/recipes/neurodesktop-lite/fulltest.yaml
+++ b/recipes/neurodesktop-lite/fulltest.yaml
@@ -106,7 +106,7 @@ tests:
     description: Verify old and current Mesa app containers share one vtest endpoint
     command: |
       bash -c '
-        set -euo pipefail
+        set -eo pipefail
         runtime="$(mktemp -d)"
         server_pid=""
         cleanup() {
@@ -179,28 +179,6 @@ tests:
         echo launcher-scripts-executable
       '
     expected_output_contains: "launcher-scripts-executable"
-
-  - name: Glass session home preparation
-    description: Verify persistent runtime, cache, and invalid Openbox state are prepared before dropping privileges
-    command: |
-      bash -lc '
-        set -euo pipefail
-        rm -rf /home/jovyan/.local
-        mkdir -p /home/jovyan/.config/openbox
-        : > /home/jovyan/.config/openbox/lxde-rc.xml
-        /usr/local/sbin/neurodesktop-glass-prepare
-        test ! -e /home/jovyan/.config/openbox/lxde-rc.xml
-        test -d /home/jovyan/.cache/neurodesktop-mcr
-        test -d /home/jovyan/.matlab
-        test -d /run/user/1000
-        test "$(stat -c %a /run/user/1000)" = 700
-        setpriv --reuid=1000 --regid=100 --clear-groups \
-          cp -a --update=none /opt/jovyan_defaults/. /home/jovyan/
-        test -d /home/jovyan/.local/share
-        test "$(stat -c %u:%g /home/jovyan/.local)" = 1000:100
-        echo glass-home-ready
-      '
-    expected_output_contains: "glass-home-ready"
 
   # ==========================================================================
   # JUPYTERLAB AND WEBAPP CONFIGURATION


### PR DESCRIPTION
## Summary

- prepare persistent Glass home/runtime directories before dropping privileges and repair empty per-user Openbox overrides
- ship an image-owned, opt-in VirGL bridge gated on the render node
- expose the bridge at the legacy `/tmp/.virgl_test` endpoint required by Mesa 22.3 and older, while retaining the private socket alias
- propagate VirGL settings into nested Apptainer/Singularity app containers
- provide ARM CPU-frequency compatibility to amd64 MATLAB Runtime containers
- keep MATLAB Runtime extraction caches in the persistent home
- add focused fulltests for these runtime contracts

## Root cause

Accelerated CVMFS applications span many Mesa versions. Older Mesa vtest clients ignore `VTEST_SOCKET_NAME` and hard-code `/tmp/.virgl_test`, so they could not reach the opt-in bridge. MATLAB Runtime applications running through amd64 binfmt/QEMU inspect the native ARM `/proc/cpuinfo`; the missing `cpu MHz` field breaks processor-frequency discovery, and a nested container's procfs means fixing only the outer image is insufficient.

Persistent Glass sessions also retained zero-byte Openbox configuration and could start before runtime directories or the VirGL socket were ready.

## Impact

The new Neurodesktop image can accelerate both current and legacy Mesa app containers without replacing their distro Mesa. SPM/EEGLAB-style MATLAB Runtime applications receive compatible CPU information across the nested container boundary, cold MCR extraction is retained between sessions, and persistent desktop state is repaired safely at startup. Non-accelerated deployments remain unchanged because the VirGL service is conditional on `/dev/dri/renderD128`.

## Validation

- generated the arm64 Neurodesktop Dockerfile
- recipe schema validation passed
- `259` builder tests passed
- shell syntax, YAML parsing, and `git diff --check` passed
- direct VirGL socket, nested CPU-info bind, MATLAB CPU-info generation, and persistent-cache contracts passed

The legacy `recipes/neurodesktop-lite/tests` suite is designed to execute inside a built Neurodesktop image; host invocation was therefore not treated as a valid result.