### PR TITLE
Clarify napari GUI menu entry

### DIFF
--- a/recipes/napari/build.yaml
+++ b/recipes/napari/build.yaml
@@ -109,7 +109,7 @@ deploy:
     - nninteractive-server
 
 gui_apps:
-  - name: napari
+  - name: napari GUI
     exec: napari
   - name: VoxTell
     exec: napari-voxtell


### PR DESCRIPTION
## Summary

Rename the explicit napari graphical launcher from `napari` to `napari GUI`.

Neurodesktop automatically creates a generic `napari 0.8.0` container entry. The explicit GUI launcher previously received the same display label, making the two entries indistinguishable. This change preserves the `napari` executable while displaying the launcher as `napari GUI 0.8.0`.

## Validation

- `python3 builder/validation.py recipes/napari/build.yaml`
- generated release metadata contains `napari GUI-napari 0.8.0` with `exec: napari`
- `git diff --check origin/main...HEAD`
