### PR TITLE
Update MuscleMap container to whole-body model v1.4

### DIFF
--- a/recipes/musclemap/OpenReconLabel.json
+++ b/recipes/musclemap/OpenReconLabel.json
@@ -13,7 +13,7 @@
       "manufacture_date":"2023/02/14",
       "material_number":"musclemap_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "gtin":"00860000171212",
-      "udi":"(01)00860000171212(21)1.3.0",
+      "udi":"(01)00860000171212(21)VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "safety_advices":"",
       "special_operating_instructions":"MuscleMap Segmentation",
       "additional_relevant_information":""
@@ -95,7 +95,7 @@
       "id": "labeltransform",
       "label": { "en": "Label Transform" },
       "type": "boolean",
-      "information": { "en": "To invert: original = 10 * (mapped // 3) + (mapped % 3) " },
+      "information": { "en": "For whole-body labels only, map IDs into the DICOM int12 range. Regional labels remain unchanged. To invert: original = 10 * (mapped // 3) + (mapped % 3)." },
       "default": true
     },
     {
@@ -152,33 +152,8 @@
           "name": { "en": "abdomen" }
         },
         {
-          "id": "pelvis",
-          "name": { "en": "pelvis" }
-        },
-        {
-          "id": "thigh",
-          "name": { "en": "thigh" }
-        },
-        {
-          "id": "leg",
-          "name": { "en": "leg" }
-        }
-      ],
-      "default": "wholebody",
-      "information": { "en": "Select the body region for segmentation" }
-    },
-    {
-      "id": "metricsregion",
-      "label": { "en": "Metrics Region" },
-      "type": "choice",
-      "values": [
-        {
-          "id": "wholebody",
-          "name": { "en": "wholebody" }
-        },
-        {
-          "id": "abdomen",
-          "name": { "en": "abdomen" }
+          "id": "forearm",
+          "name": { "en": "forearm" }
         },
         {
           "id": "pelvis",
@@ -194,7 +169,7 @@
         }
       ],
       "default": "wholebody",
-      "information": { "en": "Region passed to MuscleMap metrics" }
+      "information": { "en": "Select the body region for segmentation and metrics." }
     },
     {
       "id": "chunksize",

--- a/recipes/musclemap/OpenReconREADME.md
+++ b/recipes/musclemap/OpenReconREADME.md
@@ -1,6 +1,11 @@
 # musclemap VERSION_WILL_BE_REPLACED_BY_SCRIPT
 
-This OpenRecon tool is based on the MuscleMap Toolbox (https://github.com/MuscleMap/MuscleMap) - A free and open-source software toolbox for whole-body muscle segmentation and analysis.
+This OpenRecon tool packages [MuscleMap](https://github.com/MuscleMap/MuscleMap),
+a free and open-source toolbox for muscle segmentation and analysis. The image
+contains MuscleMap software 2.0 at the audited model-v1.4 commit, whole-body
+model v1.4, regional model v0.0, and the abdomen registration template. These
+assets are baked into the read-only container, so scanner-side runs do not need
+to download data or write into `/opt`.
 
 It runs on the selected image type from a Dixon sequence and generates muscle segmentations. Opposed Phase is selected by default.
 
@@ -30,10 +35,10 @@ https://doi.org/10.3390/jimaging10110262
 | `segmentinphase` | Segment Inphase | boolean | `false` | Run MuscleMap segmentation on the Dixon in-phase image |
 | `segmentopposedphase` | Segment Opposed Phase | boolean | `true` | Run MuscleMap segmentation on the Dixon opposed-phase image |
 | `segmentfat` | Segment Fat | boolean | `false` | Run MuscleMap segmentation on the Dixon fat image |
-| `labeltransform` | Scale labels to lower integer range for DICOM 12BIT | boolean | `true` | Applying label transformation: 3 * (label_in // 10) + (label_in % 10) |
+| `labeltransform` | Scale whole-body labels into the DICOM int12 range | boolean | `true` | Apply `3 * (label_in // 10) + (label_in % 10)` to whole-body labels. Regional labels remain unchanged |
 | `metricsoutput` | Metrics output | choice | `all` | Select where MuscleMap average metrics are returned |
-| `bodyregion` | Body Region | choice | `wholebody, abdomen, pelvis, thigh, leg` | Select the body region for segmentation |
-| `chunksize` | Chunk Size | string | `100` | Chunk size between 5 and 200 - change for memory optimization on GPU |
+| `bodyregion` | Body Region | choice | `wholebody` | Select wholebody, abdomen, forearm, pelvis, thigh, or leg for segmentation and metrics |
+| `chunksize` | Chunk Size | string | `auto` | Use automatic memory-aware chunk sizing, or set a positive integer |
 | `spatialoverlap` | Spatial Overlap | int | `50` | Spatial overlap percentage |
 
 # Scanner output handling
@@ -97,9 +102,9 @@ Caveats:
   the composer has no matching channel to combine them (a warning is logged).
 - **Only one segmentation contrast** is composed. The Fat-Fraction compose
   container is statically pre-sized to a single contrast's slot count, so if more
-  than one segmentation contrast is selected (e.g. Water and Fat) compose mode
+  than one segmentation contrast is selected, such as Water and Fat, compose mode
   restricts segmentation to the first one (display order Water, In-Phase,
-  Opposed-Phase, Fat) — emitting two `FAT_FRAC` series would overfill the channel
+  Opposed-Phase, Fat). Emitting two `FAT_FRAC` series would overfill the channel
   and switch composing off for the whole measurement.
 
 ### How the routing works (ICE composing model)
@@ -110,7 +115,7 @@ compose functor listens for a fixed `ComposingGroup` (the configurator-owned
 and is pre-sized to `m_iNumberTotal` slots. The only image-controllable lever is
 the `ImageType` / `ImageTypeValue4` filter, which selects the `ComposeType`
 channel. `ComposingGroup` is **not** present in the MRD/IceMiniHead data and
-cannot be set from the OpenRecon module — it is assigned on the ICE side. Within
+cannot be set from the OpenRecon module. ICE assigns it on the scanner side. Within
 one Dixon acquisition the Water, Fat and Fat-Fraction channels all share the same
 `ComposingGroup` and differ only by `ComposeType`. MuscleMap reuses the genuine
 Fat-Fraction images as return carriers so the scanner assigns the labels to the
@@ -119,6 +124,13 @@ same Fat-Fraction compose container.
 # Labels
 
 Label values are model-specific and depend on the selected `bodyregion`.
+The [whole-body v1.4 record](https://zenodo.org/records/21929873) and the
+regional records for [abdomen](https://zenodo.org/records/19631081),
+[forearm](https://zenodo.org/records/19633115),
+[leg](https://zenodo.org/records/19633057),
+[pelvis](https://zenodo.org/records/19632902), and
+[thigh](https://zenodo.org/records/19633000) are the immutable sources for the
+tables below.
 
 ## `wholebody`
 
@@ -128,7 +140,7 @@ For running this in Open Recon we need a reversible int12-safe mapping:
 
 `original = 10 * (mapped // 3) + (mapped % 3)`
 
-This transform is valid for labels ending in `0`, `1`, or `2`
+This transform is valid for labels ending in `0`, `1`, or `2`.
 
 Metrics extraction uses the original unscaled labels so MuscleMap can map label
 IDs to anatomy names, even when the returned segmentation overlay is scaled for
@@ -168,16 +180,16 @@ DICOM.
 | abdomen | psoas major | right | 5122 | 1538 |
 | abdomen | quadratus lumborum | left | 5131 | 1540 |
 | abdomen | quadratus lumborum | right | 5132 | 1541 |
-| abdomen | lattisimus dorsi | left | 5141 | 1543 |
-| abdomen | lattisimus dorsi | right | 5142 | 1544 |
+| abdomen | latissimus dorsi | left | 5141 | 1543 |
+| abdomen | latissimus dorsi | right | 5142 | 1544 |
 | pelvis | gluteus minimus | left | 6101 | 1831 |
 | pelvis | gluteus minimus | right | 6102 | 1832 |
 | pelvis | gluteus medius | left | 6111 | 1834 |
 | pelvis | gluteus medius | right | 6112 | 1835 |
 | pelvis | gluteus maximus | left | 6121 | 1837 |
 | pelvis | gluteus maximus | right | 6122 | 1838 |
-| pelvis | tensor fascia latae | left | 6131 | 1840 |
-| pelvis | tensor fascia latae | right | 6132 | 1841 |
+| pelvis | tensor fasciae latae | left | 6131 | 1840 |
+| pelvis | tensor fasciae latae | right | 6132 | 1841 |
 | pelvis | iliacus | left | 6141 | 1843 |
 | pelvis | iliacus | right | 6142 | 1844 |
 | pelvis | ilium | left | 6151 | 1846 |
@@ -221,20 +233,34 @@ DICOM.
 | thigh | adductor longus | right | 7212 | 2165 |
 | thigh | adductor brevis | left | 7221 | 2167 |
 | thigh | adductor brevis | right | 7222 | 2168 |
-| leg | anterior compartment | left | 8101 | 2431 |
-| leg | anterior compartment | right | 8102 | 2432 |
-| leg | deep posterior compartment | left | 8111 | 2434 |
-| leg | deep posterior compartment | right | 8112 | 2435 |
-| leg | lateral compartment | left | 8121 | 2437 |
-| leg | lateral compartment | right | 8122 | 2438 |
+| thigh | patella | left | 7231 | 2170 |
+| thigh | patella | right | 7232 | 2171 |
+| leg | tibialis anterior | left | 8101 | 2431 |
+| leg | tibialis anterior | right | 8102 | 2432 |
+| leg | tibialis posterior | left | 8111 | 2434 |
+| leg | tibialis posterior | right | 8112 | 2435 |
+| leg | peroneus longus | left | 8121 | 2437 |
+| leg | peroneus longus | right | 8122 | 2438 |
 | leg | soleus | left | 8131 | 2440 |
 | leg | soleus | right | 8132 | 2441 |
-| leg | gastrocnemius | left | 8141 | 2443 |
-| leg | gastrocnemius | right | 8142 | 2444 |
-| leg | tibia | left | 8151 | 2446 |
-| leg | tibia | right | 8152 | 2447 |
-| leg | fibula | left | 8161 | 2449 |
-| leg | fibula | right | 8162 | 2450 |
+| leg | medial gastrocnemius | left | 8141 | 2443 |
+| leg | medial gastrocnemius | right | 8142 | 2444 |
+| leg | lateral gastrocnemius | left | 8151 | 2446 |
+| leg | lateral gastrocnemius | right | 8152 | 2447 |
+| leg | tibia | left | 8161 | 2449 |
+| leg | tibia | right | 8162 | 2450 |
+| leg | fibula | left | 8171 | 2452 |
+| leg | fibula | right | 8172 | 2453 |
+| leg | flexor hallucis longus | left | 8181 | 2455 |
+| leg | flexor hallucis longus | right | 8182 | 2456 |
+| leg | extensor digitorum / hallucis longus | left | 8191 | 2458 |
+| leg | extensor digitorum / hallucis longus | right | 8192 | 2459 |
+| leg | flexor digitorum longus | left | 8201 | 2461 |
+| leg | flexor digitorum longus | right | 8202 | 2462 |
+| leg | popliteus | left | 8211 | 2464 |
+| leg | popliteus | right | 8212 | 2465 |
+| leg | plantaris | left | 8221 | 2467 |
+| leg | plantaris | right | 8222 | 2468 |
 
 ## `abdomen`
 
@@ -249,15 +275,18 @@ DICOM.
 | abdomen | quadratus lumborum | right | 7 |
 | abdomen | quadratus lumborum | left | 8 |
 
-## `forarm`
+Regional models use dense class IDs. The `labeltransform` setting does not
+change these values.
+
+## `forearm`
 
 | Region | Anatomy | Side | Value |
 | :--- | :--- | :--- | ---: |
-| leg | other muscles | no side | 1 |
-| leg | radius | no side | 2 |
-| leg | ulna | no side | 3 |
-| leg | extensor compartment | no side | 4 |
-| leg | flexor compartment | no side | 5 |
+| forearm | other muscles | no side | 1 |
+| forearm | radius | no side | 2 |
+| forearm | ulna | no side | 3 |
+| forearm | extensor compartment | no side | 4 |
+| forearm | flexor compartment | no side | 5 |
 
 ## `leg`
 

--- a/recipes/musclemap/build.yaml
+++ b/recipes/musclemap/build.yaml
@@ -1,13 +1,23 @@
 name: musclemap
-version: 1.3.45
+version: 1.4.0
 architectures:
     - x86_64
 
 variables:
-    # Upstream publishes the official release as tag "1.3", while the
-    # NeuroContainers recipe version is kept as 1.3.x.
-    musclemap_source_tag: "{{ context.version.split('.')[:2] | join('.') }}"
-    musclemap_archive_url: "https://github.com/MuscleMap/MuscleMap/archive/refs/tags/{{ context.musclemap_source_tag }}.zip"
+    musclemap_model_version: "{{ context.version.split('.')[:2] | join('.') }}"
+    musclemap_regional_model_version: "0.0"
+    musclemap_software_version: "2.0"
+    # The requested model support landed after the upstream software tag. Pin
+    # the exact audited commit instead of following the mutable main branch.
+    musclemap_source_revision: "6e1e1eb6732337c13cab53bd5cc800c69024774f"
+    musclemap_archive_url: "https://github.com/MuscleMap/MuscleMap/archive/{{ context.musclemap_source_revision }}.zip"
+    wholebody_model_record: "21929873"
+    abdomen_model_record: "19631081"
+    forearm_model_record: "19633115"
+    leg_model_record: "19633057"
+    pelvis_model_record: "19632902"
+    thigh_model_record: "19633000"
+    abdomen_template_record: "20043148"
     spinalcordtoolbox_version: "6.5"
     spinalcordtoolbox_archive_url: "https://github.com/spinalcordtoolbox/spinalcordtoolbox/archive/refs/tags/{{ context.spinalcordtoolbox_version }}.tar.gz"
 
@@ -22,16 +32,62 @@ files:
       filename: OpenReconLabel.json
     - name: OpenReconREADME.md
       filename: OpenReconREADME.md
+    - name: musclemap-container-defaults.patch
+      filename: musclemap-container-defaults.patch
+    - name: verify_musclemap_install.py
+      filename: verify_musclemap_install.py
     - name: musclemap_zip
       url: "{{ context.musclemap_archive_url }}"
     - name: spinalcordtoolbox_tar
       url: "{{ context.spinalcordtoolbox_archive_url }}"
+    - name: wholebody_model_pth
+      url: "https://zenodo.org/api/records/{{ context.wholebody_model_record }}/files/contrast_agnostic_wholebody_model.pth/content"
+    - name: wholebody_model_json
+      url: "https://zenodo.org/api/records/{{ context.wholebody_model_record }}/files/contrast_agnostic_wholebody_model.json/content"
+    - name: abdomen_model_pth
+      url: "https://zenodo.org/api/records/{{ context.abdomen_model_record }}/files/contrast_agnostic_abdomen_model.pth/content"
+    - name: abdomen_model_json
+      url: "https://zenodo.org/api/records/{{ context.abdomen_model_record }}/files/contrast_agnostic_abdomen_model.json/content"
+    - name: forearm_model_pth
+      url: "https://zenodo.org/api/records/{{ context.forearm_model_record }}/files/contrast_agnostic_forearm_model.pth/content"
+    - name: forearm_model_json
+      url: "https://zenodo.org/api/records/{{ context.forearm_model_record }}/files/contrast_agnostic_forearm_model.json/content"
+    - name: leg_model_pth
+      url: "https://zenodo.org/api/records/{{ context.leg_model_record }}/files/contrast_agnostic_leg_model.pth/content"
+    - name: leg_model_json
+      url: "https://zenodo.org/api/records/{{ context.leg_model_record }}/files/contrast_agnostic_leg_model.json/content"
+    - name: pelvis_model_pth
+      url: "https://zenodo.org/api/records/{{ context.pelvis_model_record }}/files/contrast_agnostic_pelvis_model.pth/content"
+    - name: pelvis_model_json
+      url: "https://zenodo.org/api/records/{{ context.pelvis_model_record }}/files/contrast_agnostic_pelvis_model.json/content"
+    - name: thigh_model_pth
+      url: "https://zenodo.org/api/records/{{ context.thigh_model_record }}/files/contrast_agnostic_thigh_model.pth/content"
+    - name: thigh_model_json
+      url: "https://zenodo.org/api/records/{{ context.thigh_model_record }}/files/contrast_agnostic_thigh_model.json/content"
+    - name: abdomen_template
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template.nii.gz/content"
+    - name: abdomen_template_dseg
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg.nii.gz/content"
+    - name: abdomen_template_label_1
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-1.nii.gz/content"
+    - name: abdomen_template_label_2
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-2.nii.gz/content"
+    - name: abdomen_template_label_3
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-3.nii.gz/content"
+    - name: abdomen_template_label_4
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-4.nii.gz/content"
+    - name: abdomen_template_label_5
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-5.nii.gz/content"
+    - name: abdomen_template_label_6
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-6.nii.gz/content"
+    - name: abdomen_template_label_7
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-7.nii.gz/content"
+    - name: abdomen_template_label_8
+      url: "https://zenodo.org/api/records/{{ context.abdomen_template_record }}/files/abdomen_template_dseg_label-8.nii.gz/content"
 
 build:
     kind: neurodocker
-    base-image: pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime
-    # Match the official MuscleMap 1.3 torch pin while keeping a CUDA 11.8 build
-    # preinstalled in the base image for scanner compatibility.
+    base-image: pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime
     pkg-manager: apt
 
     directives:
@@ -45,8 +101,8 @@ build:
             - git
             - libglib2.0-0
             - libmpich-dev
+            - patch
             - python3-pip
-            - python3-pyqt5
             - python-is-python3
             - rsync
             - unzip
@@ -54,13 +110,39 @@ build:
         - include: macros/openrecon/neurodocker.yaml
 
         - workdir: /opt/
-        - run: 
+        - run:
             - unzip {{ get_file("musclemap_zip") }} -d /opt
-            - mv MuscleMap-{{ context.musclemap_source_tag }} MuscleMap
+            - mv MuscleMap-{{ context.musclemap_source_revision }} MuscleMap
             - cd MuscleMap
+            - patch -p1 < {{ get_file("musclemap-container-defaults.patch") }}
             - pip install -e .
-            - pip install pillow==10.4.0
-            - python -c "from PIL import Image, ImageDraw, ImageFont"
+            - python -c "import customtkinter, tkinter; from PIL import Image; import torch; assert torch.__version__.startswith('2.4.1')"
+
+        - workdir: /opt/MuscleMap
+        - run:
+            - install -D -m 0444 {{ get_file("wholebody_model_pth") }} scripts/models/wholebody/v{{ context.musclemap_model_version }}/contrast_agnostic_wholebody_model.pth
+            - install -D -m 0444 {{ get_file("wholebody_model_json") }} scripts/models/wholebody/v{{ context.musclemap_model_version }}/contrast_agnostic_wholebody_model.json
+            - install -D -m 0444 {{ get_file("abdomen_model_pth") }} scripts/models/abdomen/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_abdomen_model.pth
+            - install -D -m 0444 {{ get_file("abdomen_model_json") }} scripts/models/abdomen/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_abdomen_model.json
+            - install -D -m 0444 {{ get_file("forearm_model_pth") }} scripts/models/forearm/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_forearm_model.pth
+            - install -D -m 0444 {{ get_file("forearm_model_json") }} scripts/models/forearm/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_forearm_model.json
+            - install -D -m 0444 {{ get_file("leg_model_pth") }} scripts/models/leg/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_leg_model.pth
+            - install -D -m 0444 {{ get_file("leg_model_json") }} scripts/models/leg/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_leg_model.json
+            - install -D -m 0444 {{ get_file("pelvis_model_pth") }} scripts/models/pelvis/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_pelvis_model.pth
+            - install -D -m 0444 {{ get_file("pelvis_model_json") }} scripts/models/pelvis/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_pelvis_model.json
+            - install -D -m 0444 {{ get_file("thigh_model_pth") }} scripts/models/thigh/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_thigh_model.pth
+            - install -D -m 0444 {{ get_file("thigh_model_json") }} scripts/models/thigh/v{{ context.musclemap_regional_model_version }}/contrast_agnostic_thigh_model.json
+            - install -D -m 0444 {{ get_file("abdomen_template") }} scripts/templates/abdomen/abdomen_template.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_dseg") }} scripts/templates/abdomen/abdomen_template_dseg.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_1") }} scripts/templates/abdomen/abdomen_template_dseg_label-1.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_2") }} scripts/templates/abdomen/abdomen_template_dseg_label-2.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_3") }} scripts/templates/abdomen/abdomen_template_dseg_label-3.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_4") }} scripts/templates/abdomen/abdomen_template_dseg_label-4.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_5") }} scripts/templates/abdomen/abdomen_template_dseg_label-5.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_6") }} scripts/templates/abdomen/abdomen_template_dseg_label-6.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_7") }} scripts/templates/abdomen/abdomen_template_dseg_label-7.nii.gz
+            - install -D -m 0444 {{ get_file("abdomen_template_label_8") }} scripts/templates/abdomen/abdomen_template_dseg_label-8.nii.gz
+            - install -D -m 0555 {{ get_file("verify_musclemap_install.py") }} /opt/code/verify_musclemap_install.py
 
         - run:
             - tar -xz -C /opt/ -f {{ get_file("spinalcordtoolbox_tar") }}
@@ -85,13 +167,18 @@ build:
 
         - environment:
               MKL_THREADING_LAYER: GNU
+              MUSCLEMAP_SOFTWARE_VERSION: "{{ context.musclemap_software_version }}"
+              MUSCLEMAP_SOURCE_REVISION: "{{ context.musclemap_source_revision }}"
+              MUSCLEMAP_WHOLEBODY_MODEL_VERSION: "{{ context.musclemap_model_version }}"
+              MUSCLEMAP_REGIONAL_MODEL_VERSION: "{{ context.musclemap_regional_model_version }}"
 
         - run:
-            - cp {{ get_file("musclemap.py") }} /opt/code/python-ismrmrd-server/musclemap.py
-            - cp {{ get_file("nifti2mrd.py") }} /opt/code/python-ismrmrd-server/nifti2mrd.py
-            - cp {{ get_file("enhanceddicom2mrd.py") }} /opt/code/python-ismrmrd-server/enhanceddicom2mrd.py
-            - cp {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
-            - cp {{ get_file("OpenReconREADME.md") }} /opt/code/python-ismrmrd-server/OpenReconREADME.md
+            - install -m 0444 {{ get_file("musclemap.py") }} /opt/code/python-ismrmrd-server/musclemap.py
+            - install -m 0444 {{ get_file("nifti2mrd.py") }} /opt/code/python-ismrmrd-server/nifti2mrd.py
+            - install -m 0444 {{ get_file("enhanceddicom2mrd.py") }} /opt/code/python-ismrmrd-server/enhanceddicom2mrd.py
+            - install -m 0444 {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
+            - install -m 0444 {{ get_file("OpenReconREADME.md") }} /opt/code/python-ismrmrd-server/OpenReconREADME.md
+            - python /opt/code/verify_musclemap_install.py
             
 deploy:
     bins:
@@ -105,22 +192,26 @@ readme: |-
   ----------------------------------
   ## musclemap/{{ context.version }} ##
 
-  An Open-Source Whole-Body Quantitative MRI tool of Muscle
+  An open-source quantitative MRI toolbox for muscle segmentation and analysis.
 
-  A free and open-source software toolbox for whole-body muscle segmentation and analysis.
+  This image packages MuscleMap software {{ context.musclemap_software_version }}
+  from commit {{ context.musclemap_source_revision }}, whole-body model
+  v{{ context.musclemap_model_version }}, regional model
+  v{{ context.musclemap_regional_model_version }}, and the abdomen registration
+  template. All model and template assets are available offline at runtime.
 
   Example:
   ```bash
-  #mm_segment -i str(input_image) -r str(bodyregion) -c int(chunksize) -s int(spatialoverlap) -g Y
-  mm_segment -i /opt/input.nii.gz -r wholebody -c 50 -s 50 -g Y
+  mm_segment -i /opt/input.nii.gz -r wholebody --model_version {{ context.musclemap_model_version }} -c auto -s 50 -g Y
 
-  mm_register_to_template -i sub-example02_t2w.nii.gz -s sub-example02_t2w_dseg.nii.gz -r wholebody
+  # Registration templates are currently available for the abdomen region.
+  mm_register_to_template -i sub-example02_t2w.nii.gz -s sub-example02_t2w_dseg.nii.gz -r abdomen
 
-  #For T1w and T2w MRI:
-  mm_extract_metrics -m gmm -r wholebody -i image.nii.gz -s image_dseg.nii.gz -c 3
+  # T1w and T2w MRI
+  mm_extract_metrics -m gmm -r wholebody --model_version {{ context.musclemap_model_version }} -i image.nii.gz -s image_dseg.nii.gz -c 3
 
-  #For Dixon Fat-Water MRI:
-  mm_extract_metrics -m dixon -r wholebody -f image_fat.nii.gz -w image_water.nii.gz -s image_dseg.nii.gz
+  # Dixon fat-water MRI
+  mm_extract_metrics -m dixon -r wholebody --model_version {{ context.musclemap_model_version }} -f image_fat.nii.gz -w image_water.nii.gz -s image_dseg.nii.gz
 
   ```
 
@@ -128,14 +219,13 @@ readme: |-
 
   McKay MJ, Weber KA 2nd, Wesselink EO, Smith ZA, Abbott R, Anderson DB, Ashton-James CE, Atyeo J, Beach AJ, Burns J, Clarke S, Collins NJ, Coppieters MW, Cornwall J, Crawford RJ, De Martino E, Dunn AG, Eyles JP, Feng HJ, Fortin M, Franettovich Smith MM, Galloway G, Gandomkar Z, Glastras S, Henderson LA, Hides JA, Hiller CE, Hilmer SN, Hoggarth MA, Kim B, Lal N, LaPorta L, Magnussen JS, Maloney S, March L, Nackley AG, O'Leary SP, Peolsson A, Perraton Z, Pool-Goudzwaard AL, Schnitzler M, Seitz AL, Semciw AI, Sheard PW, Smith AC, Snodgrass SJ, Sullivan J, Tran V, Valentin S, Walton DM, Wishart LR, Elliott JM. MuscleMap: An Open-Source, Community-Supported Consortium for Whole-Body Quantitative MRI of Muscle. J Imaging. 2024;10(11):262. https://doi.org/10.3390/jimaging10110262
   
-  label values can be found here:
-  wholebody: https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_tag }}/scripts/models/wholebody/contrast_agnostic_wholebody_model.json
-  abdomen: https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_tag }}/scripts/models/abdomen/contrast_agnostic_abdomen_model.json
-  forearm: https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_tag }}/scripts/models/forearm/contrast_agnostic_forearm_model.json
-  leg: https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_tag }}/scripts/models/leg/contrast_agnostic_leg_model.json
-  pelvis: https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_tag }}/scripts/models/pelvis/contrast_agnostic_pelvis_model.json
-  thigh: https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_tag }}/scripts/models/thigh/contrast_agnostic_thigh_model.json
-  
+  Immutable model records and label definitions:
+  - wholebody: https://zenodo.org/records/{{ context.wholebody_model_record }}
+  - abdomen: https://zenodo.org/records/{{ context.abdomen_model_record }}
+  - forearm: https://zenodo.org/records/{{ context.forearm_model_record }}
+  - leg: https://zenodo.org/records/{{ context.leg_model_record }}
+  - pelvis: https://zenodo.org/records/{{ context.pelvis_model_record }}
+  - thigh: https://zenodo.org/records/{{ context.thigh_model_record }}
 
   ----------------------------------
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAB/ElEQVR4AbSUS8tpURzGn+1e5BYGKIpiZqbMTQyUAV/WJ5CJZOSSJHIXueTueNab98z81+m8r/ayN2uv57ee9b+YADx1RzgcfkajUe33qUvA6653FYtFVCoVmEz6y/TffO1hv99jNBrh+aSJ1x8alzYgEAjgfr/DbDbD6/VqSH+9IgKsVitKpRLK5TLm8zlmsxny+TwKhcKXgvAtAoLBoDqSbreLzWaD3W6H4/GoQDpORADPnS4sFgt8Ph8SiYQ6osfjAcMwIH1EAMUZWIrTDWOQyWRgt9txOp0kfYgA7jQUCiGVSiGdTsPtdmO1WuFVE7jdbv8PYEput1uVQc1mE3zu9XoYDoegO4kgOqDA9XrFeDxWDpLJJKbTKc7n8884YNXmcjlEIhG1ezrIZrPq9+VyIf/jEB0wqNxxtVpFp9NBq9VCvV6HzWaD0+n8KM5JEcDqZd5z58wcj8ejgrxYLFTaUuTTEAEsrFqtBr/fr9oEz54F1mg0VF/6JM45EcAATyYTxGIxrNdrsPBeLVsFmQLSEAFvATqIx+NgFhmGXMHvddoAxoKpOhgMtNLznwHsoqxg3tlV3wLSXdvBcrkE48H+czgcJN3veW0Ai4riPCr2p28F4UEbYBiG6j0OhwMul0uQ/TutDWA9cBkBvxKDdrsNdlG2in6/T5bW+AMAAP//wtg5bQAAAAZJREFUAwAZcfw0V/0rGAAAAABJRU5ErkJggg==
@@ -143,6 +233,12 @@ categories:
   - body
 copyright:
   - license: MIT
-    url: https://github.com/MuscleMap/MuscleMap?tab=MIT-1-ov-file#readme
+    url: "https://github.com/MuscleMap/MuscleMap/blob/{{ context.musclemap_source_revision }}/LICENSE"
+  - license: CC-BY-4.0
+    url: https://zenodo.org/records/19633057
+  - license: CC-BY-4.0
+    url: https://zenodo.org/records/19632902
+  - license: CC-BY-4.0
+    url: https://zenodo.org/records/20043148
   - license: LGPL-3.0
     url: https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/LICENSE

--- a/recipes/musclemap/full_body_exam_research.md
+++ b/recipes/musclemap/full_body_exam_research.md
@@ -1,0 +1,198 @@
+# Full-body exam smoke test for MuscleMap v1.4
+
+Research and execution date: 2026-08-27
+
+## Outcome
+
+The updated `musclemap:1.4.0` image completed offline, CPU-only whole-body
+segmentation on five coronal MRI stations from the NLM Visible Human male. The
+stations jointly cover the neck, chest, pelvis, knees, and ankles. All five
+outputs passed structural and label-map validation.
+
+This is a runtime and anatomical-coverage smoke test, not clinical accuracy
+validation. The Visible Human data are regional cadaver acquisitions with
+station-specific positioning and contrast, whereas MuscleMap's documented
+whole-body workflow is aimed at in-vivo axial MRI. The pelvis and knee results
+were correspondingly sparse.
+
+## Why this exam was selected
+
+The [NLM Visible Human Project](https://www.nlm.nih.gov/research/visible/)
+provides complete, anatomically detailed male and female cadaver datasets for
+medical education and for testing medical imaging algorithms. The
+[Imaging Data Commons collection](https://portal.imaging.datacommons.cancer.gov/collections/nlm_visible_human_project/)
+provides the project's MR and CT DICOM series without an account. The source
+data are public domain.
+
+No public living-subject MRI examined during this search contained strict
+head-to-ankle coverage in a practical, directly downloadable NIfTI. The
+Visible Human male therefore provided the strongest reproducible test that
+every MuscleMap v1.4 whole-body region could be exercised in one subject.
+
+Five T1 coronal series were selected from study `VHP-M`:
+
+| Station | Series instance UID | DICOM files | Converted NIfTI shape | Spacing (mm) |
+| --- | --- | ---: | --- | --- |
+| Neck | `1.3.6.1.4.1.5962.1.3.2297.6.1672334394.26545` | 63 | `256 x 256 x 63` | `1.172 x 1.172 x 4.0` |
+| Chest | `1.3.6.1.4.1.5962.1.3.2297.9.1672334394.26545` | 70 | `256 x 256 x 70` | `1.875 x 1.875 x 4.0` |
+| Pelvis | `1.3.6.1.4.1.5962.1.3.2297.13.1672334394.26545` | 74 | `256 x 256 x 74` | `1.875 x 1.875 x 4.0` |
+| Knee | `1.3.6.1.4.1.5962.1.3.2297.18.1672334394.26545` | 45 | `256 x 256 x 45` | `1.875 x 1.875 x 5.0` |
+| Ankle | `1.3.6.1.4.1.5962.1.3.2297.21.1672334394.26545` | 56 | `256 x 256 x 56` | `1.875 x 1.875 x 4.0` |
+
+The download contained 308 DICOM instances and occupied approximately 40 MB.
+`dcm2niix` converted the five series to compressed NIfTI before inference.
+
+## Container and execution
+
+The exact generated NeuroContainers recipe built successfully as
+`musclemap:1.4.0`:
+
+```text
+Image ID: sha256:bf49fcaf86907b133da0479176189b2d81f2c066fc02f5000920cbd4ac63e7f3
+Image size: 6,757,731,199 bytes
+Runtime network: disabled
+Runtime compute: 8 CPUs, no GPU, 28 GiB memory limit
+```
+
+Before inference, the packaged verifier loaded the real whole-body model while
+the container had no network access:
+
+```bash
+docker run --rm --network none musclemap:1.4.0 \
+  python /opt/code/verify_musclemap_install.py --load-wholebody-model
+```
+
+It reported `MuscleMap installation verified`.
+
+Neck and chest completed with automatic chunk sizing and 50 percent overlap.
+The original command used one comma-separated input list:
+
+```bash
+docker run --rm --network none --memory 28g --cpus 8 \
+  -v "$PWD/vhp-m-nifti:/input:ro" \
+  -v "$PWD/vhp-m-output:/output" \
+  musclemap:1.4.0 \
+  mm_segment \
+    --input_image /input/NECK_6.nii.gz,/input/T1_CORONAL_CHEST_9.nii.gz,/input/T1_CORONAL_PELVIS_13.nii.gz,/input/T1_CORONAL_KNEE_18.nii.gz,/input/T1_CORONAL_ANKLE_21.nii.gz \
+    --output_dir /output \
+    --region wholebody \
+    --model_version 1.4 \
+    --chunk_size auto \
+    --overlap 50 \
+    --use_GPU N
+```
+
+Automatic sizing selected 17 slices for the pelvis. The process was killed at
+the 28 GiB limit during inverse resampling after neck and chest had completed.
+The estimator treats the input's third axis as the inference slice axis, but
+reorientation of these coronal images changes the dimensions that determine
+the logits and post-processing peak. This edge case is not representative of
+OpenRecon's axial input, but it matters for arbitrary command-line NIfTI use.
+
+Pelvis, knee, and ankle were rerun successfully with explicit five-slice chunks:
+
+```bash
+docker run --rm --network none --memory 28g --cpus 8 \
+  -v "$PWD/vhp-m-nifti:/input:ro" \
+  -v "$PWD/vhp-m-output-retry:/output" \
+  musclemap:1.4.0 \
+  mm_segment \
+    --input_image /input/T1_CORONAL_PELVIS_13.nii.gz,/input/T1_CORONAL_KNEE_18.nii.gz,/input/T1_CORONAL_ANKLE_21.nii.gz \
+    --output_dir /output \
+    --region wholebody \
+    --model_version 1.4 \
+    --chunk_size 5 \
+    --overlap 0 \
+    --use_GPU N
+```
+
+The retry completed in 44:26 wall time: pelvis inference took 17:40, knee
+11:59, and ankle 14:16. Zero overlap was deliberately used to make the
+CPU-only feasibility run tractable; it can introduce chunk-boundary seams and
+is not the recommended quality setting.
+
+## Output validation
+
+For every station, an offline validation script loaded the source and mask with
+Nibabel and asserted:
+
+- identical voxel shape;
+- numerically identical affine;
+- `int16` mask datatype;
+- nonzero foreground; and
+- every observed value belongs to the packaged whole-body v1.4 JSON label map.
+
+Results:
+
+| Station | Foreground labels | Foreground voxels | Result |
+| --- | ---: | ---: | --- |
+| Neck | 30 | 147,957 | Pass |
+| Chest | 36 | 82,597 | Pass |
+| Pelvis | 20 | 545 | Pass, sparse |
+| Knee | 26 | 3,029 | Pass, sparse |
+| Ankle | 21 | 6,842 | Pass |
+
+The union contained 64 of the 113 foreground label values represented by the
+v1.4 model. Visual overlays were anatomically localized in all five stations,
+but the sparse pelvis and knee masks reinforce that this out-of-distribution
+cadaver exam must not be interpreted as an accuracy benchmark.
+
+Artifacts are under `build/musclemap-e2e/`:
+
+- source station montage: `vhp-m-stations.png`;
+- segmentation overlay montage: `vhp-m-musclemap-overlay.png`;
+- neck and chest masks: `vhp-m-output/`;
+- pelvis, knee, and ankle masks: `vhp-m-output-retry/`.
+
+## Living-subject cross-check
+
+TotalSegmentator MRI v2 case `s0175` was also run as an in-vivo cross-check.
+The official release contains 616 clinical MRI scans under CC BY-NC-SA 2.0.
+[Official Zenodo record](https://zenodo.org/records/14710732),
+[official TotalSegmentator repository](https://github.com/wasserth/TotalSegmentator)
+
+The standalone NIfTI came from a mirror pinned to commit
+`1afa2dfd85b57d41608c073ead6fd4b19520394f`:
+
+```text
+File:    s0175/mri.nii.gz
+Size:    16,134,253 bytes
+SHA-256: 0f311daa4f19d8b89c1380832332db11d5f32cf406d2b591ba6800e6433eb379
+Shape:   320 x 240 x 360
+Spacing: 1.2813 x 1.2813 x 3.0 mm
+```
+
+The updated image segmented it offline on CPU with automatic chunks and 50
+percent overlap. Inference took 293 seconds (5:05 wall time). The output
+matched the input shape and affine, used `int16`, contained 85 foreground
+labels and 1,532,869 foreground voxels, and contained no unknown label values.
+
+Although catalogued as whole-body and spanning 1,080 mm, visual inspection
+showed that `s0175` ends at the upper thighs. It is a useful living-subject
+runtime check, but it does not exercise the lower-leg regions.
+
+## Other candidates screened
+
+- All 393 standalone TotalSegmentator MRI mirror files were screened from
+  their NIfTI headers. None provided verified strict head-to-ankle anatomy;
+  the longest fields of view were `s0112` at 1,094.4 mm and `s0175` at
+  1,080 mm.
+- All 1,202 TotalSegmentator CT mirror files were likewise screened. The
+  longest was 1,276.5 mm, but sampled long-volume candidates were still
+  regional rather than head-to-ankle.
+- CMB-MML patient `MSB-00268` explicitly describes a whole-body MRI and is
+  de-identified, but the four public axial T2 series available for the chosen
+  exam covered abdomen through lower legs and omitted the upper-body station.
+  [IDC CMB-MML collection](https://portal.imaging.datacommons.cancer.gov/collections/cmb_mml/)
+- The UK Biobank whole-body atlas contains population averages rather than one
+  exam. [Atlas record](https://zenodo.org/records/13136891)
+- The whole-body golden-angle dataset provides raw k-space rather than an image
+  MuscleMap can consume directly. [Raw-data record](https://zenodo.org/records/45080)
+
+## Reuse and privacy
+
+The Visible Human test uses a public-domain cadaver dataset and therefore has
+no living-subject privacy issue. TotalSegmentator `s0175` is a publicly released
+pseudonymized clinical NIfTI under CC BY-NC-SA 2.0; the mirror is not the
+publisher, so reproducible reuse should retain the pinned commit and checksum,
+and redistribution should follow the official dataset license.

--- a/recipes/musclemap/fulltest.yaml
+++ b/recipes/musclemap/fulltest.yaml
@@ -2,7 +2,7 @@
 # Focused verification for runtime packaging and lightweight entrypoints.
 
 name: musclemap
-version: "1.3.45"
+version: "1.4.0"
 
 test_data:
   output_dir: test_output
@@ -15,17 +15,45 @@ setup:
 
 tests:
   - name: MuscleMap command line tools
-    description: Verify deployed MuscleMap and SCT command line tools start
+    description: Verify deployed MuscleMap and SCT command line tools start.
     script: |
-      mm_segment -h 2>&1 | grep -E 'usage:|Usage:'
+      mm_segment -h 2>&1 | tee ${output_dir}/mm_segment_help.txt | grep -E 'usage:|Usage:'
+      grep -- '--model_version' ${output_dir}/mm_segment_help.txt
+      grep -E -- '-c|--chunk_size' ${output_dir}/mm_segment_help.txt
       mm_register_to_template -h 2>&1 | grep -E 'usage:|Usage:'
-      mm_extract_metrics -h 2>&1 | grep -E 'usage:|Usage:'
+      mm_extract_metrics -h 2>&1 | tee ${output_dir}/mm_extract_metrics_help.txt | grep -E 'usage:|Usage:'
+      grep -- '--model_version' ${output_dir}/mm_extract_metrics_help.txt
       sct_check_dependencies -short
 
-  - name: CUDA runtime pin
-    description: Verify the image keeps a CUDA 11 runtime for scanner compatibility
+  - name: Upstream software and dependencies
+    description: Verify the audited MuscleMap software and exact upstream dependency pins.
     script: |
-      python -c "import torch; print(torch.version.cuda)" | grep '^11\.'
+      python - <<'PY'
+      import importlib.metadata
+      import os
+      from pathlib import Path
+
+      assert Path("/opt/MuscleMap/version.txt").read_text().strip() == os.environ["MUSCLEMAP_SOFTWARE_VERSION"]
+      expected = {
+          "customtkinter": "5.2.2",
+          "monai": "1.3.2",
+          "Pillow": "11.3.0",
+          "torch": "2.4.1",
+      }
+      actual = {name: importlib.metadata.version(name).split("+")[0] for name in expected}
+      assert actual == expected, (actual, expected)
+      print(actual)
+      PY
+
+  - name: CUDA runtime pin
+    description: Verify the image keeps the CUDA 11.8 runtime used by the scanner deployment.
+    script: |
+      python -c "import torch; print(torch.version.cuda)" | grep '^11\.8$'
+
+  - name: Immutable models and templates
+    description: Verify all baked checksums, metadata, defaults, and whole-body state-dict compatibility.
+    script: |
+      python /opt/code/verify_musclemap_install.py --load-wholebody-model
 
   - name: OpenRecon server help
     description: Verify the python-ismrmrd server entrypoint starts correctly
@@ -33,7 +61,7 @@ tests:
       python /opt/code/python-ismrmrd-server/main.py -h 2>&1 | sed -n '1,20p' | grep 'Example server for MRD streaming format'
 
   - name: OpenRecon assets
-    description: Verify packaged OpenRecon label and README assets are present and readable
+    description: Verify packaged OpenRecon label and README assets are present and current.
     script: |
       python - <<'PY'
       import json
@@ -41,24 +69,20 @@ tests:
 
       label = Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json")
       readme = Path("/opt/code/python-ismrmrd-server/OpenReconREADME.md")
-      if not label.exists() or not readme.exists():
-          print("OpenRecon label assets are not present in this release image")
-          raise SystemExit(0)
-
       data = json.loads(label.read_text())
-      parameters = {parameter["id"] for parameter in data["parameters"]}
+      parameters = {parameter["id"]: parameter for parameter in data["parameters"]}
       assert {"sendoriginal", "segmentopposedphase", "metricsoutput"} <= parameters
-      assert "MuscleMap" in readme.read_text()
+      assert "metricsregion" not in parameters
+      assert "forearm" in {value["id"] for value in parameters["bodyregion"]["values"]}
+      readme_text = readme.read_text()
+      assert "whole-body v1.4 record" in readme_text
+      assert "plantaris" in readme_text
       print(label)
       PY
 
   - name: MuscleMap OpenRecon module imports
-    description: Verify the OpenRecon module imports with its runtime dependencies
+    description: Verify the OpenRecon module imports with its runtime dependencies.
     script: |
-      if [ ! -f /opt/code/python-ismrmrd-server/OpenReconLabel.json ]; then
-        echo "OpenRecon label assets are not present in this release image"
-        exit 0
-      fi
       PYTHONPATH=/opt/code/python-ismrmrd-server python -c "import musclemap, ismrmrd, nibabel, numpy; print(musclemap.muscleMapDisplayLabel)" | grep -x 'Musclemap'
 
   - name: Helper scripts render help

--- a/recipes/musclemap/fulltest.yaml
+++ b/recipes/musclemap/fulltest.yaml
@@ -71,7 +71,7 @@ tests:
       readme = Path("/opt/code/python-ismrmrd-server/OpenReconREADME.md")
       data = json.loads(label.read_text())
       parameters = {parameter["id"]: parameter for parameter in data["parameters"]}
-      assert {"sendoriginal", "segmentopposedphase", "metricsoutput"} <= parameters
+      assert {"sendoriginal", "segmentopposedphase", "metricsoutput"} <= parameters.keys()
       assert "metricsregion" not in parameters
       assert "forearm" in {value["id"] for value in parameters["bodyregion"]["values"]}
       readme_text = readme.read_text()

--- a/recipes/musclemap/musclemap-container-defaults.patch
+++ b/recipes/musclemap/musclemap-container-defaults.patch
@@ -1,0 +1,22 @@
+diff --git a/scripts/mm_util.py b/scripts/mm_util.py
+index 839f812..7491f53 100644
+--- a/scripts/mm_util.py
++++ b/scripts/mm_util.py
+@@ -68,0 +69,15 @@
++_CONTAINER_MODEL_VERSION_ENV = {
++    "wholebody": "MUSCLEMAP_WHOLEBODY_MODEL_VERSION",
++}
++
++
++def _resolve_container_model_version(region: str, version: str) -> str:
++    """Resolve ``latest`` to the immutable model baked into a container."""
++    if version != "latest":
++        return version
++    environment_name = _CONTAINER_MODEL_VERSION_ENV.get(
++        region, "MUSCLEMAP_REGIONAL_MODEL_VERSION"
++    )
++    return os.environ.get(environment_name, version)
++
++
+@@ -172,0 +188 @@
++    version = _resolve_container_model_version(region, version)

--- a/recipes/musclemap/musclemap.py
+++ b/recipes/musclemap/musclemap.py
@@ -29,6 +29,8 @@ mmSegmentOutputPath = "/opt/input_dseg.nii.gz"
 mmMetricsSegmentationPath = "/tmp/musclemap_input_dseg_metrics.nii.gz"
 mmMetricsOutputDir = "/tmp/musclemap_metrics"
 mmMetricsMethod = "average"
+muscleMapWholebodyModelVersionEnv = "MUSCLEMAP_WHOLEBODY_MODEL_VERSION"
+muscleMapRegionalModelVersionEnv = "MUSCLEMAP_REGIONAL_MODEL_VERSION"
 metricsSeriesIndex = 120
 muscleMapDisplayLabel = "Musclemap"
 muscleMapImageTypeToken = "MUSCLEMAP"
@@ -3326,11 +3328,28 @@ def _read_metrics_csv(csv_path):
     return fieldnames, rows
 
 
-def _run_mm_extract_metrics(method, region, components, segmentation_path, input_image_path, output_dir):
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-    os.makedirs(output_dir, exist_ok=True)
+def _resolve_musclemap_model_version(region):
+    environment_name = (
+        muscleMapWholebodyModelVersionEnv
+        if region == "wholebody"
+        else muscleMapRegionalModelVersionEnv
+    )
+    model_version = os.environ.get(environment_name, "").strip()
+    if not model_version:
+        raise RuntimeError(
+            f"{environment_name} is not set; cannot select the baked MuscleMap model"
+        )
+    return model_version
 
+
+def _build_mm_extract_metrics_command(
+    method,
+    region,
+    components,
+    segmentation_path,
+    input_image_path,
+    output_dir,
+):
     metrics_cmd = [
         "python",
         "/opt/MuscleMap/scripts/mm_extract_metrics.py",
@@ -3338,11 +3357,28 @@ def _run_mm_extract_metrics(method, region, components, segmentation_path, input
         "-s", segmentation_path,
         "-i", input_image_path,
         "-o", output_dir,
+        "--model_version", _resolve_musclemap_model_version(region),
     ]
     if region:
         metrics_cmd.extend(["-r", region])
     if method in ("kmeans", "gmm") and components is not None:
         metrics_cmd.extend(["-c", str(components)])
+    return metrics_cmd
+
+
+def _run_mm_extract_metrics(method, region, components, segmentation_path, input_image_path, output_dir):
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+
+    metrics_cmd = _build_mm_extract_metrics_command(
+        method,
+        region,
+        components,
+        segmentation_path,
+        input_image_path,
+        output_dir,
+    )
 
     logging.info("Running command: %s", " ".join(metrics_cmd))
     metrics_result = subprocess.run(
@@ -3554,6 +3590,10 @@ def _transform_musclemap_label_values(labels):
 def _restore_musclemap_label_values(labels):
     labels = np.asarray(labels, dtype=np.int64)
     return 10 * (labels // 3) + (labels % 3)
+
+
+def _resolve_label_transform(region, requested):
+    return bool(requested and region == "wholebody")
 
 
 def _metrics_segmentation_labels_for_lookup(segmentation_labels, label_transform):
@@ -3926,6 +3966,7 @@ def _build_mm_segment_command(bodyregion, chunksize, spatialoverlap):
         "mm_segment",
         "-i", mmSegmentInputPath,
         "-r", bodyregion,
+        "--model_version", _resolve_musclemap_model_version(bodyregion),
     ]
 
     if _mm_segment_supports_option("-c", "--chunksize"):
@@ -4397,8 +4438,14 @@ def process_image(
 
     # Extract UI parameters from JSON config
     bodyregion = mrdhelper.get_json_config_param(config, 'bodyregion', default='wholebody', type='str')
-    metrics_region = mrdhelper.get_json_config_param(config, 'metricsregion', default='', type='str')
-    metrics_region = _first_non_empty_text(metrics_region) or bodyregion
+    configured_metrics_region = mrdhelper.get_json_config_param(config, 'metricsregion', default='', type='str')
+    if configured_metrics_region and configured_metrics_region != bodyregion:
+        logging.warning(
+            "Ignoring legacy metricsregion=%s; metrics must use segmentation bodyregion=%s",
+            configured_metrics_region,
+            bodyregion,
+        )
+    metrics_region = bodyregion
     chunksize = mrdhelper.get_json_config_param(config, 'chunksize', default='auto', type='str')
     spatialoverlap = mrdhelper.get_json_config_param(config, 'spatialoverlap', default=50, type='int')
     
@@ -4461,10 +4508,12 @@ def process_image(
 
     data = data.astype(np.int64, copy=False)
 
-    # Expected label coding ends in 0/1/2 (except background 0).
-    bad_labels = np.unique(data[(data != 0) & ((data % 10) > 2)])
-    if bad_labels.size > 0:
-        raise ValueError(f"Unexpected labels detected (first 20): {bad_labels[:20].tolist()}")
+    # Whole-body labels encode center/left/right in the final digit. Regional
+    # models use dense class IDs and must remain on their native label scale.
+    if bodyregion == "wholebody":
+        bad_labels = np.unique(data[(data != 0) & ((data % 10) > 2)])
+        if bad_labels.size > 0:
+            raise ValueError(f"Unexpected labels detected (first 20): {bad_labels[:20].tolist()}")
 
     print("maximum value in segmented data:")
     print(np.max(data))
@@ -4503,10 +4552,16 @@ def process_image(
     print("data shape after crop:")
     print(data.shape)
 
-    label_transform = _as_config_bool(
+    label_transform_requested = _as_config_bool(
         mrdhelper.get_json_config_param(config, 'labeltransform', default=True, type='bool')
     )
-    logging.info("labeltransform resolved to %s", label_transform)
+    label_transform = _resolve_label_transform(bodyregion, label_transform_requested)
+    logging.info(
+        "labeltransform requested=%s resolved=%s for bodyregion=%s",
+        label_transform_requested,
+        label_transform,
+        bodyregion,
+    )
 
     if label_transform:
         logging.info("Applying label transformation: 3 * (label_in // 10) + (label_in % 10)")

--- a/recipes/musclemap/test_musclemap_openrecon.py
+++ b/recipes/musclemap/test_musclemap_openrecon.py
@@ -176,6 +176,20 @@ def test_openrecon_label_exposes_dixon_segmentation_checkboxes_with_opposed_defa
         assert parameters[parameter_id]["type"] == "boolean"
         assert parameters[parameter_id]["default"] is default
 
+    assert "metricsregion" not in parameters
+    assert [value["id"] for value in parameters["bodyregion"]["values"]] == [
+        "wholebody",
+        "abdomen",
+        "forearm",
+        "pelvis",
+        "thigh",
+        "leg",
+    ]
+    assert (
+        label["general"]["regulatory_information"]["udi"]
+        == "(01)00860000171212(21)VERSION_WILL_BE_REPLACED_BY_SCRIPT"
+    )
+
 
 def test_openrecon_label_collapses_metrics_outputs_into_one_choice():
     label = json.loads(OPENRECON_LABEL_PATH.read_text())
@@ -301,6 +315,64 @@ def test_metrics_label_transform_restores_original_ids_for_anatomy_lookup():
     )
     assert helpers["_metrics_label_scale_name"](True) == "original"
     assert helpers["_metrics_label_scale_name"](False) == "native"
+
+
+def test_model_version_selection_uses_baked_wholebody_and_regional_versions(monkeypatch):
+    helpers = _load_runtime_helpers_for_test(
+        ["_resolve_musclemap_model_version"],
+        assignments=[
+            "muscleMapRegionalModelVersionEnv",
+            "muscleMapWholebodyModelVersionEnv",
+        ],
+    )
+    monkeypatch.setenv("MUSCLEMAP_WHOLEBODY_MODEL_VERSION", "1.4")
+    monkeypatch.setenv("MUSCLEMAP_REGIONAL_MODEL_VERSION", "0.0")
+
+    assert helpers["_resolve_musclemap_model_version"]("wholebody") == "1.4"
+    assert helpers["_resolve_musclemap_model_version"]("abdomen") == "0.0"
+    assert helpers["_resolve_musclemap_model_version"]("leg") == "0.0"
+
+
+def test_musclemap_commands_pass_an_explicit_baked_model_version(monkeypatch):
+    helpers = _load_runtime_helpers_for_test(
+        [
+            "_build_mm_extract_metrics_command",
+            "_build_mm_segment_command",
+            "_resolve_musclemap_model_version",
+        ],
+        assignments=[
+            "mmSegmentInputPath",
+            "muscleMapRegionalModelVersionEnv",
+            "muscleMapWholebodyModelVersionEnv",
+        ],
+    )
+    monkeypatch.setenv("MUSCLEMAP_WHOLEBODY_MODEL_VERSION", "1.4")
+    monkeypatch.setenv("MUSCLEMAP_REGIONAL_MODEL_VERSION", "0.0")
+    helpers["_mm_segment_supports_option"] = lambda *names: True
+
+    segment_command = helpers["_build_mm_segment_command"]("wholebody", "auto", 50)
+    assert segment_command[segment_command.index("--model_version") + 1] == "1.4"
+
+    metrics_command = helpers["_build_mm_extract_metrics_command"](
+        method="average",
+        region="abdomen",
+        components=None,
+        segmentation_path="/opt/input_dseg.nii.gz",
+        input_image_path="/opt/input.nii.gz",
+        output_dir="/tmp/musclemap_metrics",
+    )
+    assert metrics_command[metrics_command.index("--model_version") + 1] == "0.0"
+
+
+def test_label_transform_is_limited_to_wholebody_model_labels():
+    helpers = _load_runtime_helpers_for_test(
+        ["_resolve_label_transform"],
+    )
+
+    assert helpers["_resolve_label_transform"]("wholebody", True) is True
+    assert helpers["_resolve_label_transform"]("wholebody", False) is False
+    assert helpers["_resolve_label_transform"]("abdomen", True) is False
+    assert helpers["_resolve_label_transform"]("leg", True) is False
 
 
 def test_dixon_segmentation_selection_defaults_to_opposed_phase_and_supports_multi_select():

--- a/recipes/musclemap/upstream_v1.4_investigation.md
+++ b/recipes/musclemap/upstream_v1.4_investigation.md
@@ -1,0 +1,227 @@
+# MuscleMap whole-body model v1.4 update investigation
+
+Research date: 2026-08-27
+
+This note compares the current NeuroContainers MuscleMap recipe with the official upstream state that introduced the whole-body model v1.4. It uses the upstream GitHub repository and Zenodo deposits as primary sources.
+
+## Finding
+
+Upstream does not publish a MuscleMap source release or Git tag named `1.4`. The upstream version numbers now describe two different artifacts:
+
+- `2.0` is the latest tagged MuscleMap software release. Upstream `setup.py`, `scripts.__version__`, and `version.txt` identify the current software as 2.0. [GitHub releases](https://github.com/MuscleMap/MuscleMap/releases), [setup.py at the audited commit](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/setup.py#L7-L23), [version.txt](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/version.txt)
+- `1.4` is the whole-body model version. Pull request 88 added its immutable Zenodo record ID to the software and merged as commit `6e1e1eb6732337c13cab53bd5cc800c69024774f` on 2026-08-16. [Pull request 88](https://github.com/MuscleMap/MuscleMap/pull/88), [model-version map](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L54-L65), [Zenodo record 21929873](https://zenodo.org/records/21929873)
+
+The container update therefore cannot be a tag substitution from `1.3` to `1.4`. It must package software 2.0 from an exact post-release commit and separately pin whole-body model 1.4.
+
+## Audited baselines
+
+The current recipe is `1.3.45`. It derives the source tag from the first two recipe-version components, so `1.3.45` resolves to upstream tag `1.3`. It installs that archive into `/opt/MuscleMap`. [Current build.yaml](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L1-L12), [install directives](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L54-L63)
+
+That baseline already has an upstream asset mismatch. The PTH bundled by tag 1.3 has MD5 `472b4880647306dfeb9dbe290f51f1e2`, exactly matching the v1.3 Zenodo weight. The JSON bundled beside it reports `model.version` as 1.2. The immutable Zenodo v1.3 JSON differs only by reporting version 1.3. [Tag 1.3 config](https://github.com/MuscleMap/MuscleMap/blob/2a38b0712dd295186a060c9f49560660eb816d07/scripts/models/wholebody/contrast_agnostic_wholebody_model.json#L8-L17), [v1.3 Zenodo metadata and checksums](https://zenodo.org/api/records/19976940), [v1.3 Zenodo config](https://zenodo.org/records/19976940/files/contrast_agnostic_wholebody_model.json)
+
+The v1.4 update must assert both file identities and the fields used to construct the network. Checking only a version string would not have caught the current mixed metadata.
+
+The current upstream model support is commit `6e1e1eb6732337c13cab53bd5cc800c69024774f`. That commit is the merge of pull request 88 and was the upstream `main` head when this investigation ran. The latest source tag remains `2.0` at commit `9f569ea27de092e511e3e9f1960bf43e352c2182`. The official release list jumps from 1.3 to 2.0 and contains no 1.4 source release. [GitHub releases](https://github.com/MuscleMap/MuscleMap/releases), [tag 2.0](https://github.com/MuscleMap/MuscleMap/releases/tag/2.0), [merge commit](https://github.com/MuscleMap/MuscleMap/commit/6e1e1eb6732337c13cab53bd5cc800c69024774f)
+
+Pin the source commit. Do not fetch `main`, because later upstream commits could change code without changing the recipe version.
+
+## Model changes from v1.3 to v1.4
+
+Zenodo publishes both versions under the same concept record. Model v1.3 is record `19976940`. Model v1.4 is record `21929873`. [v1.3 record](https://zenodo.org/records/19976940), [v1.4 record](https://zenodo.org/records/21929873)
+
+| Property | Whole-body v1.3 | Whole-body v1.4 | Container impact |
+| --- | ---: | ---: | --- |
+| Published | 2026-05-02 | 2026-08-16 | Use the immutable v1.4 record, not the concept `latest` URL. |
+| Weight size | 54,417,738 bytes | 104,884,148 bytes | The baked model grows by about 50.5 MB. |
+| Weight MD5 | `472b4880647306dfeb9dbe290f51f1e2` | `910b722aeb641c380404c99ec6d1af97` | Assert the v1.4 file identity during the build or release test. |
+| Config size and MD5 | 9,296 bytes, `d75bf2b324860c0188f80d2700e20a03` | 10,555 bytes, `b586ac488b2e40a4e8624a9a1c52d6b5` | Bake the config beside the weight. |
+| Output channels | 100 | 114 | The v1.3 weights and v1.4 config cannot be mixed. |
+| Residual units | 1 | 2 | Loading the state dictionary is the minimum useful compatibility test. |
+| Label entries | 99 | 113 | Documentation, metrics lookup, and label tests must follow the v1.4 config. |
+
+The record supplies `contrast_agnostic_wholebody_model.pth`, `contrast_agnostic_wholebody_model.json`, and `LICENSE`. The config sets `version` to 1.4, `out_channels` to 114, `num_res_units` to 2, and 113 label entries. [Zenodo API metadata](https://zenodo.org/api/records/21929873), [v1.4 model config](https://zenodo.org/records/21929873/files/contrast_agnostic_wholebody_model.json)
+
+The label update is not append-only:
+
+- v1.4 adds patella labels `7231` and `7232`, fibula labels `8171` and `8172`, and ten deep-leg muscle labels from `8181` through `8222`.
+- Values `8151` and `8152` change meaning from tibia to lateral gastrocnemius.
+- Values `8161` and `8162` change meaning from fibula to tibia.
+- Values `8101` through `8122` change from compartment labels to individual muscles.
+- Values `8141` and `8142` change from gastrocnemius to medial gastrocnemius.
+- The config corrects the names of latissimus dorsi and tensor fasciae latae without changing their values.
+
+These names and values come directly from the two immutable configs. [v1.3 config](https://zenodo.org/records/19976940/files/contrast_agnostic_wholebody_model.json), [v1.4 config](https://zenodo.org/records/21929873/files/contrast_agnostic_wholebody_model.json). The current upstream README also lists all 113 v1.4 labels. [Current label list](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/README.md#L134-L252)
+
+Treat the shifted leg values as a user-visible compatibility change. A segmentation with label `8151` means tibia in v1.3 and lateral gastrocnemius in v1.4. Any lookup table or downstream report that assumes the old meaning will be wrong without raising an error.
+
+## Upstream software changes since tag 1.3
+
+The full source comparison is [tag 1.3 to the audited commit](https://github.com/MuscleMap/MuscleMap/compare/1.3...6e1e1eb6732337c13cab53bd5cc800c69024774f). The update includes more than model weights.
+
+### Model and template storage
+
+Software 2.0 removes all model weights, model configs, and abdomen templates from Git. It downloads them from Zenodo into directories below the installed package. The source uses these paths:
+
+- `scripts/models/<region>/v<version>/` for model weights and configs
+- `scripts/templates/<region>/` for templates
+
+The resolver contacts Zenodo when callers request `latest`. A caller that requests an explicit version uses an already cached pair before any network request. [Cache paths and record map](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L23-L85), [explicit-version resolution](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L168-L225), [latest-version resolution](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L227-L271)
+
+This design does not work unchanged in a read-only SIF. The first-use download target is below `/opt/MuscleMap`, and the runtime cannot write there. A network-enabled run can also move to a later model because both `mm_segment` and `mm_extract_metrics` default to `--model_version latest`. [mm_segment option](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_segment.py#L72-L85), [mm_extract_metrics option](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_extract_metrics.py#L43-L53)
+
+The recipe must declare the immutable Zenodo files, use `get_file()` in the build directives, and copy the pair to `/opt/MuscleMap/scripts/models/wholebody/v1.4/`. The OpenRecon bridge must pass an explicit model version to both upstream commands.
+
+### Launchers and behavior
+
+Upstream still installs four console scripts: `mm_segment`, `mm_extract_metrics`, `mm_gui`, and `mm_register_to_template`. [Entry points](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/setup.py#L15-L21)
+
+The behavior changes that affect the recipe are:
+
+- `mm_segment` adds `--model_version`, resolves the selected model through Zenodo, and logs the model version from the config. Existing `-i`, `-r`, `-c`, `-s`, and `-g` calls remain accepted. [Parser and startup](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_segment.py#L54-L110), [model loading](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_segment.py#L125-L167)
+- `mm_extract_metrics` adds `--model_version` and `--qc`. A region-specific metrics run now resolves its model config through Zenodo. [Metrics parser and config loading](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_extract_metrics.py#L22-L81)
+- `mm_extract_metrics --qc` loads the new `scripts/mm_qc_gui.py`. Upstream does not add a separate console entry point for that module. [v2.0 release notes](https://github.com/MuscleMap/MuscleMap/releases/tag/2.0), [QC call path](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L1097-L1128)
+- `mm_gui` discovers cached versions for its segmentation panel and passes the chosen version there. Its metrics panel and chained workflow do not pass `--model_version`, so those paths still resolve `latest`. [Segmentation panel](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_gui.py#L585-L638), [metrics panel](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_gui.py#L640-L704), [chained workflow](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_gui.py#L739-L760)
+- `mm_register_to_template` still expects Spinal Cord Toolbox 6.5. Upstream documents and checks that version. The registration command supports abdomen templates, not the `wholebody` example in the current recipe README. [Upstream installation note](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/README.md#L117-L119), [registration parser](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_register_to_template.py#L11-L64), [current incorrect example](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L112-L123)
+
+The `mm_extract_metrics` help text gives 2.0 as an example model version even though the configured whole-body model versions end at 1.4. This text confuses the software version with the model version. [Metrics option text](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_extract_metrics.py#L49-L53), [configured model versions](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L54-L65). Container documentation must use 1.4 for `--model_version`.
+
+### Dependencies
+
+The upstream source now requires Python 3.11 or newer. Its README asks for Python 3.11.8. [setup.py](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/setup.py#L23), [installation instructions](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/README.md#L24-L47)
+
+Compared with tag 1.3, the audited requirements make three changes:
+
+- `torch` changes from 2.4.0 to 2.4.1.
+- `customtkinter==5.2.2` is added.
+- `Pillow==11.3.0` is added.
+
+All other direct requirements keep their existing pins. [Current requirements](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/requirements.txt), [tag 1.3 requirements](https://github.com/MuscleMap/MuscleMap/blob/2a38b0712dd295186a060c9f49560660eb816d07/requirements.txt)
+
+The current recipe uses a PyTorch 2.4.0 CUDA 11.8 base and then forces Pillow 10.4.0 after installing MuscleMap. Both pins conflict with the audited upstream requirements. [Current dependency directives](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L30-L35), [Pillow override](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L56-L63)
+
+Upstream has one inconsistency. `requirements.txt` pins torch 2.4.1, but the README still tells GPU users to install PyTorch 2.4.0. [requirements.txt](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/requirements.txt#L1-L2), [README GPU instructions](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/README.md#L85-L107). Use the machine-readable 2.4.1 pin for the update, then prove CUDA 11 compatibility in the built image.
+
+### Platforms and architectures
+
+Upstream documents CPU execution, NVIDIA CUDA, and AMD ROCm. It says ROCm support is Linux-only. Upstream does not publish an architecture matrix or CI workflow, and `setup.py` has no architecture markers. [GPU instructions](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/README.md#L85-L115), [setup.py](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/setup.py)
+
+The current recipe declares only `x86_64`. Keep that architecture for this update. The official `pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime` tag exists as a Linux `amd64` image, so the base can move with the upstream torch pin without changing the scanner CUDA 11 contract. [PyTorch image tag](https://hub.docker.com/r/pytorch/pytorch/tags?name=2.4.1-cuda11.8-cudnn9-runtime)
+
+### Licenses
+
+The audited GitHub source and the whole-body model v1.4 are MIT licensed. [Source LICENSE](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/LICENSE), [v1.4 Zenodo metadata](https://zenodo.org/api/records/21929873). Spinal Cord Toolbox 6.5 remains LGPL-3.0. [SCT 6.5 LICENSE](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/6.5/LICENSE)
+
+The source 2.0 move to Zenodo matters if the container preserves legacy regional models and registration templates. Zenodo marks the pelvis and leg records and the abdomen template record as CC-BY-4.0, while the `LICENSE` file uploaded inside those records contains the MIT text. [Pelvis record](https://zenodo.org/api/records/19632902), [leg record](https://zenodo.org/api/records/19633057), [abdomen template record](https://zenodo.org/api/records/20043148). Do not silently copy the old recipe's MIT-only declaration onto these separately published assets. Record CC-BY-4.0 in `copyright` if the update bakes them, or ask upstream to resolve the metadata conflict first.
+
+## NeuroContainers impact
+
+### Source and version variables
+
+The existing `musclemap_source_tag` expression would turn a recipe version such as `1.4.x` into source tag `1.4`. That archive does not exist. [Current variables](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L6-L12), [upstream release list](https://github.com/MuscleMap/MuscleMap/releases)
+
+Decouple these identities in the recipe:
+
+- the NeuroContainers release version, proposed as `1.4.0` so the image continues to track the packaged whole-body model
+- the exact MuscleMap source commit
+- the upstream software version, 2.0
+- the whole-body model version, derived from `context.version` where practical
+- the immutable Zenodo record ID, 21929873
+
+Use the source commit in the archive URL and extracted-directory name. Do not construct a source tag from the model version.
+
+### Build assets and offline behavior
+
+Declare both v1.4 whole-body files in `files:` and reference them with `get_file()` in `run:` directives. Install them at the cache path that upstream already understands:
+
+```text
+/opt/MuscleMap/scripts/models/wholebody/v1.4/
+├── contrast_agnostic_wholebody_model.json
+└── contrast_agnostic_wholebody_model.pth
+```
+
+The immutable file endpoints are listed in the [Zenodo API record](https://zenodo.org/api/records/21929873). Do not call Zenodo through `curl` or `wget` in a build directive.
+
+Software 2.0 also removes the legacy regional weights and abdomen templates that tag 1.3 carried in the source tree. The current recipe exposes abdomen, pelvis, thigh, and leg in the OpenRecon configuration, and it deploys `mm_register_to_template`. [Current region choices](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/OpenReconLabel.json#L141-L197), [current deployed commands](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/build.yaml#L96-L101)
+
+Preserve the existing commands and region choices. Bake all five upstream v0.0 regional model pairs for abdomen, forearm, leg, pelvis, and thigh. Bake the complete abdomen template record too. Install every asset in the cache path expected by upstream. This keeps the current OpenRecon choices, `mm_gui`, and `mm_register_to_template` usable without runtime writes or downloads. It also preserves forearm through the direct CLI, where upstream has a record but neither GUI currently lists it. The upstream record IDs are defined in `ZENODO_MODELS` and `ZENODO_TEMPLATES`. [Model record map](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L28-L66), [template record map](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L273-L333)
+
+The six model pairs and ten abdomen template NIfTIs total 630,133,839 bytes before source code, configs, and license files. This is about 50.5 MB more model data than the current image because the v1.4 whole-body weight replaces the smaller v1.3 weight.
+
+Pin `wholebody` to 1.4 and every regional model to 0.0. Make the label transform region-aware. Whole-body output uses the reversible transformed coding. Regional output keeps its native dense labels.
+
+### OpenRecon bridge
+
+The bridge currently runs `mm_segment` and `mm_extract_metrics` without `--model_version`. [Segmentation command](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/musclemap.py#L3924-L3942), [metrics command](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/musclemap.py#L3329-L3350). Under software 2.0, both commands would contact Zenodo for `latest` and could fail against a read-only `/opt` tree or select a later model.
+
+Pass the pinned version on both paths. For `wholebody`, pass 1.4. If the image preserves legacy regional models, pass 0.0 for those regions. Derive the command value from one recipe-controlled constant so segmentation and metrics cannot use different configs.
+
+Apply the same rule to every deployed launcher. Direct CLI calls default to `latest`, and upstream `mm_gui` omits a version on its metrics and chained-workflow paths. Either patch those paths to choose the baked version or stop deploying `mm_gui` until it can honor the container pin. A read-only image cannot promise model 1.4 while a launcher still asks Zenodo for `latest`.
+
+The current bridge's label transform is reversible for all v1.4 whole-body values, including the new maximum `8222`. The existing unit test covers only values through `1122`. [Transform functions](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/musclemap.py#L3549-L3563), [current test](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/test_musclemap_openrecon.py#L260-L304). Extend the test through `8222` and include the shifted `8151`, `8161`, and `8171` values.
+
+Legacy regional models use dense values such as 1 through 28, not the whole-body `xx0`, `xx1`, and `xx2` coding. The bridge applies the whole-body transform whenever `labeltransform` is true. A full preservation of regional OpenRecon choices therefore needs region-aware label handling. Baking the assets alone is not enough. The upstream configs define those dense values. [Legacy model records](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_util.py#L28-L53), [current unconditional transform](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/musclemap.py#L4495-L4521)
+
+### Documentation and metadata
+
+Update both `build.yaml` readme text and `OpenReconREADME.md`:
+
+- Say that the image packages MuscleMap software 2.0 at the pinned commit and whole-body model 1.4 from Zenodo.
+- Link whole-body labels to the immutable v1.4 config. The current GitHub `scripts/models` link cannot work with software 2.0 because upstream removed the file.
+- Document the changed leg label meanings.
+- Add `--model_version` to direct CLI examples.
+- Change the registration example from `wholebody` to `abdomen`.
+- Keep the scanner-specific spatial overlap default only if it is intentional. Upstream's code default is 90, the current README recommendation for large scans is 75, and the upstream parser help still says 50. [README recommendation](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/README.md#L254-L260), [parser defaults](https://github.com/MuscleMap/MuscleMap/blob/6e1e1eb6732337c13cab53bd5cc800c69024774f/scripts/mm_segment.py#L78-L85)
+- Preserve the existing base64 icon and `body` category. They already satisfy recipe validation.
+- Keep MIT and LGPL-3.0. Add CC-BY-4.0 for the Zenodo assets whose records declare it.
+- Replace the hardcoded `1.3.0` component in the OpenRecon UDI with `VERSION_WILL_BE_REPLACED_BY_SCRIPT`, as used by the other versioned regulatory fields. [Current OpenRecon UDI](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/OpenReconLabel.json#L8-L19)
+
+Update the recipe and `fulltest.yaml` versions together. The current fulltest still declares `1.3.45`. [Current fulltest header](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/fulltest.yaml#L1-L6)
+
+Committed release metadata currently ends at `releases/musclemap/1.3.10.json`, while the recipe and fulltest are already 1.3.45. [Committed MuscleMap releases](https://github.com/neurodesk/neurocontainers/tree/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/releases/musclemap). Do not hand-edit an old release JSON. Build and test the new image first, then generate fresh release metadata through the normal release workflow.
+
+## Recommended implementation sequence
+
+1. Set the new recipe version and decouple the source commit, software version, model version, and Zenodo record variables.
+2. Change the base to PyTorch 2.4.1 with CUDA 11.8. Remove the Pillow 10.4.0 override and assert Python 3.11 or newer, torch 2.4.1, CUDA 11.x, customtkinter 5.2.2, and Pillow 11.3.0 after installation.
+3. Declare the source archive and every retained Zenodo asset in `files:`. Use only `get_file()` to unpack or copy them. Install the whole-body pair in `scripts/models/wholebody/v1.4/`.
+4. Bake the five v0.0 regional model pairs and all abdomen template NIfTIs. Add the applicable Zenodo license metadata.
+5. Pass the explicit model version in the OpenRecon segmentation and metrics subprocesses. Add region-aware version selection for the retained regional models. Make the direct CLI and `mm_gui` paths honor the same baked versions.
+6. Make label validation and transformation region-aware. Whole-body uses the existing transformed coding. Regional models retain their native dense labels. Do not ship the current regional choices with software 2.0 until a real regional run passes.
+7. Update the readmes, label links, CLI examples, model identity, and leg-label compatibility note.
+8. Update focused unit tests before the image build. Then generate the Dockerfile, validate the recipe, build the x86_64 image, and run the release tests.
+9. Measure a representative whole-body scanner run before retaining the current OpenRecon resource declaration. The v1.4 model doubles residual units and adds 14 output channels. Confirm that auto-chunking and retry behavior stay within `min_required_gpu_memory = 10048` and `min_required_memory = 40096`, or update those values from measured peaks.
+
+## Verification contract
+
+The current fulltest checks launcher help, CUDA 11, OpenRecon imports, and local assets. It does not prove which upstream software or model is installed. [Current fulltest](https://github.com/neurodesk/neurocontainers/blob/cf9a6e80aeac99a42f40ad1e344b8bdbed998dd9/recipes/musclemap/fulltest.yaml#L16-L68)
+
+The local pre-update baseline is green when run with NumPy and Pillow available: all 25 tests in `test_musclemap_openrecon.py` pass, `builder/validation.py` accepts `build.yaml`, and `validate_openrecon_labels.py` accepts the MuscleMap label against the OpenRecon 1.1.0 schema. Preserve that baseline while adding the version and asset checks.
+
+Upstream pull request 88 changed the README, one Zenodo record mapping, `version.txt`, `.gitignore`, and an image asset. It added no automated tests. [Pull request 88 files](https://github.com/MuscleMap/MuscleMap/pull/88/files). NeuroContainers must supply the packaging and runtime proof.
+
+Add these checks:
+
+- Assert `scripts.__version__ == "2.0"` and inspect installed package metadata.
+- Assert Python is at least 3.11, torch is 2.4.1, and `torch.version.cuda` starts with 11.
+- Resolve `get_model_and_config_paths("wholebody", version="1.4")` with outbound network disabled. Assert both paths are below `/opt/MuscleMap/scripts/models/wholebody/v1.4`.
+- Assert the baked config reports version 1.4, 114 output channels, two residual units, 113 labels, and the exact values for `8151`, `8161`, `8171`, and `8222`.
+- Load the v1.4 state dictionary into the UNet described by the config. This catches a mixed v1.3 weight and v1.4 config without requiring a full segmentation run.
+- Run `mm_extract_metrics -m average` on a tiny generated NIfTI and segmentation with `--model_version 1.4`. Assert that the output CSV uses v1.4 anatomy names.
+- Exercise `_build_mm_segment_command` and `_run_mm_extract_metrics` unit tests. Assert that both commands carry the same pinned version.
+- Round-trip the label transform for all 113 v1.4 values, not a hand-picked prefix.
+- Run one tiny real regional inference or a model-load test per retained region. Assert that regional labels bypass the whole-body transform.
+- Assert that the baked abdomen template resolver works without network access.
+- Run one scanner-format OpenRecon sample through segmentation, metrics, label transformation, and output composition. Confirm that the new leg labels survive the MRD and DICOM metadata paths.
+- Record peak GPU and host memory for that scanner sample. Confirm that the declared resource minimums cover the measured peaks with operational headroom.
+
+Run the repository checks after those focused tests:
+
+```bash
+python3 builder/validation.py recipes/musclemap/build.yaml
+python -m builder generate musclemap --recreate
+pytest recipes/musclemap/test_musclemap_openrecon.py
+sf-build musclemap
+sf-test musclemap
+```
+
+The final acceptance condition is specific: the image must complete whole-body segmentation and metrics with model v1.4 while Zenodo is unreachable and `/opt` is read-only. Launcher help and import tests do not prove that contract.

--- a/recipes/musclemap/verify_musclemap_install.py
+++ b/recipes/musclemap/verify_musclemap_install.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Verify the immutable MuscleMap assets installed in the container."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MODEL_SPECS = {
+    "wholebody": {
+        "filenames": (
+            "contrast_agnostic_wholebody_model.pth",
+            "contrast_agnostic_wholebody_model.json",
+        ),
+        "checksums": (
+            "910b722aeb641c380404c99ec6d1af97",
+            "b586ac488b2e40a4e8624a9a1c52d6b5",
+        ),
+        "out_channels": 114,
+        "num_res_units": 2,
+        "label_count": 113,
+    },
+    "abdomen": {
+        "filenames": (
+            "contrast_agnostic_abdomen_model.pth",
+            "contrast_agnostic_abdomen_model.json",
+        ),
+        "checksums": (
+            "25d777a05b00a8106bec6acb034c212c",
+            "35e0efb873497ad063fee30fdd4ea69b",
+        ),
+        "out_channels": 9,
+        "num_res_units": 2,
+        "label_count": 8,
+    },
+    "forearm": {
+        "filenames": (
+            "contrast_agnostic_forearm_model.pth",
+            "contrast_agnostic_forearm_model.json",
+        ),
+        "checksums": (
+            "aee13b1f942328cf787679a83fb88137",
+            "f80881b5372b0bba403f2f94f1a68e0b",
+        ),
+        "out_channels": 6,
+        "num_res_units": 1,
+        "label_count": 5,
+    },
+    "leg": {
+        "filenames": (
+            "contrast_agnostic_leg_model.pth",
+            "contrast_agnostic_leg_model.json",
+        ),
+        "checksums": (
+            "a293a5fed25a2b298c9fe58a0bfda5f1",
+            "9da4d3ae4857a015f615649646e34bd1",
+        ),
+        "out_channels": 15,
+        "num_res_units": 2,
+        "label_count": 14,
+    },
+    "pelvis": {
+        "filenames": (
+            "contrast_agnostic_pelvis_model.pth",
+            "contrast_agnostic_pelvis_model.json",
+        ),
+        "checksums": (
+            "1a085c3c1cee45e8d48120c8805d28f2",
+            "c8cba0118c5dfa5f870ff138187c1c55",
+        ),
+        "out_channels": 14,
+        "num_res_units": 2,
+        "label_count": 13,
+    },
+    "thigh": {
+        "filenames": (
+            "contrast_agnostic_thigh_model.pth",
+            "contrast_agnostic_thigh_model.json",
+        ),
+        "checksums": (
+            "4e570b2cab9125dfe53cf20b86398581",
+            "1f820178021a866103e901d7bfa0af68",
+        ),
+        "out_channels": 29,
+        "num_res_units": 2,
+        "label_count": 28,
+    },
+}
+
+TEMPLATE_CHECKSUMS = {
+    "abdomen_template.nii.gz": "c2c7828b0bbbe2f5dcd78bc3454be573",
+    "abdomen_template_dseg.nii.gz": "ca685cd35cf8212b52abca177571455c",
+    "abdomen_template_dseg_label-1.nii.gz": "7e712776154de9d4e7c1317f53193ca1",
+    "abdomen_template_dseg_label-2.nii.gz": "89281562711639604b8bd9ebacc06f52",
+    "abdomen_template_dseg_label-3.nii.gz": "b8d91d68d12f1166c70529e7e60ca620",
+    "abdomen_template_dseg_label-4.nii.gz": "7350c21220e42f9837f0527681f1a97a",
+    "abdomen_template_dseg_label-5.nii.gz": "66342aaf7ed11ee733c1aa86a4a7f71f",
+    "abdomen_template_dseg_label-6.nii.gz": "d852b3cc640af8f6c413fbd0556629f6",
+    "abdomen_template_dseg_label-7.nii.gz": "1fa85278c89cd3913357d42fc34ea943",
+    "abdomen_template_dseg_label-8.nii.gz": "f8bde003ca64c8198ac513780068347b",
+}
+
+
+def md5sum(path: Path) -> str:
+    digest = hashlib.md5()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise AssertionError(f"required environment variable is unset: {name}")
+    return value
+
+
+def verify_file(path: Path, expected_checksum: str) -> None:
+    if not path.is_file():
+        raise AssertionError(f"missing installed asset: {path}")
+    actual_checksum = md5sum(path)
+    if actual_checksum != expected_checksum:
+        raise AssertionError(
+            f"checksum mismatch for {path}: {actual_checksum} != {expected_checksum}"
+        )
+
+
+def verify_model(
+    root: Path,
+    region: str,
+    spec: dict[str, Any],
+    version: str,
+) -> tuple[Path, dict[str, Any]]:
+    model_dir = root / "scripts" / "models" / region / f"v{version}"
+    weight_name, config_name = spec["filenames"]
+    weight_path = model_dir / weight_name
+    config_path = model_dir / config_name
+    verify_file(weight_path, spec["checksums"][0])
+    verify_file(config_path, spec["checksums"][1])
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    model = config["model"]
+    labels = config["labels"]
+    expected = {
+        "version": version,
+        "out_channels": spec["out_channels"],
+        "num_res_units": spec["num_res_units"],
+    }
+    actual = {key: model[key] for key in expected}
+    actual["version"] = str(actual["version"])
+    if actual != expected:
+        raise AssertionError(f"unexpected {region} model metadata: {actual} != {expected}")
+    if len(labels) != spec["label_count"]:
+        raise AssertionError(
+            f"unexpected {region} label count: {len(labels)} != {spec['label_count']}"
+        )
+    return weight_path, config
+
+
+def load_wholebody_model(weight_path: Path, config: dict[str, Any]) -> None:
+    import torch
+    from monai.networks.layers import Norm
+    from monai.networks.nets import UNet
+
+    model_config = config["model"]
+    norms = {"instance": Norm.INSTANCE}
+    model = UNet(
+        spatial_dims=model_config["spatial_dims"],
+        in_channels=model_config["in_channels"],
+        out_channels=model_config["out_channels"],
+        channels=tuple(model_config["channels"]),
+        act=model_config["act"],
+        strides=tuple(model_config["strides"]),
+        num_res_units=model_config["num_res_units"],
+        norm=norms[model_config["norm"]],
+    )
+    state = torch.load(weight_path, map_location="cpu", weights_only=True)
+    model.load_state_dict(state)
+
+
+def verify_install(
+    root: Path,
+    load_model: bool,
+    verify_runtime_defaults: bool = True,
+) -> None:
+    wholebody_version = require_environment("MUSCLEMAP_WHOLEBODY_MODEL_VERSION")
+    regional_version = require_environment("MUSCLEMAP_REGIONAL_MODEL_VERSION")
+    software_version = require_environment("MUSCLEMAP_SOFTWARE_VERSION")
+
+    installed_version = (root / "version.txt").read_text(encoding="utf-8").strip()
+    if installed_version != software_version:
+        raise AssertionError(
+            f"unexpected MuscleMap software version: {installed_version} != {software_version}"
+        )
+
+    wholebody_weight = None
+    wholebody_config = None
+    for region, spec in MODEL_SPECS.items():
+        version = wholebody_version if region == "wholebody" else regional_version
+        weight_path, config = verify_model(root, region, spec, version)
+        if region == "wholebody":
+            wholebody_weight = weight_path
+            wholebody_config = config
+
+    if wholebody_weight is None or wholebody_config is None:
+        raise AssertionError("whole-body model specification was not verified")
+    labels = wholebody_config["labels"]
+    values = {entry["value"] for entry in labels}
+    if len(values) != 113 or max(values) != 8222:
+        raise AssertionError("whole-body v1.4 label values are incomplete")
+
+    template_dir = root / "scripts" / "templates" / "abdomen"
+    for filename, checksum in TEMPLATE_CHECKSUMS.items():
+        verify_file(template_dir / filename, checksum)
+
+    if verify_runtime_defaults:
+        sys.path.insert(0, str(root))
+        mm_util = importlib.import_module("scripts.mm_util")
+        for region in MODEL_SPECS:
+            expected_version = wholebody_version if region == "wholebody" else regional_version
+            actual_version = mm_util._resolve_container_model_version(region, "latest")
+            if actual_version != expected_version:
+                raise AssertionError(
+                    f"container default mismatch for {region}: {actual_version} != {expected_version}"
+                )
+
+    if load_model:
+        load_wholebody_model(wholebody_weight, wholebody_config)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("/opt/MuscleMap"))
+    parser.add_argument(
+        "--load-wholebody-model",
+        action="store_true",
+        help="Instantiate the v1.4 MONAI network and load its state dictionary.",
+    )
+    parser.add_argument(
+        "--skip-runtime-defaults",
+        action="store_true",
+        help="Skip importing mm_util; intended only for host-side cache verification.",
+    )
+    args = parser.parse_args()
+    verify_install(
+        args.root,
+        args.load_wholebody_model,
+        verify_runtime_defaults=not args.skip_runtime_defaults,
+    )
+    print("MuscleMap installation verified")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- update the recipe to `1.4.0`, using MuscleMap software 2.0 at audited commit `6e1e1eb6732337c13cab53bd5cc800c69024774f` and whole-body model v1.4
- bake the whole-body model, regional models, and abdomen template from immutable Zenodo records so runtime use does not need network or write access to `/opt`
- pin explicit model versions in the CLI and OpenRecon paths, preserve native regional labels, and update the v1.4 whole-body label table
- add installation checks, focused OpenRecon tests, updated release tests, and investigation notes

## Verification

- `28 passed` in `recipes/musclemap/test_musclemap_openrecon.py`
- recipe validation and OpenRecon 1.1.0 label-schema validation pass
- Dockerfile regeneration matches the Dockerfile used for the tested image
- built `musclemap:1.4.0` as `sha256:bf49fcaf86907b133da0479176189b2d81f2c066fc02f5000920cbd4ac63e7f3`
- loaded the packaged v1.4 state dictionary with `--network none`
- completed an offline CPU segmentation of TotalSegmentator MRI case `s0175` in 293 seconds, producing 85 foreground labels with matching shape and affine
- completed an offline CPU five-station NLM Visible Human exam covering neck through ankles; all masks have matching shape and affine, `int16` values, nonzero foreground, and only packaged v1.4 labels

The Visible Human coronal pelvis exceeded the 28 GiB limit with automatic chunk sizing. An explicit five-slice chunk completed the remaining stations. This is documented as a command-line edge case; OpenRecon supplies axial images.

See `recipes/musclemap/upstream_v1.4_investigation.md` and `recipes/musclemap/full_body_exam_research.md` for sources, commands, results, and limitations.
