### PR TITLE
Fix deep-quality-estimation --verbose no-op and validate -o path up front

### DIFF
--- a/recipes/deep-quality-estimation/build.yaml
+++ b/recipes/deep-quality-estimation/build.yaml
@@ -188,19 +188,29 @@ files:
                               "device actually used (upstream disables it)")
           a = p.parse_args(argv)
 
+          if a.output:
+              # Checked up front like the inputs: a bad output path otherwise
+              # costs a full inference before failing with a raw traceback.
+              parent = os.path.dirname(os.path.abspath(a.output))
+              if not os.path.isdir(parent):
+                  _fail("output directory does not exist: %s" % parent)
+              if not os.access(parent, os.W_OK):
+                  _fail("output directory is not writable: %s" % parent)
+
           _validate({
               "t1c": a.t1c, "t1": a.t1, "t2": a.t2,
               "flair": a.flair, "segmentation": a.segmentation,
           })
 
+          from deep_quality_estimation import DQE
+
           if a.verbose:
               # Upstream's __init__ calls logger.disable("deep_quality_estimation")
-              # so it stays quiet as a library. A successful run therefore prints
-              # nothing about which device it used.
+              # at import time, so this enable must come after the import above --
+              # the other way round, the import's disable undoes it and the flag
+              # is a silent no-op.
               from loguru import logger
               logger.enable("deep_quality_estimation")
-
-          from deep_quality_estimation import DQE
 
           dqe = DQE(device=a.device, cuda_devices=a.cuda_devices)
           mean_score, view_scores = dqe.predict(

--- a/recipes/deep-quality-estimation/fulltest.yaml
+++ b/recipes/deep-quality-estimation/fulltest.yaml
@@ -76,6 +76,7 @@ tests:
       deep-quality-estimation -t1c t1c.nii.gz $base -s empty.nii.gz 2>&1 | grep -q 'no labelled voxels' && echo "empty-seg-ok"
       deep-quality-estimation -t1c t1c.nii.gz $base -s seg4d.nii.gz 2>&1 | grep -q 'expected a 3D volume' && echo "4d-ok"
       deep-quality-estimation -t1c big.nii.gz $base -s seg.nii.gz 2>&1 | grep -q 'same grid' && echo "shape-mismatch-ok"
+      deep-quality-estimation -t1c t1c.nii.gz $base -s seg.nii.gz -o /nonexistent-dir/out.json 2>&1 | grep -q 'output directory does not exist' && echo "bad-output-ok"
       echo "validation-done"
     expected_output_contains: "validation-done"
 
@@ -84,6 +85,9 @@ tests:
       The README claimed DQE defaults to cuda and that --device cpu is required
       without a GPU. _set_device already auto-detects, so no flag is needed.
       This also covers the critical path end to end and the new -o/--json.
+      --verbose must surface the library's "Using device" line: upstream
+      disables its logger at import time, so an enable placed before the
+      import is silently undone and the flag becomes a no-op.
     timeout: 900
     command: |
       cd "$(mktemp -d)"
@@ -96,7 +100,8 @@ tests:
       nib.save(nib.Nifti1Image(seg,aff), 'seg.nii.gz')
       "
       deep-quality-estimation -t1c t1c.nii.gz -t1 t1.nii.gz -t2 t2.nii.gz \
-          -fla fla.nii.gz -s seg.nii.gz --json -o score.json
+          -fla fla.nii.gz -s seg.nii.gz --json -o score.json --verbose 2>verbose.log
+      grep -q 'Using device' verbose.log && echo "verbose-ok"
       python -c "
       import json
       d = json.load(open('score.json'))


### PR DESCRIPTION
## Summary

The retest of `deep-quality-estimation/0.0.3` (build `20260820`) confirmed four of the six earlier recommendations as fixed, and sent two small items back. Both live in the CLI wrapper this recipe ships, and both are fixed here:

- **`--verbose` was a silent no-op** (retest R4). The wrapper called `logger.enable("deep_quality_estimation")` *before* `from deep_quality_estimation import DQE`, but upstream's `__init__` calls `logger.disable()` at import time, so the import undid the enable and the flag changed nothing — while the README advertised it. The enable now runs after the import, so the library's `Using device: ...` line is surfaced as documented. (The retest isolated this experimentally: enable-after-import emits the log, enable-before does not.)
- **Bad `-o/--output` paths failed late and opaquely** (retest R6 rough edge). An output path whose parent directory did not exist cost a full ~44 s inference before dying with a raw `FileNotFoundError` traceback. The parent directory is now checked right after argument parsing — exists and writable — failing in under a second with a named `error:` line, consistent with the input pre-flight checks this release added.

## Regression guards

`fulltest.yaml` now covers both, as the retest suggested:

- the end-to-end rating test runs with `--verbose` and asserts `Using device` reaches stderr — the one-line check that would have caught the no-op;
- the input-validation test probes a bad `-o` path and asserts the fast named failure.

## Validation

- `python3 builder/validation.py recipes/deep-quality-estimation/build.yaml` passes
- Dockerfile regenerates; staged wrapper parses as valid Python, with enable-after-import and output-check-before-validate ordering verified programmatically
- The staged script run directly with a bad `-o` path fails immediately with `error: output directory does not exist: ...`, exit code 1

Note: the upstream wheel is unchanged, so this stays `0.0.3` and will produce a third build of that version — as the retest noted, bug reports should quote the image name, not the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)