### PR TITLE
Validate DQE inputs, correct the device note, carry upstream's warnings

### DIFF
--- a/recipes/deep-quality-estimation/build.yaml
+++ b/recipes/deep-quality-estimation/build.yaml
@@ -56,6 +56,13 @@ build:
         # its own beyond argument validation.
         - install -m 0755 {{ get_file("deep-quality-estimation") }} /usr/local/bin/deep-quality-estimation
         - . "${VENV}/bin/activate" && deep-quality-estimation --help > /dev/null && echo "deep-quality-estimation CLI ok"
+        # The help text carries the atlas-space requirement and the label table,
+        # which are the two things upstream marks as most important.
+        - . "${VENV}/bin/activate" && deep-quality-estimation --help | grep -q 'atlas space' && echo "input requirements documented"
+        # python itself is deliberately not exported (see deploy), so give the
+        # library a named interpreter rather than no route in at all.
+        - install -m 0755 {{ get_file("dqe_python_helper") }} /usr/local/bin/dqe-python
+        - dqe-python -c "import deep_quality_estimation; print('dqe-python ok')"
         - chmod -R a+rX "${VENV}"
         - rm -rf /root/.cache/pip /tmp/mpl-deep-quality-estimation /tmp/cache-deep-quality-estimation
 
@@ -76,13 +83,90 @@ files:
       """
       import argparse
       import json
+      import os
       import sys
+
+      EPILOG = """\
+      Inputs must be in atlas space (240x240x155 at 1 mm), skull-stripped and
+      co-registered, and the segmentation must use BraTS labels:
+
+        1  necrotic / non-enhancing tumour core
+        2  peritumoral edema
+        3  GD-enhancing tumour (the legacy label 4 is also accepted)
+
+      The model is biased to overestimate segmentation quality. It reads three
+      slices through the segmentation's own centre of mass, so it does not see
+      over-segmentation, scattered false positives, or a mask placed on the wrong
+      anatomy. Treat a score below 4.5 as a real signal and anything above it as
+      weak evidence.
+      """
+
+
+      def _fail(message):
+          sys.stderr.write("error: %s\n" % message)
+          raise SystemExit(1)
+
+
+      def _validate(paths):
+          """Check the five volumes before torch is imported.
+
+          DQE reports a single number, so bad input does not look like a failure,
+          it looks like a score. A segmentation misaligned with the images is
+          rated silently; a shape mismatch or a trailing singleton dimension
+          fails deep inside a MONAI transform with a message naming neither the
+          file nor the problem.
+          """
+          import nibabel as nib
+          import numpy as np
+
+          missing = [path for path in paths.values() if not os.path.isfile(path)]
+          if missing:
+              _fail("input file not found: %s" % ", ".join(missing))
+
+          loaded = {}
+          for key, path in paths.items():
+              try:
+                  loaded[key] = nib.load(path)
+              except Exception as exc:
+                  _fail("%s: cannot read %s (%s)" % (key, path, exc))
+
+          for key, img in loaded.items():
+              if len(img.shape) != 3:
+                  _fail(
+                      "%s: expected a 3D volume, got shape %s in %s. Many pipelines "
+                      "emit (X, Y, Z, 1); squeeze the trailing dimension first."
+                      % (key, tuple(img.shape), paths[key])
+                  )
+
+          reference = loaded["segmentation"]
+          for key, img in loaded.items():
+              if img.shape != reference.shape:
+                  _fail(
+                      "%s has shape %s but the segmentation has %s; all five "
+                      "volumes must be on the same grid"
+                      % (key, tuple(img.shape), tuple(reference.shape))
+                  )
+
+          for key, img in loaded.items():
+              if not np.allclose(img.affine, reference.affine, atol=1e-4):
+                  sys.stderr.write(
+                      "warning: %s has a different affine from the segmentation. "
+                      "A score is still produced, but a misaligned segmentation is "
+                      "rated silently and the number does not mean anything.\n" % key
+                  )
+                  break
+
+          if not np.any(np.asanyarray(reference.dataobj)):
+              _fail("segmentation contains no labelled voxels: %s"
+                    % paths["segmentation"])
 
 
       def main(argv=None):
           p = argparse.ArgumentParser(
               prog="deep-quality-estimation",
               description="Rate a BraTS glioma segmentation from 1 to 6 stars.",
+              epilog=EPILOG,
+              formatter_class=argparse.RawDescriptionHelpFormatter,
           )
           p.add_argument("-t1c", "--t1c", required=True, help="T1 contrast-enhanced image (NIfTI)")
           p.add_argument("-t1", "--t1", required=True, help="T1 image (NIfTI)")
@@ -91,12 +175,30 @@ files:
           p.add_argument("-s", "--segmentation", required=True,
                          help="Segmentation to rate, in BraTS label style (NIfTI)")
           p.add_argument("--device", default=None,
-                         help='Torch device, e.g. "cuda" or "cpu" (default: upstream default)')
+                         help="Torch device, e.g. cuda or cpu "
+                              "(default: cuda when one is available, otherwise cpu)")
           p.add_argument("--cuda-devices", default="0",
                          help='Visible CUDA devices, e.g. "0" or "0,1" (default: 0)')
           p.add_argument("--json", action="store_true",
                          help="Emit the scores as JSON instead of plain text")
+          p.add_argument("-o", "--output",
+                         help="Also write the result to this file")
+          p.add_argument("--verbose", action="store_true",
+                         help="Show the library's own log output, including the "
+                              "device actually used (upstream disables it)")
           a = p.parse_args(argv)
+
+          _validate({
+              "t1c": a.t1c, "t1": a.t1, "t2": a.t2,
+              "flair": a.flair, "segmentation": a.segmentation,
+          })
+
+          if a.verbose:
+              # Upstream's __init__ calls logger.disable("deep_quality_estimation")
+              # so it stays quiet as a library. A successful run therefore prints
+              # nothing about which device it used.
+              from loguru import logger
+              logger.enable("deep_quality_estimation")
 
           from deep_quality_estimation import DQE
 
@@ -105,24 +207,43 @@ files:
               t1c=a.t1c, t1=a.t1, t2=a.t2, flair=a.flair, segmentation=a.segmentation,
           )
           views = {getattr(k, "name", str(k)): v for k, v in view_scores.items()}
+
           if a.json:
-              print(json.dumps({"mean_score": mean_score, "view_scores": views}, indent=2))
+              text = json.dumps({"mean_score": mean_score, "view_scores": views}, indent=2)
           else:
-              print(f"mean score: {mean_score}")
-              for name, score in views.items():
-                  print(f"  {name}: {score}")
+              lines = ["mean score: %s" % mean_score]
+              lines += ["  %s: %s" % (name, score) for name, score in views.items()]
+              text = "\n".join(lines)
+
+          print(text)
+          if a.output:
+              with open(a.output, "w") as handle:
+                  handle.write(text + "\n")
           return 0
 
 
       if __name__ == "__main__":
           sys.exit(main())
 
+  - name: dqe_python_helper
+    contents: |
+      #!/usr/bin/env bash
+      # Run python from inside this container.
+      #
+      # deep_quality_estimation is installed in the container's environment, not
+      # on the host, so "import deep_quality_estimation" only works with this
+      # interpreter. The container does not put python on your PATH, because
+      # doing so silently replaced the host interpreter for the rest of the shell.
+      exec {{ context.venv }}/bin/python3 "$@"
 
 deploy:
+  # Named individually rather than exporting the venv bin directory, which also
+  # put python, python3, python3.12, pip3.12 and torchrun on the user's PATH, so
+  # loading this module silently replaced the host interpreter for the rest of
+  # the shell. The CLI does not need it: its shebang points into the venv.
   bins:
     - deep-quality-estimation
-  path:
-    - "{{ context.venv }}/bin"
+    - dqe-python
 
 categories:
   - quality control
@@ -135,24 +256,75 @@ readme: |-
   ----------------------------------
   ## deep-quality-estimation/{{ context.version }} ##
 
-  Deep Quality Estimation rates BraTS glioma segmentation quality on a one to six star scale.
+  Deep Quality Estimation rates BraTS glioma segmentation quality on a one to
+  six star scale.
 
-  Example:
+  ### Example
+
   ```
-  deep-quality-estimation -t1c t1c.nii.gz -t1 t1.nii.gz -t2 t2.nii.gz -fla flair.nii.gz -s seg.nii.gz
+  deep-quality-estimation -t1c t1c.nii.gz -t1 t1.nii.gz -t2 t2.nii.gz \
+      -fla flair.nii.gz -s seg.nii.gz
 
-  # or from python:
-  python -c 'from deep_quality_estimation import DQE'
+  # from python, using this container's interpreter:
+  dqe-python -c 'from deep_quality_estimation import DQE'
   ```
 
-  Notes:
-  Upstream ships no console_scripts, so this container adds a thin `deep-quality-estimation` CLI
-  over the documented Python API
-  (`from deep_quality_estimation import DQE`). DQE defaults to device="cuda";
-  pass device="cpu" on machines without a GPU.
+  `python` is deliberately not exported: putting this environment's bin
+  directory on your PATH replaced the host interpreter for the rest of the
+  shell. Use `dqe-python`.
+
+  `--json` emits machine-readable output, `-o/--output` also writes the result
+  to a file, and `--verbose` shows the library's own log output including which
+  device was selected.
+
+  ### Input requirements
+
+  Upstream marks this as **IMPORTANT**: the images must be in **atlas space**
+  (240x240x155 at 1 mm), skull-stripped and co-registered, and the segmentation
+  must use BraTS labels:
+
+  ```
+  1  necrotic / non-enhancing tumour core
+  2  peritumoral edema
+  3  GD-enhancing tumour (the legacy label 4 is also accepted)
+  ```
+
+  The CLI checks what it can before loading the model: that the files exist and
+  are readable, that all five volumes are 3D and share a grid, and that the
+  segmentation has at least one labelled voxel. A differing affine is reported
+  as a warning rather than an error, because it cannot be distinguished from
+  benign rounding -- but a segmentation misaligned with its images is still
+  rated silently, and that number does not mean anything.
+
+  ### How to read the score
+
+  Upstream marks this as a **CAUTION**: the model is biased to overestimate
+  segmentation quality. It reads only three slices, taken through the
+  segmentation's own centre of mass, so damage outside those planes is never
+  seen and a rigid shift carries the sampling window along with the mask.
+
+  Measured on real data, it does **not** register over-segmentation (dilating a
+  mask raised the score), scattered false positives (invisible), or a mask
+  placed 25 mm off the lesion (under 0.3 stars). It does register label-class
+  confusion, strongly. Observed scores on genuine segmentations span roughly
+  4.8 to 5.4, so treat below 4.5 as a real signal and anything above it as weak
+  evidence, and do not use the score alone to rank segmentations.
+
+  ### Device
+
+  DQE auto-detects CUDA and falls back to CPU, so no flag is needed on a
+  CPU-only node. Use `--device cpu` to force CPU on a machine that has a GPU.
+  A rating takes roughly 30-60 s on 4 CPUs.
+
+  ### Notes
+
+  Upstream ships no console_scripts, so this container adds a thin
+  `deep-quality-estimation` CLI over the documented Python API
+  (`from deep_quality_estimation import DQE`).
 
   The trained weights ship inside the wheel at
   deep_quality_estimation/weights/dqe_weights.pth, so nothing is downloaded and
   inference works offline.
 
-  More documentation can be found here: https://github.com/BrainLesion
+  More documentation can be found here:
+  https://github.com/BrainLesion/deep_quality_estimation

--- a/recipes/deep-quality-estimation/fulltest.yaml
+++ b/recipes/deep-quality-estimation/fulltest.yaml
@@ -35,3 +35,73 @@ tests:
       would catch it going missing or failing to import its dependencies.
     command: deep-quality-estimation --help
     expected_output_contains: "usage: deep-quality-estimation"
+
+  - name: help carries the atlas-space requirement and label table
+    description: >-
+      Upstream marks the atlas-space requirement IMPORTANT and the
+      overestimation bias CAUTION. Neither reached the container, and §3.4 of
+      the container test showed a misaligned segmentation is scored silently --
+      so a user supplying native-space images gets a plausible number and no
+      warning anywhere.
+    command: env NO_COLOR=1 COLUMNS=200 deep-quality-estimation --help
+    expected_output_contains: "atlas space"
+
+  - name: help documents the overestimation bias
+    command: env NO_COLOR=1 COLUMNS=200 deep-quality-estimation --help
+    expected_output_contains: "overestimate segmentation quality"
+
+  - name: inputs are validated before the model is loaded
+    description: >-
+      Each of these previously failed either opaquely or not at all. A 4D input
+      raised "RuntimeError: applying transform <SpatialPadd object at 0x...>",
+      naming neither the file nor the problem, when the fix is a one-line
+      squeeze; an all-zero segmentation raised "cannot convert float NaN to
+      integer"; a shape mismatch surfaced as a ConcatItemsd failure.
+    timeout: 300
+    command: |
+      cd "$(mktemp -d)"
+      python -c "
+      import nibabel as nib, numpy as np
+      aff = np.eye(4)
+      img = np.random.rand(32,32,24).astype('float32')
+      seg = np.zeros((32,32,24),'float32'); seg[12:18,12:18,8:12] = 1
+      for n in ('t1c','t1','t2','fla'): nib.save(nib.Nifti1Image(img,aff), n+'.nii.gz')
+      nib.save(nib.Nifti1Image(seg,aff), 'seg.nii.gz')
+      nib.save(nib.Nifti1Image(np.zeros((32,32,24),'float32'),aff), 'empty.nii.gz')
+      nib.save(nib.Nifti1Image(seg[...,None],aff), 'seg4d.nii.gz')
+      nib.save(nib.Nifti1Image(np.random.rand(40,40,24).astype('float32'),aff), 'big.nii.gz')
+      "
+      base="-t1 t1.nii.gz -t2 t2.nii.gz -fla fla.nii.gz"
+      deep-quality-estimation -t1c missing.nii.gz $base -s seg.nii.gz 2>&1 | grep -q 'input file not found' && echo "missing-file-ok"
+      deep-quality-estimation -t1c t1c.nii.gz $base -s empty.nii.gz 2>&1 | grep -q 'no labelled voxels' && echo "empty-seg-ok"
+      deep-quality-estimation -t1c t1c.nii.gz $base -s seg4d.nii.gz 2>&1 | grep -q 'expected a 3D volume' && echo "4d-ok"
+      deep-quality-estimation -t1c big.nii.gz $base -s seg.nii.gz 2>&1 | grep -q 'same grid' && echo "shape-mismatch-ok"
+      echo "validation-done"
+    expected_output_contains: "validation-done"
+
+  - name: rates a segmentation with no --device flag
+    description: >-
+      The README claimed DQE defaults to cuda and that --device cpu is required
+      without a GPU. _set_device already auto-detects, so no flag is needed.
+      This also covers the critical path end to end and the new -o/--json.
+    timeout: 900
+    command: |
+      cd "$(mktemp -d)"
+      python -c "
+      import nibabel as nib, numpy as np
+      aff = np.eye(4)
+      img = np.random.rand(64,64,32).astype('float32')
+      seg = np.zeros((64,64,32),'float32'); seg[26:38,26:38,12:20] = 1; seg[30:34,30:34,14:18] = 3
+      for n in ('t1c','t1','t2','fla'): nib.save(nib.Nifti1Image(img,aff), n+'.nii.gz')
+      nib.save(nib.Nifti1Image(seg,aff), 'seg.nii.gz')
+      "
+      deep-quality-estimation -t1c t1c.nii.gz -t1 t1.nii.gz -t2 t2.nii.gz \
+          -fla fla.nii.gz -s seg.nii.gz --json -o score.json
+      python -c "
+      import json
+      d = json.load(open('score.json'))
+      assert isinstance(d['mean_score'], float), d
+      assert len(d['view_scores']) == 3, d
+      print('rated-ok', round(d['mean_score'], 2))
+      "
+    expected_output_contains: "rated-ok"


### PR DESCRIPTION
From container testing of `deep-quality-estimation/0.0.3`. The container itself works — 12/12 ratings, 3/3 geometry probes and 21/21 degradation runs completed on a CPU-only node, offline and unmodified. Everything here is interface and documentation.

### The device guidance described a default the code does not have
The README said DQE defaults to `device="cuda"` and that `device="cpu"` must be passed without a GPU. `_set_device` already auto-detects:

```python
if device is None:
    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
```

A run with no flag on a CPU-only node returned exactly the same score as an explicit `--device cpu`. The claim came from upstream's own README and propagated in.

### Upstream's two most important warnings were missing
Upstream marks one **IMPORTANT** and one **CAUTION**; the container carried neither:

1. **Images must be in atlas space** (240x240x155) with BraTS labels (1 necrotic/non-enhancing, 2 edema, 3 GD-enhancing, legacy 4 accepted).
2. **The model is biased to overestimate segmentation quality.**

The first matters most because the container *cannot detect a violation*: testing scored an anatomically misaligned segmentation at 4.81 — well inside the range it gives genuine segmentations, so not recognisable as invalid from the output.

The second is measurable: dilating a mask *raised* the score on all three subjects, scattered false positives moved it by under 0.003, and a 25 mm translation cost under 0.3 stars. Only label confusion registered strongly. The README now says how to read a score and warns against using it alone to rank segmentations.

### Inputs are now validated before the model loads
Each of these previously failed opaquely, or not at all:

| Input | Before | Now |
|---|---|---|
| Missing file | traceback | `input file not found: <path>` |
| Empty segmentation | `cannot convert float NaN to integer` | `segmentation contains no labelled voxels: <path>` |
| 4D volume | `applying transform <SpatialPadd object at 0x...>` | names the file, shape, and that a squeeze is the fix |
| Shape mismatch | `applying transform <ConcatItemsd object at 0x...>` | names both shapes |
| Differing affine | **silently scored** | warning |

The affine case is a warning, not an error, since it cannot be distinguished from benign rounding — but it is no longer silent.

### Also
- `--verbose` calls the `logger.enable` matching upstream's `logger.disable`, so a run can report which device it used — the exact question the device note raises.
- `-o/--output` writes the rating to a file; previously `--json` went only to stdout, so a batch user had to redirect and any stray library output would corrupt it.
- `deploy.path` exported the whole venv bin (`python`, `python3`, `python3.12`, `pip3.12`, `torchrun`), silently replacing the host interpreter. Narrowed to the CLI plus a named `dqe-python`.
- Documentation link now points at `BrainLesion/deep_quality_estimation` rather than the org page.

Every validation path was exercised locally against real NIfTIs before pushing, and the CLI's claims were checked against the published 0.0.3 wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
