### PR TITLE
Install Apptainer in the release-PR container tests when it is missing

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -98,10 +98,56 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Apptainer is not in the stock GitHub/ARC runner image. The standalone VMs
+      # only have it because it was pre-installed there, so install it when it is
+      # missing. Skipping when present keeps this genuinely inert on the VMs: no
+      # apt-get (which would race the dpkg lock against sibling matrix legs sharing
+      # the machine) and no risk of changing the Apptainer version under tests that
+      # currently pass.
+      - name: Check for Apptainer
+        id: apptainer-check
+        run: |
+          if command -v apptainer >/dev/null 2>&1 || command -v singularity >/dev/null 2>&1; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # NOTE: this job checks out with `path: source`, so a local action must be
+      # referenced through that path - `./.github/actions/...` resolves against
+      # GITHUB_WORKSPACE, which is empty here.
+      - name: Install Apptainer
+        if: steps.apptainer-check.outputs.present != 'true'
+        uses: ./source/.github/actions/setup-apptainer
+        with:
+          apptainer-version: 1.4.3
+
+      # Defensive, and currently unused: this job only exec's a downloaded .simg, so
+      # Apptainer needs no build cache. Kept so a runner without a writable $HOME
+      # has somewhere to go if that changes.
+      - name: Prepare Apptainer scratch directories
+        if: steps.apptainer-check.outputs.present != 'true'
+        run: |
+          set -euo pipefail
+          # Refuse to fall back to /tmp: on an ARC pod that is the container
+          # writable layer on the NODE'S root disk (~28GB, shared with production
+          # containerd). Staging a multi-GB SIF there can trigger DiskPressure and
+          # evict a neighbouring production runner - a failure that hits someone
+          # else, not this job. RUNNER_TEMP is always set by the runner.
+          BASE_PATH="${RUNNER_TEMP:?RUNNER_TEMP unset - refusing to stage a multi-GB SIF on /tmp}"
+          mkdir -p "$BASE_PATH/apptainer/cache" "$BASE_PATH/apptainer/tmp"
+          {
+            echo "APPTAINER_CACHEDIR=$BASE_PATH/apptainer/cache"
+            echo "APPTAINER_TMPDIR=$BASE_PATH/apptainer/tmp"
+            echo "SINGULARITY_CACHEDIR=$BASE_PATH/apptainer/cache"
+            echo "SINGULARITY_TMPDIR=$BASE_PATH/apptainer/tmp"
+          } >> "$GITHUB_ENV"
+
       - name: Verify container runtimes
         run: |
-          # Verify that container runtimes are available on self-hosted runner
-          docker --version
+          # Docker is not required: the release test downloads a .simg over HTTPS
+          # and exec's it. Report it if present, but do not fail a runner without it.
+          docker --version || echo "docker not present (not required by this job)"
           apptainer --version || singularity --version
 
       - name: Debug matrix values

--- a/recipes/ants/fulltest.yaml
+++ b/recipes/ants/fulltest.yaml
@@ -1,5 +1,5 @@
 # ANTs container test suite
-# Tests for ANTs (Advanced Normalization Tools) v2.6.0
+# Tests for ANTs (Advanced Normalization Tools) v2.6.5
 #
 # ANTs is a state-of-the-art medical image registration and segmentation toolkit.
 # It provides tools for image registration, bias correction, segmentation, and more.


### PR DESCRIPTION
## Problem

`test-containers` assumes Apptainer is already on the runner. That only holds on
the eight standalone VMs, which have it pre-installed and are being
decommissioned. On a stock runner image the "Verify container runtimes" step exits
127 on `apptainer --version || singularity --version` before any test runs.

Runner-agnostic: works on the current VMs, prepares the job for ARC. `runs-on` is
unchanged and remains a separate decision.

## Changes

- **Check for Apptainer; install only if missing.** `setup-apptainer` has no
  skip-if-present branch and shells out to `apt-get`. Unconditionally it would race
  the dpkg lock against sibling matrix legs sharing a VM, add an apt dependency to a
  job that had none, and change the Apptainer version under currently-passing tests.
- **`./source/.github/actions/setup-apptainer`.** This job checks out with
  `path: source`; a bare `./.github/...` resolves against `GITHUB_WORKSPACE`, which
  is empty here, and fails on every runner.
- **Apptainer scratch dirs, no `/tmp` fallback.** On an ARC pod `/tmp` is the
  container writable layer on the node's root disk (~28 GB, shared with production
  containerd). Staging a multi-GB SIF there risks DiskPressure and eviction of a
  neighbouring runner, so an unset `RUNNER_TEMP` fails loudly instead.
- **Guard `docker --version`.** Docker is not required: the test downloads a `.simg`
  over HTTPS and `exec`s it.

## ANTs change

`recipes/ants/fulltest.yaml` declared `version: 2.6.5` under a header saying v2.6.0.

It is also the trigger. This workflow's `paths:` filter is `releases/*/**.json` and
`recipes/**/fulltest.yaml`, so a workflow-only edit never runs the workflow it
changes. ANTs has both a `fulltest.yaml` and `releases/ants/*.json`. Its
`build.yaml` is deliberately untouched - `workflows/release_pr_changes.py:184`
short-circuits on `if recipe in candidate_recipes: continue` and would skip the job.

## Scope of a green run

Runs on the VMs, where Apptainer is present and both new steps skip. Proves the
trigger fires and nothing regressed; does not exercise the install path. That is
covered when `runs-on` moves to ARC.

Note: `test-containers` last executed on 2026-08-01 (run `30689212385`); every run
since has skipped.
