### PR TITLE
Fix spinalcordtoolbox OpenRecon dataflow and enable GPU

### DIFF
--- a/recipes/spinalcordtoolbox/build.yaml
+++ b/recipes/spinalcordtoolbox/build.yaml
@@ -1,5 +1,5 @@
 name: spinalcordtoolbox
-version: "7.3.2"
+version: "7.3.3"
 copyright:
   - license: LGPL-3.0
     url: https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/LICENSE
@@ -9,7 +9,7 @@ variables:
   upstream_version: "7.3"
 build:
   kind: neurodocker
-  base-image: pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime
+  base-image: ubuntu:22.04
   pkg-manager: apt
   directives:
     - environment:
@@ -18,6 +18,9 @@ build:
         - gcc
         - ca-certificates
         - libmpich-dev
+        - python3
+        - python-is-python3
+        - python3-pip
         - python3-pyqt5
         - git
         - curl
@@ -33,10 +36,14 @@ build:
         - chmod a+rwx /opt/spinalcordtoolbox-{{ context.version }}/ -R
     - user: spinalcordtoolbox
     - run:
-        - yes | ./install_sct -i
+        - ./install_sct -i -y -g -c
+        - rm -rf /home/spinalcordtoolbox/.cache /opt/spinalcordtoolbox-{{ context.version }}/python/pkgs
     - environment:
         PATH: /opt/spinalcordtoolbox-{{ context.version }}/bin/:$PATH
         SCT_DIR: /opt/spinalcordtoolbox-{{ context.version }}
+        SCT_USE_GPU: "1"
+    - run:
+        - /opt/spinalcordtoolbox-{{ context.version }}/python/envs/venv_sct/bin/python -c 'import os, torch; assert torch.version.cuda; assert os.environ.get("SCT_USE_GPU") == "1"; print(torch.__version__, torch.version.cuda)'
     - run:
         - sct_deepseg spinalcord -install
         - sct_deepseg sc_epi -install
@@ -56,8 +63,6 @@ build:
         - sct_deepseg rootlets -install
         - sct_deepseg sc_canal_t2 -install
         - sct_deepseg spine -install
-    - run:
-        - sct_check_dependencies
     - user: root
     - copy: spinalcordtoolbox.py /opt/code/python-ismrmrd-server/spinalcordtoolbox.py
     - copy: nifti2mrd.py /opt/code/python-ismrmrd-server/nifti2mrd.py

--- a/recipes/spinalcordtoolbox/fulltest.yaml
+++ b/recipes/spinalcordtoolbox/fulltest.yaml
@@ -10,7 +10,7 @@
 # These tests use brain MRI data for basic functionality verification.
 
 name: spinalcordtoolbox
-version: "7.3.2"
+version: "7.3.3"
 upstream_version: "7.3"
 
 required_files:
@@ -54,10 +54,10 @@ tests:
     command: sct_version
     expected_output_contains: "${upstream_version}"
 
-  - name: Check dependencies (short)
-    description: Run minimal dependency check
-    command: sct_check_dependencies -short
-    expected_output_contains: "SCT"
+  - name: CUDA-enabled PyTorch build
+    description: Verify SCT's isolated Python environment contains a CUDA-enabled PyTorch build
+    command: /opt/spinalcordtoolbox-${version}/python/envs/venv_sct/bin/python -c 'import os, torch; assert torch.version.cuda; assert os.environ.get("SCT_USE_GPU") == "1"; print(f"cuda={torch.version.cuda}")'
+    expected_output_contains: "cuda="
 
   # ==========================================================================
   # IMAGE CONVERSION (sct_convert)

--- a/recipes/spinalcordtoolbox/spinalcordtoolbox.py
+++ b/recipes/spinalcordtoolbox/spinalcordtoolbox.py
@@ -169,6 +169,13 @@ OPENRECON_DEFAULTS = {
 }
 
 OPENRECON_SEND_IMAGE_CHUNK_SIZE = 96
+MRD_VOLUME_DIMENSION_FIELDS = (
+    "repetition",
+    "contrast",
+    "phase",
+    "set",
+    "average",
+)
 RESERVED_SCANNER_SERIES_INDICES = {99}
 # Returned originals stay 2D. SCT segmentations are returned as source-geometry
 # 2D slices after originals, without detached/explicit-volume output.
@@ -311,7 +318,7 @@ def process(connection, config, metadata):
                 input_images_for_series_registry.append(item)
 
                 # Only process magnitude images -- send phase images back without modification (fallback for images with unknown type)
-                if (item.image_type is ismrmrd.IMTYPE_MAGNITUDE) or (item.image_type == 0):
+                if (item.image_type == ismrmrd.IMTYPE_MAGNITUDE) or (item.image_type == 0):
                     image_groups.setdefault(_get_image_series_index(item), []).append(item)
                 else:
                     passthrough_images.append(item)
@@ -337,15 +344,23 @@ def process(connection, config, metadata):
             sum(len(group) for group in image_groups.values()),
         )
 
-        if passthrough_images:
+        passthrough_groups = _group_passthrough_images_by_source_series(
+            passthrough_images
+        )
+        for passthrough_key, passthrough_group in sorted(passthrough_groups.items()):
+            source_series_index = passthrough_key[0]
             passthrough_series_index = derived_series_allocator.allocate("PASSTHROUGH")
-            output_images.extend(
-                _restamp_passthrough_images(
-                    passthrough_images,
-                    "PASSTHROUGH",
-                    passthrough_series_index,
-                )
+            staged_passthrough = _restamp_passthrough_images(
+                passthrough_group,
+                "PASSTHROUGH",
+                passthrough_series_index,
             )
+            _log_and_validate_output_series_contract(
+                staged_passthrough,
+                passthrough_group,
+                context=f"passthrough_source_series_{source_series_index}",
+            )
+            output_images.extend(staged_passthrough)
 
         for series_index, imgGroup in sorted(image_groups.items()):
             logging.info(
@@ -354,14 +369,21 @@ def process(connection, config, metadata):
                 len(imgGroup),
             )
             try:
-                image = process_image(
-                    imgGroup,
-                    connection,
-                    config,
-                    metadata,
-                    derived_series_allocator=derived_series_allocator,
+                image = _as_image_list(
+                    process_image(
+                        imgGroup,
+                        connection,
+                        config,
+                        metadata,
+                        derived_series_allocator=derived_series_allocator,
+                    )
                 )
-            except subprocess.CalledProcessError:
+                _log_and_validate_output_series_contract(
+                    image,
+                    imgGroup,
+                    context=f"processed_source_series_{series_index}",
+                )
+            except Exception:
                 if not _get_boolean_config_param(
                     config,
                     "sendoriginal",
@@ -378,6 +400,11 @@ def process(connection, config, metadata):
                     "ORIGINAL",
                     original_series_index,
                 )
+                _log_and_validate_output_series_contract(
+                    image,
+                    imgGroup,
+                    context=f"fallback_source_series_{series_index}",
+                )
                 logging.warning(
                     "SCT analysis failed for image_series_index=%d; returning %d "
                     "original images as series_index=%d",
@@ -385,7 +412,7 @@ def process(connection, config, metadata):
                     len(image),
                     original_series_index,
                 )
-            output_images.extend(_as_image_list(image))
+            output_images.extend(image)
 
         if output_images:
             _log_and_validate_output_series_contract(
@@ -657,6 +684,105 @@ def _slice_slot_key(record, use_projected_position=True):
     return (int(record["slice"]),)
 
 
+def _mrd_volume_dimension_key(image_header):
+    values = []
+    for field_name in MRD_VOLUME_DIMENSION_FIELDS:
+        try:
+            values.append(int(getattr(image_header, field_name, 0)))
+        except (TypeError, ValueError):
+            values.append(0)
+    return tuple(values)
+
+
+def _validate_volume_groups(image_headers, groups, slice_axis, method):
+    image_headers = list(image_headers)
+    flattened_indices = [input_index for group in groups for input_index in group]
+    if sorted(flattened_indices) != list(range(len(image_headers))):
+        raise ValueError(
+            f"Invalid {method} volume grouping: groups do not partition all source images"
+        )
+
+    _, records = _build_slice_geometry_records(
+        image_headers,
+        input_indices=list(range(len(image_headers))),
+        slice_axis=slice_axis,
+    )
+    projected_slot_keys = [
+        _slice_slot_key(record, use_projected_position=True)
+        for record in records
+    ]
+    use_projected_position = len(set(projected_slot_keys)) > 1
+    slot_keys = (
+        projected_slot_keys
+        if use_projected_position
+        else [
+            _slice_slot_key(record, use_projected_position=False)
+            for record in records
+        ]
+    )
+
+    reference_signature = None
+    for volume_index, group in enumerate(groups, start=1):
+        group_slot_keys = [slot_keys[input_index] for input_index in group]
+        if len(set(group_slot_keys)) != len(group_slot_keys):
+            raise ValueError(
+                f"Invalid {method} volume grouping: volume {volume_index} "
+                "contains duplicate spatial slice slots"
+            )
+        signature = tuple(sorted(group_slot_keys))
+        if reference_signature is None:
+            reference_signature = signature
+        elif signature != reference_signature:
+            raise ValueError(
+                f"Invalid {method} volume grouping: inferred volumes do not "
+                "contain the same spatial slice slots"
+            )
+
+    if not image_headers:
+        return
+
+    reference_header = image_headers[0]
+    reference_matrix = tuple(int(value) for value in reference_header.matrix_size[:])
+    reference_fov = np.asarray(reference_header.field_of_view[:], dtype=float)
+    reference_directions = tuple(
+        _header_vector(reference_header, field_name)
+        for field_name in ("read_dir", "phase_dir", "slice_dir")
+    )
+    for input_index, image_header in enumerate(image_headers[1:], start=1):
+        matrix = tuple(int(value) for value in image_header.matrix_size[:])
+        fov = np.asarray(image_header.field_of_view[:], dtype=float)
+        directions = tuple(
+            _header_vector(image_header, field_name)
+            for field_name in ("read_dir", "phase_dir", "slice_dir")
+        )
+        if matrix != reference_matrix or not np.allclose(
+            fov,
+            reference_fov,
+            rtol=1e-5,
+            atol=1e-4,
+        ):
+            raise ValueError(
+                f"Invalid {method} volume grouping: source image {input_index} "
+                "has incompatible matrix size or field of view"
+            )
+        if any(
+            not np.allclose(
+                direction,
+                reference_direction,
+                rtol=1e-5,
+                atol=1e-4,
+            )
+            for direction, reference_direction in zip(
+                directions,
+                reference_directions,
+            )
+        ):
+            raise ValueError(
+                f"Invalid {method} volume grouping: source image {input_index} "
+                "has incompatible orientation"
+            )
+
+
 def _split_source_images_by_volume(image_headers, slice_axis=None):
     image_headers = list(image_headers)
     if len(image_headers) <= 1:
@@ -664,6 +790,28 @@ def _split_source_images_by_volume(image_headers, slice_axis=None):
 
     if slice_axis is None:
         slice_axis = _infer_slice_axis(image_headers)
+
+    explicit_groups = {}
+    for input_index, image_header in enumerate(image_headers):
+        dimension_key = _mrd_volume_dimension_key(image_header)
+        explicit_groups.setdefault(dimension_key, []).append(input_index)
+    if len(explicit_groups) > 1:
+        groups = [
+            explicit_groups[key]
+            for key in sorted(explicit_groups)
+        ]
+        _validate_volume_groups(
+            image_headers,
+            groups,
+            slice_axis,
+            "explicit MRD dimensions",
+        )
+        logging.info(
+            "Grouped SCT input into %d volume(s) using explicit MRD dimensions %s",
+            len(groups),
+            ",".join(MRD_VOLUME_DIMENSION_FIELDS),
+        )
+        return groups
 
     _, records = _build_slice_geometry_records(
         image_headers,
@@ -683,7 +831,14 @@ def _split_source_images_by_volume(image_headers, slice_axis=None):
             for record in records
         ]
     if len(set(slot_keys)) == len(slot_keys):
-        return [list(range(len(image_headers)))]
+        groups = [list(range(len(image_headers)))]
+        _validate_volume_groups(
+            image_headers,
+            groups,
+            slice_axis,
+            "spatial fallback",
+        )
+        return groups
 
     volumes = []
     volume_slot_keys = []
@@ -702,6 +857,16 @@ def _split_source_images_by_volume(image_headers, slice_axis=None):
         volumes[target_volume_index].append(input_index)
         volume_slot_keys[target_volume_index].add(slot_key)
 
+    _validate_volume_groups(
+        image_headers,
+        volumes,
+        slice_axis,
+        "spatial fallback",
+    )
+    logging.info(
+        "Grouped SCT input into %d volume(s) using validated spatial fallback",
+        len(volumes),
+    )
     return volumes
 
 
@@ -888,6 +1053,43 @@ def _get_image_series_index(image):
             exc_info=True,
         )
         return 0
+
+
+def _group_passthrough_images_by_source_series(images):
+    groups = {}
+    series_instance_uids = {}
+    for image in _as_image_list(images):
+        series_index = _get_image_series_index(image)
+        source_meta = _meta_from_image(image)
+        source_minihead = _decode_ice_minihead(source_meta)
+        series_instance_uid = _first_non_empty_text(
+            _get_meta_text(source_meta, "SeriesInstanceUID"),
+            _extract_minihead_string_value(
+                source_minihead,
+                "SeriesInstanceUID",
+            ),
+        )
+        if series_instance_uid:
+            previous_uid = series_instance_uids.setdefault(
+                series_index,
+                series_instance_uid,
+            )
+            if previous_uid != series_instance_uid:
+                raise ValueError(
+                    "Passthrough source image_series_index "
+                    f"{series_index} has conflicting SeriesInstanceUID values: "
+                    f"{previous_uid} != {series_instance_uid}"
+                )
+
+        _, complex_component = _source_image_component(image, source_meta)
+        try:
+            image_type = int(getattr(image.getHead(), "image_type", 0))
+        except Exception:
+            image_type = 0
+        group_key = (series_index, image_type, complex_component)
+        groups.setdefault(group_key, []).append(image)
+
+    return groups
 
 
 def _send_images_by_series(connection, images, context):
@@ -2250,7 +2452,8 @@ def _patch_ice_minihead(
     target_display_token=None,
     output_index=0,
     output_image_index=None,
-    preserve_image_type_value3=False,
+    image_type_value3=None,
+    complex_image_component="MAGNITUDE",
     is_last_in_series=False,
 ):
     if not minihead_text:
@@ -2259,12 +2462,18 @@ def _patch_ice_minihead(
     changed = False
     current_text = minihead_text
     target_display_token = target_display_token or target_type_token
+    image_type_token = image_type_value3 or "M"
 
-    if preserve_image_type_value3:
+    if image_type_value3:
+        current_text, did_change = _remove_minihead_array_param(
+            current_text,
+            "ImageTypeValue3",
+        )
+        changed = changed or did_change
         current_text, did_change = _replace_or_append_minihead_string_param(
             current_text,
             "ImageTypeValue3",
-            "M",
+            image_type_value3,
         )
         changed = changed or did_change
     else:
@@ -2283,8 +2492,11 @@ def _patch_ice_minihead(
         ("SeriesNumberRangeNameUID", series_grouping),
         ("SeriesInstanceUID", series_instance_uid),
         ("SOPInstanceUID", sop_instance_uid),
-        ("ImageType", f"DERIVED\\PRIMARY\\M\\{target_type_token}"),
-        ("ComplexImageComponent", "MAGNITUDE"),
+        (
+            "ImageType",
+            f"DERIVED\\PRIMARY\\{image_type_token}\\{target_type_token}",
+        ),
+        ("ComplexImageComponent", complex_image_component),
     ):
         current_text, did_change = _replace_or_append_minihead_string_param(
             current_text,
@@ -2524,6 +2736,53 @@ def _build_passthrough_output_identity(
     }
 
 
+def _source_image_component(image, source_meta):
+    image_type_components = {
+        1: ("M", "MAGNITUDE"),
+        2: ("P", "PHASE"),
+        3: ("R", "REAL"),
+        4: ("I", "IMAGINARY"),
+        5: ("C", "COMPLEX"),
+    }
+    try:
+        header_image_type = int(getattr(image.getHead(), "image_type", 0))
+    except Exception:
+        header_image_type = 0
+    if header_image_type in image_type_components:
+        return image_type_components[header_image_type]
+
+    source_minihead = _decode_ice_minihead(source_meta)
+    image_type_token = _first_non_empty_text(
+        _get_meta_text(source_meta, "ImageTypeValue3"),
+        _extract_minihead_string_value(source_minihead, "ImageTypeValue3"),
+        _get_meta_text(source_meta, "ImageTypeValue4"),
+        _extract_minihead_array_tokens(source_minihead, "ImageTypeValue4"),
+    ).upper()
+    complex_component = _first_non_empty_text(
+        _get_meta_text(source_meta, "ComplexImageComponent"),
+        _extract_minihead_string_value(
+            source_minihead,
+            "ComplexImageComponent",
+        ),
+    ).upper()
+    component_tokens = {
+        "MAGNITUDE": "M",
+        "PHASE": "P",
+        "REAL": "R",
+        "IMAGINARY": "I",
+        "COMPLEX": "C",
+    }
+    token_components = {
+        token: component
+        for component, token in component_tokens.items()
+    }
+    if not image_type_token:
+        image_type_token = component_tokens.get(complex_component, "U")
+    if not complex_component:
+        complex_component = token_components.get(image_type_token, "UNKNOWN")
+    return image_type_token, complex_component
+
+
 def _restamp_passthrough_images(
     images,
     role,
@@ -2546,11 +2805,15 @@ def _restamp_passthrough_images(
         oldHeader.image_series_index = output_series_index
         oldHeader.image_index = output_header_image_index
         oldHeader.slice = output_header_slice
-        oldHeader.contrast = 0
-        oldHeader.image_type = ismrmrd.IMTYPE_MAGNITUDE
+        if role_is_original:
+            oldHeader.contrast = 0
         output_image.setHead(oldHeader)
 
         source_meta = _copy_meta(ismrmrd.Meta.deserialize(image.attribute_string))
+        image_type_value3, complex_image_component = _source_image_component(
+            image,
+            source_meta,
+        )
         tmpMeta = _copy_meta(source_meta)
         _strip_source_parent_refs(tmpMeta)
         output_identity = _build_passthrough_output_identity(
@@ -2577,12 +2840,15 @@ def _restamp_passthrough_images(
         tmpMeta["SeriesNumberRangeNameUID"] = output_identity["grouping"]
         tmpMeta["SeriesInstanceUID"] = output_identity["series_instance_uid"]
         tmpMeta["SOPInstanceUID"] = sop_instance_uid
-        tmpMeta["ImageType"] = f"DERIVED\\PRIMARY\\M\\{output_identity['type_token']}"
-        if is_original_output:
-            tmpMeta["ImageTypeValue3"] = "M"
+        output_image_type = (
+            f"DERIVED\\PRIMARY\\{image_type_value3}\\"
+            f"{output_identity['type_token']}"
+        )
+        tmpMeta["ImageType"] = output_image_type
+        tmpMeta["ImageTypeValue3"] = image_type_value3
         tmpMeta["ImageTypeValue4"] = output_identity["display_token"]
-        tmpMeta["DicomImageType"] = f"DERIVED\\PRIMARY\\M\\{output_identity['type_token']}"
-        tmpMeta["ComplexImageComponent"] = "MAGNITUDE"
+        tmpMeta["DicomImageType"] = output_image_type
+        tmpMeta["ComplexImageComponent"] = complex_image_component
         tmpMeta["ImageComments"] = output_identity["image_comment"]
         tmpMeta["ImageComment"] = output_identity["image_comment"]
         tmpMeta["SequenceDescriptionAdditional"] = "or"
@@ -2615,7 +2881,8 @@ def _restamp_passthrough_images(
                 target_display_token=output_identity["display_token"],
                 output_index=output_header_slice,
                 output_image_index=output_header_image_index,
-                preserve_image_type_value3=is_original_output,
+                image_type_value3=image_type_value3,
+                complex_image_component=complex_image_component,
                 is_last_in_series=(iImg == output_count - 1),
             )
             if minihead_changed:
@@ -3981,6 +4248,47 @@ def _run_sct_analysis(analysis, input_path, work_dir, precomputed_outputs=None):
     raise ValueError(f"Unsupported SCT analysis kind: {analysis_config['kind']}")
 
 
+def _require_matching_nifti_grid(output_image, source_image):
+    output_shape = tuple(int(value) for value in output_image.shape)
+    source_shape = tuple(int(value) for value in source_image.shape)
+    if len(output_shape) == 2:
+        output_shape = output_shape + (1,)
+    if len(source_shape) == 2:
+        source_shape = source_shape + (1,)
+    if len(output_shape) != 3 or len(source_shape) != 3:
+        raise ValueError(
+            "SCT output and source NIfTI grids must be 3D after normalization: "
+            f"output_shape={output_shape} source_shape={source_shape}"
+        )
+    if output_shape != source_shape:
+        raise ValueError(
+            "SCT output NIfTI shape does not match the source grid: "
+            f"output_shape={output_shape} source_shape={source_shape}"
+        )
+
+    output_affine = np.asarray(output_image.affine, dtype=float)
+    source_affine = np.asarray(source_image.affine, dtype=float)
+    if not np.all(np.isfinite(output_affine)) or not np.all(
+        np.isfinite(source_affine)
+    ):
+        raise ValueError("SCT output and source NIfTI affines must contain finite values")
+    if abs(float(np.linalg.det(output_affine[:3, :3]))) < 1e-8 or abs(
+        float(np.linalg.det(source_affine[:3, :3]))
+    ) < 1e-8:
+        raise ValueError("SCT output and source NIfTI affines must be invertible")
+    if not np.allclose(
+        output_affine,
+        source_affine,
+        rtol=1e-5,
+        atol=1e-4,
+    ):
+        max_delta = float(np.max(np.abs(output_affine - source_affine)))
+        raise ValueError(
+            "SCT output NIfTI affine does not match the source grid: "
+            f"max_abs_delta={max_delta:.6g}"
+        )
+
+
 def _sct_output_to_mrd_images(
     output_path,
     analysis,
@@ -3992,8 +4300,14 @@ def _sct_output_to_mrd_images(
     series_suffix=None,
     dicom_metrics=None,
     series_label_suffix=None,
+    source_nifti=None,
 ):
     img = nib.load(str(output_path))
+    if source_nifti is None:
+        raise ValueError(
+            "source_nifti is required to validate the SCT output grid"
+        )
+    _require_matching_nifti_grid(img, source_nifti)
     data = img.get_fdata(dtype=np.float32)
     logging.info("Loaded SCT output %s with shape=%s", output_path, data.shape)
 
@@ -4530,6 +4844,7 @@ def process_image(imgGroup, connection, config, metadata, derived_series_allocat
                         series_suffix=output_spec["series_suffix"],
                         dicom_metrics=output_spec.get("dicom_metrics"),
                         series_label_suffix=volume_label_suffix,
+                        source_nifti=new_img,
                     )
                 )
                 if output_spec.get("dicom_metrics"):

--- a/recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py
+++ b/recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import h5py
 import nibabel as nib
 import numpy as np
+import pytest
 
 
 RECIPE_DIR = Path(__file__).resolve().parent
@@ -310,7 +311,11 @@ def _load_runtime_helpers_for_test(function_names, assignments=()):
             self.image_series_index = image_series_index
             self.image_index = image_index
             self.slice = slice
+            self.average = 0
             self.contrast = 0
+            self.phase = 0
+            self.repetition = 0
+            self.set = 0
             self.image_type = 1
             self.matrix_size = [1, 1, 1]
             self.field_of_view = [1.0, 1.0, 1.0]
@@ -426,7 +431,7 @@ def test_openrecon_exposes_debug_threshold_segment_toggle():
     assert defaults["sctdebugthresholdsegment"] is False
 
 
-def test_process_returns_original_images_when_sct_analysis_fails():
+def test_process_returns_original_images_when_series_conversion_fails():
     helpers = _load_runtime_helpers_for_test(
         ["_get_boolean_config_param", "process"],
         assignments=["OPENRECON_DEFAULTS"],
@@ -484,14 +489,15 @@ def test_process_returns_original_images_when_sct_analysis_fails():
     helpers["_build_connection_series_allocator"] = (
         lambda source_images: FakeAllocator()
     )
+    helpers["_group_passthrough_images_by_source_series"] = lambda images: {}
     helpers["_as_image_list"] = (
         lambda value: list(value) if isinstance(value, list) else [value]
     )
 
-    def fail_sct(*args, **kwargs):
-        raise subprocess.CalledProcessError(1, ["sct_deepseg", "spine"])
+    def fail_conversion(*args, **kwargs):
+        raise ValueError("SCT output grid does not match the source grid")
 
-    helpers["process_image"] = fail_sct
+    helpers["process_image"] = fail_conversion
 
     def restamp_originals(images, role, series_index):
         assert images == [image]
@@ -500,9 +506,12 @@ def test_process_returns_original_images_when_sct_analysis_fails():
         return [fallback_image]
 
     helpers["_restamp_passthrough_images"] = restamp_originals
-    helpers["_log_and_validate_output_series_contract"] = (
-        lambda *args, **kwargs: None
-    )
+    validation_contexts = []
+
+    def record_validation(output_images, input_images, context):
+        validation_contexts.append(context)
+
+    helpers["_log_and_validate_output_series_contract"] = record_validation
     helpers["_send_images_by_series"] = (
         lambda connection, images, label: connection.sent_images.extend(images)
     )
@@ -513,8 +522,164 @@ def test_process_returns_original_images_when_sct_analysis_fails():
 
     assert connection.sent_images == [fallback_image]
     assert len(connection.logged_errors) == 1
-    assert "CalledProcessError" in connection.logged_errors[0][1]
+    assert "ValueError" in connection.logged_errors[0][1]
+    assert validation_contexts == [
+        "fallback_source_series_1",
+        "before_connection_send",
+    ]
     assert connection.closed is True
+
+
+def test_process_groups_passthrough_images_by_source_series():
+    helpers = _load_runtime_helpers_for_test(
+        ["_get_boolean_config_param", "process"],
+        assignments=["OPENRECON_DEFAULTS"],
+    )
+    source_images = []
+    for series_index in (7, 3, 7):
+        image = helpers["FakeImage"](np.ones((1, 2, 2), dtype=np.int16))
+        image.image_type = 2
+        image.getHead().image_type = 2
+        image.getHead().image_series_index = series_index
+        source_images.append(image)
+
+    class FakeConnection:
+        def __init__(self):
+            self.sent_images = []
+            self.closed = False
+
+        def __iter__(self):
+            return iter(source_images)
+
+        def send_logging(self, severity, message):
+            raise AssertionError(message)
+
+        def send_close(self):
+            self.closed = True
+
+    class FakeAllocator:
+        def __init__(self):
+            self.next_index = 8
+
+        def allocate(self, role):
+            assert role == "PASSTHROUGH"
+            value = self.next_index
+            self.next_index += 1
+            return value
+
+    class FakeLogging:
+        @staticmethod
+        def info(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def warning(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def error(*args, **kwargs):
+            pass
+
+    class FakeMrdHelper:
+        @staticmethod
+        def get_json_config_param(config, parameter_id, default, type=None):
+            return config.get(parameter_id, default)
+
+    helpers["ismrmrd"].Acquisition = type("FakeAcquisition", (), {})
+    helpers["ismrmrd"].Waveform = type("FakeWaveform", (), {})
+    helpers["logging"] = FakeLogging
+    helpers["mrdhelper"] = FakeMrdHelper
+    helpers["traceback"] = __import__("traceback")
+    helpers["constants"] = type("FakeConstants", (), {"MRD_LOGGING_ERROR": 2})
+    helpers["_get_image_series_index"] = (
+        lambda image: image.getHead().image_series_index
+    )
+    helpers["_build_connection_series_allocator"] = (
+        lambda source: FakeAllocator()
+    )
+    helpers["_group_passthrough_images_by_source_series"] = (
+        lambda images: {
+            (3, 2, "PHASE"): [images[1]],
+            (7, 2, "PHASE"): [images[0], images[2]],
+        }
+    )
+    helpers["_as_image_list"] = (
+        lambda value: list(value) if isinstance(value, list) else [value]
+    )
+
+    restamp_calls = []
+
+    def restamp_passthrough(images, role, series_index):
+        restamp_calls.append(
+            (
+                [image.getHead().image_series_index for image in images],
+                role,
+                series_index,
+            )
+        )
+        return [object() for _ in images]
+
+    helpers["_restamp_passthrough_images"] = restamp_passthrough
+    helpers["process_image"] = lambda *args, **kwargs: []
+    helpers["_log_and_validate_output_series_contract"] = (
+        lambda *args, **kwargs: None
+    )
+    helpers["_send_images_by_series"] = (
+        lambda connection, images, label: connection.sent_images.extend(images)
+    )
+
+    connection = FakeConnection()
+    metadata = type("Metadata", (), {"encoding": []})()
+    helpers["process"](connection, {}, metadata)
+
+    assert restamp_calls == [
+        ([3], "PASSTHROUGH", 8),
+        ([7, 7], "PASSTHROUGH", 9),
+    ]
+    assert len(connection.sent_images) == 3
+    assert connection.closed is True
+
+
+def test_passthrough_grouping_separates_components_and_rejects_uid_conflicts():
+    helpers = _load_runtime_helpers_for_test(
+        [
+            "_as_image_list",
+            "_decode_ice_minihead",
+            "_extract_minihead_string_value",
+            "_first_non_empty_text",
+            "_get_image_series_index",
+            "_get_meta_text",
+            "_group_passthrough_images_by_source_series",
+            "_meta_from_image",
+            "_source_image_component",
+        ],
+    )
+
+    def source_image(series_index, image_type, series_uid):
+        image = helpers["FakeImage"](np.ones((1, 2, 2), dtype=np.int16))
+        image.getHead().image_series_index = series_index
+        image.getHead().image_type = image_type
+        image.attribute_string = helpers["FakeMeta"]({
+            "SeriesInstanceUID": series_uid,
+        }).serialize()
+        return image
+
+    phase = source_image(4, 2, "1.2.3")
+    real = source_image(4, 3, "1.2.3")
+    other_phase = source_image(8, 2, "8.9.10")
+
+    groups = helpers["_group_passthrough_images_by_source_series"](
+        [phase, real, other_phase]
+    )
+
+    assert list(groups.values()) == [[phase], [real], [other_phase]]
+    assert {key[0] for key in groups} == {4, 8}
+
+    conflicting_uid = source_image(4, 2, "9.9.9")
+    with pytest.raises(ValueError, match="conflicting SeriesInstanceUID"):
+        helpers["_group_passthrough_images_by_source_series"](
+            [phase, conflicting_uid]
+        )
 
 
 def test_repeated_slice_positions_are_split_into_sct_input_volumes():
@@ -528,11 +693,14 @@ def test_repeated_slice_positions_are_split_into_sct_input_volumes():
             "_log_affine_slice_consistency",
             "_log_slice_geometry",
             "_log_slice_sort_mapping",
+            "_mrd_volume_dimension_key",
             "_normalize_vector",
             "_slice_slot_key",
             "_slice_sort_indices",
             "_split_source_images_by_volume",
+            "_validate_volume_groups",
         ],
+        assignments=["MRD_VOLUME_DIMENSION_FIELDS"],
     )
     images = []
     for slice_index in range(3):
@@ -569,10 +737,13 @@ def test_repeated_positions_split_volumes_even_with_global_slice_numbers():
             "_build_slice_geometry_records",
             "_header_vector",
             "_infer_slice_axis",
+            "_mrd_volume_dimension_key",
             "_normalize_vector",
             "_slice_slot_key",
             "_split_source_images_by_volume",
+            "_validate_volume_groups",
         ],
+        assignments=["MRD_VOLUME_DIMENSION_FIELDS"],
     )
     headers = []
     for volume_index in range(2):
@@ -584,6 +755,58 @@ def test_repeated_positions_split_volumes_even_with_global_slice_numbers():
             headers.append(header)
 
     assert helpers["_split_source_images_by_volume"](headers) == [[0, 1, 2], [3, 4, 5]]
+
+
+def test_explicit_mrd_dimensions_override_spatial_arrival_order():
+    helpers = _load_runtime_helpers_for_test(
+        [
+            "_build_slice_geometry_records",
+            "_header_vector",
+            "_infer_slice_axis",
+            "_mrd_volume_dimension_key",
+            "_normalize_vector",
+            "_slice_slot_key",
+            "_split_source_images_by_volume",
+            "_validate_volume_groups",
+        ],
+        assignments=["MRD_VOLUME_DIMENSION_FIELDS"],
+    )
+    headers = []
+    for repetition, slice_index in ((0, 0), (1, 0), (1, 1), (0, 1)):
+        header = helpers["FakeHead"]()
+        header.repetition = repetition
+        header.slice = slice_index
+        header.position = [0.0, 0.0, slice_index * 3.0]
+        header.slice_dir = [0.0, 0.0, 1.0]
+        headers.append(header)
+
+    assert helpers["_split_source_images_by_volume"](headers) == [[0, 3], [1, 2]]
+
+
+def test_spatial_volume_fallback_rejects_incomplete_slice_sets():
+    helpers = _load_runtime_helpers_for_test(
+        [
+            "_build_slice_geometry_records",
+            "_header_vector",
+            "_infer_slice_axis",
+            "_mrd_volume_dimension_key",
+            "_normalize_vector",
+            "_slice_slot_key",
+            "_split_source_images_by_volume",
+            "_validate_volume_groups",
+        ],
+        assignments=["MRD_VOLUME_DIMENSION_FIELDS"],
+    )
+    headers = []
+    for slice_index in (0, 0, 1):
+        header = helpers["FakeHead"]()
+        header.slice = slice_index
+        header.position = [0.0, 0.0, slice_index * 3.0]
+        header.slice_dir = [0.0, 0.0, 1.0]
+        headers.append(header)
+
+    with pytest.raises(ValueError, match="spatial fallback"):
+        helpers["_split_source_images_by_volume"](headers)
 
 
 def test_compute_nifti_affine_matches_phase_read_slice_data_axes():
@@ -600,6 +823,63 @@ def test_compute_nifti_affine_matches_phase_read_slice_data_axes():
     np.testing.assert_allclose(affine[:3, 1], [-0.82, 0.0, 0.0])
     np.testing.assert_allclose(affine[:3, 2], [0.0, 0.0, 3.3])
     np.testing.assert_allclose(affine[:3, 3], [-10.0, -20.0, 30.0])
+
+
+def test_matching_nifti_grid_requires_shape_and_full_affine_equivalence():
+    helpers = _load_runtime_helpers_for_test(["_require_matching_nifti_grid"])
+    source = nib.Nifti1Image(np.zeros((2, 3, 4), dtype=np.uint8), np.eye(4))
+    matching = nib.Nifti1Image(np.ones((2, 3, 4), dtype=np.uint8), np.eye(4))
+
+    helpers["_require_matching_nifti_grid"](matching, source)
+
+    wrong_shape = nib.Nifti1Image(
+        np.zeros((3, 2, 4), dtype=np.uint8),
+        np.eye(4),
+    )
+    with pytest.raises(ValueError, match="shape"):
+        helpers["_require_matching_nifti_grid"](wrong_shape, source)
+
+    shifted_affine = np.eye(4)
+    shifted_affine[0, 3] = 2.0
+    shifted = nib.Nifti1Image(
+        np.zeros((2, 3, 4), dtype=np.uint8),
+        shifted_affine,
+    )
+    with pytest.raises(ValueError, match="affine"):
+        helpers["_require_matching_nifti_grid"](shifted, source)
+
+    singular_affine = np.eye(4)
+    singular_affine[2, 2] = 0.0
+    singular = type(
+        "SingularNiftiGrid",
+        (),
+        {"shape": (2, 3, 4), "affine": singular_affine},
+    )()
+    with pytest.raises(ValueError, match="invertible"):
+        helpers["_require_matching_nifti_grid"](singular, source)
+
+
+def test_sct_output_conversion_checks_the_source_nifti_grid(tmp_path):
+    helpers = _load_runtime_helpers_for_test(
+        ["_require_matching_nifti_grid", "_sct_output_to_mrd_images"],
+    )
+    source = nib.Nifti1Image(np.zeros((2, 3, 4), dtype=np.uint8), np.eye(4))
+    output_path = tmp_path / "wrong-grid.nii.gz"
+    nib.save(
+        nib.Nifti1Image(np.zeros((3, 2, 4), dtype=np.uint8), np.eye(4)),
+        output_path,
+    )
+
+    with pytest.raises(ValueError, match="shape"):
+        helpers["_sct_output_to_mrd_images"](
+            output_path,
+            "sct_deepseg_spinalcord",
+            [],
+            [],
+            2,
+            source_images=[],
+            source_nifti=source,
+        )
 
 
 def test_volume_series_label_uniquifies_grouping_without_changing_role_token():
@@ -704,6 +984,7 @@ def test_passthrough_restamp_uses_fresh_series_identity():
             "_sanitize_minihead_param_value",
             "_set_meta_scalar",
             "_set_output_position_meta",
+            "_source_image_component",
             "_source_geometry_header_image_index",
             "_source_geometry_header_slice",
             "_strip_source_parent_refs",
@@ -819,6 +1100,7 @@ def test_passthrough_non_original_role_skips_explicit_geometry():
             "_restamp_passthrough_images",
             "_set_meta_scalar",
             "_set_output_position_meta",
+            "_source_image_component",
             "_strip_scanner_write_unsafe_meta",
             "_strip_source_parent_refs",
         ],
@@ -833,6 +1115,8 @@ def test_passthrough_non_original_role_skips_explicit_geometry():
     image.getHead().image_series_index = 1
     image.getHead().image_index = 3
     image.getHead().slice = 2
+    image.getHead().contrast = 4
+    image.getHead().image_type = 2
     image.getHead().read_dir = [1.0, 0.0, 0.0]
     image.getHead().phase_dir = [0.0, 1.0, 0.0]
     image.getHead().slice_dir = [0.0, 0.0, 1.0]
@@ -842,7 +1126,11 @@ def test_passthrough_non_original_role_skips_explicit_geometry():
         "SeriesInstanceUID": "1.2.3",
         "SOPInstanceUID": "1.2.3.4.5",
         "SeriesNumberRangeNameUID": "source_group",
+        "ImageType": "ORIGINAL\\PRIMARY\\P",
+        "DicomImageType": "ORIGINAL\\PRIMARY\\P",
+        "ImageTypeValue3": "P",
         "ImageTypeValue4": "P",
+        "ComplexImageComponent": "PHASE",
     }).serialize()
 
     restamped = helpers["_restamp_passthrough_images"]([image], "PASSTHROUGH", 2)
@@ -850,12 +1138,76 @@ def test_passthrough_non_original_role_skips_explicit_geometry():
     assert len(restamped) == 1
     output_meta = helpers["FakeMeta"].deserialize(restamped[0].attribute_string)
     assert restamped[0].getHead().image_series_index == 2
+    assert restamped[0].getHead().image_type == 2
+    assert restamped[0].getHead().contrast == 4
+    assert output_meta["ImageType"] == "DERIVED\\PRIMARY\\P\\PASSTHROUGH"
+    assert output_meta["DicomImageType"] == "DERIVED\\PRIMARY\\P\\PASSTHROUGH"
+    assert output_meta["ImageTypeValue3"] == "P"
     assert output_meta["ImageTypeValue4"] == "PASSTHROUGH"
+    assert output_meta["ComplexImageComponent"] == "PHASE"
     # No explicit per-slice geometry tags on the non-original passthrough path.
     assert "ImageRowDir" not in output_meta
     assert "ImageColumnDir" not in output_meta
     assert "ImageSliceNormDir" not in output_meta
     assert "SlicePosLightMarker" not in output_meta
+
+
+def test_passthrough_minihead_preserves_phase_component():
+    helpers = _load_runtime_helpers_for_test(
+        [
+            "_extract_minihead_string_value",
+            "_first_non_empty_text",
+            "_patch_ice_minihead",
+            "_remove_minihead_array_param",
+            "_remove_minihead_string_param",
+            "_replace_minihead_array_token",
+            "_replace_or_append_minihead_array_token",
+            "_replace_or_append_minihead_bool_param",
+            "_replace_or_append_minihead_long_param",
+            "_replace_or_append_minihead_string_param",
+            "_sanitize_minihead_param_value",
+        ],
+        assignments=["SCANNER_PARTITION_INDEX"],
+    )
+    minihead = base64.b64decode(
+        _contract_minihead(
+            sequence_description="source",
+            series_grouping="source_group",
+            series_uid="1.2.3",
+            sop_uid="1.2.3.4",
+            image_type_value3="P",
+            image_type_value4="P",
+        )
+    ).decode("utf-8")
+
+    patched, changed = helpers["_patch_ice_minihead"](
+        minihead,
+        "source_passthrough",
+        "source_group_passthrough",
+        "2.25.1",
+        "2.25.2",
+        "P",
+        "PASSTHROUGH",
+        image_type_value3="P",
+        complex_image_component="PHASE",
+    )
+
+    assert changed is True
+    assert (
+        helpers["_extract_minihead_string_value"](patched, "ImageType")
+        == "DERIVED\\PRIMARY\\P\\PASSTHROUGH"
+    )
+    assert (
+        helpers["_extract_minihead_string_value"](
+            patched,
+            "ComplexImageComponent",
+        )
+        == "PHASE"
+    )
+    assert helpers["_extract_minihead_string_value"](
+        patched,
+        "ImageTypeValue3",
+    ) == "P"
 
 
 def test_sct_segment_outputs_source_geometry_2d_slices():


### PR DESCRIPTION
## Summary

- install SCT 7.3 with GPU-enabled PyTorch, set `SCT_USE_GPU=1`, and verify the isolated SCT environment has a CUDA build
- preserve passthrough image type and complex-component metadata while allocating a separate derived output for each source series and component
- treat analysis, output loading, grid checks, conversion, and per-series validation as one failure boundary, returning validated originals when `sendoriginal` is enabled
- group multi-volume input by MRD repetition, contrast, phase, set, and average counters before using a validated spatial fallback
- require SCT outputs to match the complete source NIfTI shape and affine before mapping them back to MRD geometry
- bump the NeuroContainers package revision from 7.3.2 to 7.3.3; upstream SCT remains at the latest stable release, 7.3

## Validation

- `64 passed` in `recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py`
- `260 passed` in `builder/tests`
- `workflows/test_all.sh` passed all recipe validation and generation checks
- spinalcordtoolbox recipe validation, OpenRecon label validation, Python compilation, Dockerfile generation, scoped codespell, and `git diff --check` passed

The fulltest now checks the actual SCT virtual environment for CUDA-enabled PyTorch without requiring a GPU device during the image build.
