### PR TITLE
Fix the preprocessor CLI, install SynthStrip, stop shadowing the host python

### DIFF
--- a/recipes/brainles-preprocessing/brainles-preprocessing-python
+++ b/recipes/brainles-preprocessing/brainles-preprocessing-python
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run python from inside this container.
+#
+# brainles_preprocessing is installed in the container's environment, not on
+# the host, so "import brainles_preprocessing" only works with this
+# interpreter. The container does not put python on your PATH, because doing so
+# silently replaced the host interpreter for the rest of the shell.
+exec /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python "$@"

--- a/recipes/brainles-preprocessing/build.yaml
+++ b/recipes/brainles-preprocessing/build.yaml
@@ -31,6 +31,35 @@ build:
         - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "import brainles_preprocessing; print('brainles-preprocessing OK')"
 
     - run:
+        # SynthStrip is one of the two brain extractors this package exposes and
+        # its weights are baked in below, but it lives behind an optional extra:
+        # brain_extraction/synthstrip.py imports nipreps.synthstrip, so without
+        # this SynthStripExtractor could not be imported and the baked weights
+        # were dead payload.
+        #
+        # nitransforms is pinned because it is what forces the version choice:
+        # 25.x requires numpy>=2.0 while brainles-preprocessing requires
+        # numpy<2.0, so an unpinned resolve either backtracks a long way or
+        # lands on an unsatisfiable pair. 24.1.x accepts numpy>=1.21.
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -m pip install --no-cache-dir "nitransforms>=24.1,<25" "nipreps-synthstrip>=0.0.1,<0.0.2"
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "from brainles_preprocessing.brain_extraction import SynthStripExtractor; print('synthstrip extractor ok')"
+
+    - run:
+        # The `preprocessor` console script fails on every invocation as
+        # shipped, including --help. See the patch for the two annotations.
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python {{ get_file("fix_preprocessor_cli") }}
+        # Fail the build rather than ship a command that cannot start. This is
+        # the check that was missing: the recipe exported the script and the
+        # test only looked for it on PATH, which passes on a broken script.
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/preprocessor --help > /dev/null && echo "preprocessor --help ok"
+
+    - run:
+        # python itself is deliberately not exported (see deploy), so give the
+        # library a named interpreter rather than no route in at all.
+        - install -m 0755 {{ get_file("preprocessing_python_helper") }} /usr/local/bin/brainles-preprocessing-python
+        - brainles-preprocessing-python -c "import brainles_preprocessing; print('wrapper ok')"
+
+    - run:
         # Bake the atlases and SynthStrip weights into the image.
         #
         # Without this the container cannot do the one job it exists for. Both
@@ -72,6 +101,10 @@ build:
         PATH: /opt/miniconda-py311_24.9.2-0/envs/brainles/bin:$PATH
 
 files:
+  - name: fix_preprocessor_cli
+    filename: fix_preprocessor_cli.py
+  - name: preprocessing_python_helper
+    filename: brainles-preprocessing-python
   - name: bake_atlases.py
     contents: |
       """Download the atlases and SynthStrip weights into the installed package.
@@ -131,8 +164,15 @@ files:
       bake(z.SYNTHSTRIP_RECORD_ID, z.SYNTHSTRIP_FOLDER, "synthstrip")
 
 deploy:
-  path:
-    - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin
+  # Named individually rather than exporting the environment's bin directory.
+  # That directory holds ~56 executables -- python, python3, python3.11, pip,
+  # conda, tclsh, wish and every dependency's console script -- so loading this
+  # module silently replaced the host interpreter for the rest of the shell
+  # while pip still resolved to the host.
+  bins:
+    - preprocessor
+    - hd-bet
+    - brainles-preprocessing-python
 
 tests:
   - name: "import brainles_preprocessing"
@@ -150,19 +190,53 @@ readme: |
   for brain MRI: co-registration, atlas alignment, skull-stripping, defacing
   and intensity normalization.
 
-  This is a Python library (no command-line tool). It is configured in code via
-  Modality / Preprocessor classes:
+  ### Commands
+
+  ```
+  preprocessor                     one-shot preprocessing of a single subject
+  hd-bet                           brain extraction on its own
+  brainles-preprocessing-python    this container's interpreter
+  ```
+
+  `python` is deliberately not exported: putting this environment's bin
+  directory on your PATH replaced the host interpreter for the rest of the
+  shell. Use `brainles-preprocessing-python` to import the library.
 
   ```
   ml brainles-preprocessing/{{ context.version }}
-  python -c "from brainles_preprocessing.preprocessor import Preprocessor; print('ok')"
+  preprocessor --help
+  brainles-preprocessing-python -c "from brainles_preprocessing.preprocessor import Preprocessor; print('ok')"
   ```
 
-  Registration uses the bundled antspyx backend (CPU) out of the box.
-  Brain extraction backends (HD-BET, SynthStrip) and extra registration
-  backends (greedy, elastix) are optional extras and are NOT installed here to
-  keep the image lean. HD-BET is available as its own Neurodesk module
-  (`ml hdbet`) and can be used alongside this one.
+  ### Backends
+
+  Registration uses the bundled antspyx backend (CPU) out of the box. The extra
+  registration backends (greedy, elastix) are optional extras and are not
+  installed here.
+
+  Both brain extractors are installed and their weights are baked into the
+  image, so nothing is downloaded at run time:
+
+  ```
+  HDBetExtractor      default; brainles_hd_bet with all five folds
+  SynthStripExtractor via the nipreps-synthstrip extra
+  ```
+
+  ### CPU
+
+  HD-BET's defaults assume a GPU: `device=0`, `mode="accurate"` and
+  `do_tta=True` (test-time augmentation over all mirror axes). On a CPU-only
+  node that combination takes hours per volume. Pass all three:
+
+  ```
+  HDBetExtractor().extract(
+      input_image_path=..., masked_image_path=..., brain_mask_path=...,
+      device="cpu", mode="fast", do_tta=False,
+  )
+  ```
+
+  The atlases are bundled too, including the SRI24 BraTS template that petu and
+  gliomoda expect their input to be registered to.
 
   Docs: https://github.com/BrainLesion/preprocessing
 

--- a/recipes/brainles-preprocessing/build.yaml
+++ b/recipes/brainles-preprocessing/build.yaml
@@ -42,7 +42,7 @@ build:
         # numpy<2.0, so an unpinned resolve either backtracks a long way or
         # lands on an unsatisfiable pair. 24.1.x accepts numpy>=1.21.
         - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -m pip install --no-cache-dir "nitransforms>=24.1,<25" "nipreps-synthstrip>=0.0.1,<0.0.2"
-        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "from brainles_preprocessing.brain_extraction import SynthStripExtractor; print('synthstrip extractor ok')"
+        - /opt/miniconda-py311_24.9.2-0/envs/brainles/bin/python -c "from brainles_preprocessing.brain_extraction.synthstrip import SynthStripExtractor; print('synthstrip extractor ok')"
 
     - run:
         # The `preprocessor` console script fails on every invocation as
@@ -218,9 +218,13 @@ readme: |
   image, so nothing is downloaded at run time:
 
   ```
-  HDBetExtractor      default; brainles_hd_bet with all five folds
-  SynthStripExtractor via the nipreps-synthstrip extra
+  from brainles_preprocessing.brain_extraction import HDBetExtractor
+  from brainles_preprocessing.brain_extraction.synthstrip import SynthStripExtractor
   ```
+
+  `HDBetExtractor` is the default. `SynthStripExtractor` is imported from its
+  own submodule rather than the package: upstream does not re-export it,
+  because it depends on the optional nipreps-synthstrip extra.
 
   ### CPU
 

--- a/recipes/brainles-preprocessing/fix_preprocessor_cli.py
+++ b/recipes/brainles-preprocessing/fix_preprocessor_cli.py
@@ -1,0 +1,57 @@
+"""Make the `preprocessor` console script usable.
+
+Two defects in brainles_preprocessing 0.6.10's cli.py, both hit before any
+work is done:
+
+1. `output_dir` is annotated `str | Path`. Typer cannot build a parameter from
+   a union type and raises at import, so every invocation fails -- including
+   `preprocessor --help`. Narrowing it to `Path` is what upstream does
+   elsewhere in the same signature, and the body already uses it as a Path
+   (`output_dir / "temp"`).
+
+2. `input_atlas` defaults to the string "SRI24 BraTS atlas", which is a label,
+   not a path. The body guards with `if input_atlas is not None`, so that
+   default is passed straight through as `atlas_image_path` and registration
+   fails on a missing file. `None` lets the guard fall through to the
+   preprocessor's own bundled atlas, which is what the label describes.
+
+Kept as a patch rather than a fork: it is two annotations, and pinning a fork
+would strand the recipe on this release.
+"""
+
+from importlib.util import find_spec
+from pathlib import Path
+
+package_spec = find_spec("brainles_preprocessing")
+if package_spec is None or package_spec.submodule_search_locations is None:
+    raise RuntimeError("brainles_preprocessing is not installed")
+
+cli_path = Path(next(iter(package_spec.submodule_search_locations))) / "cli.py"
+source = cli_path.read_text()
+
+replacements = [
+    (
+        """output_dir: Annotated[
+        str | Path,
+""",
+        """output_dir: Annotated[
+        Path,
+""",
+    ),
+    (
+        """    ] = "SRI24 BraTS atlas",
+""",
+        """    ] = None,
+""",
+    ),
+]
+
+for old, new in replacements:
+    if old not in source:
+        raise RuntimeError(
+            f"brainles_preprocessing CLI layout changed; review this patch:\n{old!r}"
+        )
+    source = source.replace(old, new, 1)
+
+cli_path.write_text(source)
+print("preprocessor CLI patched")

--- a/recipes/brainles-preprocessing/fulltest.yaml
+++ b/recipes/brainles-preprocessing/fulltest.yaml
@@ -85,7 +85,7 @@ tests:
       nipreps.synthstrip, which lives behind the package's `synthstrip` extra
       and was not installed -- so the extractor could not be constructed and
       the baked weights were dead payload. The recipe installs the extra.
-    command: python -c "from brainles_preprocessing.brain_extraction import SynthStripExtractor; print('synthstrip extractor ok')"
+    command: python -c "from brainles_preprocessing.brain_extraction.synthstrip import SynthStripExtractor; print('synthstrip extractor ok')"
     expected_output_contains: "synthstrip extractor ok"
 
   - name: runs outside HOME

--- a/recipes/brainles-preprocessing/fulltest.yaml
+++ b/recipes/brainles-preprocessing/fulltest.yaml
@@ -14,9 +14,29 @@ tests:
     command: python -c "from brainles_preprocessing.preprocessor import Preprocessor, AtlasCentricPreprocessor; print('preprocessors ok')"
     expected_output_contains: "preprocessors ok"
 
-  - name: the preprocessor console script is on PATH
-    command: command -v preprocessor
-    expected_output_contains: "preprocessor"
+  - name: the preprocessor console script runs
+    description: >-
+      As shipped, cli.py annotates output_dir as `str | Path`. Typer cannot
+      build a parameter from a union type and raises at import, so every
+      invocation failed -- including --help. The recipe patches the annotation.
+      The previous test only ran `command -v preprocessor`, which passes on a
+      script that cannot start, so the broken CLI shipped and was exported.
+    command: env NO_COLOR=1 TERM=dumb COLUMNS=200 preprocessor --help
+    expected_output_contains: "output_dir"
+
+  - name: the preprocessor atlas default is not a label
+    description: >-
+      input_atlas defaulted to the string "SRI24 BraTS atlas", which is a name,
+      not a path, and the body only guards with `if input_atlas is not None` --
+      so the default was passed through as atlas_image_path and registration
+      failed on a missing file. None lets it fall through to the bundled atlas.
+    command: |
+      python -c "
+      import inspect
+      from brainles_preprocessing import cli
+      print('input_atlas default:', repr(inspect.signature(cli.main).parameters['input_atlas'].default))
+      "
+    expected_output_contains: "input_atlas default: None"
 
   - name: the SRI24 atlas is bundled
     description: >-
@@ -54,9 +74,19 @@ tests:
       python -c "
       import pathlib, brainles_preprocessing as m
       d = pathlib.Path(m.__file__).parent / 'brain_extraction' / 'weights'
-      print('synthstrip-files', len(list(d.rglob('*'))) if d.is_dir() else 0)
+      n = len(list(d.rglob('*.pt'))) if d.is_dir() else 0
+      print('synthstrip-weights', 'ok' if n else 'MISSING', n)
       "
-    expected_output_contains: "synthstrip-files"
+    expected_output_contains: "synthstrip-weights ok"
+
+  - name: the SynthStrip extractor imports
+    description: >-
+      The weights were baked but brain_extraction/synthstrip.py imports
+      nipreps.synthstrip, which lives behind the package's `synthstrip` extra
+      and was not installed -- so the extractor could not be constructed and
+      the baked weights were dead payload. The recipe installs the extra.
+    command: python -c "from brainles_preprocessing.brain_extraction import SynthStripExtractor; print('synthstrip extractor ok')"
+    expected_output_contains: "synthstrip extractor ok"
 
   - name: runs outside HOME
     description: $HOME does not exist at container runtime.


### PR DESCRIPTION
Follow-up to the atlas-baking work, from container testing of `brainles-preprocessing/0.6.10`.

### The `preprocessor` command could not start
`cli.py` annotates `output_dir` as `str | Path`. Typer cannot build a parameter from a union type, so it raises at import and *every* invocation fails — including `preprocessor --help`. The container exported that command anyway.

Patched to `Path`, which the function body already assumes (`output_dir / "temp"`). The build now fails if `preprocessor --help` does not run.

### `input_atlas` default was a label, not a path
Latent behind the above: `input_atlas` defaulted to the string `"SRI24 BraTS atlas"`, and the body only guards with `if input_atlas is not None`, so that string was passed through as `atlas_image_path` and registration failed on a missing file. Now `None`, which falls through to the bundled atlas.

### SynthStrip weights were dead payload
The weights are baked in, but `brain_extraction/synthstrip.py` imports `nipreps.synthstrip` — behind the package optional extra, which was never installed, so `SynthStripExtractor` could not be imported.

Installs the extra. `nitransforms` is pinned to 24.1.x deliberately: 25.x requires `numpy>=2.0` while this package requires `numpy<2.0`, so an unpinned resolve lands on an unsatisfiable pair.

### Deploy exported 56 commands
`deploy.path` put the whole environment bin on the user PATH — `python`, `python3`, `python3.11`, `pip`, `conda`, `tclsh`, `wish` — silently replacing the host interpreter for the rest of the shell. Narrowed to `preprocessor`, `hd-bet`, and a named `brainles-preprocessing-python`, matching petu and panoptica.

### The README said the opposite of the truth
It claimed this is a Python library with no command-line tool, and that HD-BET and SynthStrip are NOT installed here, pointing users at a separate `hdbet` module. `brainles_hd_bet` is a hard dependency, is installed, has all five folds baked, and is the default extractor. Corrected, and now documents that HD-BET defaults (`device=0`, `mode="accurate"`, `do_tta=True`) assume a GPU and take hours per volume on CPU.

### Tests
- `command -v preprocessor` passed on a script that could not start, so it is now `preprocessor --help`.
- The SynthStrip weights check matched even on a count of zero, so it now asserts a positive count.
- Adds checks for the SynthStrip extractor import and the `input_atlas` default.

Both CLI patch anchors were verified against the published 0.6.10 wheel, and the patched `cli.py` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
