### PR TITLE
Retry candidate artifact downloads

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -244,7 +244,17 @@ jobs:
             container="${name#candidate-}"
             container="${container%-${HEAD_SHA}}"
             mkdir -p "promotion-bundle/${container}"
-            gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" > artifact.zip
+            for attempt in 1 2 3 4 5; do
+              rm -f artifact.zip
+              if gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" > artifact.zip; then
+                break
+              fi
+              if [ "${attempt}" = 5 ]; then
+                echo "Failed to download ${name} after ${attempt} attempts" >&2
+                exit 1
+              fi
+              sleep "$((attempt * 10))"
+            done
             unzip -q artifact.zip -d "promotion-bundle/${container}"
             rm artifact.zip
           done


### PR DESCRIPTION
## What changed

Retry each candidate artifact download up to five times with bounded backoff, deleting any partial ZIP before retrying.

## Why

The promotion for merged Neurodesktop PR #3019 failed twice while downloading its already-tested candidate bundle. Both failures were transient connection resets; verification and publication never ran. Candidate bundles are large enough that a single unretired HTTP transfer is too fragile for the release path.

The exact artifact ID remains fixed across attempts, so this does not weaken the existing provenance or checksum verification.

## Validation

- workflow diff and shell control flow reviewed
- `git diff --check`
- observed failure is confined to `gh api .../artifacts/{id}/zip`; later verification remains unchanged
