### PR TITLE
Verify the ARC candidate runner after capability removal

### DIFF
--- a/recipes/workshopdemo/build.yaml
+++ b/recipes/workshopdemo/build.yaml
@@ -1,5 +1,5 @@
 name: workshopdemo
-version: 1.0.0
+version: 1.0.1
 architectures:
   - x86_64
   - aarch64
@@ -19,6 +19,9 @@ build:
   base-image: ubuntu:24.04
   pkg-manager: apt
   directives:
+    # Deliberately minimal: workshopdemo exists to exercise the build and
+    # release pipeline end to end, so it installs one tiny package and nothing
+    # else. Changes here should keep it that way.
     - install: hello
 categories:
   - functional imaging
@@ -28,7 +31,7 @@ icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABKCAYAAAAL8lK4AAAACXBI
 readme: >-
   ----------------------------------
 
-  ## workshopdemo/1.0.0 ##
+  ## workshopdemo/{{ context.version }} ##
 
 
   This tool was committed for the workshop.
@@ -56,7 +59,7 @@ readme: >-
   ```
 
 
-  To run container outside of this environment: ml workshopdemo/1.0.0
+  To run container outside of this environment: ml workshopdemo/{{ context.version }}
 
 
   ----------------------------------

--- a/recipes/workshopdemo/fulltest.yaml
+++ b/recipes/workshopdemo/fulltest.yaml
@@ -1,5 +1,5 @@
 # workshopdemo container test suite
-# Tests for workshopdemo v1.0.0 - Minimal hello-world workshop example
+# Tests for workshopdemo v1.0.1 - Minimal hello-world workshop example
 #
 # This container includes:
 #   - hello: GNU hello example program
@@ -7,7 +7,7 @@
 # Tests focus on the packaged runtime and documented example command.
 
 name: workshopdemo
-version: 1.0.0
+version: 1.0.1
 
 setup:
   script: |


### PR DESCRIPTION
**What changed.** `SYS_ADMIN` and `DAC_READ_SEARCH` were removed from the `neurodesk-syd-arcrunner-neurocontainers` pool on syd1 (helm rev 5).

**Why it matters.** The candidate job mounts and executes the container it builds — `apptainer exec --writable-tmpfs`. Mounting is what `SYS_ADMIN` governs, so this could break the fulltest step. It has been validated on a probe runner, but not through this workflow on that pool.

**Why a PR.** `pr-container-candidate.yml` only builds when a recipe's build-affecting fields change, so this bumps workshopdemo's version. The container content is unchanged — still a single `hello` package.

**Looking for** `FULLTEST_OUTCOME: success` on the x86_64 leg. Baseline is run `30785153782` — same recipe, same pool, before the change.

**Expect this to go red on Dive.** `highestUserWastedPercent` is unpassable for a recipe this minimal. Dive runs after the Apptainer steps, so a red PR here does not mean the test failed.

Draft, not for merge.
