### PR TITLE
Fix deepwmh: let nnU-Net log outside the read-only model directory

### DIFF
--- a/recipes/deepwmh/build.yaml
+++ b/recipes/deepwmh/build.yaml
@@ -153,7 +153,13 @@ build:
         # does not help: the path comes from the pickle, not the supplied root.
         - python {{ get_file("patch_nnunet_logdir.py") }} /opt/nnunet_for_deepwmh
         # Fail the build if the patch stops applying to a future fork revision.
-        - grep -q 'neurocontainers: fall back to a writable log dir' /opt/nnunet_for_deepwmh/nnunet/training/network_training/network_trainer.py
+        # Matched with a wildcard for the colon: an unquoted ": " inside a
+        # YAML list entry turns the whole command into a mapping, which is
+        # valid YAML and silently rendered {"grep -q ...": "..."} into the
+        # Dockerfile, failing with "not found" at build time.
+        - >-
+          grep -q 'neurocontainers. fall back to a writable log dir'
+          /opt/nnunet_for_deepwmh/nnunet/training/network_training/network_trainer.py
 
     - run:
         - git clone https://github.com/lchdl/DeepWMH /opt/deepwmh

--- a/recipes/deepwmh/build.yaml
+++ b/recipes/deepwmh/build.yaml
@@ -145,6 +145,15 @@ build:
         - cd /opt/nnunet_for_deepwmh
         - git checkout {{ context.nnunet_fork_commit }}
         - python -m pip install --no-cache-dir -e .
+        # The fork opens a training log inside self.output_folder even when only
+        # doing inference, and output_folder is restored from the model pickle,
+        # so it points at the baked-in /opt/deepwmh-model. That path is inside
+        # the read-only squashfs at run time, so prediction died after N4 with
+        # "OSError: [Errno 30] Read-only file system". Passing --trained-model
+        # does not help: the path comes from the pickle, not the supplied root.
+        - python {{ get_file("patch_nnunet_logdir.py") }} /opt/nnunet_for_deepwmh
+        # Fail the build if the patch stops applying to a future fork revision.
+        - grep -q 'neurocontainers: fall back to a writable log dir' /opt/nnunet_for_deepwmh/nnunet/training/network_training/network_trainer.py
 
     - run:
         - git clone https://github.com/lchdl/DeepWMH /opt/deepwmh
@@ -211,6 +220,54 @@ build:
           command -v runROBEX.sh >/dev/null || test -x "$ROBEX_DIR/runROBEX.sh"
           command -v N4BiasFieldCorrection
           python -c "import torch; print('cuda available:', torch.cuda.is_available())"
+
+files:
+  - name: patch_nnunet_logdir.py
+    contents: |
+      """Make the nnU-Net fork tolerate a read-only model directory.
+
+      network_trainer.print_to_log_file() creates training_log_<stamp>.txt in
+      self.output_folder. During inference that folder comes from the restored
+      model pickle and points into the image, which is read-only under
+      apptainer. Training still logs where it always did; only the unwritable
+      case falls back, so this does not change behaviour on a writable tree.
+      """
+      import pathlib
+      import sys
+
+      root = pathlib.Path(sys.argv[1])
+      target = root / "nnunet/training/network_training/network_trainer.py"
+      src = target.read_text()
+
+      old = (
+          "        if self.log_file is None:\n"
+          "            maybe_mkdir_p(self.output_folder)\n"
+          "            timestamp = datetime.now()\n"
+          "            self.log_file = join(self.output_folder, "
+      )
+      new = (
+          "        if self.log_file is None:\n"
+          "            # neurocontainers: fall back to a writable log dir\n"
+          "            import os as _os\n"
+          "            _log_dir = self.output_folder\n"
+          "            try:\n"
+          "                maybe_mkdir_p(_log_dir)\n"
+          "                _ok = _os.access(_log_dir, _os.W_OK)\n"
+          "            except OSError:\n"
+          "                _ok = False\n"
+          "            if not _ok:\n"
+          "                _log_dir = _os.path.join(\n"
+          "                    _os.environ.get('TMPDIR', '/tmp'), 'deepwmh-nnunet-logs')\n"
+          "                maybe_mkdir_p(_log_dir)\n"
+          "            timestamp = datetime.now()\n"
+          "            self.log_file = join(_log_dir, "
+      )
+      if src.count(old) != 1:
+          raise SystemExit(
+              f"expected exactly one log-file block in {target}, found {src.count(old)}; "
+              "the fork changed and this patch needs revisiting")
+      target.write_text(src.replace(old, new, 1))
+      print(f"patched {target}")
 
 deploy:
   path:

--- a/recipes/deepwmh/fulltest.yaml
+++ b/recipes/deepwmh/fulltest.yaml
@@ -183,3 +183,27 @@ tests:
     description: Confirms argument handling fails cleanly rather than hanging.
     command: bash -lc 'DeepWMH_predict -i /tmp/does-not-exist.nii.gz -n s1 -o /tmp/out -g -1 >/dev/null 2>&1; test $? -ne 0 && echo rejected'
     expected_output_contains: rejected
+
+  - name: nnU-Net tolerates a read-only model directory
+    description: >-
+      The fork opens a training log in the model folder even during inference,
+      and that path comes from the model pickle, so it points into the read-only
+      image. Unpatched, prediction dies after N4 with Errno 30. This asserts the
+      patch is present in the shipped image.
+    command: >-
+      grep -c "neurocontainers. fall back to a writable log dir"
+      /opt/nnunet_for_deepwmh/nnunet/training/network_training/network_trainer.py
+    expected_output_contains: "1"
+
+  - name: the log fallback resolves to a writable directory
+    description: Exercises the fallback against the real read-only model directory.
+    command: |
+      python -c "
+      import os
+      d = os.environ.get('DEEPWMH_MODEL_DIR', '/opt/deepwmh-model')
+      ok = os.access(d, os.W_OK)
+      fb = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'deepwmh-nnunet-logs')
+      os.makedirs(fb, exist_ok=True)
+      print('model-dir-writable', ok, 'fallback-writable', os.access(fb, os.W_OK))
+      "
+    expected_output_contains: "fallback-writable True"


### PR DESCRIPTION
## What

As shipped, `deepwmh/1.0.1` cannot segment anything. Prediction dies after N4 preprocessing with:

```
OSError: [Errno 30] Read-only file system
```

This patches the bundled nnU-Net fork so it logs outside the read-only model directory.

## Why

`network_trainer.print_to_log_file()` in the pinned fork opens a **training** log even when only running inference:

```python
if self.log_file is None:
    maybe_mkdir_p(self.output_folder)
    self.log_file = join(self.output_folder, "training_log_....txt")
```

During inference `self.output_folder` is restored from the model pickle. This recipe re-packages the model at build time (`DeepWMH_install -o /opt/deepwmh-model`), so the pickle holds that absolute path — which lives inside the read-only squashfs at run time.

Notably, `--trained-model <writable copy>` does **not** work around it: the log path comes from the pickle, not from the supplied model root.

This does not reproduce in the Docker build, where the filesystem is writable. It only appears under apptainer, which is why the existing tests pass.

## How

The fork now falls back to a writable directory **only when `output_folder` is not writable**, so training keeps logging exactly where it always did and behaviour on a writable tree is unchanged.

The patch script requires exactly one match and errors otherwise, so a future fork revision fails the build rather than silently reshipping the defect.

## Verification

Before pushing, the patch was applied to the pinned fork source (`lchdl/nnUNet_for_DeepWMH` @ `3509d4e0`) and checked:

- applies exactly once
- patched file remains valid Python
- fallback resolves to a writable path when given a genuinely read-only directory

Two fulltests were added: the marker is present in the shipped image, and the fallback path is writable at run time.

## Notes for the reviewer

- **Version unchanged at 1.0.1** — the upstream tool version has not changed; this is a recipe fix and the release flow supports same-version rebuilds. Happy to bump if you'd rather it be visibly distinct in the app list.
- **Reported from a real run in neurodesk**, where the workaround was staging a writable copy of the 237 MB model and binding it over `/opt/deepwmh-model`. That bind should no longer be needed once this lands, so it is worth retesting against the rebuilt image.
- **No CPU-mode change was needed.** The report also flagged CPU support; the readme already documents `-g -1` with an example, so nothing was changed there.
- Same failure class is worth watching for elsewhere: a tool writing inside the image at run time passes in the Docker build and fails under apptainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
