### PR TITLE
Fix hypermapp3r: exit code, stats_wmh crash, prob-map quantisation

### DIFF
--- a/recipes/hypermapp3r/build.yaml
+++ b/recipes/hypermapp3r/build.yaml
@@ -194,10 +194,27 @@ build:
           python -m pip install --no-cache-dir --only-binary=:all: "PyQt5==5.15.9" "PyQt5-sip==12.12.2" "PyQt5-Qt5==5.15.2"
         - python -c "from PyQt5 import QtWidgets; print('PyQt5 ok')"
 
+    # Three small fixes to the pinned source, kept as a git patch so the build
+    # fails loudly if the pinned commit ever changes underneath them. See the
+    # prologue inside the patch file for the full story; in short:
+    #   1. endstatement.py: seg_wmh exited 1 on every successful run under
+    #      apptainer (empty GECOS + `--cleanenv` stripping USER -> KeyError
+    #      after the outputs were already written).
+    #   2. summary_wmh_vols.py: stats_wmh crashed unconditionally with an
+    #      IndexError copy-pasted from the hippocampus module.
+    #   3. hypermapper.py copy_orient(): the published *_wmh_prob.nii.gz
+    #      probability map was silently quantised to uint8 {0,1} whenever the
+    #      input was not already RPI/LPI.
+    # Each fix is exercised by a build step further down.
+    - file:
+        name: neurodesk_fixes_patch
+        filename: neurodesk-fixes.patch
+
     - run:
         - git clone https://github.com/AICONSlab/HyperMapp3r {{ context.hypermapper_dir }}
         - cd {{ context.hypermapper_dir }}
         - git checkout {{ context.hypermapper_commit }}
+        - git apply --verbose {{ get_file("neurodesk_fixes_patch") }}
         # --no-deps: setup.py re-pins keras, which would undo the resolve above.
         # PyQt5 is installed explicitly in the step before this one.
         - python -m pip install --no-cache-dir --no-deps -e .
@@ -256,6 +273,27 @@ build:
         - hypermapper --help
         - hypermapper seg_wmh --help
 
+    # Prove each of the three patched defects is actually fixed, at the layer
+    # that applied the patch. All three checks fail on the unpatched source.
+    - run:
+        # 1. endstatement must survive the apptainer runtime conditions: an
+        #    empty GECOS field AND no USER in the environment. Unpatched code
+        #    dies here with KeyError: 'USER'.
+        - env -u USER python -c "import unittest.mock as m, pwd; m.patch('pwd.getpwuid', return_value=pwd.struct_passwd(('jovyan', 'x', 1000, 1000, '', '/home/jovyan', '/bin/bash'))).start(); from hypermapper.utils import endstatement; endstatement.main('endstatement patch check', '0:00:01')"
+        # 2. stats_wmh must complete on a minimal subject tree. Unpatched code
+        #    dies unconditionally with IndexError before writing the csv.
+        - mkdir -p /tmp/statscheck/subj01
+        - python -c "import nibabel as nib, numpy as np; nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.uint8), np.eye(4)), '/tmp/statscheck/subj01/subj01_wmh_pred.nii.gz')"
+        - hypermapper stats_wmh -i /tmp/statscheck -o /tmp/statscheck/vols.csv
+        - grep -q WMH_Volume /tmp/statscheck/vols.csv
+        - rm -rf /tmp/statscheck
+        # 3. copy_orient must be able to publish a float image intact. The
+        #    unpatched signature has no dtype argument (TypeError), and the
+        #    hardcoded uchar cast would leave <= 2 distinct values.
+        - cd /tmp
+        - python -c "import numpy as np, nibabel as nib; nib.save(nib.Nifti1Image(np.random.RandomState(0).rand(8, 8, 8).astype('float32'), np.eye(4)), '/tmp/pc_in.nii.gz'); nib.save(nib.Nifti1Image(np.zeros((8, 8, 8), dtype='uint8'), np.eye(4)), '/tmp/pc_ref.nii.gz'); from hypermapper.segment.hypermapper import copy_orient; copy_orient('/tmp/pc_in.nii.gz', '/tmp/pc_ref.nii.gz', '/tmp/pc_out.nii.gz', dtype='float'); assert len(np.unique(np.asarray(nib.load('/tmp/pc_out.nii.gz').dataobj))) > 2, 'probability map still quantised'; print('copy_orient float ok')"
+        - rm -f /tmp/pc_in.nii.gz /tmp/pc_ref.nii.gz /tmp/pc_out.nii.gz
+
     # Run the bundled test case during the build.
     #
     # The fulltest runner reports only an exit code to the CI log and keeps the
@@ -279,11 +317,15 @@ build:
         # kept failing. HOME alone was already ruled out by a previous run, so
         # this varies the user as well: anything hypermapper tries to write
         # inside /opt succeeds for root here and cannot succeed in a read-only
-        # SIF.
+        # SIF. `env -u USER` reproduces `singularity exec --cleanenv`, which
+        # strips USER: combined with the tester user's empty GECOS field this
+        # is exactly the condition that made unpatched seg_wmh exit 1 after
+        # every successful segmentation, so this step now regression-tests the
+        # endstatement patch through the whole pipeline.
         - useradd -m tester
         - cp -r {{ context.hypermapper_dir }}/data/test_case /tmp/e2e_user
         - chown -R tester /tmp/e2e_user
-        - runuser -u tester -- env PATH="$PATH" HOME=/nonexistent sh -c 'cd /tmp/e2e_user && hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi'
+        - runuser -u tester -- env -u USER PATH="$PATH" HOME=/nonexistent sh -c 'cd /tmp/e2e_user && hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi'
         - test -s /tmp/e2e_user/wmh_pred.nii.gz
         - echo "end-to-end segmentation ok as unprivileged user"
         - rm -rf /tmp/e2e_user
@@ -347,19 +389,41 @@ readme: |-
   ```
   ml hypermapp3r/{{ context.version }}
 
-  # Multimodal (T1 + FLAIR), with a brain mask
+  # A brain mask is REQUIRED and this container does not ship a skull
+  # stripper; make one first with another module, e.g.:
+  #   ml freesurfer
+  #   mri_synthstrip -i T1.nii.gz -o T1_brain.nii.gz -m brainmask.nii.gz
+
+  # Default model: 224 isotropic multimodal (T1 + FLAIR)
+  hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz
+
+  # Original multimodal model
   hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz -id multi
 
-  # 224 isotropic multimodal model
-  hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz -id 224multi
+  # QC mosaic for one segmentation
+  hypermapper seg_qc -i FLAIR.nii.gz -s subj_wmh_pred.nii.gz
 
-  # Lesion volume summary and QC
-  hypermapper stats_wmh -s subject_dir
-  hypermapper seg_qc   -s subject_dir
+  # Lesion volume summary over a directory of subject directories
+  hypermapper stats_wmh -i /path/to/subjects_dir -o wmh_volumes.csv
   ```
 
-  Available models via `-id`: `multi` (default, T1+FLAIR), `224multi`
-  (224 isotropic T1+FLAIR) and `con`.
+  Available models via `-id`: `224multi` (the default; 224 isotropic
+  T1+FLAIR), `multi` (T1+FLAIR) and `con`.
+
+  Important usage notes:
+  - T1 and FLAIR must already be coregistered. Preprocessing only reslices
+    onto a common grid (`c3d -reslice-identity`); it does not register.
+    Misaligned inputs produce a wrong segmentation, not an error.
+  - `seg_wmh` writes its intermediates (`pred_process*/`, `qc/`, `logs/`,
+    `*_std_orient.nii.gz`) into the directory containing the input T1; `-o`
+    only names the final prediction. Copy inputs to a writable scratch
+    directory first — a read-only input directory will fail.
+  - `<subj>_wmh_prob.nii.gz` is the Monte-Carlo-dropout probability
+    (uncertainty) map, published at floating-point precision.
+  - The `-t2` flag is accepted but ignored: the shipped models use T1+FLAIR
+    only.
+  - Runtime scales with the MC sample count `-n` (default 20): roughly 10
+    minutes on 8 CPU cores at the default, ~1.5 minutes with `-n 2`.
 
   Note: the CLI also accepts `-id 224all` and `-id t1m`, but the authors have
   never published weights for those two, so they will fail at runtime. Only the
@@ -395,7 +459,8 @@ structured_readme:
     with large lesion burden and brain atrophy. Runs on CPU.
   example: |-
     ml hypermapp3r/{{ context.version }}
-    hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz -id multi
+    # T1 and FLAIR must be coregistered; the brain mask is required
+    hypermapper seg_wmh -t1 T1.nii.gz -fl FLAIR.nii.gz -m brainmask.nii.gz
   documentation: https://hypermapp3r.readthedocs.io
   citation: |-
     Mojiri Forooshani P, Biparva M, Ntiri EE, Ramirez J, Boone L, Holmes MF,

--- a/recipes/hypermapp3r/fulltest.yaml
+++ b/recipes/hypermapp3r/fulltest.yaml
@@ -8,6 +8,12 @@
 # so an end-to-end segmentation is included at the end. It is the slowest test
 # here by a wide margin; everything before it is a fast interface or asset
 # check.
+#
+# The recipe patches three upstream defects (see neurodesk-fixes.patch next to
+# build.yaml): a KeyError that made every successful seg_wmh exit 1 under
+# apptainer, an IndexError that made stats_wmh unconditionally unusable, and a
+# uchar cast that silently quantised the published probability map. The
+# "PATCHED DEFECTS" section regression-tests each one from the runtime side.
 
 name: hypermapp3r
 version: 0.1.0
@@ -185,6 +191,63 @@ tests:
     expected_output_contains: gui ok
 
   # ==========================================================================
+  # PATCHED DEFECTS
+  # ==========================================================================
+  - name: endstatement survives an empty GECOS with no USER in the environment
+    description: >-
+      Regression test for the exit-code defect: apptainer's --cleanenv strips
+      USER and the runtime user's passwd GECOS field is empty, so unpatched
+      endstatement.py raised KeyError AFTER a successful segmentation, turning
+      every good run into exit status 1. The mock reproduces both conditions
+      independently of whoever runs this test.
+    command: |
+      bash -lc '
+      env -u USER python -c "import unittest.mock as m, pwd; m.patch(\"pwd.getpwuid\", return_value=pwd.struct_passwd((\"jovyan\", \"x\", 1000, 1000, \"\", \"/home/jovyan\", \"/bin/bash\"))).start(); from hypermapper.utils import endstatement; endstatement.main(\"endstatement check\", \"0:00:01\")" && echo endstatement-ok'
+    expected_output_contains: endstatement-ok
+
+  - name: stats_wmh produces a volume csv
+    description: >-
+      Regression test for the IndexError that made stats_wmh crash on every
+      input (a two-element column list copy-pasted from the hippocampus
+      module). Builds a minimal subject tree with one synthetic prediction and
+      requires a csv with the WMH_Volume column to come out.
+    command: |
+      bash -lc '
+      set -e
+      workdir=$(mktemp -d)
+      mkdir -p "$workdir/subj01"
+      python -c "import nibabel as nib, numpy as np; import sys; nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.uint8), np.eye(4)), sys.argv[1])" "$workdir/subj01/subj01_wmh_pred.nii.gz"
+      hypermapper stats_wmh -i "$workdir" -o "$workdir/vols.csv"
+      grep WMH_Volume "$workdir/vols.csv"
+      rm -rf "$workdir"'
+    expected_output_contains: WMH_Volume
+
+  - name: copy_orient can publish a float image intact
+    description: >-
+      Regression test for the probability-map quantisation: copy_orient()
+      hardcoded a uchar cast, so on any non-RPI/LPI input the published
+      MC-dropout uncertainty map collapsed to the two values {0,1} with no
+      warning. The patched function takes a dtype argument; verify a float
+      image round-trips with more than two distinct values.
+    command: |
+      bash -lc '
+      set -e
+      workdir=$(mktemp -d)
+      cd "$workdir"
+      python -c "
+      import numpy as np, nibabel as nib
+      nib.save(nib.Nifti1Image(np.random.RandomState(0).rand(8, 8, 8).astype(\"float32\"), np.eye(4)), \"pc_in.nii.gz\")
+      nib.save(nib.Nifti1Image(np.zeros((8, 8, 8), dtype=\"uint8\"), np.eye(4)), \"pc_ref.nii.gz\")
+      from hypermapper.segment.hypermapper import copy_orient
+      copy_orient(\"pc_in.nii.gz\", \"pc_ref.nii.gz\", \"pc_out.nii.gz\", dtype=\"float\")
+      values = len(np.unique(np.asarray(nib.load(\"pc_out.nii.gz\").dataobj)))
+      assert values > 2, \"quantised: %d distinct values\" % values
+      print(\"float-roundtrip-ok\", values, \"distinct values\")
+      "
+      rm -rf "$workdir"'
+    expected_output_contains: float-roundtrip-ok
+
+  # ==========================================================================
   # EXTERNAL TOOLS
   # ==========================================================================
   - name: Convert3D is available
@@ -225,19 +288,17 @@ tests:
       Runs the default multimodal model over the case that ships in the
       repository and validates the prediction that comes out.
 
-      This asserts the segmentation, not seg_wmh's exit status. Under apptainer
-      the command writes a correct prediction and then exits 1 anyway; the same
-      command exits 0 during the docker build, as root, without HOME, and as an
-      unprivileged user. Since the exit code was the only thing the runner
-      reports, the failure paths are encoded in this test's own exit codes:
+      seg_wmh must now exit 0 on success: the endstatement patch removed the
+      KeyError that previously turned every successful apptainer run into exit
+      status 1, so a non-zero exit is a real failure again. The failure paths
+      are encoded in this test's own exit codes:
         10  could not stage the test case
         11/12/13/14  hypermapper, antsRegistration, c3d or ANTSPATH missing
         20  no prediction written at the -o path
         21  prediction is not a readable NIfTI
         22  prediction is empty: no labelled voxels
-      Reaching those means the tool really is broken. A non-zero exit from
-      seg_wmh with a valid prediction is recorded and tolerated, because the
-      user-visible contract is the segmentation.
+        23  probability map missing or quantised (fewer than 3 distinct values)
+        30  seg_wmh exited non-zero
     timeout: 1800
     command: |
       bash -lc '
@@ -248,10 +309,10 @@ tests:
       command -v antsRegistration >/dev/null 2>&1 || exit 12
       command -v c3d >/dev/null 2>&1 || exit 13
       [ -n "$ANTSPATH" ] || exit 14
-      rc=0
-      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi || rc=$?
+      hypermapper seg_wmh -t1 t1.nii.gz -fl fl.nii.gz -m mask.nii.gz -o wmh_pred.nii.gz -id multi || exit 30
       [ -s wmh_pred.nii.gz ] || exit 20
-      python - <<PYEOF || exit $?
+      subj=$(basename "$workdir")
+      python - "$subj" <<PYEOF || exit $?
       import sys
       import nibabel as nib, numpy as np
       try:
@@ -261,7 +322,14 @@ tests:
           sys.exit(21)
       if not np.any(data > 0):
           sys.exit(22)
-      print("prediction shape", data.shape, "labelled voxels", int((data > 0).sum()))
+      try:
+          prob = nib.load("%s_wmh_prob.nii.gz" % sys.argv[1]).get_fdata()
+      except Exception:
+          sys.exit(23)
+      if len(np.unique(prob)) < 3:
+          sys.exit(23)
+      print("prediction shape", data.shape, "labelled voxels", int((data > 0).sum()),
+            "prob values", len(np.unique(prob)))
       PYEOF
-      echo "segmentation-ok seg_wmh_exit=$rc"'
+      echo "segmentation-ok"'
     expected_output_contains: segmentation-ok

--- a/recipes/hypermapp3r/neurodesk-fixes.patch
+++ b/recipes/hypermapp3r/neurodesk-fixes.patch
@@ -1,0 +1,77 @@
+Neurodesk fixes for HyperMapp3r at commit 00c0b7693c2be27b9aaf6ff43f8547beee313b96.
+Applied by build.yaml with `git apply` right after the pinned checkout; text
+before the first diff header is ignored by git apply.
+
+Three surgical fixes for defects found in the 2026-08 Neurodesk container
+review of hypermapp3r/0.1.0; all three verified against upstream master and
+worth offering upstream:
+
+1. utils/endstatement.py -- seg_wmh exited 1 on every successful run under
+   apptainer. The passwd GECOS field is empty for the runtime user, so the
+   code falls back to os.environ['USER'], and `singularity exec --cleanenv`
+   strips USER: KeyError after the prediction is already written. Use
+   .get() with the passwd username as default.
+
+2. stats/summary_wmh_vols.py -- the subcommand crashed unconditionally with
+   IndexError: wmh_abb has one element but the cols line indexes two. The
+   line is an unedited copy-paste from the sibling hippocampus module.
+
+3. segment/hypermapper.py -- copy_orient() hardcodes `-type uchar`, correct
+   for the binary mask but destructive for the MC-dropout probability map:
+   whenever the input is not already RPI/LPI (i.e. most real data) the
+   published *_wmh_prob.nii.gz was silently quantised to {0,1}. Give
+   copy_orient a dtype argument and publish the probability map as float.
+
+diff --git a/hypermapper/segment/hypermapper.py b/hypermapper/segment/hypermapper.py
+index 1819e34..4c7b318 100755
+--- a/hypermapper/segment/hypermapper.py
++++ b/hypermapper/segment/hypermapper.py
+@@ -241,11 +241,11 @@ def resample_like(img, ref, out, interp=0):
+     c3.inputs.out_file = out
+     c3.run()
+ 
+-def copy_orient(in_img_file, ref_img_file, out_img_file):
++def copy_orient(in_img_file, ref_img_file, out_img_file, dtype="uchar"):
+     print("\n copy orientation ...")
+     c3 = C3d()
+     c3.inputs.in_file = ref_img_file
+-    c3.inputs.args = "%s -copy-transform -type uchar" % in_img_file
++    c3.inputs.args = "%s -copy-transform -type %s" % (in_img_file, dtype)
+     c3.inputs.out_file = out_img_file
+     c3.run()
+ 
+@@ -432,7 +432,7 @@ def main(args):
+             nib.save(pred_res_th, prediction_std_orient)
+             copy_orient(pred_name, t1, prediction)
+ 
+-            copy_orient(pred_prob_name, t1, prediction_prob)
++            copy_orient(pred_prob_name, t1, prediction_prob, dtype="float")
+         else:
+             nib.save(pred_res_th, prediction)
+             nib.save(pred_res, prediction_prob)
+diff --git a/hypermapper/stats/summary_wmh_vols.py b/hypermapper/stats/summary_wmh_vols.py
+index 489aee9..29aa663 100755
+--- a/hypermapper/stats/summary_wmh_vols.py
++++ b/hypermapper/stats/summary_wmh_vols.py
+@@ -65,7 +65,7 @@ def main(args):
+         else:
+             print(subjs_dirs[i], ' is missing')
+ 
+-    cols = ['%s_Volume' % wmh_abb[0], '%s_Volume' % wmh_abb[1]]
++    cols = ['%s_Volume' % a for a in wmh_abb]
+ 
+     df = pd.DataFrame(volume, index=subjs_dirs, columns=cols)
+     df.index.name = 'Subjects'
+diff --git a/hypermapper/utils/endstatement.py b/hypermapper/utils/endstatement.py
+index 5d11143..9b2dedd 100755
+--- a/hypermapper/utils/endstatement.py
++++ b/hypermapper/utils/endstatement.py
+@@ -21,7 +21,7 @@ def main(task=None, timediff=None):
+         user = name.split(" ")[0]
+         user = user.replace(',', '').strip()
+     else:
+-        user = os.environ['USER']
++        user = os.environ.get('USER', pwd.getpwuid(os.getuid()).pw_name)
+ 
+     if 6 < datetime.now().hour < 12:
+         timeday = 'morning'


### PR DESCRIPTION
## Summary

The 2026-08 container review of `hypermapp3r/0.1.0` found three code defects and several README errors. All three code bugs live in upstream glue code (the recipe installs AICONSlab/HyperMapp3r at a pinned commit), so the fixes ship as a git patch applied right after the checkout.

### Code fixes (`recipes/hypermapp3r/neurodesk-fixes.patch`)

1. **`seg_wmh` exited 1 on every successful run.** Under apptainer the runtime user's passwd GECOS field is empty, so `endstatement.py` falls back to `os.environ['USER']` — which `singularity exec --cleanenv` strips. The resulting `KeyError` fired *after* all outputs were written, so every good run reported failure, breaking `set -e` scripts and workflow engines. Fixed with `os.environ.get('USER', pwd.getpwuid(os.getuid()).pw_name)`.
2. **`stats_wmh` crashed unconditionally.** `summary_wmh_vols.py:68` indexed two elements of a one-element list — an unedited copy-paste from the sibling hippocampus module. No input could avoid it. Fixed with a list comprehension.
3. **The MC-dropout probability map was silently quantised to uint8 `{0,1}`.** `copy_orient()` hardcoded `-type uchar`, correct for the binary mask but destructive for `*_wmh_prob.nii.gz` whenever the input was not already RPI/LPI (i.e. most real data). `copy_orient()` now takes a `dtype` argument and the probability map is published as float.

The patch is applied with `git apply` so the build fails loudly if the pinned source ever drifts underneath it. All three fixes were verified against upstream master too and are worth offering upstream.

### Build-time verification

A new build step proves each fix at the layer that applied it: endstatement runs under mocked empty-GECOS/no-`USER` conditions, `stats_wmh` runs end-to-end on a synthetic subject tree, and a float image round-trips through `copy_orient(..., dtype='float')`. The unprivileged end-to-end step now runs with `env -u USER`, reproducing the exact apptainer `--cleanenv` condition through the whole pipeline.

### fulltest.yaml

New "PATCHED DEFECTS" section with runtime regression tests for all three fixes. The end-to-end test now **requires exit code 0** from `seg_wmh` (previously tolerated as always-1) and checks the published probability map is float-valued.

### README corrections

- Default model corrected to `224multi` (the README claimed `multi`; the code default is `224multi`).
- Correct `stats_wmh -i <dir> -o <csv>` and `seg_qc -i FLAIR -s pred` invocations (both documented forms exited 2).
- The mandatory brain mask is now documented, with an `mri_synthstrip` pointer since the container ships no skull-stripper.
- Added: T1/FLAIR must already be coregistered (preprocessing only reslices); outputs land next to the input T1 (copy inputs to scratch, read-only mounts fail); `-t2` is accepted but ignored; runtime figures (~10 min at default `-n 20`, ~1.5 min at `-n 2`).
- Kept the accurate CPU-only rationale, the `224all`/`t1m` no-published-weights note, and the citation.

## Test plan

- [x] `builder/validation.py` passes; `python -m builder generate hypermapp3r --recreate` produces a correct Dockerfile with the patch and checks wired in
- [x] Fulltest contract validator passes (38 tests)
- [x] Patch applies cleanly to a pristine checkout of the pinned commit
- [x] Patched endstatement exercised locally with `USER` unset and empty GECOS
- [ ] CI build (x86_64-only image; the new build steps fail on unpatched source, so a green build proves the fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
