### PR TITLE
Make the brats orchestrator able to run a segmentation at all

### DIFF
--- a/recipes/brats/brats-workdir
+++ b/recipes/brats/brats-workdir
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+# stdlib only, deliberately: the system interpreter never moves when the
+# venv path changes with the brats version.
+"""Print the OCI WorkingDir of a Docker Hub image.
+
+Used by brats-pull to record the working directory next to each sandbox.
+Apptainer discards the OCI WorkingDir when it converts an image (only
+ENTRYPOINT, CMD, ENV and labels survive into .singularity.d), and at run time
+there is no docker daemon to ask -- so algorithms whose ENTRYPOINT is a
+relative path, such as brats23_africa_blackbean's "python3 mlcube.py", started
+in the wrong directory and exited immediately. Recording it at pull time is
+the one moment the registry is guaranteed reachable.
+
+Prints an empty line for images that define no WorkingDir; exits non-zero on
+any failure so the caller can warn instead of recording garbage.
+"""
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+ACCEPT = ", ".join([
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.index.v1+json",
+])
+
+
+def fetch(url, headers=None):
+    request = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.loads(response.read().decode())
+
+
+def main(argv):
+    if len(argv) != 2 or argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        print("\nusage: brats-workdir <image>")
+        return 0 if len(argv) == 2 else 2
+
+    image = argv[1]
+    repo, _, tag = image.partition(":")
+    tag = tag or "latest"
+    if "/" not in repo:
+        repo = "library/" + repo
+
+    token = fetch(
+        "https://auth.docker.io/token?service=registry.docker.io&scope="
+        + urllib.parse.quote(f"repository:{repo}:pull")
+    )["token"]
+    headers = {"Authorization": "Bearer " + token, "Accept": ACCEPT}
+
+    manifest = fetch(
+        f"https://registry-1.docker.io/v2/{repo}/manifests/{tag}", headers
+    )
+    if "manifests" in manifest:  # multi-arch index: this stack is x86_64 only
+        digest = next(
+            entry["digest"]
+            for entry in manifest["manifests"]
+            if entry.get("platform", {}).get("architecture") == "amd64"
+        )
+        manifest = fetch(
+            f"https://registry-1.docker.io/v2/{repo}/manifests/{digest}", headers
+        )
+
+    config = fetch(
+        f"https://registry-1.docker.io/v2/{repo}/blobs/{manifest['config']['digest']}",
+        headers,
+    )
+    print(config.get("config", {}).get("WorkingDir", ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/recipes/brats/build.yaml
+++ b/recipes/brats/build.yaml
@@ -264,7 +264,17 @@ files:
               # also return meningioma_rt (11 images instead of 5) and
               # --task adult-glioma-pre also return pre-post, so the readme's
               # "pull every image for a task" pipeline silently over-pulled.
+              #
+              # The two adult-glioma task names do not equal their metadata
+              # stems, so they are mapped explicitly. Without this,
+              # adult-glioma-pre kept falling back to the substring match, and
+              # adult-glioma-pre-post -- whose "pre_post" is a substring of
+              # nothing -- had always errored with "no task matching".
               want = a.task.replace("-", "_")
+              want = {
+                  "adult_glioma_pre": "adult_glioma_pre_treatment",
+                  "adult_glioma_pre_post": "adult_glioma_pre_and_post_treatment",
+              }.get(want, want)
               exact = [f for f in files if f.stem == want]
               files = exact or [f for f in files if want in f.stem]
               if not files:

--- a/recipes/brats/build.yaml
+++ b/recipes/brats/build.yaml
@@ -30,6 +30,10 @@ build:
         MPLCONFIGDIR: /tmp/mpl-brats
         XDG_CACHE_HOME: /tmp/cache-brats
         PYTHONNOUSERSITE: "1"
+        # loguru's default sink shows DEBUG and above, so even after demoting
+        # the docker-daemon probe from ERROR to debug it would still print on
+        # every command. INFO keeps the inference progress logs.
+        LOGURU_LEVEL: INFO
         PATH: "{{ context.venv }}/bin:$PATH"
         # brats caches algorithm sandboxes under tempfile.gettempdir(), which
         # honours TMPDIR. It is deliberately NOT pinned here: a user must point
@@ -73,13 +77,37 @@ build:
         # The singularity backend must be importable: it imports docker as well,
         # so a partial install would only surface when a user tried to run.
         - . "${VENV}/bin/activate" && python -c "from brats.constants import Backends; from brats.core.singularity import run_container; print('singularity backend ok', Backends.SINGULARITY.value)"
+        # Four run-time blockers in the singularity backend; see the patch.
+        - . "${VENV}/bin/activate" && python {{ get_file("fix_brats_singularity") }} "${VENV}/lib/python3.12/site-packages"
+        # The additional-files folder must never resolve into site-packages,
+        # which is read-only at run time: every one of the 66 algorithms
+        # touches it and died there with Errno 30.
+        - >-
+          . "${VENV}/bin/activate" && env TMPDIR=/tmp/brats-afcheck python -c "import brats.constants as c, pathlib; p=pathlib.Path(c.ADDITIONAL_FILES_FOLDER); assert 'site-packages' not in str(p), p; assert str(p).startswith('/tmp/brats-afcheck'), p; p.mkdir(parents=True, exist_ok=True); print('additional files land in', p)"
+        - rm -rf /tmp/brats-afcheck
+        # The stderr drain: without stream_type='both' an algorithm that fills
+        # its stderr pipe deadlocks against brats until walltime.
+        - . "${VENV}/bin/activate" && grep -q "stream_type=\"both\"" "${VENV}/lib/python3.12/site-packages/brats/core/singularity.py"
+        - . "${VENV}/bin/activate" && python -c "import brats.core.singularity as m, inspect; src=inspect.getsource(m.run_container); assert src.index('_handle_device_requests') < src.index('_ensure_image(image='), 'CPU check must precede the pull'; print('device check precedes the image pull')"
         - mkdir -p /tmp/brats
         # Upstream ships no console_scripts. These add a task-oriented CLI plus
         # the two discovery/pull helpers the readme points at.
         - install -m 0755 {{ get_file("brats") }} /usr/local/bin/brats
         - install -m 0755 {{ get_file("brats-algorithms") }} /usr/local/bin/brats-algorithms
         - install -m 0755 {{ get_file("brats-pull") }} /usr/local/bin/brats-pull
-        - . "${VENV}/bin/activate" && brats --help > /dev/null && brats-algorithms --help > /dev/null && brats-pull --help > /dev/null
+        - install -m 0755 {{ get_file("brats-workdir") }} /usr/local/bin/brats-workdir
+        - . "${VENV}/bin/activate" && brats --help > /dev/null && brats-algorithms --help > /dev/null && brats-pull --help > /dev/null && brats-workdir --help > /dev/null
+        # D1 regression: with valid arguments the old CLI raised TypeError
+        # about an unexpected 'backend' kwarg before even checking the input
+        # files, so no documented command had ever run. The nonexistent input
+        # must now be what fails, not the constructor call.
+        - "! brats --task meningioma-rt --t1c /nonexistent.nii.gz -o /tmp/o.nii.gz > /tmp/brats-cli-check.log 2>&1"
+        - "! grep -q 'unexpected keyword argument' /tmp/brats-cli-check.log"
+        - rm -f /tmp/brats-cli-check.log /tmp/o.nii.gz
+        # The docker-absent probe must not shout ERROR at every command (docker
+        # can never exist here, and the message told users to install it).
+        - . "${VENV}/bin/activate" && brats-algorithms --images-only 2>/tmp/brats-stderr.log >/dev/null; test ! -s /tmp/brats-stderr.log || { echo '--- stderr not clean ---'; cat /tmp/brats-stderr.log; exit 1; }
+        - rm -f /tmp/brats-stderr.log
         # The lister reads the packaged metadata, so prove it parses it here.
         - . "${VENV}/bin/activate" && test "$(brats-algorithms --images-only | wc -l)" -gt 50
         - chmod -R a+rX "${VENV}"
@@ -92,6 +120,10 @@ build:
         builtin: test_deploy.sh
 
 files:
+  - name: fix_brats_singularity
+    filename: fix_brats_singularity.py
+  - name: brats-workdir
+    filename: brats-workdir
   - name: brats
     contents: |
       #!{{ context.venv }}/bin/python3
@@ -131,6 +163,12 @@ files:
           p.add_argument("-a", "--algorithm",
                          help="Algorithm key, e.g. BraTS23_1. Defaults to upstream's choice.")
           p.add_argument("--log-file", help="Optional log file")
+          p.add_argument("--force-cpu", action="store_true",
+                         help="Run on CPU even when a GPU is present. Only 16 of "
+                              "the 66 algorithms are CPU-compatible; see "
+                              "brats-algorithms.")
+          p.add_argument("--cuda-devices", default="0",
+                         help='Visible CUDA devices, e.g. "0" or "0,1" (default: 0)')
           a = p.parse_args(argv)
 
           cls_name, required = TASKS[a.task]
@@ -142,7 +180,11 @@ files:
           from brats.constants import Backends
 
           cls = getattr(brats, cls_name)
-          kwargs = {"backend": Backends.SINGULARITY}
+          # backend is an infer_single() parameter, not a constructor one.
+          # Passing it to the constructor raised TypeError on every valid
+          # invocation, before input files were even checked, so the documented
+          # command had never run a single segmentation.
+          kwargs = {"force_cpu": a.force_cpu, "cuda_devices": a.cuda_devices}
           if a.algorithm:
               import brats.constants as C
               enum_name = cls_name.replace("Segmenter", "Algorithms")
@@ -153,7 +195,10 @@ files:
               kwargs["algorithm"] = getattr(enum, a.algorithm)
 
           inputs = {m: getattr(a, m) for m in required}
-          cls(**kwargs).infer_single(output_file=a.output, log_file=a.log_file, **inputs)
+          cls(**kwargs).infer_single(
+              output_file=a.output, log_file=a.log_file,
+              backend=Backends.SINGULARITY, **inputs,
+          )
           print(f"wrote {a.output}")
           return 0
 
@@ -188,6 +233,13 @@ files:
           return Path(tempfile.gettempdir()) / "brats_singularity_images" / image.replace(":", "_")
 
 
+      def sandbox_complete(image: str) -> bool:
+          """A finished apptainer build always writes .singularity.d/runscript;
+          a directory without it is a partial left by an interrupted pull, which
+          used to be reported as [cached]."""
+          return (sandbox_path(image) / ".singularity.d" / "runscript").exists()
+
+
       def main(argv=None):
           p = argparse.ArgumentParser(
               prog="brats-algorithms",
@@ -203,15 +255,23 @@ files:
           tmp = tempfile.gettempdir()
           files = sorted(meta_dir().glob("*.yml"))
           if a.task:
-              files = [f for f in files if a.task.replace("-", "_") in f.stem]
+              # Exact stem first: a plain substring match made --task meningioma
+              # also return meningioma_rt (11 images instead of 5) and
+              # --task adult-glioma-pre also return pre-post, so the readme's
+              # "pull every image for a task" pipeline silently over-pulled.
+              want = a.task.replace("-", "_")
+              exact = [f for f in files if f.stem == want]
+              files = exact or [f for f in files if want in f.stem]
               if not files:
                   p.error(f"no task matching {a.task!r}")
 
           if not a.images_only:
               print(f"Algorithm cache: {tmp}/brats_singularity_images")
-              print("Set TMPDIR to persistent storage before pulling or running,")
-              print("otherwise every session re-downloads. For example:")
-              print("  export TMPDIR=/neurodesktop-storage/brats-cache\n")
+              print("Point the cache at persistent storage before pulling or running,")
+              print("otherwise every session re-downloads. The module wrapper runs")
+              print("this container with --cleanenv, which strips a plain TMPDIR")
+              print("export; use the prefixed form, which survives it:")
+              print("  export APPTAINERENV_TMPDIR=/neurodesktop-storage/brats-cache\n")
 
           for f in files:
               data = yaml.safe_load(f.read_text()) or {}
@@ -228,7 +288,7 @@ files:
                   meta = spec.get("meta") or {}
                   rank = meta.get("rank", "?")
                   year = meta.get("year", "?")
-                  ready = sandbox_path(image).exists()
+                  ready = sandbox_complete(image)
                   mark = "[cached]" if ready else "[not pulled]"
                   print(f"  {key:12} {rank:>4} {year}  {image}")
                   print(f"               {mark}  brats-pull {image}")
@@ -260,28 +320,66 @@ files:
         brats-algorithms
         brats-algorithms --task meningioma
 
-      Set TMPDIR to persistent storage FIRST, or the pull is lost with the session:
-        export TMPDIR=/neurodesktop-storage/brats-cache
+      Point the cache at persistent storage FIRST, or the pull is lost with the
+      session. The module wrapper runs this container with --cleanenv, which
+      strips a plain TMPDIR export, so use the prefixed form:
+        export APPTAINERENV_TMPDIR=/neurodesktop-storage/brats-cache
       USAGE
         exit 0
       fi
 
       CACHE="${TMPDIR:-/tmp}/brats_singularity_images"
       if [ "${TMPDIR:-/tmp}" = "/tmp" ]; then
-        echo "WARNING: TMPDIR is unset, so the cache lives in /tmp and will not" >&2
-        echo "         survive the session. Set TMPDIR to persistent storage." >&2
+        echo "WARNING: the cache lives in /tmp and will not survive the session." >&2
+        echo "         Set APPTAINERENV_TMPDIR to persistent storage first; a plain" >&2
+        echo "         TMPDIR export is stripped by the module wrapper's --cleanenv." >&2
       fi
 
       for image in "$@"; do
         dest="${CACHE}/${image//:/_}"
         if [ -d "$dest" ]; then
-          echo "already present: $dest"
-          continue
+          # A previous non-atomic version of this script built straight into
+          # $dest, so an interrupted pull left a partial directory that was
+          # then skipped as "already present". A finished apptainer build
+          # always writes .singularity.d/runscript, so a directory without it
+          # is a partial from an interrupted pull and is rebuilt. One with it
+          # is kept -- destroying a legacy multi-GB pull would be worse -- and
+          # is upgraded in place with the workdir record it predates.
+          if [ -f "$dest/.singularity.d/runscript" ]; then
+            if [ ! -f "$dest/.brats_docker_workdir" ]; then
+              if wd="$(brats-workdir "$image")"; then
+                printf '%s\n' "$wd" > "$dest/.brats_docker_workdir"
+                echo "recorded working directory for existing sandbox: ${wd:-<none>}"
+              fi
+            fi
+            echo "already present: $dest"
+            continue
+          fi
+          echo "removing partial sandbox from an interrupted pull: $dest"
+          rm -rf "$dest"
         fi
         echo "building sandbox for ${image}"
         echo "  -> ${dest}"
         mkdir -p "$(dirname "$dest")"
-        singularity build --sandbox --fakeroot "$dest" "docker://${image}"
+        # Build into a temporary path and move into place on success, so an
+        # interrupted build can never masquerade as a cached algorithm.
+        partial="${dest}.partial.$$"
+        trap 'rm -rf "$partial"' EXIT
+        singularity build --sandbox --fakeroot "$partial" "docker://${image}"
+        # Record the image's OCI WorkingDir while the registry is reachable.
+        # Apptainer discards it during sandbox conversion and there is no
+        # docker daemon at run time, so without this record algorithms whose
+        # entrypoint is a relative path (e.g. "python3 mlcube.py") start in
+        # the wrong directory and exit immediately.
+        if wd="$(brats-workdir "$image")"; then
+          printf '%s\n' "$wd" > "$partial/.brats_docker_workdir"
+          echo "recorded working directory: ${wd:-<none>}"
+        else
+          echo "WARNING: could not record the image working directory;" >&2
+          echo "         algorithms with a relative entrypoint may not start." >&2
+        fi
+        mv "$partial" "$dest"
+        trap - EXIT
         echo "done: ${dest}"
       done
 
@@ -311,28 +409,45 @@ readme: |-
   ### Read this first: no algorithms are bundled
 
   This container is an orchestrator. It contains no model and no weights. Each
-  of the 67 algorithms is a separate container published by its authors,
-  between roughly 4 GB and over 30 GB each, so bundling even one would make this
-  image unusable. You pull the ones you want, once.
+  of the 66 algorithms is a separate container published by its authors,
+  between roughly 4 GB and over 30 GB compressed -- and the cached sandbox is
+  larger still: a 4 GB pull unpacks to about 8 GB on disk, a 9 GB pull to about
+  14 GB. You pull the ones you want, once.
 
-  **Step 1 — point TMPDIR at persistent storage.** The cache lives under
-  `$TMPDIR`; anything in `/tmp` is lost when the session ends.
-  ```
-  export TMPDIR=/neurodesktop-storage/brats-cache
-  mkdir -p "$TMPDIR"
-  ```
+  ### GPU or CPU?
 
-  **Step 2 — find the algorithm you want.** This lists every algorithm for every
-  task, with its rank, year, image, whether it is already cached, and the exact
-  command to fetch it:
+  Most algorithms need a GPU: only 16 of the 66 are CPU-compatible, and 7 of
+  the 8 task defaults are GPU-only, so on a CPU node `brats -t <task>` without
+  `-a` fails for every task except `africa`. The `adult-glioma-pre`,
+  `pediatric` and `goat` tasks have no CPU-compatible algorithm at all.
+  `brats-algorithms` lists the keys; pick a CPU-capable one with `-a`.
+  Incompatibility is now detected before anything is downloaded.
+
+  Expect roughly 20 minutes per subject for CPU inference on 8 cores; size
+  Slurm walltimes accordingly.
+
+  **Step 1 -- point the cache at persistent storage.** The cache lives under
+  `$TMPDIR` inside the container; anything in `/tmp` is lost with the session.
+  The module wrapper runs this container with `--cleanenv`, which strips a
+  plain `TMPDIR` export, so use the prefixed form, which survives it:
+  ```
+  export APPTAINERENV_TMPDIR=/neurodesktop-storage/brats-cache
+  mkdir -p /neurodesktop-storage/brats-cache
+  ```
+  (`SINGULARITYENV_TMPDIR` works identically. When running the image directly
+  rather than through the module, plain `TMPDIR` is fine.)
+
+  **Step 2 -- find the algorithm you want.** This lists every algorithm for
+  every task, with its rank, year, image, whether it is already cached, and the
+  exact command to fetch it:
   ```
   brats-algorithms
-  brats-algorithms --task meningioma
+  brats-algorithms --task africa
   ```
 
-  **Step 3 — pull it.** Once per algorithm, per machine:
+  **Step 3 -- pull it.** Once per algorithm, per machine:
   ```
-  brats-pull brainles/brats23_faking_it:latest
+  brats-pull brainles/brats23_africa_blackbean:latest
   ```
   Pull several at once by listing them, or pull every algorithm for a task:
   ```
@@ -341,27 +456,36 @@ readme: |-
   To fetch everything, which is many hundreds of GB, use
   `brats-pull $(brats-algorithms --images-only)`.
 
-  **Step 4 — run it.**
+  **Step 4 -- run it.** This example is CPU-compatible end to end:
   ```
-  brats --task adult-glioma-pre \
+  brats --task africa -a BraTS23_3 \
         --t1c t1c.nii.gz --t1n t1n.nii.gz \
         --t2f t2f.nii.gz --t2w t2w.nii.gz \
         -o segmentation.nii.gz
   ```
-  Each task has a default algorithm; choose another with `-a`, for example
-  `-a BraTS23_2`. `brats-algorithms --task <task>` lists the valid keys.
+  Each task has a default algorithm; choose another with `-a`. On a machine
+  with a GPU, `--force-cpu` forces CPU execution and `--cuda-devices` selects
+  GPUs.
 
-  The Python API works too, and must select the singularity backend because
-  docker is not available here:
+  The Python API works too. The backend goes on `infer_single()` -- docker is
+  upstream's default and is not available here:
   ```
   python -c "
-  from brats import MetastasesSegmenter
-  from brats.constants import Backends
-  MetastasesSegmenter(backend=Backends.SINGULARITY).infer_single(
+  from brats import AfricaSegmenter
+  from brats.constants import AfricaAlgorithms, Backends
+  AfricaSegmenter(algorithm=AfricaAlgorithms.BraTS23_3, force_cpu=True).infer_single(
       t1c='t1c.nii.gz', t1n='t1n.nii.gz', t2f='t2f.nii.gz', t2w='t2w.nii.gz',
-      output_file='seg.nii.gz')
+      output_file='seg.nii.gz', backend=Backends.SINGULARITY)
   "
   ```
+
+  ### Input requirements
+
+  BraTS algorithms expect skull-stripped, co-registered images on the
+  240x240x155 at 1 mm SRI24 atlas grid, one file per modality (T1c, T1n, T2f,
+  T2w). Nothing validates this: raw scanner images produce plausible-looking
+  nonsense with no warning. The `brainles-preprocessing` module in this stack
+  produces exactly this input.
 
   ### Requirements
 

--- a/recipes/brats/build.yaml
+++ b/recipes/brats/build.yaml
@@ -82,6 +82,10 @@ build:
         # The additional-files folder must never resolve into site-packages,
         # which is read-only at run time: every one of the 66 algorithms
         # touches it and died there with Errno 30.
+        # The directory must exist first: tempfile.gettempdir() validates its
+        # candidates and silently falls back to /tmp when TMPDIR names a
+        # directory that does not exist.
+        - mkdir -p /tmp/brats-afcheck
         - >-
           . "${VENV}/bin/activate" && env TMPDIR=/tmp/brats-afcheck python -c "import brats.constants as c, pathlib; p=pathlib.Path(c.ADDITIONAL_FILES_FOLDER); assert 'site-packages' not in str(p), p; assert str(p).startswith('/tmp/brats-afcheck'), p; p.mkdir(parents=True, exist_ok=True); print('additional files land in', p)"
         - rm -rf /tmp/brats-afcheck
@@ -106,7 +110,8 @@ build:
         - rm -f /tmp/brats-cli-check.log /tmp/o.nii.gz
         # The docker-absent probe must not shout ERROR at every command (docker
         # can never exist here, and the message told users to install it).
-        - . "${VENV}/bin/activate" && brats-algorithms --images-only 2>/tmp/brats-stderr.log >/dev/null; test ! -s /tmp/brats-stderr.log || { echo '--- stderr not clean ---'; cat /tmp/brats-stderr.log; exit 1; }
+        - . "${VENV}/bin/activate" && brats-algorithms --images-only 2>/tmp/brats-stderr.log >/dev/null
+        - bash -c "test ! -s /tmp/brats-stderr.log || { echo '--- stderr not clean ---'; cat /tmp/brats-stderr.log; exit 1; }"
         - rm -f /tmp/brats-stderr.log
         # The lister reads the packaged metadata, so prove it parses it here.
         - . "${VENV}/bin/activate" && test "$(brats-algorithms --images-only | wc -l)" -gt 50

--- a/recipes/brats/fix_brats_singularity.py
+++ b/recipes/brats/fix_brats_singularity.py
@@ -1,0 +1,158 @@
+"""Make the brats singularity backend work in a read-only, daemonless image.
+
+Four defects, found by container testing, each blocking on its own:
+
+1. brats/constants.py resolves ADDITIONAL_FILES_FOLDER inside its own installed
+   package. run_container() touches it for every algorithm -- 16 download
+   Zenodo weights there, the other 50 mkdir a dummy in it -- and site-packages
+   is read-only at run time, so all 66 algorithms died with Errno 30. It now
+   honours $BRATS_ADDITIONAL_FILES_DIR and defaults under tempfile.gettempdir(),
+   which follows TMPDIR into the same persistent cache as the sandboxes.
+
+2. brats/core/singularity.py ran algorithms via spython with stream=True but no
+   stream_type, which drains only stdout: once an algorithm filled its stderr
+   pipe (3.7 MB observed), it blocked writing while brats blocked reading, and
+   the job sat idle until walltime with the real error stuck in the pipe.
+   stream_type="both" drains both.
+
+3. run_container() pulled the multi-GB algorithm image before checking CPU
+   compatibility, so a CPU-only user paid for the whole download and then got
+   AlgorithmNotCPUCompatibleException. The check now runs first; it is a pure
+   inspect-and-raise, so calling it early changes nothing else.
+
+4. _get_docker_working_dir() asks the Docker daemon for the image's WorkingDir
+   and returns None when there is no daemon -- always, here. Algorithms whose
+   ENTRYPOINT is a relative path (brats23_africa_blackbean: "python3 mlcube.py")
+   then start in the wrong directory and exit immediately. Apptainer discards
+   the OCI WorkingDir when it converts an image to a sandbox (verified in
+   apptainer 1.4.4's conveyorPacker_oci.go: only ENTRYPOINT/CMD/ENV/labels
+   survive), so it cannot be recovered locally; brats-pull records it from the
+   registry at pull time into <sandbox>/.brats_docker_workdir, and the fallback
+   reads that.
+
+Plus one cosmetic: the docker probe at import logged at ERROR, telling every
+user to install docker on a platform where docker will never exist. It logs at
+debug now, and the image sets LOGURU_LEVEL=INFO.
+"""
+
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+
+def patch(path, old, new, must=1):
+    src = path.read_text()
+    if src.count(old) != must:
+        raise SystemExit(
+            f"expected {must} occurrence(s) of anchor in {path}, found "
+            f"{src.count(old)}; upstream changed and this patch needs revisiting:"
+            f"\n{old!r}"
+        )
+    path.write_text(src.replace(old, new, must))
+
+
+constants = root / "brats" / "constants.py"
+patch(
+    constants,
+    "from enum import Enum\nfrom pathlib import Path\n",
+    "import os\nimport tempfile\nfrom enum import Enum\nfrom pathlib import Path\n",
+)
+patch(
+    constants,
+    'ADDITIONAL_FILES_FOLDER = DATA_DIR / "additional_files"',
+    '# neurocontainers: never inside site-packages, which is read-only at run\n'
+    '# time. Defaults under tempfile.gettempdir() so it follows TMPDIR into the\n'
+    '# same persistent cache as the algorithm sandboxes.\n'
+    'ADDITIONAL_FILES_FOLDER = Path(\n'
+    '    os.environ.get("BRATS_ADDITIONAL_FILES_DIR")\n'
+    '    or Path(tempfile.gettempdir()) / "brats_additional_files"\n'
+    ')',
+)
+
+sing = root / "brats" / "core" / "singularity.py"
+patch(
+    sing,
+    """        executor = Client.run(
+            image,
+            options=options,
+            args=args,
+            stream=True,
+            bind=singularity_bindings,
+        )""",
+    """        executor = Client.run(
+            image,
+            options=options,
+            args=args,
+            stream=True,
+            # neurocontainers: without this spython drains only stdout, so an
+            # algorithm that fills its stderr pipe deadlocks against brats and
+            # the job sits idle until walltime with the error stuck in the pipe.
+            stream_type="both",
+            bind=singularity_bindings,
+        )""",
+)
+patch(
+    sing,
+    """    _log_algorithm_info(algorithm=algorithm)
+    # ensure image is present, if not pull it
+    image = _ensure_image(image=algorithm.run_args.docker_image)""",
+    """    _log_algorithm_info(algorithm=algorithm)
+    # neurocontainers: refuse CPU-incompatible algorithms BEFORE the multi-GB
+    # pull. Upstream checks only after _ensure_image, so a CPU-only user paid
+    # for the whole download and then got the exception. Pure inspect-and-raise;
+    # the original call below still supplies the device requests.
+    _handle_device_requests(
+        algorithm=algorithm, cuda_devices=cuda_devices, force_cpu=force_cpu
+    )
+    # ensure image is present, if not pull it
+    image = _ensure_image(image=algorithm.run_args.docker_image)""",
+)
+patch(
+    sing,
+    """    if docker_client is None:
+        return None
+    try:
+        logger.debug(f"Inspecting image {image}")""",
+    """    if docker_client is None:
+        # neurocontainers: there is never a docker daemon here. Apptainer
+        # discards the OCI WorkingDir when converting to a sandbox, so it
+        # cannot be read locally; brats-pull records it from the registry at
+        # pull time, next to the sandbox.
+        marker = (
+            Path(tempfile.gettempdir())
+            / "brats_singularity_images"
+            / image.replace(":", "_")
+            / ".brats_docker_workdir"
+        )
+        try:
+            recorded = marker.read_text().strip()
+        except OSError:
+            recorded = ""
+        if recorded:
+            logger.debug(f"Working directory from pull-time record: {recorded}")
+            return Path(recorded)
+        logger.warning(
+            "No pull-time record of this image's working directory. Algorithms "
+            "whose entrypoint is a relative path will exit immediately; re-run "
+            "brats-pull on this image to record it."
+        )
+        return None
+    try:
+        logger.debug(f"Inspecting image {image}")""",
+)
+
+dock = root / "brats" / "core" / "docker.py"
+patch(
+    dock,
+    '''    logger.error(
+        f"Failed to connect to docker daemon. Please make sure docker is installed and running. Error: {e}"
+    )''',
+    '''    # neurocontainers: docker never exists on this platform, so an ERROR
+    # telling the user to install it is noise on every single command.
+    logger.debug(
+        f"No docker daemon (expected here; the singularity backend is used). Error: {e}"
+    )''',
+)
+
+print("brats singularity backend patched")

--- a/recipes/brats/fulltest.yaml
+++ b/recipes/brats/fulltest.yaml
@@ -54,6 +54,142 @@ tests:
     expected_output_contains: "brats-pull"
 
   - name: brats-pull explains itself without arguments
-    description: The pull step is mandatory before any inference, so its help must work.
+    description: >-
+      The pull step is mandatory before any inference, so its help must work --
+      and it must name the prefixed variable that actually survives the module
+      wrapper's --cleanenv. The readme's old "export TMPDIR" advice did nothing:
+      every session re-downloaded 4-30 GB, brats-pull warned even when the user
+      had followed the readme, and pulled images were listed as [not pulled].
     command: brats-pull --help
-    expected_output_contains: "TMPDIR"
+    expected_output_contains: "APPTAINERENV_TMPDIR"
+
+  - name: valid arguments reach the input check, not a TypeError
+    description: >-
+      The CLI passed backend= to the segmenter constructor, which only accepts
+      it on infer_single(), so every invocation with valid arguments raised
+      "TypeError: ... unexpected keyword argument 'backend'" before input files
+      were even checked. The documented Step 4 command had never run a single
+      segmentation. With the fix, the nonexistent input is what fails.
+    command: |
+      brats --task meningioma-rt --t1c /nonexistent.nii.gz -o /tmp/o.nii.gz > cli.log 2>&1 || true
+      grep -q "unexpected keyword argument" cli.log && { echo "CONSTRUCTOR-TYPEERROR"; cat cli.log; } || echo "constructor-ok"
+    expected_output_contains: "constructor-ok"
+
+  - name: the CLI exposes CPU control
+    description: >-
+      Upstream accepts force_cpu and cuda_devices on the constructor, but the
+      CLI exposed neither, so on a GPU node there was no way to ask for CPU.
+    command: brats --help
+    expected_output_contains: "--force-cpu"
+
+  - name: additional files resolve outside site-packages
+    description: >-
+      brats resolved ADDITIONAL_FILES_FOLDER inside its own installed package;
+      run_container touches it for every algorithm (16 download weights there,
+      the other 50 mkdir a dummy), and site-packages is read-only at run time,
+      so all 66 algorithms died with Errno 30 before doing anything.
+    command: |
+      env TMPDIR=/tmp/brats-af-test python -c "
+      import pathlib
+      import brats.constants as c
+      p = pathlib.Path(c.ADDITIONAL_FILES_FOLDER)
+      assert 'site-packages' not in str(p), p
+      assert str(p).startswith('/tmp/brats-af-test'), p
+      p.mkdir(parents=True, exist_ok=True)
+      (p / 'probe').write_text('x')
+      print('additional-files-writable', p)
+      "
+    expected_output_contains: "additional-files-writable"
+
+  - name: the algorithm stream drains stderr
+    description: >-
+      spython with stream=True and no stream_type drains only stdout: an
+      algorithm that filled its stderr pipe (3.7 MB observed) blocked writing
+      while brats blocked reading, and the job sat idle until walltime with the
+      real error stuck in the pipe -- no error, no output, no CPU use.
+    command: |
+      python -c "
+      import brats.core.singularity as m
+      n = open(m.__file__).read().count('stream_type=\"both\"')
+      print('stream-type-both', n)
+      "
+    expected_output_contains: "stream-type-both 1"
+
+  - name: CPU compatibility is checked before the download
+    description: >-
+      run_container pulled the multi-GB image and only then raised
+      AlgorithmNotCPUCompatibleException, so a CPU-only user paid for the whole
+      download before learning it could never run.
+    command: |
+      python -c "
+      import inspect
+      import brats.core.singularity as m
+      src = inspect.getsource(m.run_container)
+      assert src.index('_handle_device_requests') < src.index('_ensure_image(image='), 'device check does not precede the pull'
+      print('device-check-first')
+      "
+    expected_output_contains: "device-check-first"
+
+  - name: the working directory survives without a docker daemon
+    description: >-
+      _get_docker_working_dir asked the docker daemon and returned None when
+      there is none -- always, here -- so algorithms whose ENTRYPOINT is a
+      relative path (brats23_africa_blackbean: "python3 mlcube.py") launched
+      without --cwd and exited immediately. Apptainer discards the OCI
+      WorkingDir during sandbox conversion, so brats-pull records it at pull
+      time and the backend reads that record. This simulates a recorded pull.
+    command: |
+      env TMPDIR=/tmp/brats-wd-test python -c "
+      import os, pathlib
+      sandbox = pathlib.Path('/tmp/brats-wd-test/brats_singularity_images/example_image_latest')
+      sandbox.mkdir(parents=True, exist_ok=True)
+      (sandbox / '.brats_docker_workdir').write_text('/mlcube_project\n')
+      from brats.core.singularity import _get_docker_working_dir
+      wd = _get_docker_working_dir('example/image:latest')
+      assert str(wd) == '/mlcube_project', wd
+      print('workdir-from-record', wd)
+      "
+    expected_output_contains: "workdir-from-record /mlcube_project"
+
+  - name: no docker ERROR on a routine command
+    description: >-
+      Every invocation printed "ERROR ... Please make sure docker is installed
+      and running" -- on a platform where docker will never exist. The probe now
+      logs at debug and the image sets LOGURU_LEVEL=INFO.
+    command: |
+      brats-algorithms --images-only 2>stderr.log >/dev/null
+      if [ -s stderr.log ]; then echo "STDERR-NOT-CLEAN"; cat stderr.log; else echo "stderr-clean"; fi
+    expected_output_contains: "stderr-clean"
+
+  - name: task filtering matches exactly
+    description: >-
+      A substring filter made --task meningioma also return meningioma_rt (11
+      images instead of 5) and --task adult-glioma-pre also return pre-post
+      (10 instead of 3), so the readme's "pull every image for a task" pipeline
+      silently over-pulled.
+    command: |
+      m=$(brats-algorithms --task meningioma --images-only | wc -l)
+      g=$(brats-algorithms --task adult-glioma-pre --images-only | wc -l)
+      echo "meningioma=$m adult-glioma-pre=$g"
+    expected_output_contains: "meningioma=5 adult-glioma-pre=3"
+
+  - name: brats-pull builds atomically
+    description: >-
+      It built straight into the final cache path, so a failed or interrupted
+      build left a partial directory that later runs skipped as "already
+      present" and the lister reported as [cached]. Now it builds into a
+      .partial path moved into place on success, cleans up on failure, and
+      treats a directory without .singularity.d/runscript as an interrupted
+      pull to be rebuilt.
+    command: |
+      grep -q 'partial="${dest}.partial' /usr/local/bin/brats-pull && echo "atomic-build"
+      grep -q "trap 'rm -rf" /usr/local/bin/brats-pull && echo "cleanup-trap"
+      grep -q '.singularity.d/runscript' /usr/local/bin/brats-pull && echo "partial-detection"
+    expected_output_contains: "partial-detection"
+
+  - name: brats-workdir renders help
+    description: >-
+      Records each image's OCI WorkingDir at pull time; without the record,
+      relative-entrypoint algorithms cannot start (see the workdir test above).
+    command: brats-workdir --help
+    expected_output_contains: "usage: brats-workdir"

--- a/recipes/brats/fulltest.yaml
+++ b/recipes/brats/fulltest.yaml
@@ -89,6 +89,8 @@ tests:
       the other 50 mkdir a dummy), and site-packages is read-only at run time,
       so all 66 algorithms died with Errno 30 before doing anything.
     command: |
+      # gettempdir() silently ignores a TMPDIR that does not exist
+      mkdir -p /tmp/brats-af-test
       env TMPDIR=/tmp/brats-af-test python -c "
       import pathlib
       import brats.constants as c
@@ -139,6 +141,7 @@ tests:
       WorkingDir during sandbox conversion, so brats-pull records it at pull
       time and the backend reads that record. This simulates a recorded pull.
     command: |
+      mkdir -p /tmp/brats-wd-test
       env TMPDIR=/tmp/brats-wd-test python -c "
       import os, pathlib
       sandbox = pathlib.Path('/tmp/brats-wd-test/brats_singularity_images/example_image_latest')

--- a/recipes/brats/fulltest.yaml
+++ b/recipes/brats/fulltest.yaml
@@ -144,7 +144,9 @@ tests:
       mkdir -p /tmp/brats-wd-test
       env TMPDIR=/tmp/brats-wd-test python -c "
       import os, pathlib
-      sandbox = pathlib.Path('/tmp/brats-wd-test/brats_singularity_images/example_image_latest')
+      # only the colon is replaced in sandbox names, so the registry
+      # namespace ('example/') stays a nested directory
+      sandbox = pathlib.Path('/tmp/brats-wd-test/brats_singularity_images/example/image_latest')
       sandbox.mkdir(parents=True, exist_ok=True)
       (sandbox / '.brats_docker_workdir').write_text('/mlcube_project\n')
       from brats.core.singularity import _get_docker_working_dir
@@ -173,8 +175,9 @@ tests:
     command: |
       m=$(brats-algorithms --task meningioma --images-only | wc -l)
       g=$(brats-algorithms --task adult-glioma-pre --images-only | wc -l)
-      echo "meningioma=$m adult-glioma-pre=$g"
-    expected_output_contains: "meningioma=5 adult-glioma-pre=3"
+      pp=$(brats-algorithms --task adult-glioma-pre-post --images-only | wc -l)
+      echo "meningioma=$m adult-glioma-pre=$g adult-glioma-pre-post=$pp"
+    expected_output_contains: "meningioma=5 adult-glioma-pre=3 adult-glioma-pre-post=7"
 
   - name: brats-pull builds atomically
     description: >-


### PR DESCRIPTION
From container testing of `brats/0.1.8`: four independent defects each blocked inference on its own, and the first meant the documented command had **never run a single segmentation**. The tester verified that with all four patched, the orchestrator produced a segmentation byte-identical to the same algorithm launched directly (Dice 0.876 vs the expert mask) — so this PR carries those four fixes into the recipe, plus the non-blocking ones.

Every claim was re-verified against the published 0.1.8 wheel before patching.

### D1 — the CLI could not run anything
It passed `backend=` to the segmenter constructor; upstream accepts it only on `infer_single()`. Every valid invocation died with `TypeError` before input files were checked. Moved to the call — and the CLI now exposes `--force-cpu` / `--cuda-devices`, which upstream accepts but the CLI hid, so on a GPU node there was no way to ask for CPU. Verified against all eight segmenter constructors, and exercised against a stub mirroring upstream's real signatures.

### D2 — writes into read-only site-packages
`ADDITIONAL_FILES_FOLDER` lived inside the installed package; `run_container` touches it for **every** algorithm (16 download Zenodo weights there, the other 50 `mkdir` a dummy), so all 66 died with Errno 30. Now honours `BRATS_ADDITIONAL_FILES_DIR`, defaulting under `tempfile.gettempdir()` so weights follow `TMPDIR` into the same persistent cache as the sandboxes.

### D3 — stderr deadlock
`Client.run(..., stream=True)` with no `stream_type` drains only stdout: an algorithm that filled its stderr pipe (3.7 MB observed) blocked writing while brats blocked reading — no error, no output, no CPU use, until walltime, with the real error stuck in the pipe. `stream_type="both"`.

### D4 — relative-entrypoint algorithms exited immediately
`_get_docker_working_dir` asks the docker daemon, which never exists here, and returned `None` — so `brats23_africa_blackbean` (`ENTRYPOINT python3 mlcube.py`) launched without `--cwd` and exited 2.

The report suggested reading the workdir from the sandbox, but that turns out to be impossible: **apptainer discards the OCI WorkingDir during conversion** (verified in 1.4.4's `conveyorPacker_oci.go` — only ENTRYPOINT/CMD/ENV/labels survive). So `brats-pull` now records it from the registry *at pull time* — the one moment network is guaranteed — via a new stdlib-only `brats-workdir` helper, and the backend reads the record. Verified live against Docker Hub: blackbean → `/mlcube_project`; mist → none recorded, none needed (absolute entrypoint).

### The rest
- **D5**: `export TMPDIR` did nothing (`--cleanenv` strips it) — every session re-downloaded 4–30 GB, and pulled images listed as `[not pulled]`. All guidance now names `APPTAINERENV_TMPDIR`.
- **D6**: CPU compatibility is now checked **before** the multi-GB pull (pure inspect-and-raise moved ahead of `_ensure_image`), and the README gains its missing GPU section: 16/66 CPU-compatible, three tasks with none, 7 of 8 defaults GPU-only.
- **D8**: `brats-pull` builds into a `.partial` path moved into place on success, with a cleanup trap; a directory lacking `.singularity.d/runscript` is treated as an interrupted pull and rebuilt. Legacy complete sandboxes are deliberately **not** destroyed — they're upgraded in place with the workdir record they predate.
- **D9**: the docker-daemon ERROR on every command (telling users to install docker on a platform where it can never exist) logs at debug, and the image sets `LOGURU_LEVEL=INFO`. A test asserts routine-command stderr is empty.
- **D10**: task filtering matches the stem exactly — `--task meningioma` returned 11 images instead of 5, and the README's pull-a-whole-task pipeline silently over-pulled. Counts pinned against the wheel metadata (meningioma=5, adult-glioma-pre=3).
- **README**: the worked example is now CPU-compatible end to end (`africa` / `BraTS23_3`, 9 GB) instead of the 30.8 GB GPU-only `faking_it`; the Python example fixed (same D1 bug); input requirements stated (skull-stripped, co-registered, SRI24 240×240×155 grid, with a pointer at `brainles-preprocessing`); sandbox disk cost and ~20 min/subject CPU runtime documented; 67 → 66.

**D7** (`brats24_adult_glioma_mist` flagged `cpu_compatible` while hardcoding a CUDA device) is upstream metadata and is not patched here — worth reporting to BrainLesion.

### Tests
10 new fulltests, one per defect class: the D1 TypeError regression, additional-files path, stream drain, device-check-before-pull ordering (via `inspect.getsource`), the workdir record round-trip, clean stderr, exact task counts, atomic pull, plus helper help checks. Build-time assertions gate the same things, so a rebuild that loses any patch fails rather than ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
