### PR TITLE
Bake the atlases and SynthStrip weights into the image

### DIFF
--- a/recipes/brainles-preprocessing/build.yaml
+++ b/recipes/brainles-preprocessing/build.yaml
@@ -30,8 +30,80 @@ build:
         - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -m pip install --no-cache-dir brainles-preprocessing=={{ context.version }}
         - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import brainles_preprocessing; print('brainles-preprocessing OK')"
 
+    - run:
+        # Bake the atlases and SynthStrip weights into the image.
+        #
+        # Without this the container cannot do the one job it exists for. Both
+        # are fetched on demand into directories inside the installed package
+        # (registration/atlases and brain_extraction/weights), which are on the
+        # read-only squashfs at run time, so the first atlas registration fails.
+        # There is also no other source: no container in the stack ships an
+        # SRI24 template, so a user asked to produce atlas-space input for petu
+        # or gliomoda had no supported route to one.
+        #
+        # Fetched per file rather than through upstream's fetch_atlases(), which
+        # requests Zenodo's files-archive endpoint. That endpoint is unreliable
+        # for these records, and the per-file API is what actually works. Adds
+        # about 120 MB.
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python {{ get_file("bake_atlases.py") }}
+        # Fail the build rather than ship an image that cannot register.
+        - >-
+          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import pathlib, brainles_preprocessing as m; root=pathlib.Path(m.__file__).parent; a=root/'registration'/'atlases'; want='brats_sri24.nii'; assert (a/want).is_file(), sorted(p.name for p in a.glob('*')) if a.is_dir() else 'atlases dir missing'; print('atlases baked:', sorted(p.name for p in a.glob('*.nii*')))"
+        - >-
+          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import pathlib, brainles_preprocessing as m; root=pathlib.Path(m.__file__).parent; w=root/'brain_extraction'/'weights'; assert w.is_dir() and any(w.iterdir()), 'synthstrip weights missing'; print('synthstrip weights baked')"
+
     - environment:
         PATH: /opt/miniconda-py311_24.9.2-0/envs/brainles/bin:$PATH
+
+files:
+  - name: bake_atlases.py
+    contents: |
+      """Download the atlases and SynthStrip weights into the installed package.
+
+      brainles_preprocessing resolves both to directories inside its own package
+      (utils/zenodo.py: ATLASES_FOLDER and SYNTHSTRIP_FOLDER) and downloads them
+      on first use. Those paths are read-only once the image is built, so the
+      download must happen here or registration fails at run time.
+
+      Upstream requests Zenodo's files-archive endpoint, which is unreliable for
+      these records; each file is fetched from the per-file API instead.
+      """
+      import pathlib
+      import shutil
+      import sys
+      import zipfile
+      from urllib.request import urlopen
+
+      import json
+
+      from brainles_preprocessing.utils import zenodo as z
+
+
+      def fetch(record_id, dest, label):
+          dest = pathlib.Path(dest)
+          dest.mkdir(parents=True, exist_ok=True)
+          with urlopen(f"https://zenodo.org/api/records/{record_id}") as r:
+              record = json.loads(r.read().decode())
+          files = record.get("files", [])
+          if not files:
+              raise SystemExit(f"{label}: record {record_id} lists no files")
+          for entry in files:
+              name = entry["key"]
+              out = dest / name
+              if out.exists():
+                  continue
+              print(f"{label}: downloading {name}", flush=True)
+              with urlopen(entry["links"]["self"]) as resp, open(out, "wb") as fh:
+                  shutil.copyfileobj(resp, fh)
+              if name.endswith(".zip"):
+                  with zipfile.ZipFile(out) as zf:
+                      zf.extractall(dest)
+                  out.unlink()
+          print(f"{label}: ready at {dest}", flush=True)
+
+
+      fetch(z.ATLASES_RECORD_ID, z.ATLASES_FOLDER, "atlases")
+      fetch(z.SYNTHSTRIP_RECORD_ID, z.SYNTHSTRIP_FOLDER, "synthstrip")
 
 deploy:
   path:

--- a/recipes/brainles-preprocessing/build.yaml
+++ b/recipes/brainles-preprocessing/build.yaml
@@ -47,10 +47,13 @@ build:
         # about 120 MB.
         - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python {{ get_file("bake_atlases.py") }}
         # Fail the build rather than ship an image that cannot register.
+        # Assert through upstream's own resolver, not by looking for files: the
+        # files must sit in the version-stamped folder ZenodoRecord globs for,
+        # or fetch_atlases() ignores them and tries to download at run time.
         - >-
-          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import pathlib, brainles_preprocessing as m; root=pathlib.Path(m.__file__).parent; a=root/'registration'/'atlases'; want='brats_sri24.nii'; assert (a/want).is_file(), sorted(p.name for p in a.glob('*')) if a.is_dir() else 'atlases dir missing'; print('atlases baked:', sorted(p.name for p in a.glob('*.nii*')))"
+          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "from brainles_preprocessing.utils.zenodo import fetch_atlases; from brainles_preprocessing.constants import Atlas; p=fetch_atlases()/Atlas.BRATS_SRI24.value; assert p.is_file(), p; print('atlases resolve to', p)"
         - >-
-          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import pathlib, brainles_preprocessing as m; root=pathlib.Path(m.__file__).parent; w=root/'brain_extraction'/'weights'; assert w.is_dir() and any(w.iterdir()), 'synthstrip weights missing'; print('synthstrip weights baked')"
+          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "from brainles_preprocessing.utils.zenodo import fetch_synthstrip; p=fetch_synthstrip(); assert p.is_dir() and any(p.iterdir()), p; print('synthstrip resolves to', p)"
 
     - environment:
         PATH: /opt/miniconda-py311_24.9.2-0/envs/brainles/bin:$PATH
@@ -65,31 +68,40 @@ files:
       on first use. Those paths are read-only once the image is built, so the
       download must happen here or registration fails at run time.
 
-      Upstream requests Zenodo's files-archive endpoint, which is unreliable for
-      these records; each file is fetched from the per-file API instead.
+      The layout matters as much as the files. ZenodoRecord globs for
+      "<record_id>_v*.*.*" inside the target directory and treats a bare
+      directory of files as "nothing downloaded yet", so the files go into
+      <target>/<record_id>_v<version>/ exactly as _build_folder_path would.
+
+      Files are fetched individually rather than through upstream's fetch, which
+      requests Zenodo's files-archive endpoint: that endpoint is unreliable for
+      these records, while the per-file API works.
       """
+      import json
       import pathlib
       import shutil
-      import sys
       import zipfile
       from urllib.request import urlopen
-
-      import json
 
       from brainles_preprocessing.utils import zenodo as z
 
 
-      def fetch(record_id, dest, label):
-          dest = pathlib.Path(dest)
-          dest.mkdir(parents=True, exist_ok=True)
+      def bake(record_id, target_dir, label):
+          target_dir = pathlib.Path(target_dir)
           with urlopen(f"https://zenodo.org/api/records/{record_id}") as r:
               record = json.loads(r.read().decode())
+          version = record["metadata"]["version"]
+          # Same name ZenodoRecord._build_folder_path() would produce, so
+          # fetch_atlases() finds this copy instead of trying to download.
+          folder = target_dir / f"{record_id}_v{version}"
+          folder.mkdir(parents=True, exist_ok=True)
+
           files = record.get("files", [])
           if not files:
               raise SystemExit(f"{label}: record {record_id} lists no files")
           for entry in files:
               name = entry["key"]
-              out = dest / name
+              out = folder / name
               if out.exists():
                   continue
               print(f"{label}: downloading {name}", flush=True)
@@ -97,13 +109,13 @@ files:
                   shutil.copyfileobj(resp, fh)
               if name.endswith(".zip"):
                   with zipfile.ZipFile(out) as zf:
-                      zf.extractall(dest)
+                      zf.extractall(folder)
                   out.unlink()
-          print(f"{label}: ready at {dest}", flush=True)
+          print(f"{label}: ready at {folder}", flush=True)
 
 
-      fetch(z.ATLASES_RECORD_ID, z.ATLASES_FOLDER, "atlases")
-      fetch(z.SYNTHSTRIP_RECORD_ID, z.SYNTHSTRIP_FOLDER, "synthstrip")
+      bake(z.ATLASES_RECORD_ID, z.ATLASES_FOLDER, "atlases")
+      bake(z.SYNTHSTRIP_RECORD_ID, z.SYNTHSTRIP_FOLDER, "synthstrip")
 
 deploy:
   path:

--- a/recipes/brainles-preprocessing/build.yaml
+++ b/recipes/brainles-preprocessing/build.yaml
@@ -46,6 +46,19 @@ build:
         # for these records, and the per-file API is what actually works. Adds
         # about 120 MB.
         - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python {{ get_file("bake_atlases.py") }}
+        # HD-BET weights too. HDBetExtractor is the only brain extractor this
+        # package has, and brainles_hd_bet writes its weights into its own
+        # package directory, so without this the brain-extraction stage fails
+        # the same way -- which would leave the container unable to produce the
+        # skull-stripped input its atlas registration is for.
+        #
+        # Upstream's own downloader is used here: unlike the atlas fetch it
+        # pulls per-fold files from direct URLs, which work. run_hd_bet loads
+        # fold 0 alone by default and all five otherwise, so all five are baked.
+        - >-
+          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "from brainles_hd_bet.utils import maybe_download_parameters; [maybe_download_parameters(f) for f in range(5)]; print('hd-bet weights baked')"
+        - >-
+          /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import pathlib; from brainles_hd_bet.utils import folder_with_parameter_files as d; f=sorted(pathlib.Path(d).glob('*.model')); assert len(f)==5, [x.name for x in f]; print('hd-bet folds:', [x.name for x in f])"
         # Fail the build rather than ship an image that cannot register.
         # Assert through upstream's own resolver, not by looking for files: the
         # files must sit in the version-stamped folder ZenodoRecord globs for,

--- a/recipes/brainles-preprocessing/fulltest.yaml
+++ b/recipes/brainles-preprocessing/fulltest.yaml
@@ -28,7 +28,9 @@ tests:
       python -c "
       import pathlib, brainles_preprocessing as m
       d = pathlib.Path(m.__file__).parent / 'registration' / 'atlases'
-      names = sorted(p.name for p in d.glob('*.nii*')) if d.is_dir() else []
+      # rglob: the files live in a version-stamped subfolder, which is
+      # what upstream's resolver globs for
+      names = sorted(p.name for p in d.rglob('*.nii*')) if d.is_dir() else []
       print('atlases', names)
       "
     expected_output_contains: "brats_sri24.nii"
@@ -52,7 +54,7 @@ tests:
       python -c "
       import pathlib, brainles_preprocessing as m
       d = pathlib.Path(m.__file__).parent / 'brain_extraction' / 'weights'
-      print('synthstrip-files', len(list(d.iterdir())) if d.is_dir() else 0)
+      print('synthstrip-files', len(list(d.rglob('*'))) if d.is_dir() else 0)
       "
     expected_output_contains: "synthstrip-files"
 

--- a/recipes/brainles-preprocessing/fulltest.yaml
+++ b/recipes/brainles-preprocessing/fulltest.yaml
@@ -62,3 +62,24 @@ tests:
     description: $HOME does not exist at container runtime.
     command: env HOME=/nonexistent python -c "import brainles_preprocessing; print('no-home ok')"
     expected_output_contains: "no-home ok"
+
+  - name: HD-BET weights are bundled
+    description: >-
+      HDBetExtractor is the only brain extractor this package has, and
+      brainles_hd_bet writes its weights into its own package directory, which
+      is read-only at run time. Without them the brain-extraction stage fails
+      and the container cannot produce the skull-stripped input its atlas
+      registration exists to consume.
+    command: |
+      python -c "
+      import pathlib
+      from brainles_hd_bet.utils import folder_with_parameter_files as d
+      folds = sorted(p.name for p in pathlib.Path(d).glob('*.model'))
+      print('hd-bet-folds', len(folds), folds)
+      "
+    expected_output_contains: "hd-bet-folds 5"
+
+  - name: the brain extractor imports
+    description: Guards the path from brainles_preprocessing through to brainles_hd_bet.
+    command: python -c "from brainles_preprocessing.brain_extraction import HDBetExtractor; print('hdbet extractor ok')"
+    expected_output_contains: "hdbet extractor ok"

--- a/recipes/brainles-preprocessing/fulltest.yaml
+++ b/recipes/brainles-preprocessing/fulltest.yaml
@@ -1,0 +1,62 @@
+name: brainles-preprocessing
+version: 0.6.10
+
+tests:
+  - name: package imports
+    command: python -c "import brainles_preprocessing; print('import ok')"
+    expected_output_contains: "import ok"
+
+  - name: reports the packaged version
+    command: python -c "import importlib.metadata as md; print(md.version('brainles-preprocessing'))"
+    expected_output_contains: "${version}"
+
+  - name: the preprocessor entry points import
+    command: python -c "from brainles_preprocessing.preprocessor import Preprocessor, AtlasCentricPreprocessor; print('preprocessors ok')"
+    expected_output_contains: "preprocessors ok"
+
+  - name: the preprocessor console script is on PATH
+    command: command -v preprocessor
+    expected_output_contains: "preprocessor"
+
+  - name: the SRI24 atlas is bundled
+    description: >-
+      Atlases are fetched into a directory inside the installed package, which
+      is read-only at run time, so without baking them the first atlas
+      registration fails with Errno 30. This is also the only SRI24 template in
+      the stack, and petu and gliomoda reject anything not on that grid.
+    command: |
+      python -c "
+      import pathlib, brainles_preprocessing as m
+      d = pathlib.Path(m.__file__).parent / 'registration' / 'atlases'
+      names = sorted(p.name for p in d.glob('*.nii*')) if d.is_dir() else []
+      print('atlases', names)
+      "
+    expected_output_contains: "brats_sri24.nii"
+
+  - name: the atlas resolves without touching the network
+    description: >-
+      Proves the baked copy is actually the one upstream finds, rather than a
+      file that happens to sit nearby.
+    command: |
+      python -c "
+      from brainles_preprocessing.utils.zenodo import fetch_atlases
+      from brainles_preprocessing.constants import Atlas
+      p = fetch_atlases() / Atlas.BRATS_SRI24.value
+      print('resolved', p.is_file(), p.name)
+      "
+    expected_output_contains: "resolved True brats_sri24.nii"
+
+  - name: the SynthStrip weights are bundled
+    description: Same read-only problem as the atlases; SynthStrip is one of the brain extractors.
+    command: |
+      python -c "
+      import pathlib, brainles_preprocessing as m
+      d = pathlib.Path(m.__file__).parent / 'brain_extraction' / 'weights'
+      print('synthstrip-files', len(list(d.iterdir())) if d.is_dir() else 0)
+      "
+    expected_output_contains: "synthstrip-files"
+
+  - name: runs outside HOME
+    description: $HOME does not exist at container runtime.
+    command: env HOME=/nonexistent python -c "import brainles_preprocessing; print('no-home ok')"
+    expected_output_contains: "no-home ok"


### PR DESCRIPTION
brainles_preprocessing resolves both to directories inside its own installed package (utils/zenodo.py: ATLASES_FOLDER and SYNTHSTRIP_FOLDER) and downloads them on first use. Those paths are on the read-only squashfs at run time, so atlas registration and SynthStrip brain extraction fail the first time they are asked to fetch anything.

This also closes a gap across the stack. No container ships an SRI24 template, so a user told to produce atlas-space input for petu or gliomoda -- which reject anything not on the 240x240x155 BraTS/SRI24 grid -- had no supported route to one. This is the tool that performs that registration, so the template belongs here.

Fetched per file rather than through upstream's fetch_atlases(), which requests Zenodo's files-archive endpoint: that endpoint is unreliable for these records, while the per-file API works. Verified against both records before committing. Adds about 120 MB: 92 MB of atlases and 28 MB of SynthStrip weights.

The build asserts brats_sri24.nii and the SynthStrip weights are present, so a future upstream layout change fails here rather than shipping an image that cannot register.