### PR TITLE
Fix OpenRecon sync for two-part versions

### DIFF
--- a/builder/tests/test_sync_openrecon.py
+++ b/builder/tests/test_sync_openrecon.py
@@ -76,6 +76,33 @@ def test_prepare_recipe_bootstraps_missing_target(tmp_path: Path) -> None:
     assert prepared.notes[0].startswith("- Create `recipes/demo`")
 
 
+def test_prepare_recipe_separates_two_part_container_and_openrecon_versions(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "neurocontainers"
+    openrecon_root = tmp_path / "openrecon"
+    write_source_recipe(source_root)
+    target = openrecon_root / "recipes" / "demo"
+    target.mkdir(parents=True)
+    (target / "params.sh").write_text(
+        "#!/bin/bash\n"
+        "export toolName=demo\n"
+        "export version=0.1\n"
+        "export baseDockerImage=vnmd/${toolName}_${version}\n",
+        encoding="utf-8",
+    )
+
+    prepared = sync_openrecon.prepare_recipe(
+        source_root, openrecon_root, "demo", "0.2"
+    )
+
+    assert prepared is not None
+    params = (target / "params.sh").read_text(encoding="utf-8")
+    assert "export version=0.2\n" in params
+    assert "export openrecon_version=0.2.0\n" in params
+    assert "export baseDockerImage=vnmd/${toolName}_${version}\n" in params
+
+
 def test_prepare_recipe_skips_recipes_without_openrecon_label(tmp_path: Path) -> None:
     source_root = tmp_path / "neurocontainers"
     (source_root / "recipes" / "demo").mkdir(parents=True)

--- a/tools/sync_openrecon.py
+++ b/tools/sync_openrecon.py
@@ -21,6 +21,17 @@ VERSION_ASSIGNMENT_PATTERN = re.compile(
     r"^(?P<prefix>[ \t]*(?:export[ \t]+)?(?:version|VERSION)=).*$",
     re.MULTILINE,
 )
+OPENRECON_VERSION_ASSIGNMENT_PATTERN = re.compile(
+    r"^(?P<prefix>[ \t]*(?:export[ \t]+)?openrecon_version=).*$",
+    re.MULTILINE,
+)
+OPENRECON_SEMVER_PATTERN = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+TWO_PART_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
 @dataclass(frozen=True)
@@ -45,15 +56,45 @@ def validate_version(version: str) -> str:
     return version
 
 
+def openrecon_version(version: str) -> str:
+    """Return a schema-valid OpenRecon version for a container release."""
+    validate_version(version)
+    if OPENRECON_SEMVER_PATTERN.fullmatch(version):
+        return version
+    if TWO_PART_VERSION_PATTERN.fullmatch(version):
+        return f"{version}.0"
+    raise ValueError(
+        f"OpenRecon requires a semantic version; cannot normalize {version!r}"
+    )
+
+
 def update_params_version(contents: str, version: str) -> str:
     """Update the first supported version assignment in params.sh."""
     validate_version(version)
     if not VERSION_ASSIGNMENT_PATTERN.search(contents):
         raise RuntimeError("params.sh has no supported version assignment")
-    return VERSION_ASSIGNMENT_PATTERN.sub(
+    updated = VERSION_ASSIGNMENT_PATTERN.sub(
         lambda match: f"{match.group('prefix')}{version}",
         contents,
         count=1,
+    )
+    metadata_version = openrecon_version(version)
+    if metadata_version == version:
+        return OPENRECON_VERSION_ASSIGNMENT_PATTERN.sub("", updated, count=1)
+    if OPENRECON_VERSION_ASSIGNMENT_PATTERN.search(updated):
+        return OPENRECON_VERSION_ASSIGNMENT_PATTERN.sub(
+            lambda match: f"{match.group('prefix')}{metadata_version}",
+            updated,
+            count=1,
+        )
+
+    version_assignment = VERSION_ASSIGNMENT_PATTERN.search(updated)
+    assert version_assignment is not None
+    insertion = f"\nexport openrecon_version={metadata_version}"
+    return (
+        updated[: version_assignment.end()]
+        + insertion
+        + updated[version_assignment.end() :]
     )
 
 


### PR DESCRIPTION
## Summary

- preserve two-part NeuroContainers image tags such as `0.2`
- emit a three-part `openrecon_version` such as `0.2.0` for OpenRecon metadata
- fail early when a release version cannot be normalized to OpenRecon SemVer
- add a regression test for an already-synced recipe

## Why

The promoted TopoFit image is tagged `0.2`, but OpenRecon product metadata requires `major.minor.patch`. OpenRecon already supports a separate `openrecon_version`; the sync helper now uses that intended seam instead of sending an invalid product version downstream.

## Validation

- `.venv/bin/python -m pytest builder/tests/test_sync_openrecon.py builder/tests/test_workflow_contract.py -q` (44 passed)
- production OpenRecon 1.1.0 schema accepts Docker `0.2` with metadata `0.2.0`
- `git diff --check`

Follow-up to neurodesk/openrecon#221 auto-build failure.