### PR TITLE
brainlesion: make preprocessing and brain extraction usable

### DIFF
--- a/recipes/brainlesion/bake_atlases.py
+++ b/recipes/brainlesion/bake_atlases.py
@@ -1,0 +1,67 @@
+"""Bake the registration atlases into the image.
+
+`AtlasCentricPreprocessor` -- what the `preprocessor` command builds -- defaults
+to `Atlas.BRATS_SRI24` and calls `fetch_atlases()` to get it. That downloads
+into `brainles_preprocessing/registration/atlases`, inside the installed
+package, which is read-only once the image is built, so the command failed
+within seconds of starting with its own default settings:
+
+    OSError: [Errno 30] Read-only file system:
+    '.../site-packages/brainles_preprocessing/registration/atlases'
+
+This is the same defect the $BLS_WEIGHTS_DIR redirect fixes for gliomoda, petu,
+brainles_aurora and brainles_hd_bet. The atlases are not weights and were not
+covered by it. They are baked in rather than redirected because they are ~92 MB
+for the whole record and the SRI24 template is what makes this bundle able to
+produce the atlas-space input that gliomoda, petu and AURORA all require -- so
+the preprocessing entry point works offline, as the standalone
+brainles-preprocessing container already does.
+
+The layout matters as much as the files. ZenodoRecord globs for
+"<record_id>_v*.*.*" inside the target directory and treats a bare directory of
+files as "nothing downloaded yet", so the files go into
+<target>/<record_id>_v<version>/ exactly as _build_folder_path would.
+
+Files are fetched individually rather than through upstream's fetch, which
+requests Zenodo's files-archive endpoint: that endpoint is unreliable for these
+records, while the per-file API works.
+"""
+
+import json
+import pathlib
+import shutil
+import zipfile
+from urllib.request import urlopen
+
+from brainles_preprocessing.utils import zenodo as z
+
+
+def bake(record_id, target_dir, label):
+    target_dir = pathlib.Path(target_dir)
+    with urlopen(f"https://zenodo.org/api/records/{record_id}") as r:
+        record = json.loads(r.read().decode())
+    version = record["metadata"]["version"]
+    # Same name ZenodoRecord._build_folder_path() would produce, so
+    # fetch_atlases() finds this copy instead of trying to download.
+    folder = target_dir / f"{record_id}_v{version}"
+    folder.mkdir(parents=True, exist_ok=True)
+
+    files = record.get("files", [])
+    if not files:
+        raise SystemExit(f"{label}: record {record_id} lists no files")
+    for entry in files:
+        name = entry["key"]
+        out = folder / name
+        if out.exists():
+            continue
+        print(f"{label}: downloading {name}", flush=True)
+        with urlopen(entry["links"]["self"]) as resp, open(out, "wb") as fh:
+            shutil.copyfileobj(resp, fh)
+        if name.endswith(".zip"):
+            with zipfile.ZipFile(out) as zf:
+                zf.extractall(folder)
+            out.unlink()
+    print(f"{label}: ready at {folder}", flush=True)
+
+
+bake(z.ATLASES_RECORD_ID, z.ATLASES_FOLDER, "atlases")

--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -21,6 +21,14 @@ structured_readme:
     EOF
   documentation: https://github.com/BrainLesion/
   citation: 'Kofler, F., Rosier, M., Astaraki, M., Möller, H., Mekki, I. I., Buchner, J. A., Schmick, A., Pfiffer, A., Oswald, E., Zimmer, L., Rosa, E. de la, Pati, S., Canisius, J., Piffer, A., Baid, U., Valizadeh, M., Linardos, A., Peeken, J. C., Shit, S., … Menze, B. (2025). BrainLesion Suite: A Flexible and User-Friendly Framework for Modular Brain Lesion Image Analysis arXiv preprint arXiv:2507.09036'
+variables:
+  # Version of the registration atlases baked into the image. The record id is
+  # a Zenodo concept DOI, which always resolves to the newest release, so
+  # without this the build silently takes whatever is current that day. Bumping
+  # it is a deliberate act; see pin_atlases.py for why a rebuild is the only
+  # way a container gets newer atlases.
+  atlas_version: "2.0.0"
+
 build:
   kind: neurodocker
   base-image: ubuntu:24.04
@@ -56,8 +64,22 @@ build:
         # time, so `preprocessor` failed within seconds using nothing but its
         # own defaults. ~92 MB, and it makes the command work offline.
         - python {{ get_file("bake_atlases.py") }}
+        # What was baked has to be the release this recipe declares. The record
+        # id is a concept DOI, so without this the image quietly takes whatever
+        # Zenodo served that day and nothing ever says so.
+        - >-
+          python -c "import pathlib; from brainles_preprocessing.utils import zenodo as z; found=sorted(p.name for p in pathlib.Path(z.ATLASES_FOLDER).glob(z.ATLASES_RECORD_ID+'_v*')); want=z.ATLASES_RECORD_ID+'_v{{ context.atlas_version }}'; assert found==[want], 'expected '+want+', found '+str(found)+' -- upstream published new atlases, bump atlas_version'; print('atlases pinned at', want)"
+        # Baking alone only fixes the first run. fetch() asks Zenodo before it
+        # looks at the disk, and deletes the local copy when the versions
+        # differ -- inside a read-only image. See pin_atlases.py.
+        - python {{ get_file("pin_atlases") }}
         - >-
           python -c "from brainles_preprocessing.utils.zenodo import fetch_atlases; from brainles_preprocessing.constants import Atlas; p=fetch_atlases()/Atlas.BRATS_SRI24.value; assert p.is_file(), p; print('atlases resolve to', p)"
+        # The pin has to survive Zenodo advertising something newer, which is
+        # the only case that ever crashed. Asserted here as well as in the
+        # fulltest because it is the whole point of the previous step.
+        - >-
+          python -c "from brainles_preprocessing.utils import zenodo as z; asked=[]; z.ZenodoRecord._get_metadata_and_archive_url=lambda self: (asked.append(1), ({'version':'99.0.0'},''))[1]; p=z.fetch_atlases(); assert p.name.endswith('_v{{ context.atlas_version }}'), p; assert not asked, 'zenodo queried at run time'; print('atlas pin survives an upstream version bump')"
         # panoptica 2.x builds its instance-label lookup with the dtype of the
         # connected-components array, so multi-lesion evaluations fail once
         # reference plus unmatched predicted instances exceed 255. Fixed on
@@ -159,6 +181,8 @@ files:
     filename: fix_hd_bet_cli.py
   - name: bake_atlases.py
     filename: bake_atlases.py
+  - name: pin_atlases
+    filename: pin_atlases.py
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAA4hJREFUSEvtlV1MW2UYx3+npYcOus51UMYcH6NlfpAZiSFFTYWwjWEzEnWhFAaYsU0YJXOZnQkxXphseMFmAtFCjGZtsl3Mqy3DLJELNQtW0UTC3A2ouAxBFmI/oF0K/TA9kyb9AOut8SQnOTnv/zy/5/k/z/seoWy8I0qGV65cicd/lsVgKMMvQPgf8E9e/YcsigTW8F69i9sxlVC1qN+Oqr6M7KfzEGZXmL80nuKKsGcvsmeqEKrrkD31LIjZcU3conXAYJ2N9vb2hCA+n4/W1la+ic5gKdmP3W5PWA+FQkxPT1PbYMJ9zIas6iWQyyWNcOpHU1SQ7+J7t4KfL48ztP8cZrOZ8vJyZDIZer2e0dFR/H4/j1fpOXbIIgGqq6tZXl6WgphMJgYGBhgbG+PlD528eLSByvxsOgPXEc7/oJU2WtbqDm45gpwwvkdTUxNKpTKe5eTkJDqdDo1uJyeOdEgAjUaD2+2Oa7xeLwsLC5w+XofdvEbh1sCjCtYBwUCU284Ax2tHJDscDgeCIEgVGI1GKejZi+/Q2dAiPRsMBjwej5SIxWKhr6+PwcFBvvvMRr9ZRKsWNga0tbWxtLQkCXJycqTb5XJxoOUwr5uaU3oQ0wWDQbRaLf2vBml5IQul4lFxaStItqi7u5vh4WEqKiqoqamJ9yBmiyiKdHV10dPTw9DQEH9+fQ7rQQW5fw9SRoDS0lJmZ2fp7e0lEonEe/B8iY/8rQLO2yFpCCYmJrh2vp53X1HwWO4mFjU3N9PY2CiVWFlZic1mk5qqVqulEY71oGhXHiNH/ZTkCbx1dRXnF3PMz8/T323gglmkaMcGgM6a4ZR9EBtHq9XKzdEJWix1EqCwoIBPOnyU75TRd22V96/cJVZpcUEOl08qMD4pRyak6cFXn/rTnl/btukoKm7gpzsfSeuiqOLjMwbqi118cGuNi5+vSe/z1QLOruxUQHgtyh8zYfyeSBywJWs7K65LeLxbUKv3EAx68K/8DkQRBDnagr3YDx7mt/uL/PogQjgCchk8UShjtybJonRph6YucP9b86Yn8r6SXzhZaNxQE5+iZEVk5k3ufdm7afD1xdf2XaE29+202rQA1cMD3Lsxgs+X2e9aqRQ4/dwpdoevp0BSAKJchf/mFHNz4YyyXxfFrHqj7AjRhw8SvksBZOL7RuR0ViUAVItnuHPD+q8yTxYnQ/4CysSosaI6GD0AAAAASUVORK5CYII=
 categories:
   - structural imaging
@@ -229,6 +253,42 @@ readme: |-
   Left alone, both settings keep upstream's values, so a run that says nothing
   about brain extraction produces what the standalone module produces.
 
+  #### `preprocessor` output is not bit-reproducible
+
+  Two runs of this image over the same four inputs, with the same flags and the
+  same thread count, produce slightly different BraTS-space output. Measured
+  across twelve artefacts, none of which matched bit for bit:
+
+  ```
+  atlas-space t1c_skull_raw     support Dice 0.9952   -5 802 voxels (-0.106%)
+  atlas-space fla_skull_raw     support Dice 0.9909  -12 017 voxels (-0.227%)
+  deface t1c_defacing_mask      support Dice 0.9968   +9 360 voxels (+0.125%)
+  brain-extraction t1c_bet_mask support Dice 0.9938     -201 voxels (-0.013%)
+  ```
+
+  The divergence starts at co-registration and propagates; the segmentation
+  models are not the cause. gliomoda, petu and HD-BET each reproduce to the
+  voxel in the same test, so nnU-Net here is deterministic. This is ANTs
+  behaviour, not something this container introduced: `ANTsRegistrator` sets no
+  seed, and antspyx 0.6.3's `ants.registration` takes no seed argument.
+
+  The practical consequence: preprocess-then-segment does not reproduce
+  exactly. Re-running preprocessing gives a marginally different atlas-space
+  volume and therefore a marginally different segmentation. Preprocess once and
+  keep the outputs if you need a fixed reference; do not expect to regenerate
+  them byte-for-byte later.
+
+  Two notes for anyone who tries to fix this. `ANTS_RANDOM_SEED` does nothing
+  here -- the string does not occur anywhere in antspyx 0.6.3, so setting it in
+  the environment has no effect. The lever that does exist is
+  `ants.config.set_ants_deterministic(on=True, seed_value=N)`, which appends
+  `--random-seed N` to the antsRegistration arguments and pins
+  `ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS` to 1. This container does not enable
+  it: single-threaded ITK has an unmeasured cost on a pipeline that already
+  takes ~11 minutes, and whether it actually makes this pipeline bit-identical
+  has not been measured either. Both statements above about antspyx come from
+  reading the installed package, not from running it.
+
   ### GPU and CPU
 
   `gliomoda`, `petu` and `AtlasCentricPreprocessor` default to a GPU and do not
@@ -281,6 +341,16 @@ readme: |-
 
   This image carries a patch to panoptica's instance relabelling, which
   otherwise overflows once an evaluation involves more than 255 instance labels.
+
+  The registration atlases are baked in and pinned. Upstream re-checks Zenodo
+  on every run and replaces the local copy when a newer release appears, which
+  cannot work inside a read-only image, so the lookup is disabled here: what
+  ships in the image is what runs, and picking up newer atlases needs a rebuild
+  of this container. This is also what makes the offline claim above true.
+
+  `preprocessor` output is not bit-reproducible between runs. See
+  "Preprocessing on a node without a GPU" above for the measured magnitude and
+  what it means for a preprocess-then-segment workflow.
 
   More documentation can be found here: https://github.com/BrainLesion/
 copyright:

--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -73,7 +73,12 @@ build:
         # first thing a user saw was a traceback from `hd-bet --help`. One
         # invocation per deployed command is what catches that.
         - /opt/miniconda/bin/preprocessor --help > /dev/null && echo "preprocessor CLI ok"
-        - /opt/miniconda/bin/preprocessor --help | grep -q -- '--bet-mode' && echo "bet profile selectable"
+        # Ask click what the command registered rather than grepping rendered
+        # help: the negative half of a boolean flag lands in secondary_opts and
+        # its appearance in --help depends on how rich lays the table out at
+        # whatever width it guesses.
+        - >-
+          python -c "import typer; from brainles_preprocessing import cli; c=typer.main.get_command(cli.app); n=set(); [n.update(p.opts+p.secondary_opts) for p in c.params]; need={'--bet-mode','--bet-tta','--no-bet-tta'}; assert need <= n, 'missing '+str(sorted(need-n)); print('bet profile selectable')"
         - /opt/miniconda/bin/hd-bet --help > /dev/null && echo "hd-bet CLI ok"
         # A failed extraction must not look like a success. Upstream printed a
         # message and returned normally, so a pipeline checking the exit code

--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -35,6 +35,11 @@ build:
         - python -m pip install --no-cache-dir --no-deps brainles-aurora==0.2.7 brainles-preprocessing==0.6.10
         - python {{ get_file("fix_aurora_import") }}
         - python {{ get_file("fix_preprocessor_cli") }}
+        # The `hd-bet` command imports a helper its own package never defines,
+        # so it died on import before parsing an argument -- and the library
+        # both it and the preprocessor use returned 0 after an extraction that
+        # produced nothing.
+        - python {{ get_file("fix_hd_bet_cli") }}
         # Every DL component resolves its weights cache inside its own installed
         # package, which is read-only at run time, so inference died with
         # "OSError: [Errno 30] Read-only file system" before doing anything.
@@ -45,6 +50,14 @@ build:
         # first use rather than baked in: together they are several GB and most
         # users need one component.
         - python {{ get_file("bls_writable_weights") }}
+        # The atlases are the one weight-like asset that redirect does not
+        # cover: AtlasCentricPreprocessor defaults to Atlas.BRATS_SRI24 and
+        # fetches it into the installed package, which is read-only at run
+        # time, so `preprocessor` failed within seconds using nothing but its
+        # own defaults. ~92 MB, and it makes the command work offline.
+        - python {{ get_file("bake_atlases.py") }}
+        - >-
+          python -c "from brainles_preprocessing.utils.zenodo import fetch_atlases; from brainles_preprocessing.constants import Atlas; p=fetch_atlases()/Atlas.BRATS_SRI24.value; assert p.is_file(), p; print('atlases resolve to', p)"
         # panoptica 2.x builds its instance-label lookup with the dtype of the
         # connected-components array, so multi-lesion evaluations fail once
         # reference plus unmatched predicted instances exceed 255. Fixed on
@@ -53,9 +66,23 @@ build:
         - python {{ get_file("fix_map_labels_dtype") }}
         - >-
           python -c "import numpy as np; from panoptica._functionals import _map_labels; a=np.zeros((4,4),dtype=np.uint8); a[0,0]=3; assert int(_map_labels(a,{3:256}).max())==256; print('instance relabelling handles >255 labels')"
-        # finding 4: both exist at /opt/miniconda/bin but were never exposed
-        - test -x /opt/miniconda/bin/preprocessor
-        - test -x /opt/miniconda/bin/hd-bet
+        # finding 4: both exist at /opt/miniconda/bin but were never exposed.
+        #
+        # Run them rather than testing the executable bit. `test -x` passed on
+        # an `hd-bet` that could not start at all: it dies on import, so the
+        # first thing a user saw was a traceback from `hd-bet --help`. One
+        # invocation per deployed command is what catches that.
+        - /opt/miniconda/bin/preprocessor --help > /dev/null && echo "preprocessor CLI ok"
+        - /opt/miniconda/bin/preprocessor --help | grep -q -- '--bet-mode' && echo "bet profile selectable"
+        - /opt/miniconda/bin/hd-bet --help > /dev/null && echo "hd-bet CLI ok"
+        # A failed extraction must not look like a success. Upstream printed a
+        # message and returned normally, so a pipeline checking the exit code
+        # carried on with a mask that was never written. Asserted on the
+        # installed source rather than by running an extraction, which would
+        # pull the five fold weight files this image deliberately does not
+        # bake in.
+        - >-
+          python -c "import inspect; from brainles_hd_bet import run as r; s=inspect.getsource(r.run_hd_bet); assert 'hd-bet could not read' in s and 'hd-bet rejected' in s, 'silent-failure patch is not in place'; print('failed extraction raises')"
     - environment:
         # Where the components cache their weights. Point this at persistent
         # storage so the download happens once rather than every session.
@@ -100,6 +127,20 @@ build:
           assert os.access(base, os.W_OK), base
           print('weights dir writable:', base)
           "
+          # Every deployed command must start. Checking the executable bit
+          # passed on an hd-bet that died on import.
+          preprocessor --help > /dev/null && echo "preprocessor runs"
+          hd-bet --help > /dev/null && echo "hd-bet runs"
+          # The atlas the preprocessor defaults to must resolve inside the
+          # image: fetching it at run time is what made the default settings
+          # fail on the read-only filesystem.
+          python -c "
+          from brainles_preprocessing.constants import Atlas
+          from brainles_preprocessing.utils.zenodo import fetch_atlases
+          atlas = fetch_atlases() / Atlas.BRATS_SRI24.value
+          assert atlas.is_file(), atlas
+          print('default atlas bundled:', atlas)
+          "
 files:
   - name: fix_aurora_import
     filename: fix_aurora_import.py
@@ -109,6 +150,10 @@ files:
     filename: bls_writable_weights.py
   - name: fix_map_labels_dtype
     filename: fix_map_labels_dtype.py
+  - name: fix_hd_bet_cli
+    filename: fix_hd_bet_cli.py
+  - name: bake_atlases.py
+    filename: bake_atlases.py
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAA4hJREFUSEvtlV1MW2UYx3+npYcOus51UMYcH6NlfpAZiSFFTYWwjWEzEnWhFAaYsU0YJXOZnQkxXphseMFmAtFCjGZtsl3Mqy3DLJELNQtW0UTC3A2ouAxBFmI/oF0K/TA9kyb9AOut8SQnOTnv/zy/5/k/z/seoWy8I0qGV65cicd/lsVgKMMvQPgf8E9e/YcsigTW8F69i9sxlVC1qN+Oqr6M7KfzEGZXmL80nuKKsGcvsmeqEKrrkD31LIjZcU3conXAYJ2N9vb2hCA+n4/W1la+ic5gKdmP3W5PWA+FQkxPT1PbYMJ9zIas6iWQyyWNcOpHU1SQ7+J7t4KfL48ztP8cZrOZ8vJyZDIZer2e0dFR/H4/j1fpOXbIIgGqq6tZXl6WgphMJgYGBhgbG+PlD528eLSByvxsOgPXEc7/oJU2WtbqDm45gpwwvkdTUxNKpTKe5eTkJDqdDo1uJyeOdEgAjUaD2+2Oa7xeLwsLC5w+XofdvEbh1sCjCtYBwUCU284Ax2tHJDscDgeCIEgVGI1GKejZi+/Q2dAiPRsMBjwej5SIxWKhr6+PwcFBvvvMRr9ZRKsWNga0tbWxtLQkCXJycqTb5XJxoOUwr5uaU3oQ0wWDQbRaLf2vBml5IQul4lFxaStItqi7u5vh4WEqKiqoqamJ9yBmiyiKdHV10dPTw9DQEH9+fQ7rQQW5fw9SRoDS0lJmZ2fp7e0lEonEe/B8iY/8rQLO2yFpCCYmJrh2vp53X1HwWO4mFjU3N9PY2CiVWFlZic1mk5qqVqulEY71oGhXHiNH/ZTkCbx1dRXnF3PMz8/T323gglmkaMcGgM6a4ZR9EBtHq9XKzdEJWix1EqCwoIBPOnyU75TRd22V96/cJVZpcUEOl08qMD4pRyak6cFXn/rTnl/btukoKm7gpzsfSeuiqOLjMwbqi118cGuNi5+vSe/z1QLOruxUQHgtyh8zYfyeSBywJWs7K65LeLxbUKv3EAx68K/8DkQRBDnagr3YDx7mt/uL/PogQjgCchk8UShjtybJonRph6YucP9b86Yn8r6SXzhZaNxQE5+iZEVk5k3ufdm7afD1xdf2XaE29+202rQA1cMD3Lsxgs+X2e9aqRQ4/dwpdoevp0BSAKJchf/mFHNz4YyyXxfFrHqj7AjRhw8SvksBZOL7RuR0ViUAVItnuHPD+q8yTxYnQ/4CysSosaI6GD0AAAAASUVORK5CYII=
 categories:
   - structural imaging
@@ -161,20 +206,44 @@ readme: |-
   `preprocessor` and `hd-bet` are available as commands. Everything else is used
   from Python, through this container's `python` or `python3`.
 
+  ### Preprocessing on a node without a GPU
+
+  `preprocessor` runs the BraTS pipeline: co-registration, atlas registration,
+  atlas correction, normalisation and brain extraction. The atlases it needs
+  are bundled, so it works offline with its own defaults.
+
+  Brain extraction is the slow half. HD-BET defaults to a five-fold ensemble
+  with test-time mirroring, which is hours per volume on CPU, so on a GPU-less
+  node ask for the single-fold profile:
+
+  ```
+  preprocessor -t1c t1c.nii.gz -t1 t1.nii.gz -t2 t2.nii.gz -fl flair.nii.gz \
+      -o out/ --bet-mode fast --no-bet-tta
+  ```
+
+  Left alone, both settings keep upstream's values, so a run that says nothing
+  about brain extraction produces what the standalone module produces.
+
   ### GPU and CPU
 
-  These tools default to a GPU and do not check whether one exists.
-  `Inferer(device="cuda")` constructs the device regardless and inference then
-  dies inside nnU-Net after the model has loaded; `AtlasCentricPreprocessor`
-  defaults to `use_gpu=True`. On a node without a GPU pass `device="cpu"` and
-  `use_gpu=False` explicitly.
+  `gliomoda`, `petu` and `AtlasCentricPreprocessor` default to a GPU and do not
+  check whether one exists. `Inferer(device="cuda")` constructs the device
+  regardless and inference then dies inside nnU-Net after the model has loaded;
+  `AtlasCentricPreprocessor` defaults to `use_gpu=True`. On a node without a
+  GPU pass `device="cpu"` and `use_gpu=False` explicitly.
+
+  HD-BET is the exception: `run_hd_bet()` falls back to CPU on its own when no
+  CUDA device is present.
 
   ### Model weights
 
   Weights are downloaded on first use into `$BLS_WEIGHTS_DIR`, which defaults to
-  `/tmp/brainlesion-weights`. That default is per-session: every new session
-  re-downloads roughly 3.5 GB. Point it at persistent storage so this happens
-  once.
+  `/tmp/brainlesion-weights`. That default is per-session, and the cost scales
+  with how much of the bundle you touch: gliomoda alone is 3.4 GB, petu another
+  2.8 GB. Point it at persistent storage so this happens once.
+
+  The registration atlases and `deep_quality_estimation`'s checkpoint are baked
+  into the image instead, so neither needs the network or this variable.
 
   It must be set with a `SINGULARITYENV_` prefix. The module wrapper runs the
   container with `--cleanenv`, so a plain `export BLS_WEIGHTS_DIR=...` is

--- a/recipes/brainlesion/fix_hd_bet_cli.py
+++ b/recipes/brainlesion/fix_hd_bet_cli.py
@@ -1,0 +1,105 @@
+"""Make brain extraction usable: revive the `hd-bet` command, and stop it
+reporting success after it has failed.
+
+Two defects in brainles_hd_bet 0.0.11, both upstream, both landing on anyone
+who uses this bundle for brain extraction -- which is the one part of the
+pipeline the container is meant to provide end to end.
+
+1. The `hd-bet` command cannot start. `hd_bet.py` opens with
+
+       from brainles_hd_bet.utils import maybe_mkdir_p, subfiles
+
+   and `utils.py` never defines `maybe_mkdir_p`, so every invocation --
+   including `hd-bet --help` -- dies with an ImportError before argument
+   parsing. The library entry point `run_hd_bet()` imports only names that do
+   exist and works fine, so the extractor itself is sound and only its command
+   is dead. The helper is restored here with the semantics its one call site
+   needs (`maybe_mkdir_p(output_dir)` before writing into it), matching the
+   nnU-Net helper of the same name it was taken from.
+
+2. A failed extraction exits 0. `run_hd_bet` wraps its loader in
+
+       except RuntimeError: print(...); continue
+       except AssertionError as e: print(e); continue
+
+   so an unreadable or missing input prints a message, writes nothing, and
+   returns normally. A pipeline that checks the exit code -- the normal thing
+   to check -- treats a total failure as success and carries on with a mask
+   that does not exist. The handlers now re-raise as RuntimeError with the
+   original message, so failure is visible to a caller and to a shell.
+
+Kept as patches rather than a fork: together they are a handful of lines, and
+pinning a fork would strand the recipe on this release. Each target is asserted
+to exist first, so an upstream fix or rename fails the build here instead of
+silently leaving the defect in place.
+"""
+
+from importlib.util import find_spec
+from pathlib import Path
+
+package_spec = find_spec("brainles_hd_bet")
+if package_spec is None or package_spec.submodule_search_locations is None:
+    raise RuntimeError("brainles_hd_bet is not installed")
+
+package_dir = Path(next(iter(package_spec.submodule_search_locations)))
+
+# --- 1. the helper the CLI imports and the package never defines -------------
+
+utils_path = package_dir / "utils.py"
+utils_source = utils_path.read_text()
+
+if "def maybe_mkdir_p(" in utils_source:
+    raise RuntimeError(
+        "brainles_hd_bet.utils already defines maybe_mkdir_p; upstream has "
+        "fixed this and the patch should be dropped"
+    )
+if "import os" not in utils_source:
+    raise RuntimeError("brainles_hd_bet.utils no longer imports os; review this patch")
+
+utils_source += '''
+
+# --- added by the neurocontainers recipe -------------------------------------
+# hd_bet.py (the console script) imports this name, and utils.py never defined
+# it, so the `hd-bet` command failed on import before parsing any argument.
+# Same behaviour as the nnU-Net helper it was taken from: create the directory
+# and every parent, and do not complain if it is already there.
+def maybe_mkdir_p(directory):
+    os.makedirs(directory, exist_ok=True)
+    return directory
+'''
+utils_path.write_text(utils_source)
+
+# --- 2. failure must not look like success -----------------------------------
+
+run_path = package_dir / "run.py"
+run_source = run_path.read_text()
+
+old_handlers = """            except RuntimeError:
+                print("\\nERROR\\nCould not read file", in_fname, "\\n")
+                continue
+            except AssertionError as e:
+                print(e)
+                continue
+"""
+new_handlers = """            # neurocontainers recipe: upstream printed and continued, so a
+            # brain extraction that produced nothing still returned normally
+            # and exited 0. Any pipeline checking the exit code took a total
+            # failure for a success and carried on without a mask.
+            except RuntimeError as e:
+                raise RuntimeError(
+                    "hd-bet could not read %s: %s" % (in_fname, e)
+                ) from e
+            except AssertionError as e:
+                raise RuntimeError(
+                    "hd-bet rejected %s: %s" % (in_fname, e)
+                ) from e
+"""
+
+if old_handlers not in run_source:
+    raise RuntimeError(
+        "brainles_hd_bet.run error handling changed; review the silent-failure fix"
+    )
+
+run_path.write_text(run_source.replace(old_handlers, new_handlers, 1))
+
+print("hd-bet CLI import repaired; failed extractions now raise")

--- a/recipes/brainlesion/fix_preprocessor_cli.py
+++ b/recipes/brainlesion/fix_preprocessor_cli.py
@@ -81,6 +81,9 @@ class _ProfiledHDBetExtractor(HDBetExtractor):
     \"\"\"
 
     def __init__(self, mode="accurate", do_tta=True):
+        # HDBetExtractor sets no instance state today, so this is a no-op --
+        # and it stays correct if upstream ever gives it some.
+        super().__init__()
         self._bet_mode = mode
         self._bet_do_tta = do_tta
 

--- a/recipes/brainlesion/fix_preprocessor_cli.py
+++ b/recipes/brainlesion/fix_preprocessor_cli.py
@@ -1,6 +1,40 @@
+"""Make the `preprocessor` console script usable.
+
+Three defects in brainles_preprocessing 0.6.10's cli.py. The first two are hit
+before any work is done; the third only shows up on a CPU node, where it is the
+difference between a run that finishes and one that does not.
+
+1. `output_dir` is annotated `str | Path`. Typer cannot build a parameter from
+   a union type and raises at import, so every invocation fails -- including
+   `preprocessor --help`. Narrowing it to `Path` is what upstream does
+   elsewhere in the same signature, and the body already uses it as a Path
+   (`output_dir / "temp"`).
+
+2. `input_atlas` defaults to the string "SRI24 BraTS atlas", which is a label,
+   not a path. The body guards with `if input_atlas is not None`, so that
+   default is passed straight through as `atlas_image_path` and registration
+   fails on a missing file. `None` lets the guard fall through to the
+   preprocessor's own bundled atlas, which is what the label describes.
+
+3. Brain extraction is nailed to HD-BET's heaviest profile. The CLI builds
+   `AtlasCentricPreprocessor` without a brain extractor, so it falls back to
+   `HDBetExtractor()`, and `Modality.extract_brain_region` calls `extract()`
+   without `mode` or `do_tta` -- leaving the defaults, a five-fold ensemble
+   with test-time mirroring. On a GPU-less node that is hours per volume with
+   no way to ask for anything cheaper: a measured run completed
+   co-registration, atlas registration, atlas correction and normalisation,
+   then sat in brain extraction until a 90-minute timeout killed it. `--bet-
+   mode fast --no-bet-tta` makes the same command finish. Upstream's defaults
+   are kept, so a run that says nothing about brain extraction still produces
+   what the standalone module produces.
+
+Kept as patches rather than a fork: pinning a fork would strand the recipe on
+this release. Every anchor is asserted to exist first, so an upstream change
+fails the build here instead of silently leaving the defect in place.
+"""
+
 from importlib.util import find_spec
 from pathlib import Path
-
 
 package_spec = find_spec("brainles_preprocessing")
 if package_spec is None or package_spec.submodule_search_locations is None:
@@ -28,6 +62,74 @@ replacements = [
         """    ] = None,
 """,
     ),
+    # A brain extractor whose profile the CLI can choose. extract() is called
+    # by Modality with only the paths, so the mode and TTA settings have to
+    # ride on the extractor instance rather than be passed at the call site.
+    (
+        """from brainles_preprocessing.preprocessor import AtlasCentricPreprocessor
+""",
+        """from brainles_preprocessing.preprocessor import AtlasCentricPreprocessor
+from brainles_preprocessing.brain_extraction.brain_extractor import HDBetExtractor
+
+
+class _ProfiledHDBetExtractor(HDBetExtractor):
+    \"\"\"HD-BET with a caller-chosen speed profile.
+
+    Added by the neurocontainers recipe. Upstream's default -- a five-fold
+    ensemble with test-time mirroring -- is hours per volume on a CPU-only
+    node, and the CLI exposed no way to ask for the single-fold profile.
+    \"\"\"
+
+    def __init__(self, mode="accurate", do_tta=True):
+        self._bet_mode = mode
+        self._bet_do_tta = do_tta
+
+    def extract(self, *args, **kwargs):
+        kwargs.setdefault("mode", self._bet_mode)
+        kwargs.setdefault("do_tta", self._bet_do_tta)
+        return super().extract(*args, **kwargs)
+""",
+    ),
+    # The two flags themselves, inserted ahead of --version so they appear
+    # with the other real options.
+    (
+        """    version: Annotated[
+        Optional[bool],
+""",
+        """    bet_mode: Annotated[
+        str,
+        typer.Option(
+            "--bet-mode",
+            help="HD-BET profile: 'accurate' (five-fold ensemble, upstream's "
+            "default) or 'fast' (single fold). 'fast' is what makes this "
+            "command finish on a node without a GPU.",
+        ),
+    ] = "accurate",
+    bet_tta: Annotated[
+        bool,
+        typer.Option(
+            "--bet-tta/--no-bet-tta",
+            help="HD-BET test-time augmentation by mirroring along all axes. "
+            "On by default, as upstream has it; --no-bet-tta is markedly "
+            "faster on CPU.",
+        ),
+    ] = True,
+    version: Annotated[
+        Optional[bool],
+""",
+    ),
+    # And the wiring. Without this the flags would parse and do nothing.
+    (
+        """        temp_folder=output_dir / "temp",
+        **optional_kwargs,
+    )
+""",
+        """        temp_folder=output_dir / "temp",
+        brain_extractor=_ProfiledHDBetExtractor(mode=bet_mode, do_tta=bet_tta),
+        **optional_kwargs,
+    )
+""",
+    ),
 ]
 
 for old, new in replacements:
@@ -38,3 +140,4 @@ for old, new in replacements:
     source = source.replace(old, new, 1)
 
 cli_path.write_text(source)
+print("preprocessor CLI patched")

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -349,15 +349,51 @@ tests:
       so an extraction that produced nothing returned normally and exited 0.
       Any pipeline checking the exit code carried on with a mask that was never
       written. Asserted on the installed source rather than by running an
-      extraction, which would pull the five fold weight files this image does
-      not bake in.
+      extraction, which produced nothing.
+
+      Run rather than grepped: reading the installed source proves the patch
+      is present, not that it is reached, and the handler it replaces is the
+      one that swallowed the error. run_hd_bet loads its fold weights before
+      it ever opens the input -- so the weight plumbing is stubbed out, which
+      is what keeps this off the network in an image that deliberately does
+      not bake the five folds. Everything after that is the real code path: a
+      genuinely missing file, upstream's real loader, and the patched handler.
     command: |
-      python -c "
-      import inspect
-      from brainles_hd_bet import run
-      src = inspect.getsource(run.run_hd_bet)
-      print('raises-on-failure' if 'hd-bet could not read' in src and 'hd-bet rejected' in src else 'SILENT-FAILURE')
-      "
+      python - <<'PY'
+      import pathlib, tempfile
+      import brainles_hd_bet.run as run
+
+      work = pathlib.Path(tempfile.mkdtemp())
+      stub = work / "fold.model"
+      stub.write_bytes(b"")
+
+      # The only two things standing between here and the loader: fetching
+      # ~350 MB of folds, and torch.load-ing them. Neither is under test.
+      run.maybe_download_parameters = lambda index: None
+      run.get_params_fname = lambda index: str(stub)
+      run.torch.load = lambda *args, **kwargs: {}
+
+      missing = str(work / "not-a-real-scan.nii.gz")
+      try:
+          run.run_hd_bet(
+              mri_fnames=[missing],
+              output_fnames=[str(work / "out.nii.gz")],
+              mode="fast",
+              device="cpu",
+              do_tta=False,
+          )
+      except RuntimeError as exc:
+          # Either patched handler is a pass: SimpleITK reports a missing file
+          # as RuntimeError, but which of the two fires is upstream's business.
+          assert "hd-bet could not read" in str(exc) or "hd-bet rejected" in str(exc), exc
+          assert exc.__cause__ is not None, "the original error was not chained"
+          print("raises-on-failure")
+      else:
+          raise SystemExit(
+              "SILENT FAILURE: a missing input returned normally, so a caller "
+              "checking the exit code would carry on without a mask"
+          )
+      PY
     expected_output_contains: "raises-on-failure"
 
   - name: the default atlas resolves inside the image
@@ -375,6 +411,51 @@ tests:
       "
     expected_output_contains: "atlas-bundled"
 
+  - name: the baked atlas survives an upstream version bump
+    description: >-
+      Baking the atlases fixes the first run, not the version check on every
+      run after it. fetch() asks Zenodo before it looks at the disk, and
+      ATLASES_RECORD_ID is a Zenodo concept DOI, which always resolves to the
+      newest release -- so on a version mismatch it rmtree'd the local copy and
+      re-downloaded into the read-only image. The day upstream published, this
+      container would have started failing on its own defaults, on every node,
+      without changing at all. A copy already on disk is now authoritative and
+      Zenodo is not consulted, so this asserts both halves: the baked files are
+      returned untouched, and no lookup happened.
+    command: |
+      python - <<'PY'
+      import pathlib
+      import requests
+      from brainles_preprocessing.utils import zenodo
+
+      baked = sorted(
+          pathlib.Path(zenodo.ATLASES_FOLDER).glob(zenodo.ATLASES_RECORD_ID + "_v*")
+      )
+      assert len(baked) == 1, baked
+      before = {p.name for p in baked[0].iterdir()}
+      assert before, "the baked atlas folder is empty"
+
+      # Zenodo advertising something newer is the case that crashed.
+      asked = []
+      def bumped(self):
+          asked.append(1)
+          return ({"version": "99.0.0"}, "https://example.invalid/archive.zip")
+      zenodo.ZenodoRecord._get_metadata_and_archive_url = bumped
+
+      got = zenodo.fetch_atlases()
+      assert got == baked[0], (got, baked[0])
+      assert not asked, "Zenodo was queried at run time"
+      assert {p.name for p in got.iterdir()} == before, "the baked files changed"
+
+      # And the pre-existing offline behaviour must not regress.
+      zenodo.requests.get = lambda *a, **k: (_ for _ in ()).throw(
+          requests.exceptions.ConnectionError("no network")
+      )
+      assert zenodo.fetch_atlases() == baked[0]
+      print("atlas-survives-version-bump")
+      PY
+    expected_output_contains: "atlas-survives-version-bump"
+
   - name: the brain-extraction profile is selectable
     description: >-
       HD-BET's default is a five-fold ensemble with test-time mirroring, hours
@@ -390,6 +471,7 @@ tests:
       timeout was.
     command: |
       python -c "
+      import inspect
       import typer.main
       from brainles_preprocessing.brain_extraction.brain_extractor import HDBetExtractor
       from brainles_preprocessing.cli import app, _ProfiledHDBetExtractor
@@ -399,13 +481,41 @@ tests:
       missing = [f for f in ('--bet-mode', '--bet-tta', '--no-bet-tta') if f not in opts]
       assert not missing, 'missing %s, have %s' % (missing, sorted(opts))
 
+      # The names have to exist on the real extractor, and be settable by
+      # keyword. A recorder with a permissive *args/**kwargs signature would
+      # swallow a rename or a positional call that fails for real at run time,
+      # so record through the genuine signature instead and let bind() reject
+      # anything it would not accept.
+      real = inspect.signature(HDBetExtractor.extract)
+      for name in ('mode', 'do_tta'):
+          kind = real.parameters[name].kind
+          assert kind is not inspect.Parameter.POSITIONAL_ONLY, (name, kind)
+
       seen = {}
-      HDBetExtractor.extract = lambda self, *a, **k: seen.update(k)
-      _ProfiledHDBetExtractor(mode='fast', do_tta=False).extract()
-      assert seen == {'mode': 'fast', 'do_tta': False}, seen
+      def recorder(self, *args, **kwargs):
+          bound = real.bind(self, *args, **kwargs)
+          bound.apply_defaults()
+          seen.update(bound.arguments)
+      HDBetExtractor.extract = recorder
+
+      required = dict(
+          input_image_path='in.nii.gz',
+          masked_image_path='out.nii.gz',
+          brain_mask_path='mask.nii.gz',
+      )
+
+      _ProfiledHDBetExtractor(mode='fast', do_tta=False).extract(**required)
+      assert (seen['mode'], seen['do_tta']) == ('fast', False), seen
+
       seen.clear()
-      _ProfiledHDBetExtractor().extract()
-      assert seen == {'mode': 'accurate', 'do_tta': True}, seen
+      _ProfiledHDBetExtractor().extract(**required)
+      assert (seen['mode'], seen['do_tta']) == ('accurate', True), seen
+
+      # An explicit call must still win over the profile, or the preprocessor
+      # passing its own value would be silently overridden.
+      seen.clear()
+      _ProfiledHDBetExtractor(mode='fast').extract(mode='accurate', **required)
+      assert seen['mode'] == 'accurate', seen
       print('bet-profile-selectable')
       "
     expected_output_contains: "bet-profile-selectable"

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -380,8 +380,32 @@ tests:
       HD-BET's default is a five-fold ensemble with test-time mirroring, hours
       per volume on CPU, and the CLI exposed no way to ask for anything
       cheaper: a measured run got through registration and then hit a
-      90-minute timeout in brain extraction.
+      90-minute timeout in brain extraction. Asked of click's parsed option
+      set rather than of the rendered help. Typer lays --help out as a rich
+      table, and rich truncates the option column with an ellipsis once the
+      width it guessed is narrow enough, so grepping the help for the flag
+      names asserts on the width the container happened to render at. The
+      profile also has to reach HD-BET, so the forwarding is exercised as
+      well: a flag that parses and changes nothing is what the 90-minute
+      timeout was.
     command: |
-      preprocessor --help | grep -q -- '--bet-mode' && \
-      preprocessor --help | grep -q -- '--no-bet-tta' && echo "bet-flags-present"
-    expected_output_contains: "bet-flags-present"
+      python -c "
+      import typer.main
+      from brainles_preprocessing.brain_extraction.brain_extractor import HDBetExtractor
+      from brainles_preprocessing.cli import app, _ProfiledHDBetExtractor
+
+      cmd = typer.main.get_command(app)
+      opts = {o for p in cmd.params for o in p.opts + p.secondary_opts}
+      missing = [f for f in ('--bet-mode', '--bet-tta', '--no-bet-tta') if f not in opts]
+      assert not missing, 'missing %s, have %s' % (missing, sorted(opts))
+
+      seen = {}
+      HDBetExtractor.extract = lambda self, *a, **k: seen.update(k)
+      _ProfiledHDBetExtractor(mode='fast', do_tta=False).extract()
+      assert seen == {'mode': 'fast', 'do_tta': False}, seen
+      seen.clear()
+      _ProfiledHDBetExtractor().extract()
+      assert seen == {'mode': 'accurate', 'do_tta': True}, seen
+      print('bet-profile-selectable')
+      "
+    expected_output_contains: "bet-profile-selectable"

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -333,3 +333,55 @@ tests:
       script as the only supported way into this container.
     command: bash -c 'command -v preprocessor && command -v hd-bet && echo "clis ok"'
     expected_output_contains: "clis ok"
+
+  - name: the hd-bet command starts
+    description: >-
+      hd_bet.py imports maybe_mkdir_p from brainles_hd_bet.utils, which never
+      defined it, so every invocation -- including --help -- died on import
+      before parsing an argument. `test -x` passed on it; running it is what
+      catches this. The helper is restored at build time.
+    command: hd-bet --help
+    expected_output_contains: "--input"
+
+  - name: a failed brain extraction is not reported as success
+    description: >-
+      run_hd_bet caught its loader's errors, printed a message and continued,
+      so an extraction that produced nothing returned normally and exited 0.
+      Any pipeline checking the exit code carried on with a mask that was never
+      written. Asserted on the installed source rather than by running an
+      extraction, which would pull the five fold weight files this image does
+      not bake in.
+    command: |
+      python -c "
+      import inspect
+      from brainles_hd_bet import run
+      src = inspect.getsource(run.run_hd_bet)
+      print('raises-on-failure' if 'hd-bet could not read' in src and 'hd-bet rejected' in src else 'SILENT-FAILURE')
+      "
+    expected_output_contains: "raises-on-failure"
+
+  - name: the default atlas resolves inside the image
+    description: >-
+      AtlasCentricPreprocessor defaults to Atlas.BRATS_SRI24 and fetched it
+      into its own installed package, which is read-only at run time, so
+      `preprocessor` failed within seconds using nothing but its own defaults.
+      The atlases are baked in, as the standalone container already does.
+    command: |
+      python -c "
+      from brainles_preprocessing.constants import Atlas
+      from brainles_preprocessing.utils.zenodo import fetch_atlases
+      atlas = fetch_atlases() / Atlas.BRATS_SRI24.value
+      print('atlas-bundled' if atlas.is_file() else 'ATLAS-MISSING')
+      "
+    expected_output_contains: "atlas-bundled"
+
+  - name: the brain-extraction profile is selectable
+    description: >-
+      HD-BET's default is a five-fold ensemble with test-time mirroring, hours
+      per volume on CPU, and the CLI exposed no way to ask for anything
+      cheaper: a measured run got through registration and then hit a
+      90-minute timeout in brain extraction.
+    command: |
+      preprocessor --help | grep -q -- '--bet-mode' && \
+      preprocessor --help | grep -q -- '--no-bet-tta' && echo "bet-flags-present"
+    expected_output_contains: "bet-flags-present"

--- a/recipes/brainlesion/pin_atlases.py
+++ b/recipes/brainlesion/pin_atlases.py
@@ -1,0 +1,107 @@
+"""Stop the baked atlases being replaced from Zenodo at run time.
+
+`bake_atlases.py` puts the registration atlases inside the installed package,
+which is read-only once the image is built. That fixes the first-run download,
+but not the version check that happens on every run after it.
+
+`ZenodoRecord.fetch()` queries Zenodo before it looks at what is already on
+disk, and `ATLASES_RECORD_ID = "15236131"` is a Zenodo *concept* DOI, which by
+design always resolves to the newest version. When the remote version differs
+from the local one, `fetch()` does:
+
+    shutil.rmtree(self.target_dir / latest_local)
+    return self._download(metadata, archive_url)
+
+and `_download` calls `folder.mkdir(parents=True, exist_ok=True)` inside the
+image. So the day upstream publishes a new atlas release, `preprocessor` fails
+on its own defaults, on every node, with the error this recipe exists to
+remove -- and the container does not have to change for it to happen:
+
+    OSError: [Errno 30] Read-only file system: '.../atlases/15236131_v2.1.0'
+
+Pointing `bake_atlases.py` at a versioned record is not enough on its own,
+because `fetch_atlases()` builds its `ZenodoRecord` from the installed
+package's `ATLASES_RECORD_ID` and would still query the concept record.
+
+So the fix is here, at run time: a copy that is already present wins, and
+Zenodo is not consulted at all. That is the same bargain the rest of this
+bundle makes for its model weights -- what ships in the image is what runs,
+and moving to a newer release is a rebuild, not something that happens to a
+user mid-session. It also makes the readme's offline claim true by
+construction rather than by the `RequestException` handler happening to be
+reached.
+
+Deliberately not conditioned on the target directory being read-only.
+`apptainer exec --writable-tmpfs` -- which the release tests use -- overlays a
+writable tmpfs, so a writability probe would report that the package directory
+can be written and quietly restore the defect in exactly the environment that
+is supposed to catch it.
+
+Only affects a record whose files are already on disk. `fetch_synthstrip()`
+uses the same class against a directory this recipe does not bake, so it keeps
+upstream's download behaviour untouched.
+"""
+
+from importlib.util import find_spec
+from pathlib import Path
+
+package_spec = find_spec("brainles_preprocessing")
+if package_spec is None or package_spec.submodule_search_locations is None:
+    raise RuntimeError("brainles_preprocessing is not installed")
+
+zenodo_path = Path(next(iter(package_spec.submodule_search_locations))) / "utils" / "zenodo.py"
+source = zenodo_path.read_text()
+
+replacements = [
+    # Consult the disk before the network, and stop there when it answers.
+    (
+        '''    def fetch(self) -> Path:
+        """Fetch the latest version of the record from Zenodo or from local storage."""
+        zenodo_response = self._get_metadata_and_archive_url()
+''',
+        '''    def fetch(self) -> Path:
+        """Fetch the latest version of the record from Zenodo or from local storage."""
+        baked = self._baked_copy()
+        if baked is not None:
+            return baked
+        zenodo_response = self._get_metadata_and_archive_url()
+''',
+    ),
+    # The check itself, placed with the other private helpers.
+    (
+        """    def _glob_pattern(self) -> str:
+""",
+        '''    def _baked_copy(self) -> Path | None:
+        """Return a copy that is already on disk, without asking Zenodo.
+
+        Added by the neurocontainers recipe. Upstream asks Zenodo first and
+        deletes the local copy when the versions differ, which cannot work
+        when the local copy lives in a read-only image -- and the record id is
+        a concept DOI, so the versions differ the moment upstream publishes.
+        """
+        name = self._get_latest_version_folder_name(
+            list(self.target_dir.glob(self._glob_pattern()))
+        )
+        if not name:
+            return None
+        logger.info(
+            f"Using the {self.label} baked into this container ({name}). "
+            "The Zenodo lookup is disabled here, so nothing is downloaded or "
+            "replaced at run time; a newer release needs a rebuild."
+        )
+        return self.target_dir / name
+
+    def _glob_pattern(self) -> str:
+''',
+    ),
+]
+
+for old, new in replacements:
+    if old not in source:
+        raise RuntimeError(
+            f"brainles_preprocessing zenodo layout changed; review this patch:\n{old!r}"
+        )
+    source = source.replace(old, new, 1)
+
+zenodo_path.write_text(source)
+print("zenodo lookup pinned off for records already present on disk")


### PR DESCRIPTION
The 20260820 test found segmentation and evaluation in good shape and everything that remained concentrated in the two components this bundle is meant to provide end to end.

The default atlas fetched into the read-only image. AtlasCentricPreprocessor defaults to Atlas.BRATS_SRI24 and calls fetch_atlases(), whose target is inside the installed package, so `preprocessor` failed within seconds using nothing but its own defaults -- the original blocker of this container surviving in the one weight-like asset the $BLS_WEIGHTS_DIR redirect did not cover. The atlases (~92 MB) are now baked in, as the standalone brainles-preprocessing container already does.

The hd-bet command could not start. hd_bet.py imports maybe_mkdir_p from brainles_hd_bet.utils, which never defines it, so every invocation died on import. The build checked `test -x`, which passes on a command that cannot run; it now runs --help for each deployed command instead. The helper is restored with the semantics its one call site needs.

A failed extraction returned success. run_hd_bet caught its loader's errors, printed a message and continued, so a run that produced nothing exited 0 and any pipeline checking the exit code carried on with a mask that does not exist. Both handlers now raise.

Brain extraction had no CPU-practical setting. The CLI built its preprocessor without a brain extractor, so HD-BET ran its five-fold ensemble with test-time mirroring -- hours per volume, and a measured run died at a 90-minute timeout there after finishing registration. --bet-mode/--bet-tta expose the profile; upstream's defaults are kept, so an unqualified run still matches the standalone module.

Also corrects two README statements the test contradicted: HD-BET does fall back to CPU, and the per-session weights figure is 3.4 GB for gliomoda plus 2.8 GB for petu, not 3.5 GB overall.