### PR TITLE
brainlesion: align bundled versions, deploy the CLIs, and document the bundle

### DIFF
--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -7,7 +7,18 @@ structured_readme:
     BrainLesion Suite (BLS) is a modular and open-source framework for brain lesion image analysis in Python. Developed by an international consortium of researchers, BLS enables efficient, reproducible, and customizable pipelines for processing and analyzing multi-modal brain image data.
 
     Whether you're a radiologist, researcher, data scientist, or clinician, BLS empowers you to build robust workflows from raw data organization to segmentation, synthesis, and evaluation.
-  example: ''
+  example: |-
+    ml brainlesion/1.0.0
+
+    # There is no `brainlesion` module: import the components directly.
+    # Pass device="cpu" on nodes without a GPU, which these tools do not check.
+    python - <<'EOF'
+    from gliomoda import Inferer
+    Inferer(device="cpu").infer(
+        t1c="t1c.nii.gz", t2f="flair.nii.gz",
+        segmentation_file="seg.nii.gz",
+    )
+    EOF
   documentation: https://github.com/BrainLesion/
   citation: 'Kofler, F., Rosier, M., Astaraki, M., Möller, H., Mekki, I. I., Buchner, J. A., Schmick, A., Pfiffer, A., Oswald, E., Zimmer, L., Rosa, E. de la, Pati, S., Canisius, J., Piffer, A., Baid, U., Valizadeh, M., Linardos, A., Peeken, J. C., Shit, S., … Menze, B. (2025). BrainLesion Suite: A Flexible and User-Friendly Framework for Modular Brain Lesion Image Analysis arXiv preprint arXiv:2507.09036'
 build:
@@ -19,7 +30,7 @@ build:
         name: miniconda
         version: py310_25.5.1-0
         install_path: /opt/miniconda
-        pip_install: loguru==0.7.3 panoptica==1.5.1 deep_quality_estimation==0.0.3 petu==0.0.5 gliomoda==0.0.3 brats==0.0.27 antspyx==0.6.3 auxiliary==0.3.1 brainles_hd_bet==0.0.11 ttictoc==0.5.6 typer==0.15.4 tqdm==4.67.1
+        pip_install: loguru==0.7.3 panoptica==2.1.6 deep_quality_estimation==0.0.3 petu==0.0.7 gliomoda==0.0.4 brats==0.0.27 antspyx==0.6.3 auxiliary==0.3.1 brainles_hd_bet==0.0.11 ttictoc==0.5.6 typer==0.15.4 tqdm==4.67.1
     - run:
         - python -m pip install --no-cache-dir --no-deps brainles-aurora==0.2.7 brainles-preprocessing==0.6.10
         - python {{ get_file("fix_aurora_import") }}
@@ -34,6 +45,17 @@ build:
         # first use rather than baked in: together they are several GB and most
         # users need one component.
         - python {{ get_file("bls_writable_weights") }}
+        # panoptica 2.x builds its instance-label lookup with the dtype of the
+        # connected-components array, so multi-lesion evaluations fail once
+        # reference plus unmatched predicted instances exceed 255. Fixed on
+        # upstream main but not in 2.1.6, and carried by the standalone
+        # panoptica container for the same reason.
+        - python {{ get_file("fix_map_labels_dtype") }}
+        - >-
+          python -c "import numpy as np; from panoptica._functionals import _map_labels; a=np.zeros((4,4),dtype=np.uint8); a[0,0]=3; assert int(_map_labels(a,{3:256}).max())==256; print('instance relabelling handles >255 labels')"
+        # finding 4: both exist at /opt/miniconda/bin but were never exposed
+        - test -x /opt/miniconda/bin/preprocessor
+        - test -x /opt/miniconda/bin/hd-bet
     - environment:
         # Where the components cache their weights. Point this at persistent
         # storage so the download happens once rather than every session.
@@ -53,6 +75,11 @@ build:
         bins:
           - python
           - python3
+          # Both are installed at /opt/miniconda/bin but were never exposed, so
+          # the only supported route into this container was a hand-written
+          # python script.
+          - preprocessor
+          - hd-bet
     - test:
         name: Components import and resolve a writable weights path
         script: |-
@@ -80,6 +107,8 @@ files:
     filename: fix_preprocessor_cli.py
   - name: bls_writable_weights
     filename: bls_writable_weights.py
+  - name: fix_map_labels_dtype
+    filename: fix_map_labels_dtype.py
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAA4hJREFUSEvtlV1MW2UYx3+npYcOus51UMYcH6NlfpAZiSFFTYWwjWEzEnWhFAaYsU0YJXOZnQkxXphseMFmAtFCjGZtsl3Mqy3DLJELNQtW0UTC3A2ouAxBFmI/oF0K/TA9kyb9AOut8SQnOTnv/zy/5/k/z/seoWy8I0qGV65cicd/lsVgKMMvQPgf8E9e/YcsigTW8F69i9sxlVC1qN+Oqr6M7KfzEGZXmL80nuKKsGcvsmeqEKrrkD31LIjZcU3conXAYJ2N9vb2hCA+n4/W1la+ic5gKdmP3W5PWA+FQkxPT1PbYMJ9zIas6iWQyyWNcOpHU1SQ7+J7t4KfL48ztP8cZrOZ8vJyZDIZer2e0dFR/H4/j1fpOXbIIgGqq6tZXl6WgphMJgYGBhgbG+PlD528eLSByvxsOgPXEc7/oJU2WtbqDm45gpwwvkdTUxNKpTKe5eTkJDqdDo1uJyeOdEgAjUaD2+2Oa7xeLwsLC5w+XofdvEbh1sCjCtYBwUCU284Ax2tHJDscDgeCIEgVGI1GKejZi+/Q2dAiPRsMBjwej5SIxWKhr6+PwcFBvvvMRr9ZRKsWNga0tbWxtLQkCXJycqTb5XJxoOUwr5uaU3oQ0wWDQbRaLf2vBml5IQul4lFxaStItqi7u5vh4WEqKiqoqamJ9yBmiyiKdHV10dPTw9DQEH9+fQ7rQQW5fw9SRoDS0lJmZ2fp7e0lEonEe/B8iY/8rQLO2yFpCCYmJrh2vp53X1HwWO4mFjU3N9PY2CiVWFlZic1mk5qqVqulEY71oGhXHiNH/ZTkCbx1dRXnF3PMz8/T323gglmkaMcGgM6a4ZR9EBtHq9XKzdEJWix1EqCwoIBPOnyU75TRd22V96/cJVZpcUEOl08qMD4pRyak6cFXn/rTnl/btukoKm7gpzsfSeuiqOLjMwbqi118cGuNi5+vSe/z1QLOruxUQHgtyh8zYfyeSBywJWs7K65LeLxbUKv3EAx68K/8DkQRBDnagr3YDx7mt/uL/PogQjgCchk8UShjtybJonRph6YucP9b86Yn8r6SXzhZaNxQE5+iZEVk5k3ufdm7afD1xdf2XaE29+202rQA1cMD3Lsxgs+X2e9aqRQ4/dwpdoevp0BSAKJchf/mFHNz4YyyXxfFrHqj7AjRhw8SvksBZOL7RuR0ViUAVItnuHPD+q8yTxYnQ/4CysSosaI6GD0AAAAASUVORK5CYII=
 categories:
   - structural imaging
@@ -91,25 +120,84 @@ readme: |-
   ----------------------------------
   ## brainlesion/1.0.0 ##
 
-  BrainLesion Suite (BLS) is a modular and open-source framework for brain lesion image analysis in Python. Developed by an international consortium of researchers, BLS enables efficient, reproducible, and customizable pipelines for processing and analyzing multi-modal brain image data.
+  BrainLesion Suite (BLS) is a modular framework for brain lesion image
+  analysis. This container bundles its components in one environment so they can
+  be used together.
 
-  Whether you're a radiologist, researcher, data scientist, or clinician, BLS empowers you to build robust workflows from raw data organization to segmentation, synthesis, and evaluation.
+  ### There is no `brainlesion` module
 
-  Example:
+  The container is named after the suite, but no package of that name exists and
+  `import brainlesion` fails. Import the components directly:
+
+  ```
+  panoptica                 evaluation metrics
+  gliomoda                  glioma segmentation
+  petu                      paediatric tumour segmentation
+  brainles_aurora           metastasis segmentation
+  deep_quality_estimation   segmentation quality rating
+  brainles_preprocessing    co-registration, atlas alignment, skull stripping
+  brainles_hd_bet           brain extraction
   ```
 
+  Bundled versions: panoptica 2.1.6, gliomoda 0.0.4, petu 0.0.7,
+  deep_quality_estimation 0.0.3, brainles-aurora 0.2.7,
+  brainles-preprocessing 0.6.10, brainles_hd_bet 0.0.11. Each is also available
+  as its own container, which adds a command line interface these do not have.
+
+  ### Example
+
   ```
+  ml brainlesion/1.0.0
+
+  python - <<'EOF'
+  from gliomoda import Inferer
+  Inferer(device="cpu").infer(
+      t1c="t1c.nii.gz", t2f="flair.nii.gz",
+      segmentation_file="seg.nii.gz",
+  )
+  EOF
+  ```
+
+  `preprocessor` and `hd-bet` are available as commands. Everything else is used
+  from Python, through this container's `python` or `python3`.
+
+  ### GPU and CPU
+
+  These tools default to a GPU and do not check whether one exists.
+  `Inferer(device="cuda")` constructs the device regardless and inference then
+  dies inside nnU-Net after the model has loaded; `AtlasCentricPreprocessor`
+  defaults to `use_gpu=True`. On a node without a GPU pass `device="cpu"` and
+  `use_gpu=False` explicitly.
+
+  ### Model weights
+
+  Weights are downloaded on first use into `$BLS_WEIGHTS_DIR`, which defaults to
+  `/tmp/brainlesion-weights`. Point it at persistent storage so this happens
+  once:
+
+  ```
+  export BLS_WEIGHTS_DIR=/neurodesktop-storage/bls-weights
+  ```
+
+  The components otherwise resolve their weights cache inside their own
+  installed package, which is read-only here, so this redirection is what lets
+  them run at all.
+
+  ### Known limitations
+
+  `brats` is installed but cannot work in this container. It orchestrates other
+  containers through a Docker daemon, which is not available here, and prints a
+  connection error on import. Use the standalone `brats` container, which runs
+  algorithms through apptainer.
+
+  brainles-preprocessing is installed without its optional registration
+  backends, so `ANTsRegistrator` is the only one available; itk-elastix and
+  picsl_greedy are absent.
+
+  This image carries a patch to panoptica's instance relabelling, which
+  otherwise overflows once an evaluation involves more than 255 instance labels.
 
   More documentation can be found here: https://github.com/BrainLesion/
-
-  Citation:
-  ```
-  Kofler, F., Rosier, M., Astaraki, M., Möller, H., Mekki, I. I., Buchner, J. A., Schmick, A., Pfiffer, A., Oswald, E., Zimmer, L., Rosa, E. de la, Pati, S., Canisius, J., Piffer, A., Baid, U., Valizadeh, M., Linardos, A., Peeken, J. C., Shit, S., … Menze, B. (2025). BrainLesion Suite: A Flexible and User-Friendly Framework for Modular Brain Lesion Image Analysis arXiv preprint arXiv:2507.09036
-  ```
-
-  To run container outside of this environment: ml brainlesion/1.0.0
-
-  ----------------------------------
 copyright:
   - license: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/recipes/brainlesion/fix_map_labels_dtype.py
+++ b/recipes/brainlesion/fix_map_labels_dtype.py
@@ -1,0 +1,68 @@
+"""Stop instance relabelling overflowing the connected-components dtype.
+
+panoptica._functionals._map_labels builds its lookup table with the dtype of the
+connected-components array. cc3d returns the narrowest dtype that fits the
+component count (uint8 for <= 255 components), but the instance matcher then
+allocates new labels up to max(ref_labels) + 1 + n_unmatched_predictions, which
+can exceed it. Ordinary multi-lesion evaluations therefore fail with either
+
+    OverflowError: Python integer 256 out of bounds for uint8
+    IndexError: index N is out of bounds for axis 0 with size 0
+
+the second because max_value wraps to 0 and np.arange returns an empty array.
+
+Casting the *input* does not help: the dtype comes from panoptica's internal CCA
+output, not the user's array. The dtype is now chosen from the values being
+written, matching the fix on upstream main. Still present in 2.1.6, so the image
+carries it until a release includes it.
+
+Do not "fix" this by pinning numpy<2: numpy 2 raises on the out-of-range cast,
+while numpy 1 wraps silently (label 256 -> 0) and corrupts instance matching with
+no error at all.
+"""
+
+import pathlib
+from importlib.util import find_spec
+
+MARKER = "neurocontainers: choose the lookup dtype from the values written"
+
+OLD = """    k = np.array(list(label_map.keys()), dtype=arr.dtype)
+    v = np.array(list(label_map.values()), dtype=arr.dtype)
+
+    max_value = max(arr.max(), max(k), max(v)) + 1
+
+    mapping_ar = np.arange(max_value, dtype=arr.dtype)
+"""
+
+NEW = f"""    # {MARKER}
+    _keys = list(label_map.keys())
+    _values = list(label_map.values())
+    # int() throughout: max(...) + 1 on a uint8 array wraps to 0 otherwise
+    max_value = int(max(int(arr.max()), int(max(_keys)), int(max(_values)))) + 1
+    _target_dtype = np.promote_types(arr.dtype, np.min_scalar_type(max_value))
+    k = np.array(_keys, dtype=_target_dtype)
+    v = np.array(_values, dtype=_target_dtype)
+
+    mapping_ar = np.arange(max_value, dtype=_target_dtype)
+"""
+
+
+def main() -> None:
+    spec = find_spec("panoptica")
+    if spec is None or not spec.submodule_search_locations:
+        raise SystemExit("panoptica is not installed")
+    target = pathlib.Path(next(iter(spec.submodule_search_locations))) / "_functionals.py"
+    src = target.read_text()
+    if MARKER in src:
+        return
+    if src.count(OLD) != 1:
+        raise SystemExit(
+            f"expected exactly one _map_labels dtype block in {target}, "
+            f"found {src.count(OLD)}; upstream changed and this patch needs revisiting"
+        )
+    target.write_text(src.replace(OLD, NEW, 1))
+    print(f"patched {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -28,16 +28,16 @@ tests:
     command: python -c 'from importlib.metadata import distribution; d=distribution("deep_quality_estimation"); assert d.version == "0.0.3" and len(tuple(d.files or ())) > 5'
 
   - name: gliomoda distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("gliomoda"); assert d.version == "0.0.3" and len(tuple(d.files or ())) > 5'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("gliomoda"); assert d.version == "0.0.4" and len(tuple(d.files or ())) > 5'
 
   - name: loguru distribution is pinned
     command: python -c 'from importlib.metadata import version; assert version("loguru") == "0.7.3"'
 
   - name: panoptica distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("panoptica"); assert d.version == "1.5.1" and len(tuple(d.files or ())) > 20'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("panoptica"); assert d.version == "2.1.6" and len(tuple(d.files or ())) > 20'
 
   - name: petu distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("petu"); assert d.version == "0.0.5" and len(tuple(d.files or ())) > 5'
+    command: python -c 'from importlib.metadata import distribution; d=distribution("petu"); assert d.version == "0.0.7" and len(tuple(d.files or ())) > 5'
 
   - name: brainles_aurora imports
     command: python -c 'import brainles_aurora'

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -331,3 +331,37 @@ tests:
     command: |
       bash -c 'grep -l "_bls_fetch_record" $(python -c "import gliomoda,petu,pathlib; print(pathlib.Path(gliomoda.__file__).parent/\"weights.py\", pathlib.Path(petu.__file__).parent/\"weights.py\")") | wc -l'
     expected_output_contains: "2"
+
+  - name: bundled versions match the standalone modules
+    description: >-
+      The bundle previously pinned panoptica 1.5.1, gliomoda 0.0.3 and petu
+      0.0.5, so the same analysis gave different results depending on which
+      module a user loaded, with nothing warning about the divergence.
+    command: |
+      python -c "
+      import importlib.metadata as md
+      for pkg in ('panoptica', 'gliomoda', 'petu'):
+          print(pkg, md.version(pkg))
+      "
+    expected_output_contains: "panoptica 2.1.6"
+
+  - name: panoptica instance relabelling survives >255 labels
+    description: >-
+      2.1.6 still builds its label lookup with the connected-components dtype,
+      so multi-lesion evaluations overflow. The image carries the upstream-main
+      fix; this fails if it is lost.
+    command: |
+      python -c "
+      import numpy as np
+      from panoptica._functionals import _map_labels
+      a = np.zeros((4, 4), dtype=np.uint8); a[0, 0] = 3
+      print('relabel-max', int(_map_labels(a, {3: 256}).max()))
+      "
+    expected_output_contains: "relabel-max 256"
+
+  - name: the preprocessor and hd-bet commands are deployed
+    description: >-
+      Both were installed but never exposed, leaving a hand-written python
+      script as the only supported way into this container.
+    command: bash -c 'command -v preprocessor && command -v hd-bet && echo "clis ok"'
+    expected_output_contains: "clis ok"


### PR DESCRIPTION
## What

Completes the remaining findings from container testing of `brainlesion/1.0.0`. #3040's sibling PR (#3043, merged) fixed the blocking ones — unreachable model weights, `python3` falling through to the host, and a build test that could never pass. This covers the rest.

## Version skew (finding 5)

The bundle shipped **panoptica 1.5.1, gliomoda 0.0.3, petu 0.0.5** while the standalone modules were on 2.1.x / 0.0.4 / 0.0.7. The same analysis therefore gave different results depending on which module a user loaded, with nothing in either help text warning about it. Now aligned to **panoptica 2.1.6, gliomoda 0.0.4, petu 0.0.7**.

Moving panoptica to 2.x brings a known defect with it: `_map_labels` builds its instance-label lookup with the dtype of the connected-components array, so multi-lesion evaluations fail with `OverflowError` or `IndexError` once reference plus unmatched predicted instances exceed 255. That is fixed on upstream `main` but **not in 2.1.6**, so this image carries the same patch as the standalone panoptica container (#3046). The build asserts a label map needing 256 actually succeeds, rather than merely that the file changed:

```
instance relabelling handles >255 labels
```

## Console scripts were installed but never exposed (finding 4)

`preprocessor` and `hd-bet` exist at `/opt/miniconda/bin` and were not deployed, leaving a hand-written Python script as the only supported way into the container. Both are now in `deploy.bins`, and the build checks they exist first so a future pin that stops shipping them fails there rather than in the deploy test.

## Documentation (findings 2, 6, 7, 9, 10)

- **There is no `brainlesion` module.** The container is named after the suite, but `import brainlesion` raises `ModuleNotFoundError` — anyone following the container name hits this immediately. The readme says so plainly and lists the real import names.
- **These tools default to a GPU and do not check for one.** `Inferer(device="cuda")` constructs the device regardless, and inference then dies inside nnU-Net *after* the model has loaded. Documented, with `device="cpu"` / `use_gpu=False` shown.
- **The example was `''`** — for a bundle whose only interface is a Python script, that left users with nothing.
- **`brats` cannot work here**: it orchestrates other containers through a Docker daemon, which is unavailable, and prints a connection error on import. Documented, pointing at the standalone `brats` container (#3041) which drives apptainer instead.
- **Optional registration backends are absent** because of the `--no-deps` install, so `ANTsRegistrator` is the only one available.

## Tests

Three added to the existing suite (84 → 87): bundled versions match the standalone modules, panoptica relabelling survives >255 labels, and both CLIs resolve.

## Notes for the reviewer

- **`brats` was documented, not dropped.** The report offered either. Removing a component changes what the bundle advertises, which felt like a maintainer call — happy to drop the pin if you prefer, since the import error is genuinely alarming.
- **The version bump is the riskiest part of this PR.** It changes three pins at once and pulls in the panoptica patch. If you would rather land the documentation and CLI changes first, the version alignment is separable.
- **This overlaps the standalone containers by design.** gliomoda, petu, panoptica, aurora and deep-quality-estimation now also exist individually, generally with a CLI the bundle does not have. The readme points that out so users can pick.
- Weights are still downloaded on first use into `$BLS_WEIGHTS_DIR` rather than baked, matching the approach merged in #3043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
