### PR TITLE
Update QSMxT OpenRecon output handling

### DIFF
--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -73,11 +73,33 @@
       "default": false
     },
     {
+      "id": "pipelinepreset",
+      "label": { "en": "Pipeline preset" },
+      "type": "choice",
+      "values": [
+        { "id": "custom", "name": { "en": "Custom algorithm controls" } },
+        { "id": "romeo-resharp-rts", "name": { "en": "1. ROMEO + RESHARP + RTS" } },
+        { "id": "romeo-ismv-hdqsm", "name": { "en": "2. ROMEO + iSMV + HD-QSM" } },
+        { "id": "romeo-resharp-tikhonov", "name": { "en": "3. ROMEO + RESHARP + Tikhonov" } },
+        { "id": "romeo-resharp-tv", "name": { "en": "4. ROMEO + RESHARP + TV (ADMM)" } },
+        { "id": "romeo-resharp-hdqsm", "name": { "en": "5. ROMEO + RESHARP + HD-QSM" } },
+        { "id": "romeo-ismv-rts", "name": { "en": "6. ROMEO + iSMV + RTS" } },
+        { "id": "romeo-ismv-whqsm", "name": { "en": "7. ROMEO + iSMV + WH-QSM" } },
+        { "id": "romeo-sharp-whqsm", "name": { "en": "8. ROMEO + SHARP + WH-QSM" } },
+        { "id": "romeo-resharp-whqsm", "name": { "en": "9. ROMEO + RESHARP + WH-QSM" } },
+        { "id": "romeo-sharp-tikhonov", "name": { "en": "10. ROMEO + SHARP + Tikhonov" } }
+      ],
+      "default": "custom",
+      "information": { "en": "Select a tested pipeline combination. A preset overrides QSM algorithm, Unwrap, and Background. Select Custom to use those controls." }
+    },
+    {
       "id": "qsmalgorithm",
       "label": { "en": "QSM algorithm" },
       "type": "choice",
       "values": [
         { "id": "default", "name": { "en": "Default" } },
+        { "id": "whqsm", "name": { "en": "WH-QSM" } },
+        { "id": "hdqsm", "name": { "en": "HD-QSM" } },
         { "id": "rts", "name": { "en": "RTS" } },
         { "id": "tv", "name": { "en": "TV" } },
         { "id": "tkd", "name": { "en": "TKD" } },
@@ -89,8 +111,8 @@
         { "id": "ilsqr", "name": { "en": "iLSQR" } },
         { "id": "qsmart", "name": { "en": "QSMART" } }
       ],
-      "default": "rts",
-      "information": { "en": "QSMxT inversion algorithm. RTS is the recommended default for robust inline QSM." }
+      "default": "whqsm",
+      "information": { "en": "QSMxT inversion algorithm for the Custom pipeline preset. WH-QSM is the OpenRecon default for its balance of accuracy, reproducibility, and resource use." }
     },
     {
       "id": "unwrappingalgorithm",
@@ -110,14 +132,15 @@
       "type": "choice",
       "values": [
         { "id": "default", "name": { "en": "Default" } },
-        { "id": "vsharp", "name": { "en": "VSHARP" } },
+        { "id": "vsharp", "name": { "en": "V-SHARP" } },
         { "id": "pdf", "name": { "en": "PDF" } },
         { "id": "lbv", "name": { "en": "LBV" } },
         { "id": "ismv", "name": { "en": "iSMV" } },
-        { "id": "sharp", "name": { "en": "SHARP" } }
+        { "id": "sharp", "name": { "en": "SHARP" } },
+        { "id": "resharp", "name": { "en": "RESHARP" } }
       ],
-      "default": "pdf",
-      "information": { "en": "QSMxT background field removal algorithm. PDF is the recommended default for inline QSM." }
+      "default": "vsharp",
+      "information": { "en": "QSMxT background-field removal algorithm for the Custom pipeline preset. V-SHARP is the OpenRecon default." }
     },
     {
       "id": "maskpreset",

--- a/recipes/qsmxt/OpenReconREADME.md
+++ b/recipes/qsmxt/OpenReconREADME.md
@@ -34,16 +34,64 @@ percentile of positive finite fits so isolated extreme fits are clipped instead
 of quantizing the useful map to zero. The original range, scaling range, scale,
 inverse formula, and clipped-voxel count are included in the returned metadata.
 
+Derived maps set the MRD `RescaleSlope` and `RescaleIntercept` attributes. The
+OpenRecon DICOM writer maps these attributes to the standard DICOM fields.
+Window center and width use the rescaled physical units.
+
+Maps with a non-zero stored-value offset, including QSM, reserve stored code `0`.
+The bridge sends `PixelPaddingValue=0`, and native map values use codes
+`1..4095`. Scanner testing must confirm that the DICOM writer preserves this
+attribute through distortion correction. If preserved, outside-FOV pixels are
+padding rather than susceptibility measurements.
+
+QSM images remain magnitude-type derived images. Their MRD `DataRole` contains
+`Quantitative` so the scanner does not normalize the parametric pixel values.
+
 QSMxT needs unfiltered phase data. SWI sequences that already apply SWI-specific
 phase processing or filtering are not suitable inputs for this OpenRecon
 adapter; for example, `t2_swi_tra_wave4_2mm` does not provide the required
 unfiltered phase data and should not be used for QSMxT. Start from a plain GRE
 sequence instead, and enable both phase and magnitude reconstruction.
 
-The scanner UI defaults are set for a robust inline QSM run: only the QSM map is
-returned, QSM inversion uses RTS, unwrapping uses ROMEO, background-field removal
-uses PDF, and masking uses the robust-threshold preset. Enable `sendoriginal`
-only when the original magnitude and phase series are needed for debugging.
+QSM processing selects WH-QSM:
+
+```text
+qsmxt run <bids_dir> --qsm-algorithm whqsm
+```
+
+The OpenRecon wrapper also supplies the output directory, resource settings,
+and algorithm defaults to the command. The default pipeline uses ROMEO for
+phase unwrapping, V-SHARP for background-field removal, and WH-QSM for QSM
+inversion. This combination provides the best balance of accuracy,
+reproducibility, and resource use for inline OpenRecon processing. Only the QSM
+map is returned by default, and masking uses the robust-threshold preset. Enable
+`sendoriginal` only when the original magnitude and phase series are needed for
+debugging.
+
+### Pipeline presets
+
+The **Pipeline preset** selection box contains the ten supplied scanner-tested
+algorithm combinations. A pipeline preset overrides **QSM algorithm**,
+**Unwrap**, and **Background**. Select **Custom algorithm controls** to use those
+three selection boxes. The custom default remains ROMEO, V-SHARP, and WH-QSM.
+
+Lower inter-scanner error and runtime are better. Higher xSIM is better.
+
+| # | Pipeline preset | Preset id | Inter-scanner error | xSIM | Runtime |
+| --- | --- | --- | ---: | ---: | ---: |
+| 1 | ROMEO + RESHARP + RTS | `romeo-resharp-rts` | 3.7% | 0.293 | 59 s |
+| 2 | ROMEO + iSMV + HD-QSM | `romeo-ismv-hdqsm` | 4.6% | 0.361 | 78 s |
+| 3 | ROMEO + RESHARP + Tikhonov | `romeo-resharp-tikhonov` | 3.8% | 0.283 | 51 s |
+| 4 | ROMEO + RESHARP + TV (ADMM) | `romeo-resharp-tv` | 4.2% | 0.308 | 72 s |
+| 5 | ROMEO + RESHARP + HD-QSM | `romeo-resharp-hdqsm` | 6.5% | 0.360 | 84 s |
+| 6 | ROMEO + iSMV + RTS | `romeo-ismv-rts` | 7.5% | 0.303 | 50 s |
+| 7 | ROMEO + iSMV + WH-QSM | `romeo-ismv-whqsm` | 3.0% | 0.388 | 221 s |
+| 8 | ROMEO + SHARP + WH-QSM | `romeo-sharp-whqsm` | 2.1% | 0.372 | 226 s |
+| 9 | ROMEO + RESHARP + WH-QSM | `romeo-resharp-whqsm` | 3.4% | 0.384 | 224 s |
+| 10 | ROMEO + SHARP + Tikhonov | `romeo-sharp-tikhonov` | 7.6% | 0.271 | 30 s |
+
+Each preset passes the corresponding `--unwrapping-algorithm`,
+`--bf-algorithm`, and `--qsm-algorithm` values to `qsmxt run`.
 
 ## Input Data
 
@@ -57,9 +105,10 @@ Do not use filtered SWI phase images as QSMxT input.
 | config | `config` | choice | `qsmxt` | Selects the MRD server configuration. |
 | Output maps | `sendoutputs` | choice | `qsm` | Selects which QSMxT derivatives are sent back. |
 | Send original | `sendoriginal` | boolean | `false` | Sends original magnitude and phase image series before derived outputs. |
-| QSM algorithm | `qsmalgorithm` | choice | `rts` | QSMxT inversion algorithm. |
+| Pipeline preset | `pipelinepreset` | choice | `custom` | Selects a three-stage algorithm preset or the custom algorithm controls. |
+| QSM algorithm | `qsmalgorithm` | choice | `whqsm` | QSMxT inversion algorithm. |
 | Unwrap | `unwrappingalgorithm` | choice | `romeo` | QSMxT phase-unwrapping algorithm. |
-| Background | `bfalgorithm` | choice | `pdf` | QSMxT background-field removal algorithm. |
+| Background | `bfalgorithm` | choice | `vsharp` | QSMxT background-field removal algorithm. |
 | Mask preset | `maskpreset` | choice | `robust-threshold` | QSMxT masking preset. |
 
 ## Open Source Development

--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -1,5 +1,5 @@
 name: qsmxt
-version: 9.11.0
+version: 9.14.0
 copyright:
   - license: GPL-3.0-only
     url: https://github.com/QSMxT/QSMxT/blob/main/LICENSE
@@ -9,7 +9,7 @@ architectures:
   - x86_64
 
 variables:
-  qsmxt_source_version: 9.11.0
+  qsmxt_source_version: 9.14.0
   qsmxt_tarball:
     try:
       - value: qsmxt_x86_64_tar_gz

--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -9,7 +9,6 @@ architectures:
   - x86_64
 
 variables:
-  qsmxt_source_version: 9.14.0
   qsmxt_tarball:
     try:
       - value: qsmxt_x86_64_tar_gz
@@ -96,7 +95,7 @@ categories:
   - workflows
 
 structured_readme:
-  description: QSMxT is an end-to-end software toolbox for Quantitative Susceptibility Mapping (QSM), rebuilt in Rust as a single self-contained binary. This container packages upstream QSMxT {{ context.qsmxt_source_version }}. It reconstructs QSM from BIDS datasets, converts DICOMs to BIDS, and provides an interactive TUI.
+  description: QSMxT is an end-to-end software toolbox for Quantitative Susceptibility Mapping (QSM), rebuilt in Rust as a single self-contained binary. This container packages upstream QSMxT {{ context.version }}. It reconstructs QSM from BIDS datasets, converts DICOMs to BIDS, and provides an interactive TUI.
   example: |-
     ml qsmxt/{{ context.version }}
 
@@ -115,7 +114,7 @@ readme: |-
   ## qsmxt/{{ context.version }} ##
 
   QSMxT is an end-to-end software toolbox for Quantitative Susceptibility Mapping
-  (QSM). This container packages upstream QSMxT {{ context.qsmxt_source_version }}.
+  (QSM). This container packages upstream QSMxT {{ context.version }}.
   Version 9 is a ground-up reimplementation in Rust: a single
   self-contained binary that reconstructs QSM from BIDS datasets, converts DICOMs
   to BIDS, and includes an interactive TUI. A pinned dcm2niix is bundled.
@@ -153,6 +152,6 @@ files:
   - name: OpenReconREADME.md
     filename: OpenReconREADME.md
   - name: qsmxt_x86_64_tar_gz
-    url: https://github.com/QSMxT/QSMxT/releases/download/v{{ context.qsmxt_source_version }}/qsmxt-v{{ context.qsmxt_source_version }}-x86_64-unknown-linux-gnu.tar.gz
+    url: https://github.com/QSMxT/QSMxT/releases/download/v{{ context.version }}/qsmxt-v{{ context.version }}-x86_64-unknown-linux-gnu.tar.gz
   - name: qsmxt_aarch64_tar_gz
-    url: https://github.com/QSMxT/QSMxT/releases/download/v{{ context.qsmxt_source_version }}/qsmxt-v{{ context.qsmxt_source_version }}-aarch64-unknown-linux-gnu.tar.gz
+    url: https://github.com/QSMxT/QSMxT/releases/download/v{{ context.version }}/qsmxt-v{{ context.version }}-aarch64-unknown-linux-gnu.tar.gz

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -1,5 +1,5 @@
 name: qsmxt
-version: 9.11.0
+version: 9.14.0
 
 test_data:
   output_dir: test_output
@@ -26,6 +26,17 @@ setup:
         raise SystemExit("qsmxt OpenRecon should pass --n-procs 24")
     if nprocs_index + 1 >= len(sys.argv) or sys.argv[nprocs_index + 1] != "24":
         raise SystemExit("qsmxt OpenRecon should pass --n-procs 24")
+    for flag, expected in (
+        ("--qsm-algorithm", "whqsm"),
+        ("--unwrapping-algorithm", "romeo"),
+        ("--bf-algorithm", "vsharp"),
+    ):
+        try:
+            flag_index = sys.argv.index(flag)
+        except ValueError:
+            raise SystemExit(f"qsmxt OpenRecon should pass {flag} {expected}")
+        if flag_index + 1 >= len(sys.argv) or sys.argv[flag_index + 1] != expected:
+            raise SystemExit(f"qsmxt OpenRecon should pass {flag} {expected}")
 
     bids = Path(sys.argv[2])
     output = Path(sys.argv[3])
@@ -33,7 +44,7 @@ setup:
     image = nib.load(str(phase))
     data = np.zeros(image.shape, dtype=np.float32) + 1.5
     name = phase.name.replace("_echo-1_part-phase_MEGRE.nii.gz", "_Chimap.nii")
-    destination = output / "derivatives" / "qsmxt.rs" / "sub-01" / "anat" / name
+    destination = output / "derivatives" / "qsmxt" / "sub-01" / "anat" / name
     destination.parent.mkdir(parents=True, exist_ok=True)
     nib.save(nib.Nifti1Image(data, image.affine), str(destination))
     print(destination)
@@ -81,12 +92,24 @@ tests:
           "config",
           "sendoutputs",
           "sendoriginal",
+          "pipelinepreset",
           "qsmalgorithm",
           "unwrappingalgorithm",
           "bfalgorithm",
           "maskpreset",
       }
       assert expected <= parameter_ids
+      parameters = {parameter["id"]: parameter for parameter in data["parameters"]}
+      pipeline_preset = parameters["pipelinepreset"]
+      assert pipeline_preset["type"] == "choice"
+      assert pipeline_preset["default"] == "custom"
+      assert len(pipeline_preset["values"]) == 11
+      assert parameters["qsmalgorithm"]["default"] == "whqsm"
+      assert "whqsm" in {
+          value["id"] for value in parameters["qsmalgorithm"]["values"]
+      }
+      assert parameters["unwrappingalgorithm"]["default"] == "romeo"
+      assert parameters["bfalgorithm"]["default"] == "vsharp"
       send_original = next(parameter for parameter in data["parameters"] if parameter["id"] == "sendoriginal")
       assert send_original["default"] is False
       assert "minip" not in parameter_ids
@@ -115,6 +138,9 @@ tests:
       assert display.tolist() == [[[1048, 2048, 3048]]]
       assert meta["scale"] == 100000.0
       assert meta["offset"] == 2048.0
+      assert meta["rescale_slope"] == 0.00001
+      assert meta["rescale_intercept"] == -0.02048
+      assert meta["padding_value"] == 0
       assert meta["formula"] == "ppm = (display - 2048) / 100000"
       assert qsmxt.DEFAULT_QSMXT_BINARY == "/opt/qsmxt/qsmxt"
       print(qsmxt.__file__)
@@ -231,6 +257,13 @@ tests:
       assert first_meta["QSMxTOutput"] == "qsm"
       assert first_meta["ImageType"] == "DERIVED\\PRIMARY\\M\\QSMXT_CHIMAP"
       assert first_meta["QSMxTDisplayFormula"] == "ppm = (display - 2048) / 1000"
+      assert first_meta["DataRole"] == ["Image", "Quantitative"]
+      assert float(first_meta["RescaleSlope"]) == 0.001
+      assert float(first_meta["RescaleIntercept"]) == -2.048
+      assert first_meta["RescaleType"] == "US"
+      assert first_meta["PixelPaddingValue"] == "0"
+      assert float(first_meta["WindowCenter"]) == 1.5
+      assert float(first_meta["WindowWidth"]) == 1.0
       assert first_meta["slice_count"] == "2"
       assert first_meta["NumberOfSlices"] == "2"
       assert first_meta["ImagesInAcquisition"] == "2"

--- a/recipes/qsmxt/qsmxt.py
+++ b/recipes/qsmxt/qsmxt.py
@@ -12,13 +12,12 @@ import copy
 import json
 import logging
 import os
-from pathlib import Path
 import re
-import shutil
 import subprocess
 import tempfile
 import traceback
 import uuid
+from pathlib import Path
 
 import ismrmrd
 import nibabel as nib
@@ -34,17 +33,74 @@ except ImportError:
 RECIPE_NAME = "qsmxt"
 DEFAULT_QSMXT_BINARY = "/opt/qsmxt/qsmxt"
 OPENRECON_WORK_ROOT = Path("/tmp/share/qsmxt_openrecon")
-QSMXT_DERIVATIVE_ROOT = Path("derivatives/qsmxt.rs")
+QSMXT_DERIVATIVE_ROOT = Path("derivatives/qsmxt")
 DEFAULT_ECHO_TIME_MS = 20.0
 DEFAULT_ECHO_SPACING_MS = 5.0
 DEFAULT_FIELD_STRENGTH_T = 3.0
 DEFAULT_B0_DIR = (0.0, 0.0, 1.0)
+DEFAULT_QSM_ALGORITHM = "whqsm"
+DEFAULT_UNWRAPPING_ALGORITHM = "romeo"
+DEFAULT_BF_ALGORITHM = "vsharp"
+ALGORITHM_PIPELINE_PRESETS = {
+    "romeo-resharp-rts": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "resharp",
+        "qsm_algorithm": "rts",
+    },
+    "romeo-ismv-hdqsm": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "ismv",
+        "qsm_algorithm": "hdqsm",
+    },
+    "romeo-resharp-tikhonov": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "resharp",
+        "qsm_algorithm": "tikhonov",
+    },
+    "romeo-resharp-tv": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "resharp",
+        "qsm_algorithm": "tv",
+    },
+    "romeo-resharp-hdqsm": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "resharp",
+        "qsm_algorithm": "hdqsm",
+    },
+    "romeo-ismv-rts": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "ismv",
+        "qsm_algorithm": "rts",
+    },
+    "romeo-ismv-whqsm": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "ismv",
+        "qsm_algorithm": "whqsm",
+    },
+    "romeo-sharp-whqsm": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "sharp",
+        "qsm_algorithm": "whqsm",
+    },
+    "romeo-resharp-whqsm": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "resharp",
+        "qsm_algorithm": "whqsm",
+    },
+    "romeo-sharp-tikhonov": {
+        "unwrapping_algorithm": "romeo",
+        "bf_algorithm": "sharp",
+        "qsm_algorithm": "tikhonov",
+    },
+}
 ORIGINAL_SERIES_START = 100
 OUTPUT_SERIES_START = 180
 SCANNER_PARTITION_INDEX = 0
 SCANNER_DISPLAY_MIN = 0
 SCANNER_DISPLAY_MAX = 4095
 SCANNER_DISPLAY_CENTER = 2048
+SCANNER_DISPLAY_PADDING_VALUE = 0
+SCANNER_DISPLAY_DATA_MIN = 1
 T2STAR_SCALE_PERCENTILE = 99.9
 T2STAR_SCALE_MIN_POSITIVE_VOXELS = 100
 SCANNER_DISPLAY_SCALE_FACTORS = (
@@ -101,6 +157,13 @@ QSMXT_OUTPUTS = {
 
 SCANNER_WRITE_UNSAFE_META_KEYS = {
     "ImageTypeValue3",
+}
+SOURCE_SCALING_META_KEYS = {
+    "PixelPaddingRangeLimit",
+    "PixelPaddingValue",
+    "RescaleIntercept",
+    "RescaleSlope",
+    "RescaleType",
 }
 ORIGINAL_STORAGE_FIELDS = (
     "Actual3DImagePartNumber",
@@ -846,7 +909,6 @@ def _nifti_to_mrd_images(
         display_meta["display_max"],
         display_meta["clipped_voxels"],
     )
-    display_data_xyz = np.transpose(display_data_zyx, (2, 1, 0))
     slice_count = int(data_zyx.shape[0])
     slice_fov = _nifti_slice_field_of_view(nifti, data_xyz.shape)
     source_geometry_images = _source_geometry_images_for_output(
@@ -921,7 +983,7 @@ def _nifti_to_mrd_images(
             image_type_token,
             output_id,
             units,
-            display_data_xyz,
+            data_xyz,
             nifti_path,
             slice_index,
             slice_count,
@@ -1270,6 +1332,8 @@ def _settings_from_config(config, metadata=None):
     else:
         b0_dir_source = "nifti_affine"
 
+    pipeline_preset, algorithm_settings = _algorithm_settings(params)
+
     return {
         "send_original": _config_bool(params, "sendoriginal", False),
         "send_outputs": str(params.get("sendoutputs", "qsm") or "qsm"),
@@ -1283,9 +1347,8 @@ def _settings_from_config(config, metadata=None):
         "b0_dir_source": b0_dir_source,
         "phase_wrap": _config_float(params, "phasewrap", 4096.0),
         "qsmxt_binary": _config_text(params, "qsmxtbinary", ""),
-        "qsm_algorithm": _optional_choice(params, "qsmalgorithm"),
-        "unwrapping_algorithm": _optional_choice(params, "unwrappingalgorithm"),
-        "bf_algorithm": _optional_choice(params, "bfalgorithm"),
+        "pipeline_preset": pipeline_preset,
+        **algorithm_settings,
         "mask_preset": _optional_choice(params, "maskpreset"),
         "qsm_reference": _optional_choice(params, "qsmreference"),
         "no_qsm": _config_bool(params, "noqsm", False),
@@ -1294,6 +1357,35 @@ def _settings_from_config(config, metadata=None):
         "do_r2starmap": _config_bool(params, "dor2starmap", False),
         "inhomogeneity_correction": _config_bool(params, "inhomogeneitycorrection", True),
     }
+
+
+def _algorithm_settings(params):
+    pipeline_preset = _config_text(params, "pipelinepreset", "custom").lower()
+    if pipeline_preset in {"", "default", "none"}:
+        pipeline_preset = "custom"
+
+    if pipeline_preset == "custom":
+        return pipeline_preset, {
+            "qsm_algorithm": (
+                _optional_choice(params, "qsmalgorithm") or DEFAULT_QSM_ALGORITHM
+            ),
+            "unwrapping_algorithm": (
+                _optional_choice(params, "unwrappingalgorithm")
+                or DEFAULT_UNWRAPPING_ALGORITHM
+            ),
+            "bf_algorithm": (
+                _optional_choice(params, "bfalgorithm") or DEFAULT_BF_ALGORITHM
+            ),
+        }
+
+    try:
+        preset = ALGORITHM_PIPELINE_PRESETS[pipeline_preset]
+    except KeyError as error:
+        choices = ", ".join(ALGORITHM_PIPELINE_PRESETS)
+        raise ValueError(
+            f"unknown pipelinepreset {pipeline_preset!r}; expected custom or {choices}"
+        ) from error
+    return pipeline_preset, dict(preset)
 
 
 def _group_images_by_series(images):
@@ -1550,7 +1642,7 @@ def _output_meta(
     image_type_token,
     output_id,
     units,
-    output_data,
+    physical_data,
     nifti_path,
     slice_index,
     slice_count,
@@ -1562,6 +1654,9 @@ def _output_meta(
     meta = _meta_from_image(source_image)
     _strip_source_parent_refs(meta)
     _strip_scanner_write_unsafe_meta(meta)
+    for key in SOURCE_SCALING_META_KEYS:
+        if key in meta:
+            del meta[key]
     if "IceMiniHead" in meta:
         del meta["IceMiniHead"]
 
@@ -1574,13 +1669,13 @@ def _output_meta(
         slice_index,
     )
     image_type = f"DERIVED\\PRIMARY\\M\\{image_type_token}"
-    center, width = _window_center_width(output_data)
+    center, width = _window_center_width(physical_data)
     if slice_number is None:
         slice_number = slice_index
     slice_number = str(int(slice_number))
     image_comment = _scanner_display_comment(series_name, display_meta)
 
-    meta["DataRole"] = "Image"
+    meta["DataRole"] = ["Image", "Quantitative"]
     meta["ImageProcessingHistory"] = ["PYTHON", "QSMXT"]
     meta["ImageType"] = image_type
     meta["DicomImageType"] = image_type
@@ -1627,6 +1722,15 @@ def _output_meta(
     meta["QSMxTDisplayMin"] = str(int(display_meta["display_min"]))
     meta["QSMxTDisplayMax"] = str(int(display_meta["display_max"]))
     meta["QSMxTDisplayClippedVoxels"] = str(int(display_meta["clipped_voxels"]))
+    meta["RescaleSlope"] = _format_display_number(
+        display_meta["rescale_slope"]
+    )
+    meta["RescaleIntercept"] = _format_display_number(
+        display_meta["rescale_intercept"]
+    )
+    meta["RescaleType"] = "US"
+    if display_meta["padding_value"] is not None:
+        meta["PixelPaddingValue"] = str(int(display_meta["padding_value"]))
     meta["WindowCenter"] = f"{float(center):.6g}"
     meta["WindowWidth"] = f"{float(width):.6g}"
     meta.update(_header_geometry_meta(header))
@@ -1666,23 +1770,70 @@ def _validate_output_images(output_images, input_images):
             errors.append(f"image {index} is missing SOPInstanceUID")
         if np.asarray(image.data).dtype != np.uint16:
             errors.append(f"image {index} data is not uint16")
+        data = np.asarray(image.data)
         if image.data.size:
-            data_min = int(np.min(image.data))
-            data_max = int(np.max(image.data))
+            data_min = int(np.min(data))
+            data_max = int(np.max(data))
             if data_min < SCANNER_DISPLAY_MIN or data_max > SCANNER_DISPLAY_MAX:
                 errors.append(
                     f"image {index} data range {data_min}..{data_max} is outside "
                     f"{SCANNER_DISPLAY_MIN}..{SCANNER_DISPLAY_MAX}"
                 )
+        data_roles = meta.get("DataRole") or []
+        if not isinstance(data_roles, (list, tuple)):
+            data_roles = [data_roles]
+        if "Quantitative" not in {str(value) for value in data_roles}:
+            errors.append(f"image {index} DataRole is not Quantitative")
         for key in (
             "QSMxTDisplayScale",
             "QSMxTDisplayOffset",
             "QSMxTDisplayFormula",
             "QSMxTDisplayScaleInputMin",
             "QSMxTDisplayScaleInputMax",
+            "RescaleSlope",
+            "RescaleIntercept",
+            "RescaleType",
         ):
             if not _meta_text(meta, key):
                 errors.append(f"image {index} is missing {key}")
+
+        display_scale = _meta_float(meta, "QSMxTDisplayScale")
+        display_offset = _meta_float(meta, "QSMxTDisplayOffset")
+        rescale_slope = _meta_float(meta, "RescaleSlope")
+        rescale_intercept = _meta_float(meta, "RescaleIntercept")
+        if display_scale is not None and display_scale > 0.0:
+            expected_slope = 1.0 / display_scale
+            expected_intercept = -(display_offset or 0.0) / display_scale
+            if rescale_slope is None or not np.isclose(
+                rescale_slope,
+                expected_slope,
+                rtol=1e-6,
+            ):
+                errors.append(
+                    f"image {index} RescaleSlope does not match display scale"
+                )
+            if rescale_intercept is None or not np.isclose(
+                rescale_intercept,
+                expected_intercept,
+                rtol=1e-6,
+                atol=1e-12,
+            ):
+                errors.append(
+                    f"image {index} RescaleIntercept does not match display offset"
+                )
+        if _meta_text(meta, "RescaleType") != "US":
+            errors.append(f"image {index} RescaleType is not US")
+
+        padding_value = _meta_int(meta, "PixelPaddingValue")
+        if display_offset:
+            if padding_value != SCANNER_DISPLAY_PADDING_VALUE:
+                errors.append(
+                    f"image {index} is missing stored-zero padding metadata"
+                )
+            elif np.any(data == padding_value):
+                errors.append(f"image {index} uses its padding value as native data")
+        elif padding_value is not None:
+            errors.append(f"image {index} keeps an inapplicable PixelPaddingValue")
 
         slice_index = _meta_int(meta, "SliceNo")
         if slice_index is None:
@@ -2051,7 +2202,7 @@ def _window_center_width(data):
     data_max = float(np.max(finite))
     width = data_max - data_min
     if width <= 0:
-        width = 1.0
+        return data_min, 1.0
     return data_min + width / 2.0, width
 
 
@@ -2065,6 +2216,9 @@ def _scanner_display_volume(data, output_id, units):
         return display, {
             "scale": float(SCANNER_DISPLAY_MAX),
             "offset": 0.0,
+            "rescale_slope": 1.0 / float(SCANNER_DISPLAY_MAX),
+            "rescale_intercept": 0.0,
+            "padding_value": None,
             "units": units,
             "formula": f"{units} = display / {SCANNER_DISPLAY_MAX}",
             "clipped_voxels": 0,
@@ -2084,11 +2238,20 @@ def _scanner_display_volume(data, output_id, units):
         input_min,
         input_max,
     )
-    offset = float(SCANNER_DISPLAY_CENTER) if _scanner_display_needs_offset(
+    needs_offset = _scanner_display_needs_offset(
         output_id,
         scale_input_min,
-    ) else 0.0
-    scale = _scanner_display_scale(scale_input_min, scale_input_max, offset)
+    )
+    offset = float(SCANNER_DISPLAY_CENTER) if needs_offset else 0.0
+    display_data_min = (
+        SCANNER_DISPLAY_DATA_MIN if needs_offset else SCANNER_DISPLAY_MIN
+    )
+    scale = _scanner_display_scale(
+        scale_input_min,
+        scale_input_max,
+        offset,
+        display_data_min,
+    )
     if output_id == "t2star":
         cleaned = np.nan_to_num(values, nan=0.0, posinf=0.0, neginf=0.0)
     else:
@@ -2096,16 +2259,19 @@ def _scanner_display_volume(data, output_id, units):
     scaled = cleaned * scale + offset
     clipped_voxels = int(
         np.count_nonzero(
-            (scaled < SCANNER_DISPLAY_MIN) | (scaled > SCANNER_DISPLAY_MAX)
+            (scaled < display_data_min) | (scaled > SCANNER_DISPLAY_MAX)
         )
     )
-    display = np.clip(np.rint(scaled), SCANNER_DISPLAY_MIN, SCANNER_DISPLAY_MAX)
+    display = np.clip(np.rint(scaled), display_data_min, SCANNER_DISPLAY_MAX)
     display = display.astype(np.uint16, copy=False)
     formula = _scanner_display_formula(units, offset, scale)
 
     return display, {
         "scale": float(scale),
         "offset": float(offset),
+        "rescale_slope": 1.0 / float(scale),
+        "rescale_intercept": -float(offset) / float(scale),
+        "padding_value": SCANNER_DISPLAY_PADDING_VALUE if needs_offset else None,
         "units": units,
         "formula": formula,
         "clipped_voxels": clipped_voxels,
@@ -2138,12 +2304,12 @@ def _scanner_display_needs_offset(output_id, input_min):
     return output_id == "qsm" or input_min < 0.0
 
 
-def _scanner_display_scale(input_min, input_max, offset):
+def _scanner_display_scale(input_min, input_max, offset, display_min):
     limits = []
     if input_max > 0.0:
         limits.append((SCANNER_DISPLAY_MAX - offset) / input_max)
     if input_min < 0.0:
-        limits.append((SCANNER_DISPLAY_MIN - offset) / input_min)
+        limits.append((display_min - offset) / input_min)
     max_scale = min(limits) if limits else SCANNER_DISPLAY_SCALE_FACTORS[0]
     if max_scale <= 0.0 or not np.isfinite(max_scale):
         max_scale = SCANNER_DISPLAY_SCALE_FACTORS[-1]
@@ -2164,10 +2330,15 @@ def _scanner_display_formula(units, offset, scale):
 
 
 def _scanner_display_comment(series_name, display_meta):
-    return (
+    comment = (
         f"{series_name}; scanner display uint16 0-{SCANNER_DISPLAY_MAX}; "
         f"{display_meta['formula']}"
     )
+    if display_meta["padding_value"] is not None:
+        comment += (
+            f"; stored {int(display_meta['padding_value'])} is DICOM pixel padding"
+        )
+    return comment
 
 
 def _format_display_number(value):

--- a/recipes/qsmxt/test_qsmxt_openrecon.py
+++ b/recipes/qsmxt/test_qsmxt_openrecon.py
@@ -2,6 +2,7 @@ import base64
 import stat
 import sys
 import textwrap
+from pathlib import Path
 
 import ismrmrd
 import nibabel as nib
@@ -271,6 +272,17 @@ def _fake_qsmxt_binary(tmp_path, affine_offset=None):
                 raise SystemExit("qsmxt OpenRecon should pass --n-procs 24")
             if nprocs_index + 1 >= len(sys.argv) or sys.argv[nprocs_index + 1] != "24":
                 raise SystemExit("qsmxt OpenRecon should pass --n-procs 24")
+            for flag, expected in (
+                ("--qsm-algorithm", "whqsm"),
+                ("--unwrapping-algorithm", "romeo"),
+                ("--bf-algorithm", "vsharp"),
+            ):
+                try:
+                    flag_index = sys.argv.index(flag)
+                except ValueError:
+                    raise SystemExit(f"qsmxt OpenRecon should pass {{flag}} {{expected}}")
+                if flag_index + 1 >= len(sys.argv) or sys.argv[flag_index + 1] != expected:
+                    raise SystemExit(f"qsmxt OpenRecon should pass {{flag}} {{expected}}")
             bids = Path(sys.argv[2])
             output = Path(sys.argv[3])
             phase = sorted(bids.glob("sub-*/anat/*_echo-1_part-phase_MEGRE.nii.gz"))[0]
@@ -279,7 +291,7 @@ def _fake_qsmxt_binary(tmp_path, affine_offset=None):
             affine = img.affine.copy()
             affine[:3, 3] += np.asarray({affine_offset!r}, dtype=float)
             name = phase.name.replace("_echo-1_part-phase_MEGRE.nii.gz", "_Chimap.nii")
-            dest = output / "derivatives" / "qsmxt.rs" / "sub-01" / "anat" / name
+            dest = output / "derivatives" / "qsmxt" / "sub-01" / "anat" / name
             dest.parent.mkdir(parents=True, exist_ok=True)
             nib.save(nib.Nifti1Image(data, affine), str(dest))
             """
@@ -287,6 +299,122 @@ def _fake_qsmxt_binary(tmp_path, affine_offset=None):
     )
     fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
     return fake
+
+
+def test_openrecon_defaults_select_whqsm_romeo_and_vsharp():
+    assert qsmxt.QSMXT_DERIVATIVE_ROOT == Path("derivatives/qsmxt")
+
+    settings = qsmxt._settings_from_config({}, FakeMetadata())
+
+    assert settings["pipeline_preset"] == "custom"
+    assert settings["qsm_algorithm"] == "whqsm"
+    assert settings["unwrapping_algorithm"] == "romeo"
+    assert settings["bf_algorithm"] == "vsharp"
+
+
+def test_openrecon_pipeline_presets_select_all_three_algorithms():
+    expected = {
+        "romeo-resharp-rts": ("romeo", "resharp", "rts"),
+        "romeo-ismv-hdqsm": ("romeo", "ismv", "hdqsm"),
+        "romeo-resharp-tikhonov": ("romeo", "resharp", "tikhonov"),
+        "romeo-resharp-tv": ("romeo", "resharp", "tv"),
+        "romeo-resharp-hdqsm": ("romeo", "resharp", "hdqsm"),
+        "romeo-ismv-rts": ("romeo", "ismv", "rts"),
+        "romeo-ismv-whqsm": ("romeo", "ismv", "whqsm"),
+        "romeo-sharp-whqsm": ("romeo", "sharp", "whqsm"),
+        "romeo-resharp-whqsm": ("romeo", "resharp", "whqsm"),
+        "romeo-sharp-tikhonov": ("romeo", "sharp", "tikhonov"),
+    }
+
+    assert len(qsmxt.ALGORITHM_PIPELINE_PRESETS) == 10
+    for preset_id, algorithms in expected.items():
+        settings = qsmxt._settings_from_config(
+            {
+                "parameters": {
+                    "pipelinepreset": preset_id,
+                    "qsmalgorithm": "tkd",
+                    "unwrappingalgorithm": "laplacian",
+                    "bfalgorithm": "pdf",
+                }
+            },
+            FakeMetadata(),
+        )
+
+        assert settings["pipeline_preset"] == preset_id
+        assert (
+            settings["unwrapping_algorithm"],
+            settings["bf_algorithm"],
+            settings["qsm_algorithm"],
+        ) == algorithms
+
+
+def test_openrecon_pipeline_preset_reaches_qsmxt_command(tmp_path, monkeypatch):
+    settings = qsmxt._settings_from_config(
+        {"parameters": {"pipelinepreset": "romeo-resharp-hdqsm"}},
+        FakeMetadata(),
+    )
+    settings["qsmxt_binary"] = "/opt/qsmxt/qsmxt"
+    bids_dir = tmp_path / "bids"
+    bids_dir.mkdir()
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        return qsmxt.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(qsmxt.subprocess, "run", fake_run)
+
+    qsmxt._run_qsmxt(bids_dir, tmp_path / "output", settings)
+
+    command, kwargs = commands[0]
+    assert command[command.index("--unwrapping-algorithm") + 1] == "romeo"
+    assert command[command.index("--bf-algorithm") + 1] == "resharp"
+    assert command[command.index("--qsm-algorithm") + 1] == "hdqsm"
+    assert kwargs["cwd"] == str(bids_dir)
+
+
+def test_openrecon_processing_defaults_can_be_overridden():
+    settings = qsmxt._settings_from_config(
+        {
+            "parameters": {
+                "qsmalgorithm": "rts",
+                "unwrappingalgorithm": "laplacian",
+                "bfalgorithm": "pdf",
+            }
+        },
+        FakeMetadata(),
+    )
+
+    assert settings["qsm_algorithm"] == "rts"
+    assert settings["unwrapping_algorithm"] == "laplacian"
+    assert settings["bf_algorithm"] == "pdf"
+
+
+def test_openrecon_label_exposes_processing_defaults():
+    label_path = Path(qsmxt.__file__).with_name("OpenReconLabel.json")
+    parameters = {
+        parameter["id"]: parameter
+        for parameter in qsmxt.json.loads(label_path.read_text())["parameters"]
+    }
+
+    pipeline_preset = parameters["pipelinepreset"]
+    assert pipeline_preset["type"] == "choice"
+    assert pipeline_preset["default"] == "custom"
+    assert [value["id"] for value in pipeline_preset["values"]] == [
+        "custom",
+        *qsmxt.ALGORITHM_PIPELINE_PRESETS,
+    ]
+    assert parameters["qsmalgorithm"]["default"] == "whqsm"
+    qsm_algorithms = {
+        value["id"] for value in parameters["qsmalgorithm"]["values"]
+    }
+    assert {"hdqsm", "whqsm"} <= qsm_algorithms
+    assert parameters["unwrappingalgorithm"]["default"] == "romeo"
+    assert parameters["bfalgorithm"]["default"] == "vsharp"
+    bf_algorithms = {
+        value["id"] for value in parameters["bfalgorithm"]["values"]
+    }
+    assert "resharp" in bf_algorithms
 
 
 def test_scanner_display_volume_scales_qsm_ppm_range_to_uint12_interval():
@@ -299,7 +427,65 @@ def test_scanner_display_volume_scales_qsm_ppm_range_to_uint12_interval():
     assert meta["scale"] == 100000.0
     assert meta["offset"] == 2048.0
     assert meta["formula"] == "ppm = (display - 2048) / 100000"
+    assert meta["rescale_slope"] == 0.00001
+    assert meta["rescale_intercept"] == -0.02048
+    assert meta["padding_value"] == 0
     assert meta["clipped_voxels"] == 0
+
+
+def test_scanner_display_volume_reserves_stored_zero_for_qsm_padding():
+    data = np.asarray([[[-0.02048, 0.0, 0.01]]], dtype=np.float32)
+
+    display, meta = qsmxt._scanner_display_volume(data, "qsm", "ppm")
+
+    assert 0 not in display
+    decoded = display.astype(np.float64) * meta["rescale_slope"]
+    decoded += meta["rescale_intercept"]
+    assert np.allclose(decoded, data, atol=meta["rescale_slope"] / 2)
+    assert meta["padding_value"] == 0
+
+
+def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
+    source = _image(
+        1,
+        1,
+        "gre_qsm",
+        np.ones((1, 1, 3), dtype=np.float32),
+        meta_values={
+            "RescaleSlope": "2",
+            "RescaleIntercept": "-4096",
+            "RescaleType": "PHASE",
+            "PixelPaddingValue": "4095",
+            "PixelPaddingRangeLimit": "4095",
+        },
+    )
+    physical = np.asarray([[[-0.01, 0.0, 0.01]]], dtype=np.float32)
+    display, display_meta = qsmxt._scanner_display_volume(physical, "qsm", "ppm")
+
+    meta = qsmxt._output_meta(
+        source,
+        source.getHead(),
+        qsmxt.OUTPUT_SERIES_START,
+        "QSMxT QSM",
+        "QSMXT_CHIMAP",
+        "qsm",
+        "ppm",
+        physical,
+        Path("/tmp/qsm.nii.gz"),
+        0,
+        1,
+        display_meta,
+    )
+
+    assert meta["DataRole"] == ["Image", "Quantitative"]
+    assert float(meta["RescaleSlope"]) == 0.00001
+    assert float(meta["RescaleIntercept"]) == -0.02048
+    assert meta["RescaleType"] == "US"
+    assert meta["PixelPaddingValue"] == "0"
+    assert "PixelPaddingRangeLimit" not in meta
+    assert float(meta["WindowCenter"]) == 0.0
+    assert float(meta["WindowWidth"]) == 0.02
+    assert 0 not in display
 
 
 def test_scanner_display_volume_maps_mask_foreground_to_valid_uint12_maximum():
@@ -546,6 +732,13 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert meta["QSMxTDisplayScale"] == "1000"
     assert meta["QSMxTDisplayOffset"] == "2048"
     assert meta["QSMxTDisplayFormula"] == "ppm = (display - 2048) / 1000"
+    assert meta["DataRole"] == ["Image", "Quantitative"]
+    assert float(meta["RescaleSlope"]) == 0.001
+    assert float(meta["RescaleIntercept"]) == -2.048
+    assert meta["RescaleType"] == "US"
+    assert meta["PixelPaddingValue"] == "0"
+    assert float(meta["WindowCenter"]) == 1.5
+    assert float(meta["WindowWidth"]) == 1.0
     assert meta["QSMxTDisplayScaleInputMin"] == "1.5"
     assert meta["QSMxTDisplayScaleInputMax"] == "1.5"
     assert meta["QSMxTDisplayMin"] == "3548"
@@ -553,7 +746,8 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert meta["QSMxTDisplayClippedVoxels"] == "0"
     assert meta["ImageComment"] == (
         "QSMxT QSM; scanner display uint16 0-4095; "
-        "ppm = (display - 2048) / 1000"
+        "ppm = (display - 2048) / 1000; "
+        "stored 0 is DICOM pixel padding"
     )
     assert meta["ImageComments"] == meta["ImageComment"]
     assert meta["slice_count"] == "2"


### PR DESCRIPTION
## Summary

- update the container from QSMxT 9.11.0 to 9.14.0 and use the current `derivatives/qsmxt` output path
- preserve quantitative QSM values with explicit rescale and stored-zero padding metadata
- default OpenRecon processing to ROMEO, V-SHARP, and WH-QSM
- add ten scanner-selectable algorithm pipeline presets and document their supplied comparison results

## Testing

- `pytest -q recipes/qsmxt/test_qsmxt_openrecon.py` (25 passed)
- `pytest -q builder/tests` (260 passed)
- `python workflows/validate_openrecon_labels.py`
- `python builder/validation.py recipes/qsmxt/build.yaml`
- `python -m builder stage qsmxt --recreate --download`
- ran the downloaded QSMxT 9.14.0 binary and checked the required algorithm flags in `qsmxt run --help`

Scanner testing is still required to confirm how distortion correction handles `PixelPaddingValue` in the final DICOM series.
