### PR TITLE
Stop promote runs being silently dropped from the concurrency queue

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -30,6 +30,12 @@ permissions: {}
 concurrency:
   group: promote-container-and-metadata
   cancel-in-progress: false
+  # Without this, GitHub keeps at most one run pending per group and a newer
+  # run evicts the one already waiting. Promote takes longer than the gap
+  # between merges, so pending runs were being discarded and their containers
+  # never published. `queue: max` keeps the same strict serialization and only
+  # stops the queue dropping work.
+  queue: max
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Promote runs are being cancelled before they start, and the containers they would have published never get released.

The concurrency group uses GitHub's default `queue: single`: *"At most one job or workflow run can be pending in the concurrency group. When a new job or workflow run is queued, any existing pending job or workflow run in the same group is canceled and replaced."* Promote does roughly 45 minutes of work and merges arrive faster than that, so something is almost always pending, and the next merge evicts it.

Attempt-1 records, since run-level records hide this (a re-run overwrites attempt 1):

| evicted run | created | cancelled | newer run arrived | lag |
|---|---|---|---|---|
| #48 brats (#3041) | 23:29:38 | 23:42:11 | #49 @ 23:42:09 | +2s |
| #49 modsort (#3042) | 23:42:09 | 00:34:51 | #50 @ 00:34:49 | +2s |
| #51 | 01:37:45 | 01:37:57 | #52 @ 01:37:56 | +1s |

All have `jobs.total_count == 0`, so they never started and nothing published partially. There is no `gh run cancel` anywhere in `.github/` or `tools/`, so this is not a manual or scripted cancellation.

As a result `recipes/brats/` and `recipes/modsort/` are on `main` with their containers built and tested, but neither has a release file, so neither reaches `apps.json` or CVMFS.

`queue: max` allows up to 100 pending runs, processed FIFO, instead of one. Serialization is unchanged, promote still runs strictly one at a time, so there is no new concurrency surface. It stops the queue discarding work, but not the wait: throughput is unchanged.

**Why not per-PR groups instead.** Promote pushes floating `:latest` to GHCR, Docker Hub, Nectar and Quay, plus an unversioned `:${version}`, and `oras attach` falls back to a shared `sha256-<digest>` tag. Out-of-order completion could clobber those. Parallelism is possible later, but only once that is handled.

**Validation.** `queue:` is unrecognised on older Actions versions and would be a hard workflow-parse failure, so it was tested out of band first rather than here. A probe workflow with `queue: max` parsed and ran; three runs pushed 12 seconds apart with a 75 second job were observed with two pending simultaneously, which is impossible under `single`, and all three completed with zero cancelled. The probe branch has been deleted.
