### PR TITLE
Document SINGULARITYENV_BLS_WEIGHTS_DIR, drop brats, extend the preprocessor patch

### DIFF
--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -30,7 +30,7 @@ build:
         name: miniconda
         version: py310_25.5.1-0
         install_path: /opt/miniconda
-        pip_install: loguru==0.7.3 panoptica==2.1.6 deep_quality_estimation==0.0.3 petu==0.0.7 gliomoda==0.0.4 brats==0.0.27 antspyx==0.6.3 auxiliary==0.3.1 brainles_hd_bet==0.0.11 ttictoc==0.5.6 typer==0.15.4 tqdm==4.67.1
+        pip_install: loguru==0.7.3 panoptica==2.1.6 deep_quality_estimation==0.0.3 petu==0.0.7 gliomoda==0.0.4 antspyx==0.6.3 auxiliary==0.3.1 brainles_hd_bet==0.0.11 ttictoc==0.5.6 typer==0.15.4 tqdm==4.67.1
     - run:
         - python -m pip install --no-cache-dir --no-deps brainles-aurora==0.2.7 brainles-preprocessing==0.6.10
         - python {{ get_file("fix_aurora_import") }}
@@ -89,7 +89,7 @@ build:
           # Import every bundled component. The previous test ran only
           # `python --version` and then `exit 1`, so it could never pass and
           # never checked that any of this works.
-          python -c "import panoptica, deep_quality_estimation, gliomoda, petu, brats; print('components import')"
+          python -c "import panoptica, deep_quality_estimation, gliomoda, petu; print('components import')"
           python -c "import brainles_aurora.inferer, brainles_preprocessing, brainles_hd_bet; print('aurora/preprocessing/hd-bet import')"
           # Weights must resolve somewhere writable. This is the check that
           # would have caught the read-only failure at build time.
@@ -172,12 +172,22 @@ readme: |-
   ### Model weights
 
   Weights are downloaded on first use into `$BLS_WEIGHTS_DIR`, which defaults to
-  `/tmp/brainlesion-weights`. Point it at persistent storage so this happens
-  once:
+  `/tmp/brainlesion-weights`. That default is per-session: every new session
+  re-downloads roughly 3.5 GB. Point it at persistent storage so this happens
+  once.
+
+  It must be set with a `SINGULARITYENV_` prefix. The module wrapper runs the
+  container with `--cleanenv`, so a plain `export BLS_WEIGHTS_DIR=...` is
+  stripped before the tools see it and the download silently happens again:
 
   ```
-  export BLS_WEIGHTS_DIR=/neurodesktop-storage/bls-weights
+  export SINGULARITYENV_BLS_WEIGHTS_DIR=/neurodesktop-storage/bls-weights
+  ml brainlesion/1.0.0
   ```
+
+  Apptainer accepts `APPTAINERENV_BLS_WEIGHTS_DIR` for the same purpose. When
+  running the image directly rather than through the module, set
+  `BLS_WEIGHTS_DIR` as normal.
 
   The components otherwise resolve their weights cache inside their own
   installed package, which is read-only here, so this redirection is what lets
@@ -185,10 +195,11 @@ readme: |-
 
   ### Known limitations
 
-  `brats` is installed but cannot work in this container. It orchestrates other
-  containers through a Docker daemon, which is not available here, and prints a
-  connection error on import. Use the standalone `brats` container, which runs
-  algorithms through apptainer.
+  `brats` is deliberately not installed. It does not run algorithms itself: it
+  orchestrates other containers through a Docker daemon, which is not available
+  here, so it could never do any work in this bundle and printed a connection
+  error on import. Use the standalone `brats` container, which ships apptainer
+  and runs the algorithms for real.
 
   brainles-preprocessing is installed without its optional registration
   backends, so `ANTsRegistrator` is the only one available; itk-elastix and

--- a/recipes/brainlesion/fix_preprocessor_cli.py
+++ b/recipes/brainlesion/fix_preprocessor_cli.py
@@ -8,16 +8,33 @@ if package_spec is None or package_spec.submodule_search_locations is None:
 
 cli_path = Path(next(iter(package_spec.submodule_search_locations))) / "cli.py"
 source = cli_path.read_text()
-old_annotation = """output_dir: Annotated[
+replacements = [
+    # Typer cannot build a parameter from a union type, so cli.py raises at
+    # import and every invocation fails, including --help.
+    (
+        """output_dir: Annotated[
         str | Path,
-"""
-replacement = """output_dir: Annotated[
+""",
+        """output_dir: Annotated[
         Path,
-"""
+""",
+    ),
+    # input_atlas defaults to a label rather than a path, and the body only
+    # guards with `if input_atlas is not None`, so the default was passed
+    # through as atlas_image_path and registration failed on a missing file.
+    (
+        """    ] = "SRI24 BraTS atlas",
+""",
+        """    ] = None,
+""",
+    ),
+]
 
-if old_annotation not in source:
-    raise RuntimeError(
-        "brainles_preprocessing CLI layout changed; review the Typer fix"
-    )
+for old, new in replacements:
+    if old not in source:
+        raise RuntimeError(
+            f"brainles_preprocessing CLI layout changed; review this patch:\n{old!r}"
+        )
+    source = source.replace(old, new, 1)
 
-cli_path.write_text(source.replace(old_annotation, replacement, 1))
+cli_path.write_text(source)

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -21,9 +21,6 @@ tests:
   - name: brainles_preprocessing distribution is healthy
     command: python -c 'from importlib.metadata import distribution; d=distribution("brainles_preprocessing"); assert d.version == "0.6.10" and len(tuple(d.files or ())) > 20'
 
-  - name: brats distribution is healthy
-    command: python -c 'from importlib.metadata import distribution; d=distribution("brats"); assert d.version == "0.0.27" and len(tuple(d.files or ())) > 10'
-
   - name: deep_quality_estimation distribution is healthy
     command: python -c 'from importlib.metadata import distribution; d=distribution("deep_quality_estimation"); assert d.version == "0.0.3" and len(tuple(d.files or ())) > 5'
 
@@ -44,9 +41,6 @@ tests:
 
   - name: brainles_preprocessing imports
     command: python -c 'import brainles_preprocessing'
-
-  - name: brats imports
-    command: python -c 'import brats'
 
   - name: deep_quality_estimation imports
     command: python -c 'import deep_quality_estimation'
@@ -92,12 +86,6 @@ tests:
 
   - name: Preprocessing registration modules import
     command: python -c 'import brainles_preprocessing.registration.ANTs.ANTs, brainles_preprocessing.registration.niftyreg.niftyreg'
-
-  - name: BraTS core modules import
-    command: python -c 'import brats.core.brats_algorithm, brats.core.inpainting_algorithms, brats.core.missing_mri_algorithms, brats.core.segmentation_algorithms'
-
-  - name: BraTS utility modules import
-    command: python -c 'import brats.utils.algorithm_config, brats.utils.data_handling, brats.utils.exceptions, brats.utils.zenodo'
 
   - name: DQE processing modules import
     command: python -c 'import deep_quality_estimation.center_of_mass, deep_quality_estimation.enums, deep_quality_estimation.transforms'
@@ -209,26 +197,6 @@ tests:
   - name: DQE packaged model weights are nonempty
     command: python -c 'from importlib.resources import files; p=files("deep_quality_estimation").joinpath("weights/dqe_weights.pth"); assert p.is_file() and p.stat().st_size > 1000000'
 
-  - name: BraTS metadata catalog loads
-    command: |
-      python - <<'PY'
-      from importlib.resources import files
-      from brats.utils.algorithm_config import load_algorithms
-      path = files("brats").joinpath("data/meta/adult_glioma_pre_treatment.yml")
-      algorithms = load_algorithms(path)
-      assert algorithms
-      assert all(item.meta.authors and item.run_args.docker_image for item in algorithms.values())
-      PY
-
-  - name: BraTS algorithm parameters are valid YAML
-    command: python -c 'from importlib.resources import files; import yaml; data=yaml.safe_load(files("brats").joinpath("data/parameters/brats24_adult_glioma_mist.yml").read_text()); assert isinstance(data, dict) and data'
-
-  - name: BraTS metadata includes multiple challenge families
-    command: python -c 'from importlib.resources import files; names={p.name for p in files("brats").joinpath("data/meta").iterdir() if p.suffix==".yml"}; assert {"africa.yml","inpainting.yml","meningioma.yml","pediatric.yml"}.issubset(names)'
-
-  - name: BraTS algorithm classes are exposed
-    command: python -c 'from brats import AdultGliomaPreTreatmentSegmenter, AfricaSegmenter, Inpainter, MissingMRI; assert all(callable(x) for x in (AdultGliomaPreTreatmentSegmenter,AfricaSegmenter,Inpainter,MissingMRI))'
-
   - name: Aurora default configuration is safe for CPU discovery
     command: python -c 'from brainles_aurora.inferer.config import AuroraInfererConfig; c=AuroraInfererConfig(); assert c.workers == 0 and c.sliding_window_batch_size == 1 and 0 < c.threshold < 1'
 
@@ -283,7 +251,7 @@ tests:
     description: >-
       The shipped build test ran only "python --version" then "exit 1", so no
       component was ever imported at build time.
-    command: python -c "import panoptica, deep_quality_estimation, gliomoda, petu, brats, brainles_preprocessing, brainles_hd_bet; print('components ok')"
+    command: python -c "import panoptica, deep_quality_estimation, gliomoda, petu, brainles_preprocessing, brainles_hd_bet; print('components ok')"
     expected_output_contains: "components ok"
 
   - name: aurora imports


### PR DESCRIPTION
Follow-up from container testing of `brainlesion/1.0.0`. The version pins were already synced in #3049; this covers the rest.

### `BLS_WEIGHTS_DIR` could not be set the way the README said
The README told users to `export BLS_WEIGHTS_DIR=...` to keep the ~3.5 GB of component weights on persistent storage. The module wrapper runs the container with `--cleanenv`, which strips it, so the export had no effect and **every session silently re-downloaded the weights into /tmp**.

Now documents `SINGULARITYENV_BLS_WEIGHTS_DIR`, which survives `--cleanenv`, notes the `APPTAINERENV_` equivalent, and says when the plain variable is the right one (running the image directly).

### Dropped `brats`
It does not run algorithms itself — it orchestrates other containers through a Docker daemon, which is not available here — so it could never do any work in this bundle and printed a connection error on import. The standalone `brats` container ships apptainer and runs the algorithms for real.

Removes the eight tests that imported the package. The two DQE tests that only share the BraTS label naming (`CustomConvertToMultiChannelBasedOnBratsClasses`) do not import it and are unaffected. 87 tests to 79.

### Extended the preprocessor CLI patch
This container exports the same `preprocessor` command from the same 0.6.10 `cli.py` being fixed in the standalone recipe, so it inherits the same `input_atlas` defect: the default is the label `"SRI24 BraTS atlas"` rather than a path, and the body only guards with `if input_atlas is not None`, so it was passed through as `atlas_image_path` and registration failed on a missing file.

The patch script was run end-to-end against the published 0.6.10 package: both anchors match, the patched `cli.py` compiles, and a second run fails loudly rather than silently no-opping.

All seven remaining version assertions were re-checked against the pins in `build.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
