### PR TITLE
Run the release-PR container tests on the ARC pool

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -42,9 +42,22 @@ jobs:
   test-containers:
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'
-    runs-on: self-hosted
+    runs-on: neurodesk-arcrunner-release-test
+    # The pool runs on syd3 with maxRunners 2. Serialise to one leg anyway while the
+    # migration is being proven, so a red result is unambiguous: extra legs then queue
+    # visibly here rather than looking like a stuck runner. Raise it once the first
+    # runs are green. Note this serialises within a run only; separate PRs still
+    # contend for the pool.
+    #
+    # 110 rather than 120: the pod's activeDeadlineSeconds is 7200s, and its clock
+    # starts at pod start while this one starts only once the runner has booted,
+    # registered and been assigned. At 120 the kubelet reap always wins that race by
+    # 30-60s, so the job reports "lost communication with the server" instead of the
+    # clean timeout this exists to give. Per-leg, not cumulative; ants measures 19 min.
+    timeout-minutes: 110
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         release: ${{ fromJson(needs.detect-changes.outputs.modified-releases) }}
 
@@ -79,8 +92,10 @@ jobs:
       - name: Install dependencies
         working-directory: source
         run: |
-          # Matrix jobs can share the same self-hosted machine and system Python.
-          # Serialize dependency installation to avoid pip/apt/git-annex races.
+          # On the VMs matrix legs shared a machine and system Python, so this lock
+          # avoided pip/apt/git-annex races. On ephemeral runners each leg is its own
+          # pod: the lock is a no-op and every leg reinstalls from scratch. Kept so the
+          # job stays correct on either runner.
           (
             flock 9
             python -m pip install --upgrade pip
@@ -97,6 +112,37 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # release_test_runner downloads the .simg into its cache dir and then copies it
+      # into <output-dir>/fulltest-containers, but skips that copy when the two resolve
+      # to the same path (release_test_runner.py:275-278). Point the cache straight at
+      # the containers directory so a large artifact is stored once, not twice: at two
+      # copies the largest release (mrsiproc 0.2.0, 24.75 GiB) would peak at 49.5 GiB of
+      # a 60 GiB volume, which is a margin the next big recipe eats.
+      #
+      # This also keeps the download off $HOME. The work volume mounts at
+      # /home/runner/_work, NOT at $HOME, so $HOME/.cache is the container writable layer
+      # and counts against the pod's ephemeral-storage limit (8Gi). Exceeding that gets
+      # the pod evicted by the kubelet mid-job, which would hit every release container
+      # over roughly 8 GiB rather than only the largest few.
+      - name: Stage the SIF cache on the work volume
+        run: |
+          set -euo pipefail
+          WS="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE unset - refusing to cache a multi-GB SIF on $HOME}"
+          CONTAINERS_DIR="$WS/source/builder/fulltest-containers"
+          mkdir -p "$CONTAINERS_DIR" "$HOME/.cache"
+          # builder/recipe.py and builder/template.py use this same path for the
+          # get_file cache. On a runner pod $HOME is per-job, so it is always absent
+          # here; on the persistent VMs it is shared and holds a multi-GB cache that
+          # manual-build.yml also uses. Refuse rather than delete, so reverting this
+          # workflow to runs-on: self-hosted cannot destroy it.
+          CACHE_LINK="$HOME/.cache/neurocontainers"
+          if [ -e "$CACHE_LINK" ] && [ ! -L "$CACHE_LINK" ]; then
+            echo "::error::${CACHE_LINK} exists and is not a symlink. This step expects a per-job HOME (runner pods); on a shared HOME that path is the get_file cache and must not be replaced. Refusing rather than deleting it."
+            exit 1
+          fi
+          ln -sfn "$CONTAINERS_DIR" "$CACHE_LINK"
+          echo "SIF cache -> $(readlink -f "$CACHE_LINK")"
 
       # Apptainer is not in the stock GitHub/ARC runner image. The standalone VMs
       # only have it because it was pre-installed there, so install it when it is

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -43,17 +43,13 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'
     runs-on: neurodesk-arcrunner-release-test
-    # The pool runs on syd3 with maxRunners 2. Serialise to one leg anyway while the
-    # migration is being proven, so a red result is unambiguous: extra legs then queue
-    # visibly here rather than looking like a stuck runner. Raise it once the first
-    # runs are green. Note this serialises within a run only; separate PRs still
-    # contend for the pool.
+    # Do not raise max-parallel. maxRunners 2 is insurance against ARC #4307, not spare
+    # throughput, and keeping this at 1 is what leaves the second slot free. Revisit
+    # only when #4307 lands or syd1 retires.
     #
-    # 110 rather than 120: the pod's activeDeadlineSeconds is 7200s, and its clock
-    # starts at pod start while this one starts only once the runner has booted,
-    # registered and been assigned. At 120 the kubelet reap always wins that race by
-    # 30-60s, so the job reports "lost communication with the server" instead of the
-    # clean timeout this exists to give. Per-leg, not cumulative; ants measures 19 min.
+    # 110 not 120: 120 ties the pod's activeDeadlineSeconds, whose clock starts earlier,
+    # so the kubelet reap wins and the job reports "lost communication with the server"
+    # instead of a clean timeout.
     timeout-minutes: 110
     strategy:
       fail-fast: false
@@ -92,10 +88,8 @@ jobs:
       - name: Install dependencies
         working-directory: source
         run: |
-          # On the VMs matrix legs shared a machine and system Python, so this lock
-          # avoided pip/apt/git-annex races. On ephemeral runners each leg is its own
-          # pod: the lock is a no-op and every leg reinstalls from scratch. Kept so the
-          # job stays correct on either runner.
+          # Serialises dependency installation: on the VMs legs shared a machine. A no-op
+          # on ephemeral runners; kept so the job stays correct on either.
           (
             flock 9
             python -m pip install --upgrade pip
@@ -113,29 +107,19 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      # release_test_runner downloads the .simg into its cache dir and then copies it
-      # into <output-dir>/fulltest-containers, but skips that copy when the two resolve
-      # to the same path (release_test_runner.py:275-278). Point the cache straight at
-      # the containers directory so a large artifact is stored once, not twice: at two
-      # copies the largest release (mrsiproc 0.2.0, 24.75 GiB) would peak at 49.5 GiB of
-      # a 60 GiB volume, which is a margin the next big recipe eats.
-      #
-      # This also keeps the download off $HOME. The work volume mounts at
-      # /home/runner/_work, NOT at $HOME, so $HOME/.cache is the container writable layer
-      # and counts against the pod's ephemeral-storage limit (8Gi). Exceeding that gets
-      # the pod evicted by the kubelet mid-job, which would hit every release container
-      # over roughly 8 GiB rather than only the largest few.
+      # Point the cache at the containers dir so release_test_runner skips its copy (one
+      # artifact on disk, not two), and so the download stays off $HOME, which counts
+      # against the pod's 8Gi ephemeral-storage limit and would evict the pod mid-job for
+      # any container over ~8 GiB.
       - name: Stage the SIF cache on the work volume
         run: |
           set -euo pipefail
           WS="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE unset - refusing to cache a multi-GB SIF on $HOME}"
           CONTAINERS_DIR="$WS/source/builder/fulltest-containers"
           mkdir -p "$CONTAINERS_DIR" "$HOME/.cache"
-          # builder/recipe.py and builder/template.py use this same path for the
-          # get_file cache. On a runner pod $HOME is per-job, so it is always absent
-          # here; on the persistent VMs it is shared and holds a multi-GB cache that
-          # manual-build.yml also uses. Refuse rather than delete, so reverting this
-          # workflow to runs-on: self-hosted cannot destroy it.
+          # builder/recipe.py and builder/template.py use this path for the get_file
+          # cache, which is shared on the VMs. Refuse rather than delete so reverting
+          # runs-on to self-hosted cannot destroy it.
           CACHE_LINK="$HOME/.cache/neurocontainers"
           if [ -e "$CACHE_LINK" ] && [ ! -L "$CACHE_LINK" ]; then
             echo "::error::${CACHE_LINK} exists and is not a symlink. This step expects a per-job HOME (runner pods); on a shared HOME that path is the get_file cache and must not be replaced. Refusing rather than deleting it."
@@ -144,12 +128,9 @@ jobs:
           ln -sfn "$CONTAINERS_DIR" "$CACHE_LINK"
           echo "SIF cache -> $(readlink -f "$CACHE_LINK")"
 
-      # Apptainer is not in the stock GitHub/ARC runner image. The standalone VMs
-      # only have it because it was pre-installed there, so install it when it is
-      # missing. Skipping when present keeps this genuinely inert on the VMs: no
-      # apt-get (which would race the dpkg lock against sibling matrix legs sharing
-      # the machine) and no risk of changing the Apptainer version under tests that
-      # currently pass.
+      # Apptainer is absent from the stock runner image; the VMs only have it because
+      # it was preinstalled. Skipping when present keeps this inert there: no apt-get
+      # racing the dpkg lock, no version change under passing tests.
       - name: Check for Apptainer
         id: apptainer-check
         run: |
@@ -159,18 +140,14 @@ jobs:
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # NOTE: this job checks out with `path: source`, so a local action must be
-      # referenced through that path - `./.github/actions/...` resolves against
-      # GITHUB_WORKSPACE, which is empty here.
+      # `path: source` checkout, so the local action needs that prefix.
       - name: Install Apptainer
         if: steps.apptainer-check.outputs.present != 'true'
         uses: ./source/.github/actions/setup-apptainer
         with:
           apptainer-version: 1.4.3
 
-      # Defensive, and currently unused: this job only exec's a downloaded .simg, so
-      # Apptainer needs no build cache. Kept so a runner without a writable $HOME
-      # has somewhere to go if that changes.
+      # Defensive: unused today (this job only exec's a downloaded .simg).
       - name: Prepare Apptainer scratch directories
         if: steps.apptainer-check.outputs.present != 'true'
         run: |

--- a/recipes/ants/fulltest.yaml
+++ b/recipes/ants/fulltest.yaml
@@ -4,6 +4,10 @@
 # ANTs is a state-of-the-art medical image registration and segmentation toolkit.
 # It provides tools for image registration, bias correction, segmentation, and more.
 #
+# Wall clock: 19 min end to end (run 32099604861, 2026-08-18). Dominated by the
+# datalad fetch of ds000001 and the registration/denoising steps - the image
+# itself is only 0.31 GiB.
+#
 # Test data: ds000001/sub-01 (OpenNeuro Balloon Analog Risk-taking Task)
 #   - T1w: 160x192x192, 1x1.33x1.33mm (3D structural)
 #   - BOLD: 64x64x33x300, 3.125x3.125x4mm, TR=2s (4D functional)


### PR DESCRIPTION
## Problem

`test-containers` runs on eight standalone VMs that are being decommissioned. It is the
last workflow that automatically uses them.

## Changes

- **`runs-on` → `neurodesk-arcrunner-release-test`** (no-DinD scale set, runner group
  `runner-neurocontainers`, repository list is this repo alone).
- **`max-parallel: 1`** while the migration is proven, so a red result is not confounded
  by contention. Raise once the first runs are green.
- **`timeout-minutes: 110`**, replacing the 360 default. Not 120: that equals the pod's
  `activeDeadlineSeconds`, whose clock starts earlier, so the kubelet reap wins and the
  job reports "lost communication with the server" instead of a clean timeout.
- **SIF cache staged on the work volume**, pointed at the containers directory.
  `release_test_runner` skips its copy when source and target resolve to the same path,
  so the artifact is stored once, not twice (at two copies the largest release,
  `mrsiproc 0.2.0`, peaks at 49.5 GiB of a 60 GiB volume). It also keeps the download
  off `$HOME`, which counts against the pod's 8Gi ephemeral-storage limit and would
  evict the pod mid-job for any container over ~8 GiB.
- **Refuse rather than delete** if that path exists and is not a symlink.
  `builder/recipe.py` and `builder/template.py` use it for the `get_file` cache, which
  is shared on the VMs, so reverting `runs-on` must not wipe it.

## ANTs change

Comment-only, recording the measured suite wall clock. It is also the trigger: the
`paths:` filter is `releases/*/**.json` and `recipes/**/fulltest.yaml`, so a
workflow-only edit never runs the workflow it changes and this would otherwise merge
unproven. ANTs has not drifted from its recipe, its artifact is 0.31 GiB and identical
on both mirrors, and its suite passed on that exact artifact in run `32099604861` - so a
red result indicts the pool, not the recipe.

## Notes

- A Dive warning is expected and is not a failure: the pool has no Docker daemon, and
  the step is `set +e` / `exit 0`.
- Do not merge on green checks alone. The only required check runs on `ubuntu-22.04`, so
  a queued `test-containers` would not block a merge. Merge only once it has executed.
