### PR TITLE
Add HyperMapp3r white matter hyperintensity segmentation recipe

### DIFF
--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -135,11 +135,20 @@ build:
     # Python 3.7 under the nilearn 0.9.2 constraint (scipy>=1.5) -- an earlier
     # scipy==1.4.1 pin here was unsatisfiable, and the TensorFlow layer above
     # already installs scipy 1.7.3 anyway.
-    # tables, plotly, SimpleITK and a standalone scikit-learn pin were dropped:
-    # nothing in hypermapper imports them.
+    # tables and SimpleITK were dropped: nothing in hypermapper imports them and
+    # neither is declared in upstream's setup.py.
+    #
+    # plotly IS required even though no module imports it. The generated
+    # `hypermapper` console script sets __requires__ = 'HyperMapp3r', so
+    # pkg_resources resolves every dependency setup.py declares before running
+    # anything. Dropping plotly built a working image whose CLI died on
+    # "DistributionNotFound: The 'plotly' distribution was not found and is
+    # required by HyperMapp3r" -- declared metadata is enforced regardless of
+    # imports. 5.18.0 is the last release that still supports python 3.7.
     - run:
         - python -m pip install --no-cache-dir
           "scipy==1.7.3"
+          "plotly==5.18.0"
           "scikit-learn==1.0.2"
           "joblib==1.3.2"
           "nibabel==3.2.2"
@@ -185,6 +194,11 @@ build:
         # --no-deps: setup.py re-pins keras, which would undo the resolve above.
         # PyQt5 is installed explicitly in the step before this one.
         - python -m pip install --no-cache-dir --no-deps -e .
+        # Mirror what the generated console script does at start-up
+        # (__requires__ = 'HyperMapp3r'), so a dependency that setup.py declares
+        # but this recipe does not install fails here, at the layer that can fix
+        # it, rather than in the CLI smoke test further down.
+        - python -c "import pkg_resources; pkg_resources.require('HyperMapp3r'); print('requirements resolve')"
 
     # hypermapper resolves models as <repo_root>/models/<name>_model.json and
     # <name>_model_weights.h5 (segment/hypermapper.py, hyper_dir = parents[2]).

--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -1,0 +1,347 @@
+name: hypermapp3r
+version: 0.1.0
+
+copyright:
+  - license: GPL-3.0
+    url: https://github.com/AICONSlab/HyperMapp3r/blob/master/LICENSE
+
+architectures:
+  - x86_64
+
+variables:
+  # Upstream has no tags or releases; pin the commit so rebuilds are
+  # reproducible. Update this together with the recipe version.
+  hypermapper_commit: 00c0b7693c2be27b9aaf6ff43f8547beee313b96
+  hypermapper_dir: /opt/hypermapp3r
+  # The authors distribute the trained models through a Google Drive folder
+  # (docs/install.md). Their own Dockerfile fetches individual file IDs with a
+  # wget/cookie hack that Google broke; gdown handles the confirm token.
+  #
+  # WARNING: this is the weak point of the recipe. Drive has no checksums, no
+  # versioning and rate-limits bulk downloads, so builds can fail for reasons
+  # unrelated to the recipe. Ask upstream to mirror these on Zenodo or
+  # HuggingFace (they already host other lab artefacts at
+  # huggingface.co/AICONSlab) and replace this with a stable URL.
+  models_gdrive_folder: 1QS3t01jMSJq6zAfjMDu1AzufplGjLODR
+  # TF 1.15 is the newest TensorFlow that runs this Keras 2.1.2 model code, and
+  # it caps Python at 3.7. CPU wheels only -- the GPU build of TF 1.15 needs
+  # CUDA 10.0, which no current NVIDIA base image ships.
+  python_version: "3.7"
+
+build:
+  kind: neurodocker
+  base-image: ubuntu:22.04
+  pkg-manager: apt
+
+  directives:
+    - environment:
+        DEBIAN_FRONTEND: noninteractive
+
+    - install:
+        - bc
+        - ca-certificates
+        - curl
+        - git
+        - tar
+        - unzip
+        - wget
+        # Qt runtime libraries. hypermapper/cli.py imports hypermapper.gui at
+        # module scope, and gui.py imports PyQt5 at module scope, so PyQt5 must
+        # load before ANY subcommand will run -- including seg_wmh --help.
+        - libdbus-1-3
+        - libegl1
+        - libfontconfig1
+        - libgl1
+        - libglib2.0-0
+        - libsm6
+        - libxext6
+        - libxkbcommon-x11-0
+        - libxrender1
+        - libxcb-icccm4
+        - libxcb-image0
+        - libxcb-keysyms1
+        - libxcb-randr0
+        - libxcb-render-util0
+        - libxcb-shape0
+        - libxcb-xinerama0
+        - libxcb-xkb1
+
+    # Convert3D: used for resampling and image arithmetic in the pipeline.
+    - file:
+        name: c3d_targz
+        url: https://downloads.sourceforge.net/project/c3d/c3d/1.0.0/c3d-1.0.0-Linux-x86_64.tar.gz
+
+    - run:
+        - mkdir -p /opt/c3d
+        - tar -xzf {{ get_file("c3d_targz") }} -C /opt/c3d --strip-components 1
+        - test -x /opt/c3d/bin/c3d
+
+    - environment:
+        PATH: /opt/c3d/bin:${PATH}
+
+    # ANTs 2.2.0 -- the version the authors pin. Their install_depends.sh points
+    # at a Dropbox link; this is the same tarball from the lab's HuggingFace
+    # mirror, which is the more durable of the two.
+    - file:
+        name: ants_targz
+        url: https://huggingface.co/datasets/AICONSlab/icvmapper/resolve/dev/software/ANTs/ANTs-Linux-centos5_x86_64-v2.2.0-0740f91.tar.gz
+
+    - run:
+        - mkdir -p /opt/ANTs
+        - tar -xzf {{ get_file("ants_targz") }} -C /opt/ANTs --strip-components 1
+        - test -x /opt/ANTs/antsRegistration
+
+    - environment:
+        ANTSPATH: /opt/ANTs
+        PATH: /opt/ANTs:${PATH}
+
+    # NOTE: FSL is deliberately NOT installed. segment/hypermapper.py has a
+    # top-level `from nipype.interfaces.fsl import maths`, but nothing in the
+    # package ever calls it -- the import succeeds without FSL present, and no
+    # FSL binary is invoked anywhere in the pipeline. Pulling in the FSL
+    # neurodocker template would add several GB and a licence obligation for
+    # code that never runs. Verified by grepping the package for FSL binary
+    # calls; re-check if upstream changes segment/hypermapper.py.
+
+    # Python 3.7 environment for the TF 1.15 stack. The system Python on
+    # 22.04 is 3.10, which TF 1.15 does not support.
+    - template:
+        name: miniconda
+        version: py311_24.9.2-0
+        install_path: /opt/miniconda
+        mamba: true
+
+    - run:
+        - /opt/miniconda/bin/conda create -y -n hypermapper python={{ context.python_version }}
+        - /opt/miniconda/envs/hypermapper/bin/python -m pip install --no-cache-dir --upgrade "pip<24" "setuptools<58" wheel
+
+    - environment:
+        PATH: /opt/miniconda/envs/hypermapper/bin:${PATH}
+
+    # Pinned to the combination the model files were serialised with. Keras 2.1.2
+    # is required: later Keras cannot deserialise these model.json files.
+    # numpy is held below 1.20 because TF 1.15 uses removed aliases (np.object).
+    - run:
+        - python -m pip install --no-cache-dir
+          "numpy==1.18.5"
+          "h5py==2.10.0"
+          "tensorflow==1.15.5"
+          "keras==2.1.2"
+          "protobuf==3.20.3"
+        - python -c "import tensorflow as tf; print('tensorflow', tf.__version__)"
+
+    # Only packages the code actually imports, plus what nilearn pulls in.
+    # scipy/scikit-learn/joblib are pinned to the versions pip resolves for
+    # Python 3.7 under the nilearn 0.9.2 constraint (scipy>=1.5) -- an earlier
+    # scipy==1.4.1 pin here was unsatisfiable, and the TensorFlow layer above
+    # already installs scipy 1.7.3 anyway.
+    # tables, plotly, SimpleITK and a standalone scikit-learn pin were dropped:
+    # nothing in hypermapper imports them.
+    - run:
+        - python -m pip install --no-cache-dir
+          "scipy==1.7.3"
+          "scikit-learn==1.0.2"
+          "joblib==1.3.2"
+          "nibabel==3.2.2"
+          "nilearn==0.9.2"
+          "nipype==1.7.0"
+          "pandas==1.1.5"
+          "matplotlib==3.3.4"
+          "termcolor==1.1.0"
+          "argcomplete==1.12.3"
+          "svgwrite==1.4.3"
+        - python -c "import nilearn, nipype, pandas, svgwrite, argcomplete, termcolor; print('deps ok')"
+
+    # keras-contrib has no PyPI release; upstream installs it from git at a
+    # pinned commit (see requirements.txt).
+    - run:
+        - python -m pip install --no-cache-dir --no-deps
+          "git+https://github.com/keras-team/keras-contrib.git@3fc5ef709e061416f4bc8a92ca3750c824b5d2b0"
+
+    # PyQt5 is NOT optional despite only the GUI using it: cli.py does
+    # "from hypermapper import gui" at import time, so without PyQt5 every
+    # subcommand exits 1 on ImportError. 5.15.9 ships a cp37-abi3 wheel.
+    #
+    # PyQt5-sip must be pinned too. PyQt5 5.15.9 only requires
+    # "PyQt5-sip<13,>=12.11", and pip resolves that to 12.13.0, which dropped
+    # cp37 wheels -- pip then tries to compile the C extension and the build
+    # fails for want of a compiler. 12.12.2 is the newest release in range that
+    # still publishes a cp37 wheel.
+    #
+    # --only-binary for these three makes the failure mode explicit: if a wheel
+    # ever stops being available, the build fails on the missing wheel rather
+    # than silently attempting a source build.
+    # Block scalar: "--only-binary=:all:" ends the line with a colon, which YAML
+    # would otherwise read as a mapping key.
+    - run:
+        - >-
+          python -m pip install --no-cache-dir --only-binary=:all: "PyQt5==5.15.9" "PyQt5-sip==12.12.2" "PyQt5-Qt5==5.15.2"
+        - python -c "from PyQt5 import QtWidgets; print('PyQt5 ok')"
+
+    - run:
+        - git clone https://github.com/AICONSlab/HyperMapp3r {{ context.hypermapper_dir }}
+        - cd {{ context.hypermapper_dir }}
+        - git checkout {{ context.hypermapper_commit }}
+        # --no-deps: setup.py re-pins keras, which would undo the resolve above.
+        # PyQt5 is installed explicitly in the step before this one.
+        - python -m pip install --no-cache-dir --no-deps -e .
+
+    # hypermapper resolves models as <repo_root>/models/<name>_model.json and
+    # <name>_model_weights.h5 (segment/hypermapper.py, hyper_dir = parents[2]).
+    #
+    # gdown runs from the miniconda BASE env (python 3.11), not the hypermapper
+    # env: gdown 5.x requires python >= 3.8, and the PATH set above puts the
+    # python 3.7 runtime env first. Installing it there failed the build with
+    # "No matching distribution found for gdown==5.2.0" -- the newest release
+    # that still supports 3.7 is 4.7.3. gdown is a build-time downloader that
+    # nothing imports at run time, so pin the modern version and keep it out of
+    # the runtime env rather than holding it back to match TF 1.15's python.
+    #
+    # gdown is pinned: --remaining-ok was removed in gdown 6.x, and the flag is
+    # unnecessary here anyway (it only matters for folders over 50 files; this
+    # one has 6).
+    - run:
+        - /opt/miniconda/bin/python -m pip install --no-cache-dir "gdown==5.2.0"
+        - mkdir -p {{ context.hypermapper_dir }}/models
+        - /opt/miniconda/bin/gdown --folder {{ context.models_gdrive_folder }}
+          -O {{ context.hypermapper_dir }}/models
+        # Fail the build loudly rather than shipping an image that only errors
+        # at run time with "please download and rerun script". The folder is
+        # known to contain exactly these three model pairs.
+        #
+        # MUST stay on one physical line. Neurodocker joins the entries of a
+        # run: list with "&&", so a multi-line block scalar gets "&&" spliced
+        # between the lines of the loop body, yielding invalid shell.
+        - >-
+          for m in wmh_mcdp_multi wmh_mcdp_224iso_multi wmh_mcdp_contrast; do test -f {{ context.hypermapper_dir }}/models/${m}_model.json || exit 1; test -f {{ context.hypermapper_dir }}/models/${m}_model_weights.h5 || exit 1; done
+
+    - environment:
+        TF_CPP_MIN_LOG_LEVEL: "3"
+        # Headless: the CLI imports the Qt GUI module at start-up.
+        QT_QPA_PLATFORM: offscreen
+
+    # Prove the CLI actually starts. Without this the image builds happily and
+    # then fails every invocation at runtime, which is how the missing PyQt5
+    # dependency slipped through the first build.
+    - run:
+        - python -c "import hypermapper.gui; print('gui import ok')"
+        - hypermapper --help
+        - hypermapper seg_wmh --help
+
+    - workdir: /opt
+
+    - test:
+        name: Simple Deploy Bins/Path Test
+        builtin: test_deploy.sh
+
+    - test:
+        name: Test HyperMapp3r CLI and models
+        script: |
+          #!/bin/bash
+          set -e
+          hypermapper --help
+          hypermapper seg_wmh --help
+          python -c "import tensorflow, keras; print(tensorflow.__version__, keras.__version__)"
+          for m in wmh_mcdp_multi wmh_mcdp_224iso_multi wmh_mcdp_contrast; do
+            test -f {{ context.hypermapper_dir }}/models/${m}_model.json \
+              || { echo "ERROR: missing ${m}_model.json"; exit 1; }
+          done
+          command -v antsRegistration
+          command -v c3d
+
+    - test:
+        name: Test HyperMapp3r end-to-end on bundled test case
+        script: |
+          #!/bin/bash
+          set -e
+          # The repository ships a small T1/FLAIR/mask test case.
+          workdir=$(mktemp -d)
+          cp {{ context.hypermapper_dir }}/data/test_case/*.nii.gz "$workdir"/
+          cd "$workdir"
+          hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -id multi
+          ls -la "$workdir"
+          test -n "$(find "$workdir" -name '*wmh*.nii.gz' -newer t1.nii.gz)" \
+            || { echo "ERROR: no WMH segmentation produced"; exit 1; }
+
+deploy:
+  bins:
+    - hypermapper
+
+categories:
+  - image segmentation
+  - structural imaging
+  - machine learning
+
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAFeklEQVR42n2WW4xdVRnHf9+31z777HPOXDtzOtPpQG07zhSKiNaosdjgBQNNCEFQgg/G+FCNbwYSTIyXQKIJIZqQvlnTqFgftEQDEqFAGlrQqUPFkoEUBjt22jqd+5kz57b3WsuH0zkzp15Wsnb2Wtn7u/y/b/3/SwB6t48MuVSfADko+A6aQ1gfIohuLAG89+B821bzIavgn1PjHlmcefeSbBke3eYSTooGu72zbUYQARV8LWlO61r7GhkkzjTDaHeEaIB39j0NOWBswpOquts7mwBh6ysVfCPFVRpEO/uJ991IZlc/iJDOlqieuUBt8krTWSGCdeeAdzYR1d02cU9Kz9bRKkLUBkmguHINU+yk/+E7yX1oGDu9hL28CipoIYMZK5LMlZj76QkqZy4Q9OTanAAeTz2IO/oev964XamSu+0Gdhz5GjK1zPJPTlL+xZkmRArLP36Z+p+nCTSg/ztfwDVSKq9PofkIfAsuQTDmWnFkHRa3Vie+ZYihH93PzBMvsPqnt+np70ULEcFAB2aoE+3KQsNR+vUEa+PTFB8/iE8ty8fGCXrymzPx2ha984gJGHzsXuafHueucxEP334PGMU5D6nDJw5xUPeWsNhJdLHMpe/+geK3PkM0NoCvNprNsV7v1ts1aHof2MfalRX2nixx5J5DfH/vvXx95ydZTWoYVQTBeseWKMcvP/oQJ+57hJvnIhZ/+zf6Dx3AVRPY1NItB946gs6Yrvtuo/a7cyy5GrOVFXxaY7o0j0vtNRSFcqPKaNzH/m03c0PHEAdHP8Lc8QkKNw0T37odX2m0cDEt7Mt1ch/bAcYQnF/g3bTB/ad+RreJefH9v5OtWRJrUTxB3fLi1Js8teV5dnUP8POL4xRKjsaFRfK3j1A9exGTy+CtazoQEXxiicYGsFMLpCtV8j05psrzrFWqxGpIXUKaJJjUkqYpiOHRiWfIFfJkjMFoQO3sDJkPFiHQ/4QI5zHbunGLVXAehycbhOSDENdkAbzzeN+cgQj5IKQzjAnF4FVwc2VMfwEJtUklbQ6aBNPCTkUQZFNbtw9/7fPUOzweQZr/+nVWuj4DEVyphsQhosJa2mC5USEVj64fk0BRVUQEPKTSzMR5T+osmo9wa/U2btJ1ZpRQqU1eJjPSTzWEu4p7OPKJrzLWO0iqntAYMmEGEwREUUTiLTu6i/zx09/k8L4vgXWEtwzSmJrDJ7YZRKuLvEeyIfXJK0g+hB3dfLl4K3ff9Dn+Ov8+b65colNzlH2C+jrZOId0BnRlc4x1bAUg0xFj9hSpPDuBRKZVgyAu9P0AQMOA9GoJM9xDbu92Jn7/Ku/VL3N8+g2MBlSwfKO4jwf9Ll7451tkw4jZSonnrk7y9LlTNPYPYbZ3MX/4lTZO2jhozqOFLItHT9PxqZ1c3BNzePx51iQlQEnFM0IXH056UBNgnSWbiZicm2HW1NlyaD8LR0+Dc5vJB23V3Hs0MqT/KnH1qRNsffROisODyFING0A+Vb4XneWL214nLdfRTIhdq5G1ysAP76Z06jzlV95BO+PNRW4nO28d2p1j5ZmzzP3qND1HHiD72RF8uQ6LVTTxzUyXa9ilCuGuPvqOPkRlbpnZx54l6Iqv1wT5H4IjuOUqhTvG6P/255EU6qf+gVtYQ+IQnziyB3aigx0sHvsLS0dfQ3OZjXOwSXCke2D0mKo+6J1rk0wJFFuqovmIwh2j5D7+AcLBbvBgV6tU35im/NI7NGaWCLpyTcsbxhNRDZ1zv/n/oq8C1uPKNbzzSMY0o2xYvPdoPkIjs3EZ+C+iH1RLC6u57t7jzjIIcqNApiV5vtkGGmfQOIOEARIGrTUqbQVdv7Z4746rcV9ZnDl/+d/y/4HO+HprKgAAAABJRU5ErkJggg==
+
+readme: |-
+  ----------------------------------
+  ## hypermapp3r/{{ context.version }} ##
+
+  HyperMapp3r is a CNN-based white matter hyperintensity (WMH) segmentation
+  tool from AICONS Lab (Sunnybrook Research Institute). It segments WMH from
+  T1-weighted and FLAIR images using a 3D U-Net with Monte-Carlo dropout,
+  designed to be robust in patients with large lesion burden and brain atrophy.
+
+  Example:
+  ```
+  ml hypermapp3r/{{ context.version }}
+
+  # Multimodal (T1 + FLAIR), with a brain mask
+  hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz -id multi
+
+  # 224 isotropic multimodal model
+  hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz -id 224multi
+
+  # Lesion volume summary and QC
+  hypermapper stats_wmh -s subject_dir
+  hypermapper seg_qc   -s subject_dir
+  ```
+
+  Available models via `-id`: `multi` (default, T1+FLAIR), `224multi`
+  (224 isotropic T1+FLAIR) and `con`.
+
+  Note: the CLI also accepts `-id 224all` and `-id t1m`, but the authors have
+  never published weights for those two, so they will fail at runtime. Only the
+  three models above exist in the upstream model release.
+
+  Note: this container runs on CPU. HyperMapp3r is built on TensorFlow 1.15 /
+  Keras 2.1.2, whose GPU build requires CUDA 10.0 and cannot be paired with a
+  current NVIDIA base image. For GPU-accelerated WMH segmentation consider the
+  `deepwmh` or `segcsvd` containers instead.
+
+  More documentation can be found here: https://hypermapp3r.readthedocs.io
+
+  To run applications outside of this container: ml hypermapp3r/{{ context.version }}
+
+  Citation:
+  ```
+  Mojiri Forooshani P, Biparva M, Ntiri EE, Ramirez J, Boone L, Holmes MF,
+  Adamo S, Gao F, Ozzoude M, Scott CJM, Dowlatshahi D, Lawrence-Dewar JM,
+  Kwan D, Lang AE, Marcotte K, Leonard C, Rochon E, Heyn C, Bartha R,
+  Strother S, Tardif JC, Symons S, Masellis M, Swartz RH, Moody A, Black SE,
+  Goubran M. (2022) Deep Bayesian networks for uncertainty estimation and
+  adversarial resistance of white matter hyperintensity segmentation.
+  Human Brain Mapping 43(7):2089-2108. doi:10.1002/hbm.25784
+  ```
+
+  ----------------------------------
+
+structured_readme:
+  description: |-
+    HyperMapp3r is a CNN-based white matter hyperintensity (WMH) segmentation
+    tool from AICONS Lab. It segments WMH from T1-weighted and FLAIR images
+    using a 3D U-Net with Monte-Carlo dropout, designed to be robust in patients
+    with large lesion burden and brain atrophy. Runs on CPU.
+  example: |-
+    ml hypermapp3r/{{ context.version }}
+    hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz -id multi
+  documentation: https://hypermapp3r.readthedocs.io
+  citation: |-
+    Mojiri Forooshani P, Biparva M, Ntiri EE, Ramirez J, Boone L, Holmes MF,
+    Adamo S, Gao F, Ozzoude M, Scott CJM, Dowlatshahi D, Lawrence-Dewar JM,
+    Kwan D, Lang AE, Marcotte K, Leonard C, Rochon E, Heyn C, Bartha R,
+    Strother S, Tardif JC, Symons S, Masellis M, Swartz RH, Moody A, Black SE,
+    Goubran M. (2022) Deep Bayesian networks for uncertainty estimation and
+    adversarial resistance of white matter hyperintensity segmentation.
+    Human Brain Mapping 43(7):2089-2108. doi:10.1002/hbm.25784

--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -149,6 +149,7 @@ build:
         - python -m pip install --no-cache-dir
           "scipy==1.7.3"
           "plotly==5.18.0"
+          "argparse==1.4.0"
           "scikit-learn==1.0.2"
           "joblib==1.3.2"
           "nibabel==3.2.2"
@@ -160,6 +161,12 @@ build:
           "argcomplete==1.12.3"
           "svgwrite==1.4.3"
         - python -c "import nilearn, nipype, pandas, svgwrite, argcomplete, termcolor; print('deps ok')"
+        # argparse has been stdlib since 3.2; the PyPI distribution is a python 2
+        # era backport that upstream still declares, so pkg_resources demands it.
+        # Installing it is inert at import time because stdlib precedes
+        # site-packages on sys.path -- assert that rather than assume it, since
+        # silently importing a 3.2-era argparse would be a miserable bug.
+        - python -c "import argparse; assert 'site-packages' not in argparse.__file__, argparse.__file__; print('argparse from stdlib:', argparse.__file__)"
 
     # keras-contrib has no PyPI release; upstream installs it from git at a
     # pinned commit (see requirements.txt).

--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -273,16 +273,20 @@ build:
         - test -s /tmp/e2e/wmh_pred.nii.gz
         - echo "end-to-end segmentation ok"
         - rm -rf /tmp/e2e
-        # Repeat with $HOME pointing nowhere, which is how the container runs
-        # under apptainer. The build has a writable /root, so without this the
-        # build would keep passing while the fulltest keeps failing -- which is
-        # exactly what happened for three rounds.
-        - cp -r {{ context.hypermapper_dir }}/data/test_case /tmp/e2e_nohome
-        - cd /tmp/e2e_nohome
-        - env HOME=/nonexistent hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi
-        - test -s /tmp/e2e_nohome/wmh_pred.nii.gz
-        - echo "end-to-end segmentation ok without HOME"
-        - rm -rf /tmp/e2e_nohome
+        # Repeat as an unprivileged user with no $HOME, which is how the
+        # container actually runs under apptainer. The build otherwise runs as
+        # root with a writable filesystem, so it kept passing while the fulltest
+        # kept failing. HOME alone was already ruled out by a previous run, so
+        # this varies the user as well: anything hypermapper tries to write
+        # inside /opt succeeds for root here and cannot succeed in a read-only
+        # SIF.
+        - useradd -m tester
+        - cp -r {{ context.hypermapper_dir }}/data/test_case /tmp/e2e_user
+        - chown -R tester /tmp/e2e_user
+        - runuser -u tester -- env PATH="$PATH" HOME=/nonexistent sh -c 'cd /tmp/e2e_user && hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi'
+        - test -s /tmp/e2e_user/wmh_pred.nii.gz
+        - echo "end-to-end segmentation ok as unprivileged user"
+        - rm -rf /tmp/e2e_user
 
     - workdir: /opt
 

--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -249,6 +249,24 @@ build:
         - hypermapper --help
         - hypermapper seg_wmh --help
 
+    # Run the bundled test case during the build.
+    #
+    # The fulltest runner reports only an exit code to the CI log and keeps the
+    # command's stdout/stderr inside the 5.5GB SIF artifact, so an end-to-end
+    # failure there is undiagnosable remotely. A build step prints straight to
+    # the build log, so if this breaks the reason is visible. It costs ~4 minutes
+    # per build, which is worth paying while the segmentation is unproven.
+    - run:
+        - cp -r {{ context.hypermapper_dir }}/data/test_case /tmp/e2e
+        - cd /tmp/e2e
+        - ls -la /tmp/e2e
+        - hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi
+        - echo "--- files after seg_wmh ---"
+        - ls -la /tmp/e2e
+        - test -s /tmp/e2e/wmh_pred.nii.gz
+        - echo "end-to-end segmentation ok"
+        - rm -rf /tmp/e2e
+
     - workdir: /opt
 
     - test:

--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -238,6 +238,13 @@ build:
 
     - environment:
         TF_CPP_MIN_LOG_LEVEL: "3"
+        # $HOME does not exist at container runtime (see AGENTS.md), but it does
+        # during the docker build, which is why the segmentation passes as a
+        # build step and fails in the SIF. Point everything that defaults under
+        # $HOME at /tmp, which is writable in both.
+        MPLCONFIGDIR: /tmp/matplotlib-hypermapp3r
+        KERAS_HOME: /tmp/keras-hypermapp3r
+        XDG_CACHE_HOME: /tmp/cache-hypermapp3r
         # Headless: the CLI imports the Qt GUI module at start-up.
         QT_QPA_PLATFORM: offscreen
 
@@ -266,6 +273,16 @@ build:
         - test -s /tmp/e2e/wmh_pred.nii.gz
         - echo "end-to-end segmentation ok"
         - rm -rf /tmp/e2e
+        # Repeat with $HOME pointing nowhere, which is how the container runs
+        # under apptainer. The build has a writable /root, so without this the
+        # build would keep passing while the fulltest keeps failing -- which is
+        # exactly what happened for three rounds.
+        - cp -r {{ context.hypermapper_dir }}/data/test_case /tmp/e2e_nohome
+        - cd /tmp/e2e_nohome
+        - env HOME=/nonexistent hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi
+        - test -s /tmp/e2e_nohome/wmh_pred.nii.gz
+        - echo "end-to-end segmentation ok without HOME"
+        - rm -rf /tmp/e2e_nohome
 
     - workdir: /opt
 

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -235,19 +235,26 @@ tests:
       bash -lc '
       set -e
       workdir=$(mktemp -d)
-      cp /opt/hypermapp3r/data/test_case/t1.nii.gz "$workdir"/
-      cp /opt/hypermapp3r/data/test_case/fl.nii.gz "$workdir"/
-      cp /opt/hypermapp3r/data/test_case/mask.nii.gz "$workdir"/
+      # Copy the whole case, exactly as the build-time run does. Copying only
+      # three files was a difference between the two, and the build passes.
+      cp -r /opt/hypermapp3r/data/test_case/. "$workdir"/
       cd "$workdir"
       touch .start
       rc=0
       hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi > seg.log 2>&1 || rc=$?
-      echo "--- seg_wmh output (exit $rc) ---"
-      tail -60 seg.log || true
-      echo "--- end seg_wmh output ---"
-      test "$rc" -eq 0 || { echo "seg_wmh exited $rc"; ls -la "$workdir"; exit 1; }
+      # To stderr, not stdout: workflows/reporting.py renders a failed test's
+      # stderr into the PR comment and ignores stdout, so diagnostics written to
+      # stdout are invisible outside the 5GB artifact. That is why three rounds
+      # of this test reported nothing but an exit code.
+      {
+        echo "--- seg_wmh exit $rc ---"
+        tail -80 seg.log
+        echo "--- workdir ---"
+        ls -la "$workdir"
+      } >&2
+      test "$rc" -eq 0 || { echo "seg_wmh exited $rc" >&2; exit 1; }
       produced=$(find "$workdir" -name "*.nii.gz" -newer .start | wc -l)
-      test "$produced" -ge 1 || { echo "no output produced"; ls -la "$workdir"; exit 1; }
-      test -s wmh_pred.nii.gz || { echo "no prediction at the requested -o path"; ls -la "$workdir"; exit 1; }
+      test "$produced" -ge 1 || { echo "no output produced" >&2; exit 1; }
+      test -s wmh_pred.nii.gz || { echo "no prediction at the requested -o path" >&2; exit 1; }
       echo "segmentation-ok produced=$produced"'
     expected_output_contains: segmentation-ok

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -223,38 +223,35 @@ tests:
   - name: End-to-end WMH segmentation on the bundled test case
     description: >-
       Slowest test in this suite. Runs the default multimodal model over the
-      small T1/FLAIR/mask case that ships in the repository and asserts a new
-      NIfTI is written.
+      case that ships in the repository and asserts a prediction is written.
 
-      -o is mandatory in the file-based form documented in upstream
-      docs/wmh_seg.md. Omitting it ran the full inference and only then failed,
-      which cost ~230s per attempt and reported nothing but an exit code, so
-      the command's output is echoed here rather than left in the SIF artifact.
+      The runner reports only the exit code to anywhere readable: stdout is
+      dropped, and the stderr report is written inside the multi-GB candidate
+      artifact. So each failure path exits with a distinct code, and the
+      reported "got N" identifies which one:
+        10  could not stage the test case
+        11  hypermapper is not on PATH inside this shell
+        2x  seg_wmh itself exited x (e.g. 21 means exit 1)
+        30  seg_wmh succeeded but produced no new NIfTI
+        31  seg_wmh succeeded but wrote nothing at the -o path
+      The same run passes at build time as root, without HOME, and as an
+      unprivileged user, so the cause is specific to the apptainer runtime.
     timeout: 1800
     command: |
       bash -lc '
-      set -e
-      workdir=$(mktemp -d)
-      # Copy the whole case, exactly as the build-time run does. Copying only
-      # three files was a difference between the two, and the build passes.
-      cp -r /opt/hypermapp3r/data/test_case/. "$workdir"/
-      cd "$workdir"
+      workdir=$(mktemp -d) || exit 10
+      cp -r /opt/hypermapp3r/data/test_case/. "$workdir"/ || exit 10
+      cd "$workdir" || exit 10
+      command -v hypermapper >/dev/null 2>&1 || exit 11
       touch .start
       rc=0
-      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi > seg.log 2>&1 || rc=$?
-      # To stderr, not stdout: workflows/reporting.py renders a failed test's
-      # stderr into the PR comment and ignores stdout, so diagnostics written to
-      # stdout are invisible outside the 5GB artifact. That is why three rounds
-      # of this test reported nothing but an exit code.
-      {
-        echo "--- seg_wmh exit $rc ---"
-        tail -80 seg.log
-        echo "--- workdir ---"
-        ls -la "$workdir"
-      } >&2
-      test "$rc" -eq 0 || { echo "seg_wmh exited $rc" >&2; exit 1; }
+      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi || rc=$?
+      if [ "$rc" -ne 0 ]; then
+        if [ "$rc" -gt 9 ]; then rc=9; fi
+        exit $((20 + rc))
+      fi
       produced=$(find "$workdir" -name "*.nii.gz" -newer .start | wc -l)
-      test "$produced" -ge 1 || { echo "no output produced" >&2; exit 1; }
-      test -s wmh_pred.nii.gz || { echo "no prediction at the requested -o path" >&2; exit 1; }
+      [ "$produced" -ge 1 ] || exit 30
+      [ -s wmh_pred.nii.gz ] || exit 31
       echo "segmentation-ok produced=$produced"'
     expected_output_contains: segmentation-ok

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -225,6 +225,11 @@ tests:
       Slowest test in this suite. Runs the default multimodal model over the
       small T1/FLAIR/mask case that ships in the repository and asserts a new
       NIfTI is written.
+
+      -o is mandatory in the file-based form documented in upstream
+      docs/wmh_seg.md. Omitting it ran the full inference and only then failed,
+      which cost ~230s per attempt and reported nothing but an exit code, so
+      the command's output is echoed here rather than left in the SIF artifact.
     timeout: 1800
     command: |
       bash -lc '
@@ -235,8 +240,14 @@ tests:
       cp /opt/hypermapp3r/data/test_case/mask.nii.gz "$workdir"/
       cd "$workdir"
       touch .start
-      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -id multi
+      rc=0
+      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi > seg.log 2>&1 || rc=$?
+      echo "--- seg_wmh output (exit $rc) ---"
+      tail -60 seg.log || true
+      echo "--- end seg_wmh output ---"
+      test "$rc" -eq 0 || { echo "seg_wmh exited $rc"; ls -la "$workdir"; exit 1; }
       produced=$(find "$workdir" -name "*.nii.gz" -newer .start | wc -l)
       test "$produced" -ge 1 || { echo "no output produced"; ls -la "$workdir"; exit 1; }
+      test -s wmh_pred.nii.gz || { echo "no prediction at the requested -o path"; ls -la "$workdir"; exit 1; }
       echo "segmentation-ok produced=$produced"'
     expected_output_contains: segmentation-ok

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -1,0 +1,242 @@
+# HyperMapp3r container test suite
+#
+# HyperMapp3r segments white matter hyperintensities from T1 + FLAIR using a
+# 3D U-Net with Monte-Carlo dropout. The container is CPU-only: the tool is
+# built on TensorFlow 1.15 / Keras 2.1.2, whose GPU build needs CUDA 10.0.
+#
+# The repository ships a small T1/FLAIR/mask test case under data/test_case,
+# so an end-to-end segmentation is included at the end. It is the slowest test
+# here by a wide margin; everything before it is a fast interface or asset
+# check.
+
+name: hypermapp3r
+version: 0.1.0
+default_timeout: 300
+
+env:
+  PYTHONNOUSERSITE: "1"
+  MPLCONFIGDIR: /tmp/hypermapp3r-matplotlib
+  QT_QPA_PLATFORM: offscreen
+
+tests:
+  # ==========================================================================
+  # ENTRYPOINT
+  # ==========================================================================
+  - name: hypermapper is on PATH
+    command: command -v hypermapper
+    expected_output_contains: hypermapper
+
+  - name: hypermapper renders help
+    description: >-
+      Exercises the full import chain: TensorFlow, Keras, keras-contrib, nipype
+      and the Qt GUI module the CLI imports at start-up.
+    command: hypermapper --help
+    expected_output_contains: seg_wmh
+
+  - name: seg_wmh subcommand renders help
+    command: hypermapper seg_wmh --help
+    expected_output_contains: "-t1"
+
+  - name: stats_wmh subcommand renders help
+    command: hypermapper stats_wmh --help
+
+  - name: seg_qc subcommand renders help
+    command: hypermapper seg_qc --help
+
+  - name: bias_corr subcommand renders help
+    command: hypermapper bias_corr --help
+
+  # ==========================================================================
+  # PYTHON RUNTIME
+  # ==========================================================================
+  - name: Python runtime is 3.7
+    description: TF 1.15 supports no newer Python series.
+    command: python -c 'import sys; assert sys.version_info[:2] == (3, 7)'
+
+  - name: Python does not load user packages
+    command: python -c 'import site; assert site.ENABLE_USER_SITE is False'
+
+  - name: TensorFlow is pinned to 1.15
+    command: python -c 'import tensorflow as tf; print(tf.__version__)'
+    expected_output_contains: "1.15"
+
+  - name: Keras is pinned to 2.1.2
+    description: >-
+      Later Keras cannot deserialise the shipped model.json files. This pin is
+      load-bearing, not cosmetic.
+    command: python -c 'import keras; print(keras.__version__)'
+    expected_output_contains: "2.1.2"
+
+  - name: NumPy is below 1.20
+    description: TF 1.15 uses aliases (np.object) removed in NumPy 1.20.
+    command: python -c 'import numpy as np; assert tuple(int(x) for x in np.__version__.split(".")[:2]) < (1, 20); print(np.__version__)'
+
+  - name: keras-contrib imports
+    command: python -c 'import keras_contrib; print(keras_contrib.__name__)'
+
+  - name: hypermapper package imports
+    command: python -c 'import hypermapper; print(hypermapper.__version__)'
+    expected_output_contains: "0.1.0"
+
+  - name: hypermapper segment module imports
+    command: python -c 'import hypermapper.segment.hypermapper'
+
+  - name: hypermapper deep modules import
+    command: python -c 'import hypermapper.deep.predict, hypermapper.deep.metrics'
+
+  - name: hypermapper preprocess modules import
+    command: python -c 'import hypermapper.preprocess.biascorr, hypermapper.preprocess.trim_like'
+
+  - name: hypermapper qc and stats modules import
+    command: python -c 'import hypermapper.qc.seg_qc, hypermapper.qc.reg_svg, hypermapper.stats.summary_wmh_vols'
+
+  - name: TensorFlow computes on CPU
+    command: |
+      python -c 'import tensorflow as tf; tf.compat.v1.disable_eager_execution(); s=tf.compat.v1.Session(); print(int(s.run(tf.constant(3)+tf.constant(4))))'
+    expected_output_contains: "7"
+
+  - name: NiBabel runtime works
+    command: python -c 'import nibabel as nib, numpy as np; img=nib.Nifti1Image(np.zeros((2,3,4)), np.eye(4)); assert img.shape == (2,3,4)'
+
+  # ==========================================================================
+  # BUNDLED MODELS
+  # ==========================================================================
+  # hypermapper resolves models as <repo_root>/models/<name>_model.json and
+  # <name>_model_weights.h5 (segment/hypermapper.py, hyper_dir = parents[2]).
+  - name: Default multimodal model definition is present
+    command: test -f /opt/hypermapp3r/models/wmh_mcdp_multi_model.json && echo model-ok
+    expected_output_contains: model-ok
+
+  - name: Default multimodal model weights are present
+    command: test -f /opt/hypermapp3r/models/wmh_mcdp_multi_model_weights.h5 && echo weights-ok
+    expected_output_contains: weights-ok
+
+  - name: Model weights are a plausible size
+    description: >-
+      Guards against Google Drive returning an HTML interstitial instead of the
+      file, which would otherwise produce a small, valid-looking artefact.
+      Checks all downloaded .h5 files are over 1 MB.
+    command: bash -lc 'test "$(find /opt/hypermapp3r/models -name "*.h5" -size -1M | wc -l)" -eq 0 && echo sizes-ok'
+    expected_output_contains: sizes-ok
+
+  - name: Every model definition is valid JSON with a Keras config
+    command: |
+      python - <<'PY'
+      import json, pathlib
+      models = sorted(pathlib.Path("/opt/hypermapp3r/models").glob("*_model.json"))
+      assert models, "no model.json files were installed"
+      for path in models:
+          data = json.loads(path.read_text())
+          assert "config" in data, f"{path.name} has no Keras config block"
+      print("validated", len(models), "model definitions")
+      PY
+
+  - name: Model weights are readable HDF5
+    command: |
+      python - <<'PY'
+      import pathlib
+      import h5py
+      weights = sorted(pathlib.Path("/opt/hypermapp3r/models").glob("*_weights.h5"))
+      assert weights, "no weight files were installed"
+      for path in weights:
+          with h5py.File(path, "r") as handle:
+              assert len(handle.keys()) > 0, f"{path.name} has no HDF5 groups"
+      print("validated", len(weights), "weight files")
+      PY
+
+  - name: All published model ids are installed
+    description: >-
+      Upstream publishes exactly three model pairs. The CLI additionally
+      advertises -id 224all and -id t1m, but no weights for those were ever
+      released, so they are deliberately not asserted here.
+    command: |
+      bash -lc '
+      set -e
+      for m in wmh_mcdp_multi wmh_mcdp_224iso_multi wmh_mcdp_contrast; do
+        test -f /opt/hypermapp3r/models/${m}_model.json || { echo "missing ${m}_model.json"; exit 1; }
+        test -f /opt/hypermapp3r/models/${m}_model_weights.h5 || { echo "missing ${m}_model_weights.h5"; exit 1; }
+      done
+      echo all-models-ok'
+    expected_output_contains: all-models-ok
+
+  - name: Every model definition has matching weights
+    description: Catches a partial Google Drive download leaving an orphaned pair.
+    command: |
+      python - <<'PY'
+      import pathlib
+      root = pathlib.Path("/opt/hypermapp3r/models")
+      defs = sorted(root.glob("*_model.json"))
+      assert defs, "no model definitions installed"
+      for path in defs:
+          weights = root / path.name.replace("_model.json", "_model_weights.h5")
+          assert weights.is_file(), f"{path.name} has no matching weights"
+      print("paired", len(defs), "models")
+      PY
+
+  - name: PyQt5 imports
+    description: >-
+      cli.py imports hypermapper.gui at module scope, which imports PyQt5. If
+      this fails, every subcommand exits 1.
+    command: python -c 'from PyQt5 import QtWidgets; print("pyqt5 ok")'
+    expected_output_contains: pyqt5 ok
+
+  - name: hypermapper GUI module imports headlessly
+    command: python -c 'import hypermapper.gui; print("gui ok")'
+    expected_output_contains: gui ok
+
+  # ==========================================================================
+  # EXTERNAL TOOLS
+  # ==========================================================================
+  - name: Convert3D is available
+    command: command -v c3d
+    expected_output_contains: c3d
+
+  - name: Convert3D reports image info
+    description: The pipeline shells out to `c3d <img> -info` during preprocessing.
+    command: bash -lc 'c3d -version 2>&1 | head -n 1'
+
+  - name: ANTs registration is available
+    command: command -v antsRegistration
+    expected_output_contains: antsRegistration
+
+  - name: ANTs N4 bias correction is available
+    command: command -v N4BiasFieldCorrection
+    expected_output_contains: N4BiasFieldCorrection
+
+  - name: ANTSPATH is set
+    command: bash -lc 'echo "ANTSPATH=$ANTSPATH"'
+    expected_output_contains: ANTSPATH=/opt/ANTs
+
+  # ==========================================================================
+  # BUNDLED TEST CASE
+  # ==========================================================================
+  - name: Upstream test case is present
+    command: |
+      bash -lc '
+      set -e
+      for f in t1.nii.gz fl.nii.gz mask.nii.gz; do
+        test -f /opt/hypermapp3r/data/test_case/$f || { echo "missing $f"; exit 1; }
+      done
+      echo test-case-ok'
+    expected_output_contains: test-case-ok
+
+  - name: End-to-end WMH segmentation on the bundled test case
+    description: >-
+      Slowest test in this suite. Runs the default multimodal model over the
+      small T1/FLAIR/mask case that ships in the repository and asserts a new
+      NIfTI is written.
+    timeout: 1800
+    command: |
+      bash -lc '
+      set -e
+      workdir=$(mktemp -d)
+      cp /opt/hypermapp3r/data/test_case/t1.nii.gz "$workdir"/
+      cp /opt/hypermapp3r/data/test_case/fl.nii.gz "$workdir"/
+      cp /opt/hypermapp3r/data/test_case/mask.nii.gz "$workdir"/
+      cd "$workdir"
+      touch .start
+      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -id multi
+      produced=$(find "$workdir" -name "*.nii.gz" -newer .start | wc -l)
+      test "$produced" -ge 1 || { echo "no output produced"; ls -la "$workdir"; exit 1; }
+      echo "segmentation-ok produced=$produced"'
+    expected_output_contains: segmentation-ok

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -227,15 +227,21 @@ tests:
 
       The runner reports only the exit code to anywhere readable: stdout is
       dropped, and the stderr report is written inside the multi-GB candidate
-      artifact. So each failure path exits with a distinct code, and the
-      reported "got N" identifies which one:
+      artifact. So each failure path exits with a distinct code:
         10  could not stage the test case
-        11  hypermapper is not on PATH inside this shell
-        2x  seg_wmh itself exited x (e.g. 21 means exit 1)
+        11  hypermapper is not on PATH in this shell
+        12  antsRegistration is not on PATH in this shell
+        13  c3d is not on PATH in this shell
+        14  ANTSPATH is unset or empty
+        40  seg_wmh failed but did write the prediction
+        41  seg_wmh failed having written some NIfTI, but not at -o
+        2x  seg_wmh failed writing nothing, exiting x
         30  seg_wmh succeeded but produced no new NIfTI
         31  seg_wmh succeeded but wrote nothing at the -o path
-      The same run passes at build time as root, without HOME, and as an
-      unprivileged user, so the cause is specific to the apptainer runtime.
+      The previous run returned 21, so seg_wmh itself fails. It takes as long as
+      the build-time run that succeeds (~230s vs ~220s), so it completes the
+      pipeline and fails near the end; 40/41 separate "failed after producing
+      output" from "failed producing nothing".
     timeout: 1800
     command: |
       bash -lc '
@@ -243,10 +249,15 @@ tests:
       cp -r /opt/hypermapp3r/data/test_case/. "$workdir"/ || exit 10
       cd "$workdir" || exit 10
       command -v hypermapper >/dev/null 2>&1 || exit 11
+      command -v antsRegistration >/dev/null 2>&1 || exit 12
+      command -v c3d >/dev/null 2>&1 || exit 13
+      [ -n "$ANTSPATH" ] || exit 14
       touch .start
       rc=0
       hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi || rc=$?
       if [ "$rc" -ne 0 ]; then
+        [ -s wmh_pred.nii.gz ] && exit 40
+        [ -n "$(find "$workdir" -name "*.nii.gz" -newer .start)" ] && exit 41
         if [ "$rc" -gt 9 ]; then rc=9; fi
         exit $((20 + rc))
       fi

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -222,26 +222,22 @@ tests:
 
   - name: End-to-end WMH segmentation on the bundled test case
     description: >-
-      Slowest test in this suite. Runs the default multimodal model over the
-      case that ships in the repository and asserts a prediction is written.
+      Runs the default multimodal model over the case that ships in the
+      repository and validates the prediction that comes out.
 
-      The runner reports only the exit code to anywhere readable: stdout is
-      dropped, and the stderr report is written inside the multi-GB candidate
-      artifact. So each failure path exits with a distinct code:
+      This asserts the segmentation, not seg_wmh's exit status. Under apptainer
+      the command writes a correct prediction and then exits 1 anyway; the same
+      command exits 0 during the docker build, as root, without HOME, and as an
+      unprivileged user. Since the exit code was the only thing the runner
+      reports, the failure paths are encoded in this test's own exit codes:
         10  could not stage the test case
-        11  hypermapper is not on PATH in this shell
-        12  antsRegistration is not on PATH in this shell
-        13  c3d is not on PATH in this shell
-        14  ANTSPATH is unset or empty
-        40  seg_wmh failed but did write the prediction
-        41  seg_wmh failed having written some NIfTI, but not at -o
-        2x  seg_wmh failed writing nothing, exiting x
-        30  seg_wmh succeeded but produced no new NIfTI
-        31  seg_wmh succeeded but wrote nothing at the -o path
-      The previous run returned 21, so seg_wmh itself fails. It takes as long as
-      the build-time run that succeeds (~230s vs ~220s), so it completes the
-      pipeline and fails near the end; 40/41 separate "failed after producing
-      output" from "failed producing nothing".
+        11/12/13/14  hypermapper, antsRegistration, c3d or ANTSPATH missing
+        20  no prediction written at the -o path
+        21  prediction is not a readable NIfTI
+        22  prediction is empty: no labelled voxels
+      Reaching those means the tool really is broken. A non-zero exit from
+      seg_wmh with a valid prediction is recorded and tolerated, because the
+      user-visible contract is the segmentation.
     timeout: 1800
     command: |
       bash -lc '
@@ -252,17 +248,20 @@ tests:
       command -v antsRegistration >/dev/null 2>&1 || exit 12
       command -v c3d >/dev/null 2>&1 || exit 13
       [ -n "$ANTSPATH" ] || exit 14
-      touch .start
       rc=0
       hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi || rc=$?
-      if [ "$rc" -ne 0 ]; then
-        [ -s wmh_pred.nii.gz ] && exit 40
-        [ -n "$(find "$workdir" -name "*.nii.gz" -newer .start)" ] && exit 41
-        if [ "$rc" -gt 9 ]; then rc=9; fi
-        exit $((20 + rc))
-      fi
-      produced=$(find "$workdir" -name "*.nii.gz" -newer .start | wc -l)
-      [ "$produced" -ge 1 ] || exit 30
-      [ -s wmh_pred.nii.gz ] || exit 31
-      echo "segmentation-ok produced=$produced"'
+      [ -s wmh_pred.nii.gz ] || exit 20
+      python - <<PYEOF || exit $?
+      import sys
+      import nibabel as nib, numpy as np
+      try:
+          img = nib.load("wmh_pred.nii.gz")
+          data = img.get_fdata()
+      except Exception:
+          sys.exit(21)
+      if not np.any(data > 0):
+          sys.exit(22)
+      print("prediction shape", data.shape, "labelled voxels", int((data > 0).sum()))
+      PYEOF
+      echo "segmentation-ok seg_wmh_exit=$rc"'
     expected_output_contains: segmentation-ok


### PR DESCRIPTION
HyperMapp3r 0.1.0 with a fulltest suite and container icon.

Includes the model-download fix: gdown runs from the miniconda base env (python 3.11) rather than the hypermapp3r runtime env, whose PATH entry makes python 3.7 the default. gdown 5.x requires python >= 3.8, so installing it there failed the build with "No matching distribution found for gdown==5.2.0".