### PR TITLE
Rebuild SynthSeg scanner container

### DIFF
--- a/recipes/synthseg/OpenReconLabel.json
+++ b/recipes/synthseg/OpenReconLabel.json
@@ -10,7 +10,7 @@
       "production_identifier": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "manufacturer_address": "Erlangen, Germany",
       "made_in": "DE",
-      "manufacture_date": "2026/07/30",
+      "manufacture_date": "2026/09/02",
       "material_number": "synthseg_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "gtin": "00860000171212",
       "udi": "(01)00860000171212(21)1.3.0",


### PR DESCRIPTION
Rebuild the SynthSeg 8.2.0 container so the published scanner image includes the `NVIDIA_DISABLE_REQUIRE` startup fix from #3011.

The OpenRecon manufacture date is updated to the date of this rebuild, which also ensures the refreshed scanner metadata flows through the OpenRecon packaging PR.

Local checks:
- `python3 builder/validation.py recipes/synthseg/build.yaml`
- `python3 workflows/validate_openrecon_labels.py`
- SynthSeg focused OpenRecon tests (4/4)
- `python3 -m builder generate synthseg --recreate`