### PR TITLE
Validate the ARC release-test pool on a large artifact (braid, 14.49 GiB)

### DIFF
--- a/recipes/braid/fulltest.yaml
+++ b/recipes/braid/fulltest.yaml
@@ -1,3 +1,5 @@
+# Artifact: braid_1.0.0_20260722.simg, 14.49 GiB - the largest container covered by
+# these suites. Download dominates the run time.
 name: braid
 version: 1.0.0
 default_timeout: 60


### PR DESCRIPTION
## Purpose

Large-artifact validation of the ARC release-test pool, following #3067.

`braid_1.0.0_20260722.simg` is 14.49 GiB - the largest container these suites cover, and
byte-identical on S3 and Nectar. #3067 was proven on ants at 0.31 GiB, which exercises the
mechanism but not the volume.

## What this checks

- A multi-GB artifact downloads and runs on the pool without exhausting the 60 GiB work
  volume. With the copy-skip from #3067 there is one copy on disk, not two, so this should
  sit at roughly 25% of the volume.
- The download stays off `$HOME`, which counts against the pod's 8Gi ephemeral-storage
  limit. Before #3067 this artifact would have evicted the pod mid-job.
- Whether the run fits inside `timeout-minutes: 110`.

## Expected

Roughly 45-50 minutes, of which about 28 is the S3 download at the 8.7-13.5 MB/s measured
from inside a syd3 pod. Slow here means the trans-Pacific pull, not the pool. The same
artifact from Nectar at ~124 MB/s would be about two minutes, which is the argument for
switching the downloader to size+ETag comparison rather than S3-first.

A Dive warning is expected and is not a failure: the pool has no Docker daemon.

## Note

The change is a comment only. This PR exists to trigger the run - `test-release-pr.yml`
filters on `releases/*/**.json` and `recipes/**/fulltest.yaml`, so a run cannot be
dispatched without touching one of them. It can be closed unmerged once the result is
recorded.
