### PR TITLE
Make modsort actually launch: readable tree, APPDIR, and a real launch test

### DIFF
--- a/recipes/modsort/build.yaml
+++ b/recipes/modsort/build.yaml
@@ -38,6 +38,7 @@ build:
         - libcups2t64
         - libdrm2
         - libgbm1
+        - libgl1
         - libglib2.0-0t64
         - libgtk-3-0t64
         - libnspr4
@@ -51,6 +52,7 @@ build:
         - libxkbcommon0
         - libxrandr2
         - xdg-utils
+        - xvfb
         - zlib1g
 
     # Upstream publishes a prebuilt Linux AppImage per release, so the container
@@ -70,8 +72,19 @@ build:
         - ./modsort.AppImage --appimage-extract
         - mkdir -p {{ context.install_dir }}
         - cp -a /tmp/modsort-extract/squashfs-root/. {{ context.install_dir }}/
+        # --appimage-extract produces a 0700 squashfs-root with 0700
+        # subdirectories, and cp -a faithfully preserves that. Every build step
+        # runs as root, for whom 0700 is fully accessible, but apptainer runs as
+        # the invoking user: without this the shipped container failed with
+        # "Permission denied" (exit 126) for every non-root user, and could not
+        # even list the directory.
+        - chmod -R a+rX {{ context.install_dir }}
         - rm -rf /tmp/modsort-extract
         - test -x {{ context.install_dir }}/AppRun
+        # Verify as a non-root user, which is the case the build is blind to.
+        - su -s /bin/bash -c "test -x {{ context.install_dir }}/AppRun && test -r {{ context.install_dir }}/resources/app.asar" nobody
+        - "! find {{ context.install_dir }} -type d ! -perm -o+rx | grep -q ."
+
 
     - run:
         # Every shared library the Electron binary needs must resolve now, so a
@@ -81,12 +94,42 @@ build:
           ldd {{ context.install_dir }}/modsort 2>/dev/null | grep 'not found' && exit 1 || echo "electron libraries resolve"
 
     - run:
-        # --no-sandbox: Chromium's setuid sandbox cannot initialise inside an
-        # unprivileged container, and without it no window ever appears.
+        # APPDIR must be exported. Upstream's AppRun resolves it by walking up
+        # from its own location looking for "$path/$1" -- the first command-line
+        # argument, not $0. Inside a real AppImage the runtime pre-sets APPDIR
+        # and that block never runs, but this recipe extracts the AppImage, so
+        # it does: handed "--no-sandbox", which is not a path, the loop strips
+        # /opt/modsort to /opt to "", leaving BIN as "/modsort" and the exec
+        # failing with "No such file or directory" (exit 127). Setting APPDIR
+        # skips the search entirely and keeps "modsort <path>" working, which
+        # dropping the flag would not.
+        #
+        # --no-sandbox is kept: Chromium's setuid sandbox cannot initialise in
+        # an unprivileged container without user namespaces. It is no longer
+        # load-bearing for the AppDir search.
+        #
+        # XDG paths are per-user: fixed /tmp/cache-modsort and
+        # /tmp/config-modsort belong to whoever launches first on a shared node.
         - >-
-          printf '%s\n' '#!/bin/bash' 'set -e' 'exec {{ context.install_dir }}/AppRun --no-sandbox "$@"' > /usr/local/bin/modsort
+          printf '%s\n'
+          '#!/bin/bash'
+          'set -e'
+          'export APPDIR={{ context.install_dir }}'
+          'export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/modsort-cache-$(id -u)}"'
+          'export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-/tmp/modsort-config-$(id -u)}"'
+          'mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"'
+          'exec {{ context.install_dir }}/AppRun --no-sandbox "$@"'
+          > /usr/local/bin/modsort
         - chmod +x /usr/local/bin/modsort
         - bash -n /usr/local/bin/modsort
+        - grep -q 'export APPDIR=' /usr/local/bin/modsort
+        # Launch it for real under a virtual display, as a non-root user. The
+        # previous suite only checked for the absence of one error string, and
+        # both blocking defects shipped past it.
+        - >-
+          su -s /bin/bash -c 'timeout 90 xvfb-run -a modsort > /tmp/launch.log 2>&1 & pid=$!; sleep 30; kill -0 $pid 2>/dev/null && echo ALIVE || echo DEAD; kill $pid 2>/dev/null; true' nobody | tee /tmp/launch_state.txt
+        - "grep -q ALIVE /tmp/launch_state.txt || { echo '--- launch log ---'; cat /tmp/launch.log; exit 1; }"
+        - rm -f /tmp/launch.log /tmp/launch_state.txt
 
     - workdir: /opt
 
@@ -115,7 +158,20 @@ readme: |-
   desktop interface, then copies and renames the files into the structure you
   choose. It is a graphical tool: there is no batch or command line mode.
 
-  Example:
+  ### Input format
+
+  modsort is **NIfTI only**. Its drop targets are BraTS-style modality tags --
+  `_t1.nii.gz`, `_t1c.nii.gz`, `_t2.nii.gz`, `_fla.nii.gz`, plus `swi`, `dwi`,
+  `adc` and `rcbv`. It does not sort DICOM; convert first with `dcm2niix` if
+  that is what you have.
+
+  ### It writes to your filesystem
+
+  Sorting means copying and renaming real files into a destination you pick.
+  Point it at a copy before running it over data you cannot regenerate.
+
+  ### Example
+
   ```
   ml modsort/{{ context.version }}
   modsort
@@ -123,14 +179,19 @@ readme: |-
 
   In NeuroDesk it also appears in the applications menu.
 
-  Notes:
+  ### Notes
+
   This container unpacks the AppImage that upstream publishes rather than
   building from source, so no node toolchain is present.
 
   It needs a display. Inside a NeuroDesk desktop session that is already the
-  case; over SSH you need X forwarding. Headless use is not meaningful here.
+  case; over SSH you need X forwarding. A virtual display works too, so
+  `xvfb-run -a modsort` is fine for a smoke test, though a tool you drag files
+  onto is not much use without a screen.
 
-  Electron runs with --no-sandbox because Chromium's setuid sandbox cannot
-  initialise in an unprivileged container.
+  Electron runs with `--no-sandbox`, because Chromium's setuid sandbox cannot
+  initialise in an unprivileged container without user namespaces. Where user
+  namespaces are available the sandbox does start, so treat this as a safeguard
+  rather than an absolute requirement.
 
   More documentation can be found here: https://github.com/BrainLesion/modsort

--- a/recipes/modsort/fulltest.yaml
+++ b/recipes/modsort/fulltest.yaml
@@ -21,22 +21,58 @@ tests:
 
   - name: the launcher passes --no-sandbox
     description: >-
-      Without it Chromium's setuid sandbox fails to initialise in an
-      unprivileged container and no window appears.
+      Chromium's setuid sandbox cannot initialise in an unprivileged container
+      without user namespaces. Note this flag is no longer load-bearing for the
+      AppDir search: testing on apptainer 1.5.3 with user namespaces available
+      found the app started with the sandbox enabled too, so the flag is kept
+      as a safeguard rather than a proven requirement.
     command: grep -c -- "--no-sandbox" /usr/local/bin/modsort
     expected_output_contains: "1"
 
-  - name: the Electron binary loads without a dynamic linker error
+  - name: the application tree is readable by a non-root user
     description: >-
-      Runs the real binary headlessly under a timeout. It cannot open a window
-      with no display and is expected to exit; what matters is that it fails for
-      that reason rather than on an unloadable library.
-
-      The match is deliberately narrow. ld.so reports exactly one message when a
-      library cannot be loaded, "error while loading shared libraries". An
-      earlier version of this test also matched "no such file or directory",
-      which Electron prints routinely for benign missing paths such as /dev/dri,
-      so it failed on healthy output.
+      --appimage-extract produces a 0700 squashfs-root and cp -a preserves it.
+      Every build step runs as root, for whom 0700 is fully accessible, but
+      apptainer runs as the invoking user: the shipped container failed with
+      "Permission denied" (exit 126) for every non-root user and could not even
+      list /opt/modsort. This check is user-independent, so it holds wherever
+      the suite runs.
     command: |
-      bash -c 'out=$(timeout 30 env -u DISPLAY -u WAYLAND_DISPLAY /opt/modsort/AppRun --no-sandbox 2>&1 | head -40 || true); if echo "$out" | grep -qi "error while loading shared libraries"; then echo "LOADER-ERROR"; else echo no-loader-error; fi'
-    expected_output_contains: "no-loader-error"
+      n=$(find /opt/modsort -type d ! -perm -o+rx | wc -l)
+      f=$(find /opt/modsort -name AppRun ! -perm -o+rx | wc -l)
+      echo "unreadable-dirs=$n unreadable-apprun=$f"
+    expected_output_contains: "unreadable-dirs=0 unreadable-apprun=0"
+
+  - name: the launcher exports APPDIR
+    description: >-
+      Upstream's AppRun resolves APPDIR by walking up from its own location
+      looking for "$path/$1" -- the first command-line argument, not $0. In a
+      real AppImage the runtime pre-sets APPDIR so that never runs; this recipe
+      extracts the AppImage, so it does. Handed "--no-sandbox", which is not a
+      path, the search walked /opt/modsort to /opt to "", leaving BIN as
+      "/modsort" and exiting 127. Exporting APPDIR skips the search and keeps
+      "modsort <path>" working, which simply dropping the flag would not.
+    command: grep -c 'export APPDIR=' /usr/local/bin/modsort
+    expected_output_contains: "1"
+
+  - name: the launcher starts the application under a virtual display
+    description: >-
+      The test this suite needed. It previously asserted only the absence of one
+      error string, and was narrowed in the same commit that produced a broken
+      image -- on the incorrect premise that the "no such file or directory" it
+      matched was benign Electron noise about /dev/dri. Electron never started,
+      so that line was the defect itself, and narrowing the matcher turned a
+      true positive into a pass. Exit 60 means the process did not survive.
+    timeout: 300
+    command: |
+      xvfb-run -a modsort > /tmp/modsort-launch.log 2>&1 &
+      pid=$!
+      sleep 30
+      if kill -0 "$pid" 2>/dev/null; then state=ALIVE; else state=DEAD; fi
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      echo "state=$state"
+      if [ "$state" != ALIVE ]; then
+          echo "--- launch log ---"; tail -40 /tmp/modsort-launch.log; exit 60
+      fi
+    expected_output_contains: "state=ALIVE"


### PR DESCRIPTION
From container testing of `modsort/0.0.2`. The container does not work as shipped: the command its own README documents fails immediately for every non-root user, and no window is ever painted.

There are **two independent blocking defects**, and fixing the first alone would have shipped a second broken image.

### 1. The application directory is unreadable (exit 126)
```
$ ml modsort/0.0.2 && modsort
/usr/local/bin/modsort: line 3: /opt/modsort/AppRun: Permission denied
```

`--appimage-extract` produces a `squashfs-root` at mode **0700** with 0700 subdirectories, and `cp -a` faithfully preserves it. Every build step runs as **root**, for whom 0700 is fully accessible — so the defect is invisible to the build by construction, while apptainer runs as the invoking user and cannot even list the directory.

Now `chmod -R a+rX`, plus a build-time check run *as a non-root user*, which is the case the build is otherwise blind to.

### 2. The launcher breaks AppRun's AppDir search (exit 127)
This one survives fixing the permissions. Upstream's `AppRun` resolves `APPDIR` by walking up from its own location looking for `"$path/$1"` — the **first command-line argument**, not `$0`. Inside a real AppImage the runtime pre-sets `APPDIR` and that block never executes; this recipe extracts the AppImage, so it does.

Handed `--no-sandbox`, which is not a path, the loop strips `/opt/modsort` → `/opt` → `""`. I reproduced the exact logic:

```
as shipped (--no-sandbox as $1):  APPDIR=[]              BIN=[/modsort]      -> exit 127
with APPDIR exported:             APPDIR=[/opt/modsort]  BIN=[/opt/modsort/modsort]
```

The launcher now exports `APPDIR`. That skips the search entirely and keeps `modsort <path>` working — dropping the flag instead would reintroduce the trap the moment anyone passes an argument.

`--no-sandbox` is kept but is no longer load-bearing, and its stated rationale is softened: with user namespaces available the app starts with the sandbox enabled, so it is a safeguard, not a proven requirement.

### 3. The test suite could not catch either — and I broke it
Test 5 was narrowed in **the very commit that produced this image**, by me, on the premise that the `no such file or directory` it matched was benign Electron noise about `/dev/dri`. That was wrong: Electron never started, so it printed nothing at all, and that single line *was* the defect. Narrowing the matcher converted a true positive into a passing test.

Replaced with:
- a **real launch under Xvfb**, asserting the process survives;
- a **user-independent permission check** (`find /opt/modsort -type d ! -perm -o+rx`), so the 0700 class of bug cannot hide behind whoever runs the suite;
- an `APPDIR` check.

The build also launches the app as a non-root user now.

### Also
- Adds `libgl1`, so launches stop emitting an ANGLE/EGL error wall before falling back to SwiftShader — it rendered fine, but it read like a crash.
- XDG cache/config paths are per-user; the fixed `/tmp/cache-modsort` and `/tmp/config-modsort` belong to whoever launches first on a shared node.
- README: modsort is **NIfTI-only** with BraTS-style modality tags and does not sort DICOM (the report's highest-value addition — a DICOM user would otherwise start a desktop session before discovering the wrong tool); that it copies and renames real files, so point it at a copy; and that a virtual display works.

Not addressed: `module whatis` returning the image filename, which the report notes is generic Neurodesk module-generation behaviour rather than anything in this recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
