### PR TITLE
Harden OpenMSK scanner output and simplify the DESS interface

### DIFF
--- a/recipes/openmsk/OpenReconLabel.json
+++ b/recipes/openmsk/OpenReconLabel.json
@@ -3,7 +3,7 @@
     "name": { "en": "openmsk" },
     "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
     "vendor": "neurodesk",
-    "information": { "en": "OpenMSK KneePipeline qDESS knee MRI analysis" },
+    "information": { "en": "OpenMSK KneePipeline DESS knee MRI analysis" },
     "id": "openmsk",
     "regulatory_information": {
       "device_trade_name": "openmsk",
@@ -38,16 +38,16 @@
   "parameters": [
     {
       "id": "config",
-      "label": { "en": "config" },
+      "label": { "en": "Analysis" },
       "type": "choice",
       "values": [
         {
           "id": "openmsk",
-          "name": { "en": "openmsk" }
+          "name": { "en": "DESS" }
         }
       ],
       "default": "openmsk",
-      "information": { "en": "Define the config to be executed by MRD server" }
+      "information": { "en": "Run OpenMSK DESS knee analysis" }
     },
     {
       "id": "sendoriginal",
@@ -63,7 +63,7 @@
       "values": [
         {
           "id": "acl_qdess_bone_july_2024",
-          "name": { "en": "DOSMA qDESS bone/cartilage July 2024" }
+          "name": { "en": "DOSMA DESS bone/cartilage July 2024" }
         },
         {
           "id": "goyal_sagittal",
@@ -91,79 +91,6 @@
       "type": "boolean",
       "information": { "en": "Run slower mesh/thickness analysis after sending the segmentation" },
       "default": false
-    },
-    {
-      "id": "runnsm",
-      "label": { "en": "Legacy NSM flag" },
-      "type": "boolean",
-      "information": { "en": "Accepted for older scanner protocols only; ignored because ShapeMedKnee assets are not packaged" },
-      "default": false
-    },
-    {
-      "id": "runbscore",
-      "label": { "en": "Legacy BScore flag" },
-      "type": "boolean",
-      "information": { "en": "Accepted for older scanner protocols only; ignored because ShapeMedKnee assets are not packaged" },
-      "default": false
-    },
-    {
-      "id": "qdesstrms",
-      "label": { "en": "qDESS TR" },
-      "type": "double",
-      "information": { "en": "Fallback repetition time for synthetic qDESS DICOM when MRD sequence parameters are absent" },
-      "minimum": 1.0,
-      "maximum": 200.0,
-      "default": 25.0,
-      "unit": { "en": "ms" }
-    },
-    {
-      "id": "qdesste1ms",
-      "label": { "en": "qDESS TE1" },
-      "type": "double",
-      "information": { "en": "Fallback echo-1 time for synthetic qDESS DICOM when MRD sequence parameters are absent" },
-      "minimum": 0.1,
-      "maximum": 200.0,
-      "default": 8.0,
-      "unit": { "en": "ms" }
-    },
-    {
-      "id": "qdesste2ms",
-      "label": { "en": "Legacy qDESS TE2" },
-      "type": "double",
-      "information": { "en": "Accepted for protocol compatibility but ignored; TE2 is computed as 2 * TR - TE1" },
-      "minimum": 0.1,
-      "maximum": 300.0,
-      "default": 42.0,
-      "unit": { "en": "ms" }
-    },
-    {
-      "id": "qdessflipangledeg",
-      "label": { "en": "qDESS flip angle" },
-      "type": "double",
-      "information": { "en": "Fallback flip angle for synthetic qDESS DICOM when MRD sequence parameters are absent" },
-      "minimum": 1.0,
-      "maximum": 180.0,
-      "default": 30.0,
-      "unit": { "en": "deg" }
-    },
-    {
-      "id": "qdessglarea",
-      "label": { "en": "qDESS GL area" },
-      "type": "double",
-      "information": { "en": "Fallback qDESS spoiler gradient area written to DICOM private tag (0019,10B6)" },
-      "minimum": 0.0,
-      "maximum": 100000.0,
-      "default": 3132.0
-    },
-    {
-      "id": "qdesstgus",
-      "label": { "en": "qDESS TG" },
-      "type": "double",
-      "information": { "en": "Fallback qDESS spoiler duration written to DICOM private tag (0019,10B7)" },
-      "minimum": 0.0,
-      "maximum": 100000.0,
-      "default": 1560.0,
-      "unit": { "en": "us" }
     }
   ]
 }

--- a/recipes/openmsk/OpenReconREADME.md
+++ b/recipes/openmsk/OpenReconREADME.md
@@ -1,7 +1,7 @@
 # OpenMSK OpenRecon
 
 `openmsk` packages the KneePipeline knee MRI toolbox as a Siemens OpenRecon
-image-to-image module. It expects reconstructed qDESS two-echo Enhanced MR
+image-to-image module. It expects reconstructed DESS two-echo Enhanced MR
 images arriving as MRD image messages from the scanner.
 
 ## Outputs
@@ -14,7 +14,7 @@ images arriving as MRD image messages from the scanner.
   directory when `computethickness` is enabled.
 - Metrics comments on derived metric-bearing outputs and a burned-in metrics
   report image series when KneePipeline writes metrics JSON/CSV files.
-- qDESS T2 map MRD images and per-region T2 metrics when KneePipeline's
+- DESS T2 map MRD images and per-region T2 metrics when KneePipeline's
   `steps.t2_mapping` writes `*_t2map.nii.gz` and `*_t2_results.json`.
 
 ## Segmentation Labels
@@ -53,19 +53,20 @@ voxel-for-voxel identical: comparing them (for example computing DSC or ASSD
 against an offline run) requires resampling one result onto the other's grid
 first. This is inherent to OpenRecon, not a defect in either output.
 
-## qDESS And T2 Caveat
+## DESS And T2 Caveat
 
-OpenRecon receives MRD images, not the original DICOM. To preserve the qDESS
+OpenRecon receives MRD images, not the original DICOM. To preserve the DESS
 T2 path, the wrapper keeps both echo groups and writes a minimal two-echo MR
-DICOM series with `EchoNumbers`, TR/TE/flip angle, and DOSMA's qDESS private
+DICOM series with `EchoNumbers`, TR/TE/flip angle, and DOSMA's DESS private
 GL/TG tags. For a three-volume `sequenceName`, `sequenceName_fid`, and
 `sequenceName_SE` input, the unsuffixed volume is excluded, segmentation uses
 the voxelwise root-sum-of-squares of `_fid` and `_SE`, and fitting uses the two
 echoes separately. Because the scanner labels both echoes with TE1, the wrapper
 writes the second echo with
 `TE2 = 2 * TR - TE1`. TR/TE1/flip are read from the MRD header or image
-metadata when available. GL/TG and missing TR/TE1 values can be supplied
-through the OpenRecon qDESS fallback fields.
+metadata when available. GL/TG can come from MRD user parameters or image
+metadata; otherwise legacy saved-protocol values and then built-in DESS
+defaults are used.
 
 Some scanner exports instead interleave the two echoes in one named series as
 equal-sized MRD `set=0` and `set=1` groups. OpenMSK keeps those sets together,
@@ -73,8 +74,8 @@ segments their root-sum-of-squares, and uses both sets separately for fitting.
 LogViewer reports the detected series/set counts, grouping method, segmentation
 and fitting routing, received TE labels, and the corrected TE values.
 
-The fallback values are only as good as the protocol values entered on the
-scanner. Runtime logs report where every qDESS value came from.
+Runtime logs report the resolved value and source for every DESS fitting
+parameter.
 
 The `pymskt` right-knee reference used for cartilage subregion registration is
 packaged into the container at build time. Subregion and T2-statistics
@@ -95,14 +96,13 @@ as a failed post-processing run.
   scanner-safe single preprocessing/export worker defaults.
 - `computethickness`: run slower mesh/thickness analysis after the segmentation
   has been sent.
-- `runnsm`, `runbscore`: accepted for legacy scanner protocol compatibility
-  only; ignored because the gated ShapeMedKnee assets are not packaged.
-- `qdesstrms`, `qdesste1ms`, `qdessflipangledeg`, `qdessglarea`, `qdesstgus`:
-  fallback TR, TE1, flip angle, GL area, and TG values used to synthesize the
-  qDESS DICOM input when MRD metadata is incomplete. TE2 is always computed as
-  `2 * TR - TE1`.
-- `qdesste2ms`: accepted for scanner protocol compatibility but ignored because
-  TE2 is computed from TR and TE1.
+
+TR, TE1, and flip angle are read from MRD sequence parameters when available;
+TE2 is computed as `2 * TR - TE1`. The current scanner MRD header does not
+expose GL area or TG, so this protocol uses the built-in defaults. Acquisition
+fallback fields and the ignored legacy `runnsm`/`runbscore` flags remain
+accepted in saved protocol configurations, but are intentionally hidden from
+the GUI.
 
 ## Build And Validate
 

--- a/recipes/openmsk/build.yaml
+++ b/recipes/openmsk/build.yaml
@@ -161,7 +161,9 @@ build:
         # duplicate CUDA wheels from torch's package metadata.
         - pip install --no-cache-dir --no-deps acvl-utils==0.2.6 dynamic-network-architectures==0.3.1 nnunetv2==2.4.2 mskt==0.1.20
         - echo "{{ context.pymskt_right_knee_reference_sha256 }}  {{ get_file("pymskt_right_knee_reference") }}" | sha256sum -c -
-        - install -D -m 0644 {{ get_file("pymskt_right_knee_reference") }} "$(python -c 'from pathlib import Path; import pymskt; print(Path(pymskt.__file__).resolve().parent / "data" / "right_knee_example.nrrd")')"
+        # Locate pyMSKT without importing it: its optional-dependency warning is
+        # printed to stdout and would corrupt a command-substitution path.
+        - pymskt_reference_path="$(python -c 'from importlib.util import find_spec; from pathlib import Path; print(Path(next(iter(find_spec("pymskt").submodule_search_locations))) / "data" / "right_knee_example.nrrd")')" && install -D -m 0644 {{ get_file("pymskt_right_knee_reference") }} "${pymskt_reference_path}" && echo "{{ context.pymskt_right_knee_reference_sha256 }}  ${pymskt_reference_path}" | sha256sum -c -
         # KneePipeline's TF 2.11 / nnU-Net numpy compromise (resolved last).
         - pip install --no-cache-dir "numpy==1.24.3"
         - install -D -m 0644 {{ get_file("nnunet_numpy_compat.py") }} /opt/openmsk_compat/sitecustomize.py

--- a/recipes/openmsk/build.yaml
+++ b/recipes/openmsk/build.yaml
@@ -126,21 +126,23 @@ build:
 
     - include: macros/openrecon/neurodocker.yaml
 
-    # Add the CUDA 11.8 PyTorch stack used by optional NSM / nnU-Net paths, then
-    # pin both deep-learning stacks so later dependency installs cannot replace
-    # the TensorFlow base or the matching PyTorch wheels.
+    # Install the CUDA-enabled PyTorch code without its duplicate NVIDIA wheel
+    # stack. The TensorFlow GPU base already provides CUDA 11.8/cuDNN; only
+    # NCCL is absent from the base and must remain as a Python wheel.
     - run:
-        - pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu118 torch==2.2.2+cu118 torchvision==0.17.2+cu118
-        - python -c "import torch, torchvision, pathlib; path = pathlib.Path('/opt/pip-constraints.txt'); path.write_text(path.read_text() + 'torch==%s\ntorchvision==%s\n' % (torch.__version__, torchvision.__version__))"
+        - pip install --no-cache-dir --no-deps --extra-index-url https://download.pytorch.org/whl/cu118 torch==2.2.2+cu118 torchvision==0.17.2+cu118
+        - pip install --no-cache-dir nvidia-nccl-cu11==2.19.3
+        - LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH python -c "from importlib.metadata import version; import torch; assert torch.version.cuda == '11.8'; print('PyTorch using system CUDA', torch.__version__, version('torchvision'))"
+        - python -c "from importlib.metadata import version; import pathlib; path = pathlib.Path('/opt/pip-constraints.txt'); path.write_text(path.read_text() + 'torch==%s\ntorchvision==%s\n' % (version('torch'), version('torchvision')))"
         - cat /opt/pip-constraints.txt
 
     - workdir: /opt
     - run:
         - pip install --no-cache-dir huggingface-hub==0.24.7
-        # NSM: drop the unpinned torch* lines and install against baseline torch.
+        # NSM: install against the baseline torch and the minimal pyMSKT set below.
         - git clone https://github.com/gattia/nsm /opt/nsm
         - cd /opt/nsm
-        - sed -i -E '/^[[:space:]]*(torch|torchvision|torchaudio)[[:space:]]*$/d' requirements.txt
+        - sed -i -E '/^[[:space:]]*(torch|torchvision|torchaudio|mskt)[[:space:]]*$/d' requirements.txt
         - pip install --no-cache-dir -r requirements.txt
         - pip install --no-cache-dir --no-deps .
         # DOSMA bone_seg branch (qDESS bone/cartilage segmentation).
@@ -148,9 +150,16 @@ build:
         - cd /opt/DOSMA
         - git checkout bone_seg
         - pip install --no-cache-dir '.[ai]'
-        # pymeshfix pinned to 0.16.2: pymskt's fix_mesh() calls
-        # MeshFix.repair(verbose=...), a kwarg removed in pymeshfix >=0.17.
-        - pip install --no-cache-dir mskt==0.1.20 nnunetv2==2.4.2 SimpleITK==2.3.1 pandas==2.0.3 Pillow==10.4.0 pymeshfix==0.16.2
+        # Install only the pyMSKT dependencies used by KneePipeline's subregion,
+        # mesh, and thickness paths. Omit ITK widgets, Jupyter/Notebook,
+        # traittypes, and optional non-rigid registration dependencies.
+        # pymeshfix is pinned because pyMSKT passes repair(verbose=...), which
+        # was removed in pymeshfix >=0.17.
+        - pip install --no-cache-dir point-cloud-utils==0.34.0 pyacvd==0.4.0 pyvista==0.48.4 vtk==9.6.2 param==2.4.1 cycpd==0.28 SimpleITK==2.3.1 pandas==2.0.3 Pillow==10.4.0 pymeshfix==0.16.2 batchgenerators==0.25.3 dicom2nifti==2.6.2 graphviz==0.21 imagecodecs==2026.1.14 yacs==0.1.8 connected-components-3d==4.0.0 blosc2==3.0.0b4 jinja2==3.1.6 sympy==1.14.0
+        # These packages declare torch dependencies. Resolve their runtime
+        # dependencies above, then install without allowing pip to backfill the
+        # duplicate CUDA wheels from torch's package metadata.
+        - pip install --no-cache-dir --no-deps acvl-utils==0.2.6 dynamic-network-architectures==0.3.1 nnunetv2==2.4.2 mskt==0.1.20
         - echo "{{ context.pymskt_right_knee_reference_sha256 }}  {{ get_file("pymskt_right_knee_reference") }}" | sha256sum -c -
         - install -D -m 0644 {{ get_file("pymskt_right_knee_reference") }} "$(python -c 'from pathlib import Path; import pymskt; print(Path(pymskt.__file__).resolve().parent / "data" / "right_knee_example.nrrd")')"
         # KneePipeline's TF 2.11 / nnU-Net numpy compromise (resolved last).

--- a/recipes/openmsk/build.yaml
+++ b/recipes/openmsk/build.yaml
@@ -226,27 +226,30 @@ readme: |-
   ## openmsk/{{ context.version }} ##
 
   OpenMSK packages the KneePipeline knee MRI toolbox as a Siemens OpenRecon
-  image-to-image module for qDESS knee MRI. The OpenRecon path receives MRD
+  image-to-image module for DESS knee MRI. The OpenRecon path receives MRD
   images from the scanner, reconstructs a both-echo RSS NIfTI, runs KneePipeline, and
   returns bone/cartilage/meniscus segmentation with geometry copied from the
-  source images. The wrapper preserves both qDESS echo groups and synthesizes a
+  source images. The wrapper preserves both DESS echo groups and synthesizes a
   minimal two-echo DICOM series with TR/TE/flip and GL/TG values so
-  KneePipeline's qDESS loader can run its analytical T2 step from OpenRecon
+  KneePipeline's DESS loader can run its analytical T2 step from OpenRecon
   MRD input. For `sequenceName`, `sequenceName_fid`, and `sequenceName_SE`,
   segmentation uses the voxelwise root-sum-of-squares of `_fid` and `_SE`,
   fitting uses the echoes separately, and the corrected second echo time is
   computed as `TE2 = 2 * TR - TE1`. Equal-sized `set=0`
   and `set=1` groups within one series are handled as an unnamed two-echo
   fallback, with the detected grouping, routing, counts, and timing reported to
-  LogViewer. Source volumes returned by `sendoriginal` retain separate scanner
-  series and source names. The pyMSKT right-knee registration reference is
+  LogViewer. TR, TE1, and flip angle come from MRD sequence parameters when
+  available, TE2 is computed, and GL/TG use built-in defaults when absent from
+  metadata and legacy saved-protocol settings. Source volumes returned by
+  `sendoriginal` retain separate scanner series and source names. The pyMSKT
+  right-knee registration reference is
   packaged at build time, so subregion and T2-statistics post-processing does
   not require runtime GitHub access. If subregion generation still fails while
   thickness is disabled, global cartilage-compartment T2 statistics are
   computed from the remapped all-label segmentation. It mirrors
   KneePipeline's split steps: it runs mesh
-  generation/cartilage thickness when requested, runs qDESS T2 mapping when
-  KneePipeline identifies qDESS input, and returns subregion segmentation,
+  generation/cartilage thickness when requested, runs DESS T2 mapping when
+  KneePipeline identifies DESS input, and returns subregion segmentation,
   T2 maps, and a burned-in metrics report image series whenever those artifacts
   are written. The same metrics are copied into output metadata comments.
   The packaged segmentation models are
@@ -264,14 +267,15 @@ readme: |-
   labels 11 through 15 retain their upstream values.
   Legacy `runnsm` and `runbscore` protocol parameters are accepted for scanner
   conversion compatibility but ignored because gated ShapeMedKnee assets are not
-  packaged.
+  packaged. Legacy DESS acquisition fallback parameters are also accepted but
+  hidden from the OpenRecon GUI.
 
-  Direct DICOM usage keeps the qDESS GL/TG private tags and can produce the
+  Direct DICOM usage keeps the DESS GL/TG private tags and can produce the
   full output set including T2:
 
   ```bash
   ml openmsk/{{ context.version }}
-  python /opt/KneePipeline/run_pipeline.py /path/to/qDESS/dicom_dir /path/to/out --config /opt/KneePipeline/config.json
+  python /opt/KneePipeline/run_pipeline.py /path/to/DESS/dicom_dir /path/to/out --config /opt/KneePipeline/config.json
   ```
 
   ----------------------------------

--- a/recipes/openmsk/fulltest.yaml
+++ b/recipes/openmsk/fulltest.yaml
@@ -66,16 +66,75 @@ tests:
       }
       PY
 
-  - name: offline pymskt reference image
-    description: Verify cartilage subregion generation can load its packaged reference without network access
+  - name: shared CUDA runtime
+    description: Verify PyTorch uses the base CUDA stack without duplicate NVIDIA wheels
     script: |
       python - <<'PY'
+      from importlib.metadata import PackageNotFoundError, version
+      from pathlib import Path
+      import subprocess
+
+      import torch
+      import torchvision
+      from torchvision.ops import nms
+
+      assert torch.__version__ == "2.2.2+cu118"
+      assert torchvision.__version__ == "0.17.2+cu118"
+      assert torch.version.cuda == "11.8"
+      assert version("nvidia-nccl-cu11") == "2.19.3"
+      for package in (
+          "nvidia-cublas-cu11",
+          "nvidia-cuda-cupti-cu11",
+          "nvidia-cuda-nvrtc-cu11",
+          "nvidia-cuda-runtime-cu11",
+          "nvidia-cudnn-cu11",
+          "nvidia-cufft-cu11",
+          "nvidia-curand-cu11",
+          "nvidia-cusolver-cu11",
+          "nvidia-cusparse-cu11",
+          "nvidia-nvtx-cu11",
+          "triton",
+      ):
+          try:
+              version(package)
+          except PackageNotFoundError:
+              continue
+          raise AssertionError(f"duplicate CUDA dependency is installed: {package}")
+
+      torch_cuda = Path(torch.__file__).resolve().parent / "lib" / "libtorch_cuda.so"
+      linked = subprocess.run(
+          ["ldd", str(torch_cuda)],
+          check=True,
+          capture_output=True,
+          text=True,
+      ).stdout
+      assert "not found" not in linked, linked
+      boxes = torch.tensor([[0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 2.0, 2.0]])
+      scores = torch.tensor([0.9, 0.8])
+      assert nms(boxes, scores, 0.5).tolist() == [0, 1]
+
+      from scripts.inference import KneeSegmentationInference
+      print(KneeSegmentationInference.__name__)
+      PY
+    environment:
+      PYTHONPATH: /opt/KneePipeline/DEPENDENCIES/nnunet_knee_inference
+
+  - name: offline pymskt reference image
+    description: Verify the minimal pyMSKT install performs offline subregion generation
+    script: |
+      python - <<'PY'
+      from importlib.metadata import PackageNotFoundError, version
       from pathlib import Path
       import inspect
 
+      import numpy as np
       import pymskt
       import SimpleITK as sitk
-      from pymskt.image.cartilage_processing import get_aligned_cartilage_subregions
+      from pymskt.image.cartilage_processing import (
+          get_aligned_cartilage_subregions,
+          get_knee_segmentation_with_femur_subregions,
+      )
+      from pymskt.mesh import BoneMesh
 
       reference = Path(pymskt.__file__).resolve().parent / "data" / "right_knee_example.nrrd"
       assert reference.is_file(), reference
@@ -85,7 +144,44 @@ tests:
       assert Path(default_reference).resolve() == reference.resolve()
       image = sitk.ReadImage(str(reference))
       assert image.GetSize() == (384, 384, 160)
-      print(reference)
+      for package in ("itk-core", "itk-filtering", "itkwidgets", "pyfocusr"):
+          try:
+              version(package)
+          except PackageNotFoundError:
+              continue
+          raise AssertionError(f"unused pyMSKT dependency is installed: {package}")
+      assert version("cycpd") == "0.28"
+
+      source = sitk.GetArrayFromImage(image)
+      canonical = np.zeros_like(source)
+      for source_label, canonical_label in {
+          5: 1,
+          6: 2,
+          1: 4,
+          2: 5,
+          3: 6,
+      }.items():
+          canonical[source == source_label] = canonical_label
+      segmentation = sitk.GetImageFromArray(canonical)
+      segmentation.CopyInformation(image)
+      subregions = get_knee_segmentation_with_femur_subregions(
+          segmentation,
+          fem_cart_label_idx=4,
+          femur_label=1,
+          med_tibia_label=5,
+          lat_tibia_label=6,
+          tibia_label=2,
+          ref_image_reg_percent_sampling=0.01,
+      )
+      subregion_labels = set(np.unique(sitk.GetArrayFromImage(subregions)))
+      assert {11, 12, 13, 14, 15} <= subregion_labels
+      mesh = BoneMesh(
+          seg_image=segmentation,
+          label_idx=1,
+          list_cartilage_labels=[4],
+          bone="femur",
+      )
+      print(reference, type(mesh).__name__, sorted(subregion_labels))
       PY
 
   - name: Helper scripts render help

--- a/recipes/openmsk/fulltest.yaml
+++ b/recipes/openmsk/fulltest.yaml
@@ -75,6 +75,7 @@ tests:
       from importlib.metadata import PackageNotFoundError, version
       from pathlib import Path
       import subprocess
+      import sys
 
       import torch
       import torchvision
@@ -115,11 +116,10 @@ tests:
       scores = torch.tensor([0.9, 0.8])
       assert nms(boxes, scores, 0.5).tolist() == [0, 1]
 
+      sys.path.insert(0, "/opt/KneePipeline/DEPENDENCIES/nnunet_knee_inference")
       from scripts.inference import KneeSegmentationInference
       print(KneeSegmentationInference.__name__)
       PY
-    environment:
-      PYTHONPATH: /opt/KneePipeline/DEPENDENCIES/nnunet_knee_inference
 
   - name: offline pymskt reference image
     description: Verify the minimal pyMSKT install performs offline subregion generation

--- a/recipes/openmsk/fulltest.yaml
+++ b/recipes/openmsk/fulltest.yaml
@@ -35,7 +35,9 @@ tests:
       readme = Path("/opt/code/python-ismrmrd-server/OpenReconREADME.md")
       data = json.loads(label.read_text())
       parameters = {parameter["id"] for parameter in data["parameters"]}
-      assert {"sendoriginal", "segmodel", "computethickness"} <= parameters
+      assert parameters == {"config", "sendoriginal", "segmodel", "computethickness"}
+      assert data["parameters"][0]["values"][0]["name"]["en"] == "DESS"
+      assert "qDESS" not in label.read_text()
       assert "OpenMSK" in readme.read_text()
       print(label)
       PY

--- a/recipes/openmsk/openmsk.py
+++ b/recipes/openmsk/openmsk.py
@@ -1,4 +1,4 @@
-"""OpenRecon module for OpenMSK/KneePipeline qDESS knee MRI analysis."""
+"""OpenRecon module for OpenMSK/KneePipeline DESS knee MRI analysis."""
 
 from __future__ import annotations
 
@@ -195,7 +195,7 @@ def process(connection, config, metadata):
         source_selection = _select_primary_source(magnitude_images)
         source_group = source_selection.get("primary") if source_selection else []
         if not source_group:
-            logging.warning("No processable qDESS source group selected")
+            logging.warning("No processable DESS source group selected")
             return
         _log_qdess_input_detection(connection, magnitude_images, source_selection)
 
@@ -306,7 +306,7 @@ def process(connection, config, metadata):
             elif _segmentation_skips_step(segmentation_result, "t2_mapping"):
                 logging.info(
                     "Skipping OpenMSK T2 mapping because KneePipeline identified "
-                    "the OpenRecon input as non-qDESS"
+                    "the OpenRecon input as non-DESS"
                 )
             else:
                 logging.info("Skipping OpenMSK mesh/thickness post-processing")
@@ -409,7 +409,7 @@ def process(connection, config, metadata):
                 sent_images.extend(t2_images)
             else:
                 logging.info(
-                    "No T2 map was written; check the qDESS echo grouping, synthesized "
+                    "No T2 map was written; check the DESS echo grouping, synthesized "
                     "DICOM parameter logs, and KneePipeline t2_mapping status."
                 )
 
@@ -703,7 +703,7 @@ def _log_qdess_input_detection(connection, images, source_selection):
     )
     _send_logviewer_info(
         connection,
-        "OpenMSK qDESS routing: "
+        "OpenMSK DESS routing: "
         f"grouping={grouping_method}; "
         f"segmentation=RSS({rss_echoes}); "
         f"fitting echoes=[{fitting_echoes}]",
@@ -723,11 +723,16 @@ def _log_qdess_timing(connection, qdess_params, source_selection):
     te_sources = sources.get("te_ms", ["", ""])
     te_values = qdess_params.get("te_ms", [None, None])
     message = (
-        "OpenMSK qDESS fitting times: "
+        "OpenMSK DESS fitting parameters: "
         f"received TE labels={qdess_params.get('received_te_ms', [])} ms; "
         f"TR={qdess_params.get('tr_ms')} ms ({sources.get('tr_ms', '')}); "
         f"TE1({first_echo_label})={te_values[0]} ms ({te_sources[0]}); "
-        f"TE2({second_echo_label})={te_values[1]} ms ({te_sources[1]})"
+        f"TE2({second_echo_label})={te_values[1]} ms ({te_sources[1]}); "
+        f"flip={qdess_params.get('flip_angle_deg')} deg "
+        f"({sources.get('flip_angle_deg', '')}); "
+        f"GL area={qdess_params.get('gl_area')} "
+        f"({sources.get('gl_area', '')}); "
+        f"TG={qdess_params.get('tg_us')} us ({sources.get('tg_us', '')})"
     )
     _send_logviewer_info(connection, message)
 
@@ -931,7 +936,7 @@ def _write_source_nifti(echo_groups_or_images, output_path, metadata):
         echo_images = [echo_images[index] for index in echo_sort_indices]
         if len(echo_images) != len(ordered_images):
             raise ValueError(
-                "Cannot compute qDESS RSS from unequal echo groups: "
+                "Cannot compute DESS RSS from unequal echo groups: "
                 f"{echo_keys[0]}={len(ordered_images)} {echo_key}={len(echo_images)}"
             )
         for slice_index, (reference_image, echo_image) in enumerate(
@@ -952,7 +957,7 @@ def _write_source_nifti(echo_groups_or_images, output_path, metadata):
             np.float32,
             copy=False,
         )
-        description = "OpenMSK RSS of both qDESS echoes"
+        description = "OpenMSK RSS of both DESS echoes"
         logging.info(
             "Computed OpenMSK segmentation RSS from echo groups %s and %s "
             "with %d slice(s); intensity range=[%s, %s]",
@@ -1031,7 +1036,7 @@ def _validate_rss_slice_geometry(reference_header, echo_header, echo_key, slice_
     )
     if not geometry_matches:
         raise ValueError(
-            "Cannot compute qDESS RSS from geometrically mismatched echoes: "
+            "Cannot compute DESS RSS from geometrically mismatched echoes: "
             f"echo={echo_key} sorted_slice={slice_index}"
         )
 
@@ -1107,7 +1112,7 @@ def _resolve_qdess_parameters(config, metadata, echo_groups):
     params["tg_us"] = tg_us
     params["sources"]["tg_us"] = source
 
-    logging.info("Resolved qDESS synthesis parameters: %s", params)
+    logging.info("Resolved DESS synthesis parameters: %s", params)
     return params
 
 
@@ -1233,21 +1238,21 @@ def _metadata_protocol_name(metadata):
 def _write_synthetic_qdess_dicom_input(echo_groups, output_dir, metadata, config, qdess_params):
     ordered_groups = _ordered_echo_groups(echo_groups)
     if len(ordered_groups) < 2:
-        logging.info("Cannot synthesize qDESS DICOM: only %d echo group(s) available", len(ordered_groups))
+        logging.info("Cannot synthesize DESS DICOM: only %d echo group(s) available", len(ordered_groups))
         return None
 
     echo_pairs = ordered_groups[:2]
     slice_count = len(echo_pairs[0][1])
     if slice_count == 0 or any(len(images) != slice_count for _key, images in echo_pairs):
         logging.warning(
-            "Cannot synthesize qDESS DICOM: echo group slice counts differ: %s",
+            "Cannot synthesize DESS DICOM: echo group slice counts differ: %s",
             [len(images) for _key, images in echo_pairs],
         )
         return None
 
     missing = [key for key in ("tr_ms", "te_ms", "flip_angle_deg", "gl_area", "tg_us") if qdess_params.get(key) is None]
     if missing:
-        logging.warning("Cannot synthesize qDESS DICOM: missing qDESS parameter(s) %s", missing)
+        logging.warning("Cannot synthesize DESS DICOM: missing DESS parameter(s) %s", missing)
         return None
 
     try:
@@ -1255,7 +1260,7 @@ def _write_synthetic_qdess_dicom_input(echo_groups, output_dir, metadata, config
         from pydicom.dataset import FileDataset, FileMetaDataset
         from pydicom.uid import ExplicitVRLittleEndian, MRImageStorage, generate_uid
     except Exception:
-        logging.warning("Cannot synthesize qDESS DICOM because pydicom import failed:\n%s", traceback.format_exc())
+        logging.warning("Cannot synthesize DESS DICOM because pydicom import failed:\n%s", traceback.format_exc())
         return None
 
     output_dir = Path(output_dir)
@@ -1273,7 +1278,7 @@ def _write_synthetic_qdess_dicom_input(echo_groups, output_dir, metadata, config
     pixel_scale = _dicom_pixel_scale(all_pixels)
 
     logging.info(
-        "Synthesizing qDESS DICOM series: out=%s slices=%d echo_keys=%s TR=%sms TE=%s flip=%sdeg "
+        "Synthesizing DESS DICOM series: out=%s slices=%d echo_keys=%s TR=%sms TE=%s flip=%sdeg "
         "GL_AREA=%s TG=%sus sources=%s",
         output_dir,
         slice_count,
@@ -1358,7 +1363,7 @@ def _write_synthetic_qdess_dicom_input(echo_groups, output_dir, metadata, config
                 ds.save_as(str(path), write_like_original=False)
             written.append(path)
 
-    logging.info("Wrote %d synthetic qDESS DICOM file(s) to %s", len(written), output_dir)
+    logging.info("Wrote %d synthetic DESS DICOM file(s) to %s", len(written), output_dir)
     return output_dir
 
 
@@ -1372,7 +1377,7 @@ def _stage_qdess_fit_input(qdess_dicom_dir, working_dir):
         shutil.copytree(source, target)
         method = "copied"
     logging.info(
-        "Staged both qDESS echoes for fitting: %s %s -> %s",
+        "Staged both DESS echoes for fitting: %s %s -> %s",
         method,
         source,
         target,
@@ -1753,7 +1758,7 @@ if compute_t2 and "label_remap" not in summary["errors"]:
         ] if fit_dicom_dir.is_dir() else []
         if not dicom_files:
             raise FileNotFoundError(
-                f"No synthetic qDESS DICOM files found in {fit_dicom_dir}"
+                f"No synthetic DESS DICOM files found in {fit_dicom_dir}"
             )
 
         from steps import t2_mapping as t2_mapping_step
@@ -1768,7 +1773,7 @@ if compute_t2 and "label_remap" not in summary["errors"]:
 elif not compute_t2:
     summary["t2_mapping"] = {
         "skipped": True,
-        "reason": "KneePipeline segmentation did not identify the input as qDESS",
+        "reason": "KneePipeline segmentation did not identify the input as DESS",
     }
 else:
     summary["t2_mapping"] = {

--- a/recipes/openmsk/openmsk.py
+++ b/recipes/openmsk/openmsk.py
@@ -2703,6 +2703,23 @@ def _set_header_sequence_field(image_header, field_name, values):
         setattr(image_header, field_name, tuple(values))
 
 
+def _explicit_header_geometry_meta(header):
+    return {
+        "ImageRowDir": [
+            f"{value:.18f}" for value in _header_vector(header, "read_dir")
+        ],
+        "ImageColumnDir": [
+            f"{value:.18f}" for value in _header_vector(header, "phase_dir")
+        ],
+        "ImageSliceNormDir": [
+            f"{value:.18f}" for value in _header_vector(header, "slice_dir")
+        ],
+        "SlicePosLightMarker": [
+            f"{value:.18f}" for value in _header_vector(header, "position")
+        ],
+    }
+
+
 def _derived_uid(*parts):
     source = ".".join(str(part) for part in parts if part is not None)
     return "2.25." + str(uuid.uuid5(uuid.NAMESPACE_URL, source).int)
@@ -2990,53 +3007,85 @@ def _build_metrics_report_images(metrics_outputs, source_images, metrics_comment
     if not pages:
         return []
 
-    series_uid = _derived_uid(METRICS_REPORT_SERIES_NAME, METRICS_REPORT_SERIES_INDEX)
-    outputs = []
+    # Match MuscleMap's scanner-tested report contract: pages are slices of one
+    # canonical explicit volume, not separate source-derived 2D images.
+    page_arrays = [np.asarray(page, dtype=np.uint16) for page in pages]
+    first_page_shape = tuple(page_arrays[0].shape)
+    if any(tuple(page.shape) != first_page_shape for page in page_arrays):
+        logging.warning(
+            "Failed to build OpenMSK metrics report image because page shapes "
+            "differ: %s",
+            [tuple(page.shape) for page in page_arrays],
+        )
+        return []
+
     page_count = len(pages)
-    for index, page in enumerate(pages):
-        page = np.ascontiguousarray(page.astype(np.uint16, copy=False))
-        output = ismrmrd.Image.from_array(page, transpose=False)
-        header = copy.deepcopy(base_header)
-        header.data_type = output.data_type
-        header.image_type = ismrmrd.IMTYPE_MAGNITUDE
-        header.image_series_index = METRICS_REPORT_SERIES_INDEX
-        header.image_index = index + 1
-        header.slice = index
-        _set_header_sequence_field(header, "matrix_size", [page.shape[1], page.shape[0], 1])
-        _set_header_sequence_field(header, "field_of_view", [float(page.shape[1]), float(page.shape[0]), float(page_count)])
-        _set_header_sequence_field(header, "position", [0.0, 0.0, float(index)])
-        _set_header_sequence_field(header, "read_dir", [1.0, 0.0, 0.0])
-        _set_header_sequence_field(header, "phase_dir", [0.0, 1.0, 0.0])
-        _set_header_sequence_field(header, "slice_dir", [0.0, 0.0, 1.0])
-        output.setHead(header)
-        output.image_series_index = METRICS_REPORT_SERIES_INDEX
-        output.image_index = index + 1
-        output.attribute_string = _derived_meta(
-            source_images[0],
-            METRICS_REPORT_SERIES_NAME,
-            series_uid,
-            METRICS_REPORT_SERIES_INDEX,
-            index,
-            METRICS_REPORT_IMAGE_TYPE,
-            "Image",
-            metrics_comment or "OpenMSK metrics report",
-            float(np.nanmax(page)) if page.size else 4095.0,
-            source_geometry_segment=False,
-            slice_count=page_count,
-            extra_meta={
-                "Keep_image_geometry": "0",
-                "OpenMSKMetricsRows": str(len(rows)),
-                **_metrics_extra_meta(metrics_comment),
-            },
-        ).serialize()
-        outputs.append(output)
+    page_height, page_width = first_page_shape
+    report_volume = np.stack(page_arrays, axis=0)
+    output = ismrmrd.Image.from_array(
+        np.ascontiguousarray(report_volume),
+        transpose=False,
+    )
+    header = copy.deepcopy(base_header)
+    header.data_type = output.data_type
+    header.image_type = ismrmrd.IMTYPE_MAGNITUDE
+    header.image_series_index = METRICS_REPORT_SERIES_INDEX
+    header.image_index = 1
+    header.slice = 0
+    header.contrast = 0
+    _set_header_sequence_field(
+        header,
+        "matrix_size",
+        [page_width, page_height, page_count],
+    )
+    _set_header_sequence_field(
+        header,
+        "field_of_view",
+        [float(page_width), float(page_height), float(page_count)],
+    )
+    _set_header_sequence_field(header, "position", [0.0, 0.0, 0.0])
+    _set_header_sequence_field(header, "read_dir", [1.0, 0.0, 0.0])
+    _set_header_sequence_field(header, "phase_dir", [0.0, 1.0, 0.0])
+    _set_header_sequence_field(header, "slice_dir", [0.0, 0.0, 1.0])
+    output.setHead(header)
+    output.image_series_index = METRICS_REPORT_SERIES_INDEX
+    output.image_index = 1
+
+    series_uid = _derived_uid(
+        METRICS_REPORT_SERIES_NAME,
+        METRICS_REPORT_SERIES_INDEX,
+    )
+    report_meta = _derived_meta(
+        source_images[0],
+        METRICS_REPORT_SERIES_NAME,
+        series_uid,
+        METRICS_REPORT_SERIES_INDEX,
+        0,
+        METRICS_REPORT_IMAGE_TYPE,
+        "Segmentation",
+        metrics_comment or "OpenMSK metrics report",
+        float(np.nanmax(report_volume)) if report_volume.size else 4095.0,
+        source_geometry_segment=False,
+        slice_count=page_count,
+        extra_meta={
+            "Keep_image_geometry": "0",
+            "OpenMSKMetricsRows": str(len(rows)),
+            **_metrics_extra_meta(metrics_comment),
+        },
+    )
+    if "IceMiniHead" in report_meta:
+        del report_meta["IceMiniHead"]
+    for key, value in _explicit_header_geometry_meta(header).items():
+        report_meta[key] = value
+    output.attribute_string = report_meta.serialize()
 
     logging.info(
-        "Created OpenMSK metrics report image series with %d page(s) in image_series_index=%d",
+        "Created OpenMSK metrics explicit-volume report image with %d page(s) "
+        "in image_series_index=%d",
         page_count,
         METRICS_REPORT_SERIES_INDEX,
     )
-    return outputs
+    return [output]
 
 
 def _send_images(connection, images, context):

--- a/recipes/openmsk/test_openmsk.py
+++ b/recipes/openmsk/test_openmsk.py
@@ -320,6 +320,14 @@ def test_recipe_uses_system_cuda_and_minimal_pymskt_dependencies():
         and "right_knee_example.nrrd" in command
         for command in run_commands
     )
+    reference_install = next(
+        command
+        for command in run_commands
+        if "pymskt_reference_path=" in command
+    )
+    assert 'find_spec("pymskt")' in reference_install
+    assert "import pymskt" not in reference_install
+    assert "sha256sum -c -" in reference_install
     torch_install = next(
         command for command in run_commands if "torch==2.2.2+cu118" in command
     )

--- a/recipes/openmsk/test_openmsk.py
+++ b/recipes/openmsk/test_openmsk.py
@@ -659,6 +659,9 @@ def test_process_routes_named_fid_and_se_to_rss_and_logs_detection(monkeypatch):
         and "TR=25.0 ms" in message
         and "TE1(FID)=5.05 ms" in message
         and "TE2(SE)=44.95 ms (computed as 2 * TR - TE1)" in message
+        and "flip=30.0 deg (mrd.sequenceParameters.flipAngle_deg)" in message
+        and "GL area=3132.0 (default.qdess_gl_area)" in message
+        and "TG=1560.0 us (default.qdess_tg_us)" in message
         for message in messages
     )
     assert connection.closed
@@ -958,10 +961,18 @@ def test_write_run_config_preserves_requested_segmentation_model(tmp_path, monke
     assert run_config["default_seg_model"] == "goyal_sagittal"
 
 
-def test_openrecon_label_keeps_packaged_model_choices():
+def test_openrecon_label_has_minimal_dess_controls_and_packaged_model_choices():
     label = json.loads(Path("OpenReconLabel.json").read_text())
     params = {param["id"]: param for param in label["parameters"]}
 
+    assert set(params) == {
+        "config",
+        "sendoriginal",
+        "segmodel",
+        "computethickness",
+    }
+    assert params["config"]["label"]["en"] == "Analysis"
+    assert params["config"]["values"][0]["name"]["en"] == "DESS"
     assert params["sendoriginal"]["default"] is True
     assert [value["id"] for value in params["segmodel"]["values"]] == [
         "acl_qdess_bone_july_2024",
@@ -970,21 +981,15 @@ def test_openrecon_label_keeps_packaged_model_choices():
         "goyal_axial",
         "nnunet_knee",
     ]
-    model_names = {value["id"]: value["name"]["en"] for value in params["segmodel"]["values"]}
-    assert model_names["acl_qdess_bone_july_2024"] == "DOSMA qDESS bone/cartilage July 2024"
-    assert params["runnsm"]["type"] == "boolean"
-    assert params["runnsm"]["default"] is False
-    assert params["runbscore"]["type"] == "boolean"
-    assert params["runbscore"]["default"] is False
-    for key in (
-        "qdesstrms",
-        "qdesste1ms",
-        "qdesste2ms",
-        "qdessflipangledeg",
-        "qdessglarea",
-        "qdesstgus",
-    ):
-        assert params[key]["type"] == "double"
+    model_names = {
+        value["id"]: value["name"]["en"]
+        for value in params["segmodel"]["values"]
+    }
+    assert (
+        model_names["acl_qdess_bone_july_2024"]
+        == "DOSMA DESS bone/cartilage July 2024"
+    )
+    assert "qDESS" not in json.dumps(label)
 
 
 def test_kneepipeline_subprocess_env_prepends_numpy_compat_path(monkeypatch):
@@ -1229,7 +1234,7 @@ def test_write_source_nifti_uses_geometry_aligned_rss_of_both_echoes(tmp_path):
     assert [int(image.slice) for image in ordered_sources] == [0, 1]
     np.testing.assert_allclose(rss_data[:, :, 0], 5.0)
     np.testing.assert_allclose(rss_data[:, :, 1], 13.0)
-    assert "RSS of both qDESS echoes" in rss.header["descrip"].tobytes().decode(
+    assert "RSS of both DESS echoes" in rss.header["descrip"].tobytes().decode(
         errors="ignore"
     )
 

--- a/recipes/openmsk/test_openmsk.py
+++ b/recipes/openmsk/test_openmsk.py
@@ -301,7 +301,7 @@ def test_original_passthrough_splits_three_source_volumes_into_labeled_subseries
     ]
 
 
-def test_recipe_packages_pymskt_reference_image_for_offline_runtime():
+def test_recipe_uses_system_cuda_and_minimal_pymskt_dependencies():
     recipe = yaml.safe_load(Path("build.yaml").read_text())
     files = {entry["name"]: entry for entry in recipe["files"]}
     reference = files["pymskt_right_knee_reference"]
@@ -320,7 +320,48 @@ def test_recipe_packages_pymskt_reference_image_for_offline_runtime():
         and "right_knee_example.nrrd" in command
         for command in run_commands
     )
-    assert any("mskt==0.1.20" in command for command in run_commands)
+    torch_install = next(
+        command for command in run_commands if "torch==2.2.2+cu118" in command
+    )
+    assert "--no-deps" in torch_install
+    assert "nvidia-nccl-cu11==2.19.3" in "\n".join(run_commands)
+    assert not any("import torch, torchvision" in command for command in run_commands)
+
+    nsm_requirement_filter = next(
+        command
+        for command in run_commands
+        if "requirements.txt" in command and "sed -i" in command
+    )
+    assert "mskt" in nsm_requirement_filter
+
+    mskt_install = next(
+        command for command in run_commands if "mskt==0.1.20" in command
+    )
+    assert "--no-deps" in mskt_install
+    assert "nnunetv2==2.4.2" in mskt_install
+    assert "acvl-utils==0.2.6" in mskt_install
+    assert "dynamic-network-architectures==0.3.1" in mskt_install
+    dependency_commands = "\n".join(run_commands)
+    for dependency in (
+        "point-cloud-utils==0.34.0",
+        "pyacvd==0.4.0",
+        "pyvista==0.48.4",
+        "vtk==9.6.2",
+        "param==2.4.1",
+        "cycpd==0.28",
+        "batchgenerators==0.25.3",
+        "connected-components-3d==4.0.0",
+    ):
+        assert dependency in dependency_commands
+    for omitted_dependency in (
+        "itkwidgets",
+        "itk-core",
+        "jupyter",
+        "notebook",
+        "traittypes",
+        "pyfocusr",
+    ):
+        assert omitted_dependency not in dependency_commands
 
 
 class FakeConnection:
@@ -1359,7 +1400,10 @@ def test_nifti_to_mrd_returns_upstream_labels_for_canonical_subregions(tmp_path)
     np.testing.assert_array_equal(np.squeeze(outputs[0].data), expected_xyz[:, :, 0].T)
 
 
-def test_metrics_report_images_include_metrics_metadata(tmp_path):
+def test_metrics_report_images_match_musclemap_explicit_volume_contract(
+    tmp_path,
+    monkeypatch,
+):
     source = make_source_image_with_minihead()
     metrics_json = tmp_path / "openmsk_echo1_thickness_results.json"
     metrics_json.write_text(json.dumps({"fem_cart_mm_mean": 1.2345}))
@@ -1372,6 +1416,15 @@ def test_metrics_report_images_include_metrics_metadata(tmp_path):
             "rows": [],
         }
     ]
+    report_pages = [
+        np.arange(20, dtype=np.uint16).reshape(4, 5),
+        np.arange(20, 40, dtype=np.uint16).reshape(4, 5),
+    ]
+    monkeypatch.setattr(
+        openmsk,
+        "_render_metrics_report_pages",
+        lambda *_args, **_kwargs: report_pages,
+    )
 
     images = openmsk._build_metrics_report_images(
         metrics_outputs,
@@ -1385,12 +1438,51 @@ def test_metrics_report_images_include_metrics_metadata(tmp_path):
     meta = ismrmrd.Meta.deserialize(image.attribute_string)
 
     assert int(header.image_series_index) == openmsk.METRICS_REPORT_SERIES_INDEX
+    assert int(header.image_index) == 1
+    assert int(header.slice) == 0
+    assert list(header.matrix_size) == [5, 4, 2]
+    assert list(header.field_of_view) == [5.0, 4.0, 2.0]
+    assert list(header.position) == [0.0, 0.0, 0.0]
+    assert list(header.read_dir) == [1.0, 0.0, 0.0]
+    assert list(header.phase_dir) == [0.0, 1.0, 0.0]
+    assert list(header.slice_dir) == [0.0, 0.0, 1.0]
     assert first(meta, "SeriesDescription") == openmsk.METRICS_REPORT_SERIES_NAME
-    assert first(meta, "DataRole") == "Image"
+    assert first(meta, "DataRole") == "Segmentation"
     assert first(meta, "Keep_image_geometry") == "0"
     assert first(meta, "OpenMSKMetricsRows") == "1"
+    assert first(meta, "slice_count") == "2"
+    assert first(meta, "NumberOfSlices") == "2"
+    assert first(meta, "ImagesInAcquisition") == "2"
+    assert meta["ImageRowDir"] == [
+        "1.000000000000000000",
+        "0.000000000000000000",
+        "0.000000000000000000",
+    ]
+    assert meta["ImageColumnDir"] == [
+        "0.000000000000000000",
+        "1.000000000000000000",
+        "0.000000000000000000",
+    ]
+    assert meta["ImageSliceNormDir"] == [
+        "0.000000000000000000",
+        "0.000000000000000000",
+        "1.000000000000000000",
+    ]
+    assert meta["SlicePosLightMarker"] == [
+        "0.000000000000000000",
+        "0.000000000000000000",
+        "0.000000000000000000",
+    ]
+    assert "IceMiniHead" not in meta
     assert "fem_cart_mm_mean" in first(meta, "ImageComments")
-    assert np.asarray(image.data).max() > 0
+    np.testing.assert_array_equal(np.asarray(image.data)[0], np.stack(report_pages))
+
+    orientation_probe = np.zeros((4, 5), dtype=np.uint16)
+    orientation_probe[0, 0] = 1
+    orientation_probe[1, 4] = 2
+    oriented_probe = openmsk._orient_metrics_report_page(orientation_probe)
+    assert oriented_probe[-1, -1] == 1
+    assert oriented_probe[-2, 0] == 2
 
 
 def test_collect_metrics_outputs_reads_csv_when_json_absent(tmp_path):


### PR DESCRIPTION
## What changed

- send burned-in metrics pages as one canonical explicit-volume MRD image, matching MuscleMap's scanner-tested report contract
- stamp canonical report geometry and remove the inherited ICE miniheader so the scanner does not display the report upside down or left-right flipped
- use the TensorFlow base image's CUDA libraries for PyTorch and install only the missing NCCL wheel
- install a minimal pyMSKT dependency set while retaining offline cartilage-subregion, mesh, and thickness support
- reduce the OpenRecon GUI from 12 controls to four meaningful DESS controls
- read TR, TE1, and flip angle from MRD metadata, compute TE2, retain built-in GL/TG defaults, and log every resolved fitting value and source
- retain parsing of hidden legacy acquisition and NSM/BScore parameters for saved-protocol compatibility

## Why

OpenMSK was sending each metrics page as a separate source-derived 2D image. MuscleMap's working scanner path instead sends all pages as one canonical explicit volume without a source ICE miniheader. The previous dependency installation also duplicated most of the CUDA runtime already present in the TensorFlow base image, while pyMSKT's default dependency set pulled unrelated ITK widget, Jupyter, Notebook, and visualization packages. Finally, the OpenRecon GUI exposed ignored or header-derived DESS acquisition values that users should not need to enter.

## User impact

The next scanner build should display the metrics report in the intended orientation, use a smaller runtime image, and present only Analysis, Send original images, Segmentation model, and Compute thickness. Existing saved protocols remain compatible.

## Validation

- `../../env/bin/python -m pytest -q test_openmsk.py` — 33 passed
- OpenRecon label validated against `OpenReconSchema_1.1.0.json` after normal version substitution
- `../../env/bin/python ../../builder/validation.py build.yaml`
- `env/bin/python -m builder generate openmsk --recreate --architecture x86_64`
- `git diff --check`

Scanner-visible report orientation still needs confirmation with the newly built image.