### PR TITLE
Add manifest-scoped Neurodesktop GPU acceleration

### DIFF
--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -286,7 +286,7 @@ build:
         - sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         - rm -f /usr/bin/lxpolkit
         - if [ -e /usr/bin/fusermount3 ]; then chmod +x /usr/bin/fusermount3; elif [ -e /usr/bin/fusermount ]; then chmod +x /usr/bin/fusermount; fi
-        - mkdir -p /usr/local/bin/start-notebook.d /usr/local/bin/before-notebook.d /opt/neurodesktop/scripts /opt/neurodesktop/webapp_wrapper
+        - mkdir -p /usr/local/bin/start-notebook.d /usr/local/bin/before-notebook.d /usr/local/libexec /opt/neurodesktop/scripts /opt/neurodesktop/webapp_wrapper
         - install -m 0755 /tmp/config/jupyter/start_notebook.sh /usr/local/bin/start-notebook.d/start_notebook.sh
         - install -m 0755 /tmp/config/jupyter/before_notebook.sh /usr/local/bin/before-notebook.d/before_notebook.sh
         - install -m 0755 /tmp/config/jupyter/jupyterlab_startup.sh /opt/neurodesktop/jupyterlab_startup.sh

--- a/recipes/neurodesktop-lite/build.yaml
+++ b/recipes/neurodesktop-lite/build.yaml
@@ -293,6 +293,11 @@ build:
         - install -m 0755 /tmp/config/jupyter/deferred_startup.sh /opt/neurodesktop/deferred_startup.sh
         - install -m 0755 /tmp/config/jupyter/nested_container_runtime.sh /opt/neurodesktop/nested_container_runtime.sh
         - install -m 0755 /tmp/config/jupyter/environment_variables.sh /opt/neurodesktop/environment_variables.sh
+        - install -D -m 0644 /tmp/config/gpu/gpu-containers.tsv /etc/neurodesktop/gpu-containers.tsv
+        - install -m 0755 /tmp/config/gpu/neurodesktop-container-runtime /usr/local/libexec/neurodesktop-container-runtime
+        - install -m 0755 /tmp/config/gpu/neurodesktop-start-virgl /usr/local/sbin/neurodesktop-start-virgl
+        - ln -sf /usr/local/libexec/neurodesktop-container-runtime /usr/local/bin/apptainer
+        - ln -sf /usr/local/libexec/neurodesktop-container-runtime /usr/local/bin/singularity
         - install -m 0755 /tmp/config/jupyter/cpuinfo_compat.sh /usr/local/sbin/neurodesktop-cpuinfo-compat
         - install -m 0755 /tmp/config/jupyter/kernel_wrapper.sh /opt/neurodesktop/kernel_wrapper.sh
         - install -m 0755 /tmp/config/jupyter/jupyterlmod_modulepath.py /opt/neurodesktop/jupyterlmod_modulepath.py
@@ -419,7 +424,6 @@ build:
         - if [ -x /usr/bin/systemctl.orig ]; then mv -f /usr/bin/systemctl.orig /usr/bin/systemctl; fi
         - mkdir -p /etc/systemd/system/glass.target.wants
         - ln -sf /etc/systemd/system/neurodesktop-glass.service /etc/systemd/system/glass.target.wants/neurodesktop-glass.service
-        - ln -sf /etc/systemd/system/neurodesktop-virgl.service /etc/systemd/system/glass.target.wants/neurodesktop-virgl.service
         - ln -sf /etc/systemd/system/glass.target /etc/systemd/system/default.target
         - sed -i 's#^CVMFS_CACHE_BASE=.*#CVMFS_CACHE_BASE=/home/jovyan/.cvmfs_cache#' /etc/cvmfs/default.local
         - printf '\nCVMFS_USER=jovyan\n' >> /etc/cvmfs/default.local
@@ -628,17 +632,6 @@ files:
       install -d -o 1000 -g 100 -m 0700 /run/user/1000
       install -d -m 0755 /run/dbus
       /usr/local/sbin/neurodesktop-glass-prepare
-      if [ -e /dev/dri/renderD128 ]; then
-          attempt=0
-          while [ ! -S /tmp/.virgl_test ]; do
-              attempt=$((attempt + 1))
-              if [ "$attempt" -ge 100 ]; then
-                  echo "neurodesktop-glass: VirGL bridge did not create /tmp/.virgl_test" >&2
-                  break
-              fi
-              sleep 0.05
-          done
-      fi
       if ! NEURODESKTOP_CPUINFO_OUTPUT=/run/neurodesktop/cpuinfo \
           /usr/local/sbin/neurodesktop-cpuinfo-compat; then
           echo "neurodesktop-glass: unable to install the MATLAB CPU-frequency workaround" >&2
@@ -719,7 +712,6 @@ files:
       Description=Neurodesktop VirGL bridge for nested app containers
       DefaultDependencies=no
       After=ccx3-stage2.service
-      Before=neurodesktop-glass.service
       ConditionPathExists=/dev/dri/renderD128
 
       [Service]

--- a/recipes/neurodesktop-lite/config/gpu/gpu-containers.tsv
+++ b/recipes/neurodesktop-lite/config/gpu/gpu-containers.tsv
@@ -1,0 +1,21 @@
+# Neurodesktop experimental VirGL allowlist, schema 1.
+#
+# Fields are the exact NeuroContainers recipe name and version. The image build
+# date is intentionally not part of the key, so rebuilding an unchanged recipe
+# does not require a desktop image update.
+mrtrix3	3.0.8
+connectomeworkbench	2.1.0
+voreen	5.3.0
+ilastik	1.4.0
+itksnap	4.4.0
+freesurfer	8.2.0
+afni	26.0.07
+brainvisa	6.0.38
+qupath	0.7.0
+dsistudio	2024.06.12
+trackvis	0.6.1
+brkraw	0.3.11
+gimp	2.10.18
+functionnectome	2.5.0
+mipav	11.3.3
+mipview	0.1.4

--- a/recipes/neurodesktop-lite/config/gpu/neurodesktop-container-runtime
+++ b/recipes/neurodesktop-lite/config/gpu/neurodesktop-container-runtime
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -eu
+
+runtime=$(basename "$0")
+case "$runtime" in
+    apptainer)
+        real_runtime=${NEURODESKTOP_APPTAINER_REAL:-/usr/bin/apptainer}
+        ;;
+    singularity)
+        real_runtime=${NEURODESKTOP_SINGULARITY_REAL:-/usr/bin/singularity}
+        ;;
+    *)
+        echo "neurodesktop: container runtime wrapper must be invoked as apptainer or singularity" >&2
+        exit 2
+        ;;
+esac
+
+gpu_enabled=false
+case "${NEURODESKTOP_GPU_ACCELERATION:-}" in
+    1|true|yes|on) gpu_enabled=true ;;
+esac
+if [ -e "${NEURODESKTOP_GPU_MARKER:-/run/neurodesktop/gpu-enabled}" ]; then
+    gpu_enabled=true
+fi
+
+container=
+for argument in "$@"; do
+    case "$argument" in
+        *.sif|*.simg)
+            container=$(basename "$argument")
+            break
+            ;;
+    esac
+done
+
+manifest=${NEURODESKTOP_GPU_MANIFEST:-/etc/neurodesktop/gpu-containers.tsv}
+allowlisted=false
+if [ "$gpu_enabled" = true ] && [ -n "$container" ] && [ -r "$manifest" ]; then
+    container_stem=${container%.sif}
+    container_stem=${container_stem%.simg}
+    while read -r name version remainder; do
+        case "$name" in ''|'#'*) continue ;; esac
+        [ -n "$version" ] || continue
+        case "$container_stem" in
+            "${name}_${version}"|"${name}_${version}_"*)
+                allowlisted=true
+                break
+                ;;
+        esac
+    done < "$manifest"
+fi
+
+# These variables must belong to this one launch. In particular, do not let a
+# previous shell or an older desktop-wide setup accelerate an unlisted image.
+unset APPTAINERENV_LIBGL_DRI3_DISABLE
+unset APPTAINERENV_LIBGL_ALWAYS_SOFTWARE
+unset APPTAINERENV_GALLIUM_DRIVER
+unset APPTAINERENV_VTEST_SOCKET_NAME
+unset APPTAINERENV_MESA_GL_VERSION_OVERRIDE
+unset APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE
+unset SINGULARITYENV_LIBGL_DRI3_DISABLE
+unset SINGULARITYENV_LIBGL_ALWAYS_SOFTWARE
+unset SINGULARITYENV_GALLIUM_DRIVER
+unset SINGULARITYENV_VTEST_SOCKET_NAME
+unset SINGULARITYENV_MESA_GL_VERSION_OVERRIDE
+unset SINGULARITYENV_MESA_GLSL_VERSION_OVERRIDE
+
+if [ "$allowlisted" = true ]; then
+    socket=${NEURODESKTOP_VTEST_SOCKET:-/tmp/.virgl_test}
+    starter=${NEURODESKTOP_VIRGL_STARTER:-/usr/local/sbin/neurodesktop-start-virgl}
+    if [ ! -S "$socket" ]; then
+        "$starter" || true
+    fi
+    if [ -S "$socket" ]; then
+        export APPTAINERENV_LIBGL_DRI3_DISABLE=true
+        export APPTAINERENV_LIBGL_ALWAYS_SOFTWARE=true
+        export APPTAINERENV_GALLIUM_DRIVER=virpipe
+        export APPTAINERENV_VTEST_SOCKET_NAME="$socket"
+        export APPTAINERENV_MESA_GL_VERSION_OVERRIDE=4.1
+        export APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE=410
+        export SINGULARITYENV_LIBGL_DRI3_DISABLE=true
+        export SINGULARITYENV_LIBGL_ALWAYS_SOFTWARE=true
+        export SINGULARITYENV_GALLIUM_DRIVER=virpipe
+        export SINGULARITYENV_VTEST_SOCKET_NAME="$socket"
+        export SINGULARITYENV_MESA_GL_VERSION_OVERRIDE=4.1
+        export SINGULARITYENV_MESA_GLSL_VERSION_OVERRIDE=410
+    else
+        echo "neurodesktop: VirGL is unavailable; launching $container without acceleration" >&2
+    fi
+fi
+
+exec "$real_runtime" "$@"

--- a/recipes/neurodesktop-lite/config/gpu/neurodesktop-start-virgl
+++ b/recipes/neurodesktop-lite/config/gpu/neurodesktop-start-virgl
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+socket=${NEURODESKTOP_VTEST_SOCKET:-/tmp/.virgl_test}
+
+if [ -S "$socket" ]; then
+    exit 0
+fi
+if [ ! -e /dev/dri/renderD128 ]; then
+    exit 1
+fi
+
+sudo -n systemctl start neurodesktop-virgl.service
+
+attempt=0
+while [ ! -S "$socket" ]; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 100 ]; then
+        echo "neurodesktop: VirGL bridge did not create $socket" >&2
+        exit 1
+    fi
+    sleep 0.05
+done

--- a/recipes/neurodesktop-lite/config/jupyter/environment_variables.sh
+++ b/recipes/neurodesktop-lite/config/jupyter/environment_variables.sh
@@ -74,33 +74,6 @@ else
         export SINGULARITY_BINDPATH="${SINGULARITY_BINDPATH:-${APPTAINER_BINDPATH}}"
 fi
 
-# NeurodeskAppX exposes its opt-in VirGL bridge through a Unix socket shared
-# with app containers. Mesa 22.3 and older ignore VTEST_SOCKET_NAME and always
-# connect to /tmp/.virgl_test, so retain that historical endpoint as an alias.
-neurodesktop_vtest_socket="${NEURODESKTOP_VTEST_SOCKET:-/tmp/.virgl_test}"
-neurodesktop_vtest_private_socket="${NEURODESKTOP_VTEST_PRIVATE_SOCKET:-/tmp/.neurodesktop-virgl}"
-if [ -S "${neurodesktop_vtest_private_socket}" ] \
-        && [ ! -e "${neurodesktop_vtest_socket}" ] \
-        && [ ! -L "${neurodesktop_vtest_socket}" ]; then
-        ln -s "${neurodesktop_vtest_private_socket}" "${neurodesktop_vtest_socket}" 2>/dev/null || true
-fi
-
-if [ -S "${neurodesktop_vtest_socket}" ]; then
-        export APPTAINERENV_LIBGL_DRI3_DISABLE="${APPTAINERENV_LIBGL_DRI3_DISABLE:-true}"
-        export APPTAINERENV_LIBGL_ALWAYS_SOFTWARE="${APPTAINERENV_LIBGL_ALWAYS_SOFTWARE:-true}"
-        export APPTAINERENV_GALLIUM_DRIVER="${APPTAINERENV_GALLIUM_DRIVER:-virpipe}"
-        export APPTAINERENV_VTEST_SOCKET_NAME="${APPTAINERENV_VTEST_SOCKET_NAME:-${neurodesktop_vtest_socket}}"
-        export APPTAINERENV_MESA_GL_VERSION_OVERRIDE="${APPTAINERENV_MESA_GL_VERSION_OVERRIDE:-4.1}"
-        export APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE="${APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE:-410}"
-        export SINGULARITYENV_LIBGL_DRI3_DISABLE="${SINGULARITYENV_LIBGL_DRI3_DISABLE:-true}"
-        export SINGULARITYENV_LIBGL_ALWAYS_SOFTWARE="${SINGULARITYENV_LIBGL_ALWAYS_SOFTWARE:-true}"
-        export SINGULARITYENV_GALLIUM_DRIVER="${SINGULARITYENV_GALLIUM_DRIVER:-virpipe}"
-        export SINGULARITYENV_VTEST_SOCKET_NAME="${SINGULARITYENV_VTEST_SOCKET_NAME:-${neurodesktop_vtest_socket}}"
-        export SINGULARITYENV_MESA_GL_VERSION_OVERRIDE="${SINGULARITYENV_MESA_GL_VERSION_OVERRIDE:-4.1}"
-        export SINGULARITYENV_MESA_GLSL_VERSION_OVERRIDE="${SINGULARITYENV_MESA_GLSL_VERSION_OVERRIDE:-410}"
-fi
-unset neurodesktop_vtest_private_socket neurodesktop_vtest_socket
-
 # Keep MATLAB Runtime extraction caches in the persistent home rather than in
 # /tmp. This turns multi-minute cold starts into a one-time cost for large apps.
 export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-${HOME}/.cache/neurodesktop-mcr}"

--- a/recipes/neurodesktop-lite/fulltest.yaml
+++ b/recipes/neurodesktop-lite/fulltest.yaml
@@ -52,8 +52,11 @@ tests:
         grep -Fq "ConditionPathExists=/dev/dri/renderD128" /etc/systemd/system/neurodesktop-virgl.service
         grep -Fq -- "virgl_test_server --multi-clients" /etc/systemd/system/neurodesktop-virgl.service
         grep -Fq -- "--socket-path /tmp/.virgl_test" /etc/systemd/system/neurodesktop-virgl.service
-        test -L /etc/systemd/system/glass.target.wants/neurodesktop-virgl.service
-        grep -Fq "while [ ! -S /tmp/.virgl_test ]" /usr/local/sbin/neurodesktop-glass-session
+        test ! -e /etc/systemd/system/glass.target.wants/neurodesktop-virgl.service
+        test -x /usr/local/sbin/neurodesktop-start-virgl
+        test -x /usr/local/libexec/neurodesktop-container-runtime
+        test -L /usr/local/bin/apptainer
+        test -L /usr/local/bin/singularity
         ! command -v guacd
         ! command -v Xvnc
         ! command -v vncserver
@@ -103,41 +106,52 @@ tests:
       '
     expected_output_contains: "app-overlay-ready"
 
-  - name: Legacy VirGL clients reach the opt-in bridge
-    description: Verify old and current Mesa app containers share one vtest endpoint
+  - name: GPU acceleration is scoped by the image manifest
+    description: Verify the master switch and exact container allowlist control VirGL injection
     command: |
       bash -c '
         set -eo pipefail
         runtime="$(mktemp -d)"
-        server_pid=""
-        cleanup() {
-          if [ -n "$server_pid" ]; then kill "$server_pid" 2>/dev/null || true; fi
-          rm -rf "$runtime"
-        }
-        trap cleanup EXIT
-        private_socket="$runtime/private-vtest"
-        legacy_socket="$runtime/legacy-vtest"
-        python3 -c "import socket,sys,time; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.listen(); time.sleep(30)" "$private_socket" &
-        server_pid=$!
-        for _ in $(seq 1 100); do
-          [ -S "$private_socket" ] && break
-          sleep 0.01
-        done
-        export XDG_RUNTIME_DIR="$runtime"
-        export NEURODESKTOP_VTEST_PRIVATE_SOCKET="$private_socket"
-        export NEURODESKTOP_VTEST_SOCKET="$legacy_socket"
-        source /opt/neurodesktop/environment_variables.sh
-        test -S "$legacy_socket"
-        test "$APPTAINERENV_GALLIUM_DRIVER" = virpipe
-        test "$APPTAINERENV_VTEST_SOCKET_NAME" = "$legacy_socket"
-        test "$APPTAINERENV_MESA_GL_VERSION_OVERRIDE" = 4.1
-        test "$APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE" = 410
-        test "$SINGULARITYENV_VTEST_SOCKET_NAME" = "$legacy_socket"
-        test "$SINGULARITYENV_MESA_GL_VERSION_OVERRIDE" = 4.1
-        test "$SINGULARITYENV_MESA_GLSL_VERSION_OVERRIDE" = 410
-        echo legacy-vtest-ready
+        trap '"'"'rm -rf "$runtime"'"'"' EXIT
+        manifest="$runtime/manifest.tsv"
+        printf "mrtrix3\t3.0.8\n" > "$manifest"
+        real_runtime="$runtime/real-runtime"
+        cat > "$real_runtime" <<'"'"'EOF'"'"'
+      #!/bin/sh
+      printf "driver=%s\n" "${APPTAINERENV_GALLIUM_DRIVER:-}"
+      printf "socket=%s\n" "${APPTAINERENV_VTEST_SOCKET_NAME:-}"
+      printf "gl=%s\n" "${APPTAINERENV_MESA_GL_VERSION_OVERRIDE:-}"
+      printf "glsl=%s\n" "${APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE:-}"
+      EOF
+        chmod +x "$real_runtime"
+        starter="$runtime/start-virgl"
+        cat > "$starter" <<'"'"'EOF'"'"'
+      #!/bin/sh
+      python3 -c '"'"'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.close()'"'"' "$NEURODESKTOP_VTEST_SOCKET"
+      EOF
+        chmod +x "$starter"
+        wrapper=/usr/local/bin/apptainer
+        common="NEURODESKTOP_APPTAINER_REAL=$real_runtime NEURODESKTOP_GPU_MANIFEST=$manifest NEURODESKTOP_VIRGL_STARTER=$starter NEURODESKTOP_VTEST_SOCKET=$runtime/vtest"
+
+        disabled="$(env $common "$wrapper" exec mrtrix3_3.0.8_20260107.simg true)"
+        ! printf "%s\n" "$disabled" | grep -q "driver=virpipe"
+        test ! -e "$runtime/vtest"
+
+        unlisted="$(env $common NEURODESKTOP_GPU_ACCELERATION=1 "$wrapper" exec blender_5.0.1_20260701.simg true)"
+        ! printf "%s\n" "$unlisted" | grep -q "driver=virpipe"
+        test ! -e "$runtime/vtest"
+
+        accelerated="$(env $common NEURODESKTOP_GPU_ACCELERATION=1 "$wrapper" exec mrtrix3_3.0.8_20260107.simg true)"
+        printf "%s\n" "$accelerated" | grep -Fq "driver=virpipe"
+        printf "%s\n" "$accelerated" | grep -Fq "socket=$runtime/vtest"
+        printf "%s\n" "$accelerated" | grep -Fq "gl=4.1"
+        printf "%s\n" "$accelerated" | grep -Fq "glsl=410"
+
+        mismatch="$(env $common NEURODESKTOP_GPU_ACCELERATION=1 "$wrapper" exec mrtrix3_3.0.80_20260107.simg true)"
+        ! printf "%s\n" "$mismatch" | grep -q "driver=virpipe"
+        echo gpu-manifest-ready
       '
-    expected_output_contains: "legacy-vtest-ready"
+    expected_output_contains: "gpu-manifest-ready"
 
   - name: MATLAB CPU information compatibility
     description: Verify ARM processor records gain the frequency field required by amd64 MATLAB Runtime

--- a/recipes/neurodesktop-lite/tests/test_gpu_manifest.py
+++ b/recipes/neurodesktop-lite/tests/test_gpu_manifest.py
@@ -1,0 +1,97 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+WRAPPER = (
+    Path(__file__).parents[1]
+    / "config"
+    / "gpu"
+    / "neurodesktop-container-runtime"
+).resolve()
+
+
+def _run_wrapper(tmp_path: Path, container: str, *, enabled: bool) -> tuple[str, Path]:
+    manifest = tmp_path / "gpu-containers.tsv"
+    manifest.write_text("mrtrix3\t3.0.8\n", encoding="utf-8")
+
+    real_runtime = tmp_path / "real-runtime"
+    real_runtime.write_text(
+        "#!/bin/sh\n"
+        "printf 'driver=%s\\n' \"${APPTAINERENV_GALLIUM_DRIVER:-}\"\n"
+        "printf 'socket=%s\\n' \"${APPTAINERENV_VTEST_SOCKET_NAME:-}\"\n"
+        "printf 'gl=%s\\n' \"${APPTAINERENV_MESA_GL_VERSION_OVERRIDE:-}\"\n"
+        "printf 'glsl=%s\\n' \"${APPTAINERENV_MESA_GLSL_VERSION_OVERRIDE:-}\"\n",
+        encoding="utf-8",
+    )
+    real_runtime.chmod(0o755)
+
+    socket_dir = Path(tempfile.mkdtemp(prefix="ndgpu-", dir="/tmp"))
+    socket_path = socket_dir / "vtest"
+    starter = tmp_path / "start-virgl"
+    starter.write_text(
+        "#!/bin/sh\n"
+        "python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); "
+        "s.bind(sys.argv[1]); s.close()' \"$NEURODESKTOP_VTEST_SOCKET\"\n",
+        encoding="utf-8",
+    )
+    starter.chmod(0o755)
+
+    apptainer = tmp_path / "apptainer"
+    apptainer.symlink_to(WRAPPER)
+    environment = {
+        **os.environ,
+        "NEURODESKTOP_APPTAINER_REAL": str(real_runtime),
+        "NEURODESKTOP_GPU_MANIFEST": str(manifest),
+        "NEURODESKTOP_VIRGL_STARTER": str(starter),
+        "NEURODESKTOP_VTEST_SOCKET": str(socket_path),
+        "NEURODESKTOP_GPU_MARKER": str(tmp_path / "disabled-marker"),
+    }
+    if enabled:
+        environment["NEURODESKTOP_GPU_ACCELERATION"] = "1"
+
+    result = subprocess.run(
+        ["/bin/sh", str(apptainer), "exec", container, "true"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    return result.stdout, socket_path
+
+
+def test_allowlisted_container_gets_scoped_virgl_environment(tmp_path: Path) -> None:
+    output, socket_path = _run_wrapper(
+        tmp_path, "mrtrix3_3.0.8_20260107.simg", enabled=True
+    )
+
+    assert "driver=virpipe\n" in output
+    assert f"socket={socket_path}\n" in output
+    assert "gl=4.1\n" in output
+    assert "glsl=410\n" in output
+    assert socket_path.is_socket()
+    socket_path.unlink()
+    socket_path.parent.rmdir()
+
+
+def test_master_switch_off_does_not_start_or_inject_virgl(tmp_path: Path) -> None:
+    output, socket_path = _run_wrapper(
+        tmp_path, "mrtrix3_3.0.8_20260107.simg", enabled=False
+    )
+
+    assert "driver=virpipe\n" not in output
+    assert not socket_path.exists()
+    socket_path.parent.rmdir()
+
+
+def test_unlisted_and_near_match_versions_do_not_get_virgl(tmp_path: Path) -> None:
+    for index, container in enumerate(
+        ("blender_5.0.1_20260701.simg", "mrtrix3_3.0.80_20260107.simg")
+    ):
+        case_dir = tmp_path / str(index)
+        case_dir.mkdir()
+        output, socket_path = _run_wrapper(case_dir, container, enabled=True)
+        assert "driver=virpipe\n" not in output
+        assert not socket_path.exists()
+        socket_path.parent.rmdir()


### PR DESCRIPTION
## Summary

- add an exact recipe/version GPU allowlist to the neurodesktop-lite image
- scope VirGL environment injection to allowlisted Apptainer/Singularity launches
- lazily start the VirGL bridge on the first eligible launch instead of at desktop boot
- keep the NeurodeskAppX experimental checkbox as the master opt-in

## Why

Desktop-wide VirGL variables accelerated every nested container and exposed incompatible legacy Mesa clients to known capset failures. Keeping compatibility policy in the desktop image allows the list to evolve with image deployments without rebuilding each application container.

## Validation

- `pytest -q recipes/neurodesktop-lite/tests/test_gpu_manifest.py` (3 passed)
- `pytest -q builder/tests` (259 passed)
- `./workflows/test_all.sh` (all recipe validation and generation passed)
- `python builder/validation.py recipes/neurodesktop-lite/build.yaml`
- shell syntax and `git diff --check`
