### PR TITLE
Readme only: note BrainLesion Suite membership in every suite tool

### DIFF
--- a/recipes/brainles-aurora/build.yaml
+++ b/recipes/brainles-aurora/build.yaml
@@ -331,6 +331,8 @@ readme: |-
   AURORA segments brain metastases from multi-modal MR images using pretrained
   deep learning models.
 
+  Part of the BrainLesion Suite (BLS): https://github.com/BrainLesion
+
   ### Example
 
   ```

--- a/recipes/brats/build.yaml
+++ b/recipes/brats/build.yaml
@@ -421,6 +421,8 @@ readme: |-
   challenges: adult and paediatric glioma, meningioma, brain metastasis and
   sub-Saharan Africa segmentation, plus inpainting and missing-MRI synthesis.
 
+  Part of the BrainLesion Suite (BLS): https://github.com/BrainLesion
+
   ### Read this first: no algorithms are bundled
 
   This container is an orchestrator. It contains no model and no weights. Each

--- a/recipes/deep-quality-estimation/build.yaml
+++ b/recipes/deep-quality-estimation/build.yaml
@@ -269,6 +269,8 @@ readme: |-
   Deep Quality Estimation rates BraTS glioma segmentation quality on a one to
   six star scale.
 
+  Part of the BrainLesion Suite (BLS): https://github.com/BrainLesion
+
   ### Example
 
   ```

--- a/recipes/modsort/build.yaml
+++ b/recipes/modsort/build.yaml
@@ -158,6 +158,8 @@ readme: |-
   desktop interface, then copies and renames the files into the structure you
   choose. It is a graphical tool: there is no batch or command line mode.
 
+  Part of the BrainLesion Suite (BLS): https://github.com/BrainLesion
+
   ### Input format
 
   modsort is **NIfTI only**. Its drop targets are BraTS-style modality tags --

--- a/recipes/petu/build.yaml
+++ b/recipes/petu/build.yaml
@@ -239,6 +239,8 @@ readme: |-
   PeTu segments paediatric brain tumours into enhancing tumour (ET), cystic
   component (CC) and T2-hyperintense (T2H) regions from multi-parametric MRI.
 
+  Part of the BrainLesion Suite (BLS): https://github.com/BrainLesion
+
   ### Input requirements
 
   Inputs must already be skull-stripped, co-registered and resampled to the


### PR DESCRIPTION
Documentation-only change: no build directives, versions or tests are touched.

Adds the uniform line `Part of the BrainLesion Suite (BLS): https://github.com/BrainLesion` after the readme intro of the five suite tools already merged on main:

- brainles-aurora
- brats
- petu
- modsort
- deep-quality-estimation

This matches the same line already added to the three suite tools with open PRs (#3061, #3062, #3063). The `brainlesion` bundle is deliberately left untouched: its readme already opens by identifying itself as the BrainLesion Suite and links the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)