### PR TITLE
Fix panoptica: carry the instance-relabelling fix, add kaleido, make the CLI usable

### DIFF
--- a/recipes/panoptica/build.yaml
+++ b/recipes/panoptica/build.yaml
@@ -1,5 +1,5 @@
 name: panoptica
-version: 2.1.3
+version: 2.1.6
 
 architectures:
   - x86_64
@@ -23,16 +23,54 @@ build:
         env_exists: "false"
 
     - run:
-        - /opt/miniconda-latest/envs/panoptica/bin/python -m pip install --no-cache-dir nibabel==5.4.2 SimpleITK==2.5.5 panoptica=={{ context.version }}
+        # kaleido: panoptica's documented plotting entry point is
+        # Panoptica_Statistic.get_summary_figure(), which returns a plotly figure.
+        # Exporting it to PNG or PDF needs kaleido, and the error tells the user
+        # to pip install it, which is impossible in a read-only image.
+        - /opt/miniconda-latest/envs/panoptica/bin/python -m pip install --no-cache-dir nibabel==5.4.2 SimpleITK==2.5.5 kaleido==0.2.1 panoptica=={{ context.version }}
         # sanity import at build time so a broken solve fails the build, not the user
         - /opt/miniconda-latest/envs/panoptica/bin/python -c "from importlib.metadata import version; import nibabel, SimpleITK, panoptica; print('panoptica', version('panoptica'))"
+        - /opt/miniconda-latest/envs/panoptica/bin/python -c "import kaleido; print('kaleido', kaleido.__version__)"
+        # Instance relabelling overflows the connected-components dtype, so
+        # ordinary multi-lesion evaluations fail once reference plus unmatched
+        # predicted instances exceed 255. Still unfixed in 2.1.6.
+        - /opt/miniconda-latest/envs/panoptica/bin/python {{ get_file("fix_map_labels_dtype") }}
+        # Prove the fix works rather than that the file changed: this map needs
+        # label 256, which the unpatched code cannot represent in uint8.
+        - >-
+          /opt/miniconda-latest/envs/panoptica/bin/python -c "import numpy as np; from panoptica._functionals import _map_labels; a=np.zeros((4,4),dtype=np.uint8); a[0,0]=3; out=_map_labels(a,{3:256}); assert int(out.max())==256, out.max(); print('instance relabelling handles >255 labels')"
+
+    - run:
+        # The bundled configs live inside the image and -c is required, so
+        # without a way to copy one out a user cannot run the CLI at all.
+        # panoptica-python exists because this container deliberately does not
+        # put python on the user's PATH.
+        - install -m 0755 {{ get_file("panoptica_config_helper") }} /usr/local/bin/panoptica-config
+        - install -m 0755 {{ get_file("panoptica_python_helper") }} /usr/local/bin/panoptica-python
+        - panoptica-python -c "import panoptica; print('panoptica-python ok')"
+        - panoptica-config --list
+        - panoptica-config BRATS | head -1
 
     - environment:
         PATH: /opt/miniconda-latest/envs/panoptica/bin:$PATH
 
 deploy:
-  path:
-    - /opt/miniconda-latest/envs/panoptica/bin
+  # Only the tool. Exporting the environment's bin directory put 35 commands on
+  # the user's PATH, including python, python3, python3.11, tclsh, wish, reset,
+  # bz* and zstd*, so the host interpreter was silently replaced for the rest of
+  # the shell while pip still resolved to the host.
+  bins:
+    - panopticacli
+    - panoptica-config
+    - panoptica-python
+
+files:
+  - name: fix_map_labels_dtype
+    filename: fix_map_labels_dtype.py
+  - name: panoptica_config_helper
+    filename: panoptica-config
+  - name: panoptica_python_helper
+    filename: panoptica-python
 
 tests:
   - name: "import panoptica"
@@ -47,20 +85,60 @@ readme: |
   ----------------------------------
   ## panoptica/{{ context.version }} ##
   panoptica is a Python framework for instance-wise evaluation of 3D
-  segmentation maps (matching, panoptic quality, Dice, etc.), from the
-  BrainLesion Suite.
+  segmentation maps (instance matching, panoptic quality, Dice, IoU, ASSD),
+  from the BrainLesion Suite.
 
-  This is a Python library (no command-line tool). Load the module, then
-  use it from Python or a Jupyter kernel:
+  This container provides both a command line tool and the Python library.
+
+  ### Command line
 
   ```
   ml panoptica/{{ context.version }}
-  python -c "from importlib.metadata import version; import panoptica; print(version('panoptica'))"
+  panopticacli -ref reference.nii.gz -pred prediction.nii.gz -c config.yaml
   ```
 
-  Docs: https://github.com/BrainLesion/panoptica
+  -c/--config is required. Seven ready-made configs ship inside the image:
+  panoptica_evaluator_default, _BRATS, _ISLES, _VERSE, _binaryMS,
+  _unmatched_instance, and panoptica_config_voronoi. They live inside the
+  container, so copy one out before editing it:
 
-  To run container outside of this environment: ml panoptica/{{ context.version }}
+  ```
+  panoptica-config BRATS > my_config.yaml
+  panoptica-config --list
+  ```
+
+  ### Python
+
+  panoptica lives inside the container, so `import panoptica` works in the
+  container's interpreter, not in a Jupyter kernel or the host python. Run a
+  script through the container:
+
+  ```
+  ml panoptica/{{ context.version }}
+  panoptica-python my_analysis.py
+  ```
+
+  ```python
+  from panoptica import Panoptica_Evaluator
+  ev = Panoptica_Evaluator.load_from_config("my_config.yaml")
+  for group, result in ev.evaluate("prediction.nii.gz", "reference.nii.gz").items():
+      print(group, result.to_dict()["global_bin_dsc"])
+  ```
+
+  Inputs may be a file path, numpy array, nibabel image or SimpleITK image.
+  Voxel spacing is read from the NIfTI header; numpy arrays default to 1 mm
+  unless you pass voxelspacing=.
+
+  ### Notes
+
+  This image carries a patch to panoptica._functionals._map_labels. Upstream
+  builds its label lookup with the dtype of the connected-components array,
+  which overflows once reference plus unmatched predicted instances exceed 255,
+  so ordinary multi-lesion evaluations fail with OverflowError or IndexError.
+  The fix is on upstream main but not in 2.1.6.
+
+  Docs: https://github.com/BrainLesion/panoptica
+  Citation: https://doi.org/10.1101/2024.10.03.24314745
   ----------------------------------
 
 copyright:

--- a/recipes/panoptica/fix_map_labels_dtype.py
+++ b/recipes/panoptica/fix_map_labels_dtype.py
@@ -1,0 +1,68 @@
+"""Stop instance relabelling overflowing the connected-components dtype.
+
+panoptica._functionals._map_labels builds its lookup table with the dtype of the
+connected-components array. cc3d returns the narrowest dtype that fits the
+component count (uint8 for <= 255 components), but the instance matcher then
+allocates new labels up to max(ref_labels) + 1 + n_unmatched_predictions, which
+can exceed it. Ordinary multi-lesion evaluations therefore fail with either
+
+    OverflowError: Python integer 256 out of bounds for uint8
+    IndexError: index N is out of bounds for axis 0 with size 0
+
+the second because max_value wraps to 0 and np.arange returns an empty array.
+
+Casting the *input* does not help: the dtype comes from panoptica's internal CCA
+output, not the user's array. The dtype is now chosen from the values being
+written, matching the fix on upstream main. Still present in 2.1.6, so the image
+carries it until a release includes it.
+
+Do not "fix" this by pinning numpy<2: numpy 2 raises on the out-of-range cast,
+while numpy 1 wraps silently (label 256 -> 0) and corrupts instance matching with
+no error at all.
+"""
+
+import pathlib
+from importlib.util import find_spec
+
+MARKER = "neurocontainers: choose the lookup dtype from the values written"
+
+OLD = """    k = np.array(list(label_map.keys()), dtype=arr.dtype)
+    v = np.array(list(label_map.values()), dtype=arr.dtype)
+
+    max_value = max(arr.max(), max(k), max(v)) + 1
+
+    mapping_ar = np.arange(max_value, dtype=arr.dtype)
+"""
+
+NEW = f"""    # {MARKER}
+    _keys = list(label_map.keys())
+    _values = list(label_map.values())
+    # int() throughout: max(...) + 1 on a uint8 array wraps to 0 otherwise
+    max_value = int(max(int(arr.max()), int(max(_keys)), int(max(_values)))) + 1
+    _target_dtype = np.promote_types(arr.dtype, np.min_scalar_type(max_value))
+    k = np.array(_keys, dtype=_target_dtype)
+    v = np.array(_values, dtype=_target_dtype)
+
+    mapping_ar = np.arange(max_value, dtype=_target_dtype)
+"""
+
+
+def main() -> None:
+    spec = find_spec("panoptica")
+    if spec is None or not spec.submodule_search_locations:
+        raise SystemExit("panoptica is not installed")
+    target = pathlib.Path(next(iter(spec.submodule_search_locations))) / "_functionals.py"
+    src = target.read_text()
+    if MARKER in src:
+        return
+    if src.count(OLD) != 1:
+        raise SystemExit(
+            f"expected exactly one _map_labels dtype block in {target}, "
+            f"found {src.count(OLD)}; upstream changed and this patch needs revisiting"
+        )
+    target.write_text(src.replace(OLD, NEW, 1))
+    print(f"patched {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/panoptica/fulltest.yaml
+++ b/recipes/panoptica/fulltest.yaml
@@ -1,5 +1,5 @@
 name: panoptica
-version: 2.1.3
+version: 2.1.6
 default_timeout: 60
 
 tests:
@@ -91,3 +91,46 @@ tests:
       print("semantic-match", result.tp, result.pq)
       PY
     expected_output_contains: "semantic-match 2 1.0"
+
+  - name: instance relabelling survives more than 255 labels
+    description: >-
+      Upstream builds its label lookup with the connected-components dtype, so
+      cc3d returning uint8 for <=255 components made ordinary multi-lesion
+      evaluations fail with OverflowError or IndexError once reference plus
+      unmatched predicted instances exceeded 255. Still unfixed in 2.1.6, so the
+      image carries a patch; this fails if it is ever lost.
+    command: |
+      panoptica-python -c "
+      import numpy as np
+      from panoptica._functionals import _map_labels
+      a = np.zeros((4, 4), dtype=np.uint8); a[0, 0] = 3
+      print('relabel-max', int(_map_labels(a, {3: 256}).max()))
+      "
+    expected_output_contains: "relabel-max 256"
+
+  - name: kaleido is present so figure export works
+    description: >-
+      get_summary_figure returns a plotly figure; exporting it needs kaleido,
+      and the error tells users to pip install it, which a read-only image
+      cannot do.
+    command: panoptica-python -c "import kaleido; print('kaleido ok')"
+    expected_output_contains: "kaleido ok"
+
+  - name: panopticacli is on PATH
+    command: command -v panopticacli
+    expected_output_contains: "panopticacli"
+
+  - name: bundled configs can be copied out
+    description: >-
+      -c/--config is required and the configs ship inside the image, so without
+      a way to read one out the CLI cannot be used.
+    command: |
+      bash -c 'panoptica-config --list | head -3; panoptica-config BRATS | head -1'
+    expected_output_contains: "panoptica_evaluator_BRATS"
+
+  - name: the container does not export a python interpreter
+    description: >-
+      Exporting the environment bin put python, python3, tclsh, bz* and 30 more
+      on the user's PATH, replacing their interpreter for the rest of the shell.
+    command: bash -c 'echo "deploy-bins=$DEPLOY_BINS"'
+    expected_output_contains: "deploy-bins=panopticacli"

--- a/recipes/panoptica/fulltest.yaml
+++ b/recipes/panoptica/fulltest.yaml
@@ -11,7 +11,7 @@ tests:
 
       print(version("panoptica"))
       PY
-    expected_output_contains: "2.1.3"
+    expected_output_contains: "${version}"
 
   - name: Panoptica runtime imports
     description: Verify Panoptica and the libraries used by its evaluation pipeline import together.

--- a/recipes/panoptica/panoptica-config
+++ b/recipes/panoptica/panoptica-config
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Print a bundled panoptica config, or list the available ones.
+#
+# The configs ship inside the image, so they are not readable from the host.
+# This copies one out so it can be edited and passed back with -c.
+set -euo pipefail
+
+CONFIG_DIR="$(panoptica-python -c 'import os, panoptica; print(os.path.join(os.path.dirname(panoptica.__file__), "configs"))')"
+
+usage() {
+  cat <<USAGE
+Usage: panoptica-config <name>     print a bundled config to stdout
+       panoptica-config --list     list the bundled configs
+
+  panoptica-config BRATS > my_config.yaml
+  panopticacli -ref ref.nii.gz -pred pred.nii.gz -c my_config.yaml
+
+Names may be given bare (BRATS) or in full (panoptica_evaluator_BRATS).
+USAGE
+}
+
+[ $# -eq 1 ] || { usage; exit 2; }
+
+case "$1" in
+  -h|--help) usage; exit 0 ;;
+  --list)
+    find "$CONFIG_DIR" -maxdepth 1 -name '*.yaml' -exec basename {} .yaml \; | sort
+    exit 0 ;;
+esac
+
+for candidate in "$1" "panoptica_evaluator_$1" "panoptica_config_$1"; do
+  if [ -f "${CONFIG_DIR}/${candidate}.yaml" ]; then
+    cat "${CONFIG_DIR}/${candidate}.yaml"
+    exit 0
+  fi
+done
+
+echo "no bundled config named '$1'. Available:" >&2
+find "$CONFIG_DIR" -maxdepth 1 -name '*.yaml' -exec basename {} .yaml \; | sort >&2
+exit 1

--- a/recipes/panoptica/panoptica-python
+++ b/recipes/panoptica/panoptica-python
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run python from inside this container.
+#
+# panoptica is installed in the container's environment, not on the host, so
+# "import panoptica" only works with this interpreter. The container does not
+# put python on your PATH, because doing so silently replaced the host
+# interpreter for the rest of the shell.
+exec /opt/miniconda-latest/envs/panoptica/bin/python "$@"


### PR DESCRIPTION
## What

Container testing against real BraTS masks found the metrics **numerically correct** — 21 evaluations agreed exactly with independently computed values, max absolute difference `0.0`. But four issues stop users reaching them. This fixes all four and bumps to 2.1.6.

## 1. High — instance relabelling overflows the label dtype

`_map_labels` builds its lookup table with the dtype of the **connected-components** array. `cc3d` returns the narrowest dtype that fits the component count (`uint8` for ≤255), but the matcher then allocates new labels up to `max(ref_labels) + 1 + n_unmatched_predictions`, which can exceed it:

```
OverflowError: Python integer 256 out of bounds for uint8
IndexError: index N is out of bounds for axis 0 with size 0
```

The second happens because `max_value` wraps to `0`, so `np.arange` returns an empty array. This hits exactly the multi-lesion workloads panoptica exists for — a real BraTS multi-class evaluation with 196 predicted instances needing labels up to 391 crashes.

**Casting the input does not help**: the dtype comes from panoptica's internal CCA output, not the user's array.

The lookup dtype is now chosen from the values being written, matching the fix on upstream `main`. I verified **2.1.6 still has `dtype=arr.dtype`**, so the bump alone does not fix this and the image carries the patch until a release contains it.

The build asserts a map needing label 256 actually succeeds, rather than merely that the file changed:

```
instance relabelling handles >255 labels
```

**Not fixed by pinning numpy<2**, deliberately: numpy 2 *raises* on the out-of-range cast, while numpy 1 wraps silently (label 256 → 0) and corrupts instance matching with no error at all. The loud failure is preferable; the dtype change is the actual fix.

## 2. Medium — `kaleido` missing

`Panoptica_Statistic.get_summary_figure()` returns a plotly figure; exporting it raised `ValueError` telling the user to `pip install kaleido`, which is impossible in a read-only image. Now installed.

## 3. Medium — the README contradicted the shipped CLI

It stated *"This is a Python library (no command-line tool)"* while `panopticacli` ships and works. It also promised use *"from Python or a Jupyter kernel"* — verified false, since panoptica exists only inside the image. Both corrected, and `-c/--config` is now documented as required.

## 4. Medium — the bundled configs were unreachable, and the module shadowed the host python

`-c` is mandatory, the seven configs live inside the image, and panoptica has no load-by-name resolution — so a user outside the container could not obtain one. Two helpers close this:

```bash
panoptica-config --list
panoptica-config BRATS > my_config.yaml
panoptica-python my_analysis.py
```

`panoptica-python` matters because the deploy list is now just the tools. Exporting the environment's bin directory put **35 commands** on the user's PATH — `python`, `python3`, `python3.11`, `tclsh`, `wish`, `reset`, `bz*`, `zstd*` — so the host interpreter was silently replaced for the rest of the shell while `pip` still resolved to the host.

## Verification

The dtype patch was applied to real 2.1.6 source before this was pushed, and the fix was exercised against both reported failure modes:

| case | unpatched | patched |
| --- | --- | --- |
| map needs label 256 | `OverflowError` | ok → `uint16` |
| map needs label 255 | `IndexError` | ok → `uint16` |
| ordinary in-range map | ok → `uint8` | ok → `uint8` (unchanged) |

Five checks were added to the fulltest suite covering each fix.

## Notes for the reviewer

- **Worth reporting upstream.** The dtype fix is on `main` but unreleased; this image carries it in the meantime and the patch fails the build if upstream's code changes shape.
- **`matplotlib` not added** (report's low-severity item 5) — panoptica plots with plotly, and `kaleido` is what actually unblocks its own figure export.
- **No `panoptica` alias for `panopticacli`** — I left the upstream name rather than inventing a second one; open to adding it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
