### PR TITLE
brainles-aurora: make inference reproducible and fix the import cycle

### DIFF
--- a/recipes/brainles-aurora/build.yaml
+++ b/recipes/brainles-aurora/build.yaml
@@ -55,6 +55,16 @@ build:
         # first use; read the version from distribution metadata because these
         # packages do not all define __version__.
         - . "${VENV}/bin/activate" && python -c "import importlib.metadata as md; import brainles_aurora; print('brainles-aurora', md.version('brainles-aurora'))"
+        # brainles_aurora.utils and brainles_aurora.inferer import each other,
+        # so half the ways of reaching the weights helper fail with a circular
+        # ImportError that looks like a broken install. One constant is inlined
+        # to break the cycle.
+        - . "${VENV}/bin/activate" && python {{ get_file("fix_weights_import") }}
+        # Every import order must work now, each in its own interpreter so the
+        # result does not depend on what a previous check imported.
+        - . "${VENV}/bin/activate" && python -c "from brainles_aurora.utils import check_model_weights"
+        - . "${VENV}/bin/activate" && python -c "from brainles_aurora.utils.weights import check_model_weights"
+        - . "${VENV}/bin/activate" && python -c "from brainles_aurora.inferer import AuroraInferer" && echo "import orders ok"
         # Bake the model weights into the image so inference runs offline and every
         # run uses the same weights. Adds ~345 MB to the image.
         #
@@ -97,9 +107,9 @@ build:
         - WMOD="$(. "${VENV}/bin/activate" && python -c "import brainles_aurora,pathlib; print(pathlib.Path(brainles_aurora.__file__).parent/'utils/weights.py')")"
         - test -f "${WMOD}"
         - cat {{ get_file("pin_weights.py") }} >> "${WMOD}"
-        - . "${VENV}/bin/activate" && python -c "import brainles_aurora.inferer; from brainles_aurora.utils.weights import _get_zenodo_metadata_and_archive_url as f; m,u=f(); assert m=={'version':'{{ context.weights_version }}'} and u=='', ('weight pin did not take', m, u); print('zenodo lookup pinned off')"
+        - . "${VENV}/bin/activate" && python -c "from brainles_aurora.utils.weights import _get_zenodo_metadata_and_archive_url as f; m,u=f(); assert m=={'version':'{{ context.weights_version }}'} and u=='', ('weight pin did not take', m, u); print('zenodo lookup pinned off')"
         # Prove the pinned lookup still resolves the baked weights.
-        - . "${VENV}/bin/activate" && python -c "import brainles_aurora.inferer; from brainles_aurora.utils.weights import check_model_weights; p=str(check_model_weights()); assert p.endswith('weights_v{{ context.weights_version }}'), p; print('resolves offline to', p)"
+        - . "${VENV}/bin/activate" && python -c "from brainles_aurora.utils.weights import check_model_weights; p=str(check_model_weights()); assert p.endswith('weights_v{{ context.weights_version }}'), p; print('resolves offline to', p)"
         # Upstream ships no console_scripts, so the container provides one: a thin
         # argparse front-end over the documented Python API. It adds no logic of
         # its own beyond argument validation.
@@ -115,6 +125,11 @@ build:
         - . "${VENV}/bin/activate" && ! aurora -t1 a.nii.gz -t2 b.nii.gz -o seg.nii.gz > /tmp/combination.txt 2>&1 && grep -q 'no model exists' /tmp/combination.txt && echo "combination rejected early"
         - . "${VENV}/bin/activate" && aurora --help | grep -q 'T2 is only usable' && echo "combination help ok"
         - rm -f /tmp/combination.txt
+        # The wrapper seeds the run so repeated inference is reproducible. This
+        # asserts the seeding reaches the transform upstream draws its
+        # test-time-augmentation noise from; it takes seconds and needs no
+        # weights, so it belongs at build time rather than in a test suite.
+        - . "${VENV}/bin/activate" && python {{ get_file("check_seeding.py") }}
         - chmod -R a+rX "${VENV}"
         - rm -rf /root/.cache/pip /tmp/mpl-brainles-aurora /tmp/cache-brainles-aurora
 
@@ -155,6 +170,10 @@ files:
     url: https://zenodo.org/api/records/10557069/files/t1c-o_best.tar/content
   - name: t1c-o_last.tar
     url: https://zenodo.org/api/records/10557069/files/t1c-o_last.tar/content
+  - name: fix_weights_import
+    filename: fix_weights_import.py
+  - name: check_seeding.py
+    filename: check_seeding.py
   - name: aurora
     contents: |
       #!{{ context.venv }}/bin/python3
@@ -230,6 +249,18 @@ files:
           p.add_argument("--no-tta", action="store_true",
                          help="Disable test-time augmentation: roughly 12x faster, "
                               "slightly less accurate")
+          # Test-time augmentation is unseeded upstream, so the default
+          # configuration returns a slightly different lesion volume on every
+          # run. Seeding by default makes a run reproducible; --no-seed
+          # restores upstream's behaviour for anyone who wants to sample the
+          # spread across repeats.
+          p.add_argument("--seed", type=int, default=0,
+                         help="Random seed for test-time augmentation "
+                              "(default: 0). Without it, repeated runs of the "
+                              "same input differ slightly")
+          p.add_argument("--no-seed", action="store_true",
+                         help="Do not seed: reproduces upstream's unseeded, "
+                              "run-to-run-variable behaviour")
           a = p.parse_args(argv)
 
           combination = (bool(a.t1), bool(a.t1c), bool(a.t2), bool(a.fla))
@@ -255,6 +286,26 @@ files:
 
           from brainles_aurora.inferer import AuroraInferer, AuroraInfererConfig
           from brainles_aurora.inferer.constants import Device
+
+          # Make the run reproducible. Upstream's _apply_test_time_augmentations
+          # draws fresh RandGaussianNoised noise in each of its four rounds and
+          # seeds none of it, so two identical runs disagree -- measured at 11
+          # voxels on a 240x240x155 subject, on a tool whose output is usually
+          # reported as a lesion volume.
+          #
+          # set_determinism is not enough on its own: it seeds torch, random and
+          # np.random, and its own docstring notes it does not affect
+          # Randomizable objects, which draw from the class-level
+          # Randomizable.R. RandGaussianNoised never calls set_random_state, so
+          # R is replaced directly. Both are needed: set_determinism covers
+          # torch, the R assignment covers the transforms.
+          if not a.no_seed:
+              import numpy as np
+              from monai.transforms import Randomizable
+              from monai.utils import set_determinism
+
+              set_determinism(seed=a.seed)
+              Randomizable.R = np.random.RandomState(a.seed)
 
           config = AuroraInfererConfig(
               device=Device(a.device),
@@ -377,6 +428,15 @@ readme: |-
   is applied to the sigmoid output of both channels and the result is cast to
   uint8. The current upstream API exposes no probability maps. The older
   `--whole-tumor-floats` and `--metastasis-floats` names still work as aliases.
+
+  ### Reproducibility
+
+  Test-time augmentation adds Gaussian noise, and upstream seeds none of it, so
+  the same input run twice returns slightly different lesion volumes. This
+  container seeds the run (`--seed`, default 0), so a repeat of the same
+  command reproduces its own output exactly. Pass `--no-seed` for upstream's
+  unseeded behaviour, for example to sample the spread across repeats.
+  `--no-tta` is deterministic either way.
 
   ### CPU, runtime and threads
 

--- a/recipes/brainles-aurora/build.yaml
+++ b/recipes/brainles-aurora/build.yaml
@@ -135,6 +135,12 @@ build:
 
     - workdir: /opt
 
+    # The runtime tests are not here. recipes/brainles-aurora/fulltest.yaml
+    # carries them -- 14 cases, including a real synthetic-volume inference and
+    # a repeat-run check that guards the seeding above -- and the release
+    # harness runs that file against the built container. Noted because
+    # build.yaml having only the deploy check below reads as though functional
+    # testing was skipped.
     - test:
         name: Simple Deploy Bins/Path Test
         builtin: test_deploy.sh
@@ -393,9 +399,18 @@ readme: |-
   aurora-python -c 'from brainles_aurora.inferer import AuroraInferer'
   ```
 
+  The Python route is not seeded, unlike the `aurora` command -- see
+  Reproducibility below before using it for anything you intend to publish.
+
   `python` is deliberately not exported: putting this environment's bin
   directory on your PATH replaced the host interpreter for the rest of the
   shell. Use `aurora-python`.
+
+  This is a change from earlier builds of this module, which did export
+  `python`, `python3` and `python3.12`. If a script of yours ran `python` after
+  `ml brainles-aurora` and now gets `command not found`, or reaches your own
+  interpreter and fails with `ModuleNotFoundError: No module named
+  'brainles_aurora'`, that is why: point it at `aurora-python`.
 
   ### Input requirements
 
@@ -432,11 +447,35 @@ readme: |-
   ### Reproducibility
 
   Test-time augmentation adds Gaussian noise, and upstream seeds none of it, so
-  the same input run twice returns slightly different lesion volumes. This
-  container seeds the run (`--seed`, default 0), so a repeat of the same
-  command reproduces its own output exactly. Pass `--no-seed` for upstream's
-  unseeded behaviour, for example to sample the spread across repeats.
+  the same input run twice returns slightly different lesion volumes.
+
+  The **`aurora` command** seeds the run (`--seed`, default 0), so a repeat of
+  the same command reproduces its own output exactly: measured at 0 differing
+  voxels between repeats, and byte-identical across 1, 2 and 4 threads, so the
+  result does not move with `--cpus-per-task`. Pass `--no-seed` for upstream's
+  unseeded behaviour, for example to sample the spread across repeats -- two
+  `--no-seed` repeats of a 240x240x155 subject differed by 15 voxels.
   `--no-tta` is deterministic either way.
+
+  **The Python API is not seeded.** The seeding above is applied by the
+  `aurora` wrapper just before it constructs the inferer, so it never reaches
+  anyone calling `AuroraInferer` directly, and two identical library calls do
+  disagree. To make a Python run reproducible, do what the wrapper does, before
+  constructing the inferer:
+
+  ```
+  import numpy as np
+  from monai.transforms import Randomizable
+  from monai.utils import set_determinism
+
+  set_determinism(seed=0)
+  Randomizable.R = np.random.RandomState(0)
+  ```
+
+  Both lines are needed. `set_determinism` alone is not sufficient: its own
+  docstring notes it does not affect `monai.transforms.Randomizable` objects,
+  and upstream's augmentation noise (`RandGaussianNoised`) draws from the
+  class-level `Randomizable.R` and never calls `set_random_state`.
 
   ### CPU, runtime and threads
 

--- a/recipes/brainles-aurora/check_seeding.py
+++ b/recipes/brainles-aurora/check_seeding.py
@@ -1,0 +1,46 @@
+"""Assert that seeding actually reaches AURORA's test-time augmentation.
+
+Upstream's `_apply_test_time_augmentations` draws fresh `RandGaussianNoised`
+noise in each of its four rounds and nothing seeds it, so the default
+configuration is not reproducible: the same image, the same flags and the same
+container return slightly different lesion volumes run to run.
+
+The obvious fix does not work. `monai.utils.set_determinism` seeds `torch`,
+`random` and `np.random`, but its own docstring says it "will not affect the
+randomizable objects in monai.transforms.Randomizable, which have independent
+random states". Those objects draw from `Randomizable.R`, a class-level
+`RandomState` built at import time, and `RandGaussianNoised` never calls
+`set_random_state`, so `R` has to be replaced directly -- which is what the
+`aurora` wrapper does.
+
+This check takes seconds and fails the build if that stops being true, e.g.
+because a MONAI release changes where the transforms get their randomness.
+"""
+
+import numpy as np
+import torch
+from monai.transforms import RandGaussianNoised, Randomizable
+from monai.utils import set_determinism
+
+
+def draw(seed):
+    """One augmented tensor, produced the way the wrapper seeds a run."""
+    set_determinism(seed=seed)
+    Randomizable.R = np.random.RandomState(seed)
+    data = {"images": torch.zeros(1, 4, 4)}
+    return RandGaussianNoised(keys="images", prob=1.0, std=0.001)(data)["images"].numpy()
+
+
+same = draw(0), draw(0)
+if not np.array_equal(*same):
+    raise SystemExit(
+        "seeding does not reach the test-time augmentation; the --seed flag "
+        "would be inert and default runs would stay irreproducible"
+    )
+
+# A different seed must still give different noise, otherwise the check above
+# would pass on a transform that had silently stopped being random at all.
+if np.array_equal(draw(0), draw(1)):
+    raise SystemExit("two different seeds produced identical noise; check is not testing anything")
+
+print("seeded augmentation is reproducible")

--- a/recipes/brainles-aurora/fix_weights_import.py
+++ b/recipes/brainles-aurora/fix_weights_import.py
@@ -1,0 +1,53 @@
+"""Break the circular import between brainles_aurora.utils and .inferer.
+
+`brainles_aurora/utils/weights.py` imports WEIGHTS_DIR_PATTERN from
+`brainles_aurora.inferer.constants`, while `brainles_aurora/inferer/model.py`
+imports `check_model_weights` from `brainles_aurora.utils`. The two packages
+therefore import each other, and every import order that reaches `utils` before
+`inferer` dies:
+
+    from brainles_aurora.utils import check_model_weights
+    ImportError: cannot import name 'check_model_weights' from partially
+    initialized module 'brainles_aurora.utils' (most likely due to a circular
+    import)
+
+Three of the six plausible ways to reach the weights helper fail this way, and
+the error reads like a broken installation rather than an import-order rule.
+This recipe hit it too: the weights module had to be located by path, because
+importing it to find its location was not reliable.
+
+WEIGHTS_DIR_PATTERN is a constant string, so defining it in weights.py removes
+the cycle without changing any behaviour. Its value is read from constants.py
+first, so if upstream ever changes it the build fails here instead of shipping
+a stale copy.
+"""
+
+from importlib.util import find_spec
+from pathlib import Path
+
+from brainles_aurora.inferer.constants import WEIGHTS_DIR_PATTERN
+
+package_spec = find_spec("brainles_aurora")
+if package_spec is None or package_spec.submodule_search_locations is None:
+    raise RuntimeError("brainles_aurora is not installed")
+
+weights_path = (
+    Path(next(iter(package_spec.submodule_search_locations))) / "utils" / "weights.py"
+)
+source = weights_path.read_text()
+
+old_import = "from brainles_aurora.inferer.constants import WEIGHTS_DIR_PATTERN"
+replacement = (
+    "# Inlined by the neurocontainers recipe: importing this constant from\n"
+    "# brainles_aurora.inferer makes utils and inferer import each other, so\n"
+    "# any import reaching utils first fails with a circular ImportError.\n"
+    f"WEIGHTS_DIR_PATTERN = {WEIGHTS_DIR_PATTERN!r}"
+)
+
+if old_import not in source:
+    raise RuntimeError(
+        "brainles_aurora import layout changed; review the circular-import fix"
+    )
+
+weights_path.write_text(source.replace(old_import, replacement, 1))
+print(f"circular import removed; WEIGHTS_DIR_PATTERN inlined as {WEIGHTS_DIR_PATTERN!r}")

--- a/recipes/brainles-aurora/fulltest.yaml
+++ b/recipes/brainles-aurora/fulltest.yaml
@@ -65,6 +65,65 @@ tests:
       "
     expected_output_contains: "no-network-warning"
 
+  - name: the weights helper imports in any order
+    description: >-
+      brainles_aurora.utils and brainles_aurora.inferer import each other
+      upstream, so three of the six plausible import orders died with a
+      circular ImportError that reads like a broken installation. One constant
+      is inlined at build time to break the cycle; each order runs in its own
+      interpreter so the result cannot depend on a previous import.
+    command: |
+      python -c "from brainles_aurora.utils import check_model_weights"
+      python -c "from brainles_aurora.utils.weights import check_model_weights"
+      python -c "import brainles_aurora; from brainles_aurora.utils import check_model_weights"
+      python -c "from brainles_aurora.inferer import AuroraInferer"
+      echo "import-orders-ok"
+    expected_output_contains: "import-orders-ok"
+
+  - name: seeding reaches the test-time augmentation
+    description: >-
+      monai.utils.set_determinism does not seed Randomizable.R, which is where
+      RandGaussianNoised -- upstream's TTA noise -- draws from, so the wrapper
+      replaces R as well. If that stops working the --seed flag goes silently
+      inert and default runs become irreproducible again.
+    command: |
+      python -c "
+      import numpy as np, torch
+      from monai.transforms import RandGaussianNoised, Randomizable
+      from monai.utils import set_determinism
+      def draw(seed):
+          set_determinism(seed=seed)
+          Randomizable.R = np.random.RandomState(seed)
+          d = {'images': torch.zeros(1, 4, 4)}
+          return RandGaussianNoised(keys='images', prob=1.0, std=0.001)(d)['images'].numpy()
+      print('seeded-reproducible' if np.array_equal(draw(0), draw(0)) and not np.array_equal(draw(0), draw(1)) else 'SEEDING-INERT')
+      "
+    expected_output_contains: "seeded-reproducible"
+
+  - name: two default runs of the same input agree
+    description: >-
+      The default configuration uses test-time augmentation, which upstream
+      leaves unseeded: two runs of the same subject differed by 11 voxels,
+      which matters for a tool whose reported output is a lesion volume. The
+      wrapper seeds it, so a repeat must reproduce the first run exactly.
+    timeout: 2400
+    command: |
+      cd "$(mktemp -d)"
+      python -c "
+      import nibabel as nib, numpy as np
+      rng = np.random.default_rng(0)
+      nib.save(nib.Nifti1Image(rng.random((128, 128, 32)).astype('float32'), np.eye(4)), 't1c.nii.gz')
+      "
+      aurora -t1c t1c.nii.gz -o seg_a.nii.gz --device cpu
+      aurora -t1c t1c.nii.gz -o seg_b.nii.gz --device cpu
+      python -c "
+      import nibabel as nib, numpy as np
+      a = nib.load('seg_a.nii.gz').get_fdata()
+      b = nib.load('seg_b.nii.gz').get_fdata()
+      print('repeats-identical' if np.array_equal(a, b) else 'REPEATS-DIFFER %d voxels' % int((a != b).sum()))
+      "
+    expected_output_contains: "repeats-identical"
+
   - name: aurora CLI is on PATH and renders help
     description: >-
       The CLI is added by this recipe rather than upstream, so nothing else


### PR DESCRIPTION
Two defects found by the 20260820 container retest, both in the tool's own behaviour rather than its packaging.

Default runs were not reproducible. Upstream's
_apply_test_time_augmentations draws fresh RandGaussianNoised noise in each of its four rounds and seeds none of it, so two runs of the same subject with the same flags disagreed by 11 voxels -- on a tool whose reported output is usually a lesion volume. The wrapper now seeds the run, with --seed (default 0) to change it and --no-seed to restore upstream's behaviour.

monai.utils.set_determinism alone does not fix this: it seeds torch, random and np.random, and its own docstring says it does not affect monai.transforms.Randomizable objects. Those draw from the class-level Randomizable.R, and RandGaussianNoised never calls set_random_state, so R is replaced directly. A build-time check asserts the seeding really reaches the transform, so the flag cannot go silently inert.

brainles_aurora.utils and brainles_aurora.inferer import each other, so three of the six plausible ways to reach check_model_weights failed with a circular ImportError that reads like a broken install. weights.py imports one constant from inferer.constants; it is now inlined, with the value read from constants.py at build time so an upstream change fails the build. The recipe's own path-based workaround for the same cycle is no longer needed.

Adds fulltest cases for both, including two default runs that must agree exactly.