### PR TITLE
Make TopoFit compatible with OpenRecon CUDA

### DIFF
--- a/recipes/topofit/build.yaml
+++ b/recipes/topofit/build.yaml
@@ -22,7 +22,7 @@ variables:
 
 build:
   kind: neurodocker
-  base-image: pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime
+  base-image: pytorch/pytorch:2.6.0-cuda11.8-cudnn9-runtime
   pkg-manager: apt
 
   directives:

--- a/recipes/topofit/build.yaml
+++ b/recipes/topofit/build.yaml
@@ -1,9 +1,9 @@
 name: topofit
-version: "0.2"
+version: "0.2.1"
 
 copyright:
   - license: GPL-3.0-only
-    url: https://github.com/simnibs/brainnet/blob/v{{ context.version }}/LICENSE
+    url: https://github.com/simnibs/brainnet/blob/v{{ context.brainnet_version }}/LICENSE
   - license: GPL-3.0-only
     url: https://github.com/simnibs/brainsynth/blob/v{{ context.brainsynth_version }}/LICENSE
   - license: GPL-3.0-only
@@ -13,15 +13,16 @@ architectures:
   - x86_64
 
 variables:
+  brainnet_version: "0.2"
   brainsynth_version: "0.1"
   cortech_version: "0.1"
-  brainnet_wheel_url: "https://github.com/simnibs/brainnet/releases/download/v{{ context.version }}/brainnet-{{ context.version }}-py3-none-any.whl"
+  brainnet_wheel_url: "https://github.com/simnibs/brainnet/releases/download/v{{ context.brainnet_version }}/brainnet-{{ context.brainnet_version }}-py3-none-any.whl"
   brainsynth_wheel_url: "https://github.com/simnibs/brainsynth/releases/download/v{{ context.brainsynth_version }}/brainsynth-{{ context.brainsynth_version }}-py3-none-any.whl"
   cortech_wheel_url: "https://github.com/simnibs/cortech/releases/download/v{{ context.cortech_version }}/cortech-{{ context.cortech_version }}-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
 
 build:
   kind: neurodocker
-  base-image: pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime
+  base-image: pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime
   pkg-manager: apt
 
   directives:
@@ -94,7 +95,7 @@ readme: |-
   ----------------------------------
   ## topofit/{{ context.version }} ##
 
-  This container packages BrainNet TopoFit {{ context.version }} for fast
+  This container packages BrainNet TopoFit {{ context.brainnet_version }} for fast
   cortical surface reconstruction. It predicts bilateral white and pial
   surfaces plus spherical registration without running a full FreeSurfer
   `recon-all` workflow.

--- a/recipes/topofit/fulltest.yaml
+++ b/recipes/topofit/fulltest.yaml
@@ -5,7 +5,7 @@
 # on CPU and can take several minutes on a CPU-only release runner.
 
 name: topofit
-version: "0.2"
+version: "0.2.1"
 
 required_files:
   - dataset: ds000001
@@ -23,6 +23,17 @@ setup:
     mkdir -p "${output_dir}"
 
 tests:
+  - name: OpenRecon-compatible CUDA runtime
+    description: Verify PyTorch stays within the CUDA ceiling enforced by the OpenRecon packager.
+    command: |
+      python3 -c "
+      import torch
+      version = tuple(map(int, torch.version.cuda.split('.')[:2]))
+      assert version <= (11, 8), torch.version.cuda
+      print('OpenRecon-compatible PyTorch CUDA', torch.version.cuda)
+      "
+    expected_output_contains: "OpenRecon-compatible PyTorch CUDA 11.8"
+
   - name: BrainNet launcher available
     description: Verify the pinned upstream command is on PATH.
     command: command -v brainnet


### PR DESCRIPTION
## Summary

- publish TopoFit as container patch release 0.2.1 while keeping BrainNet pinned to upstream 0.2
- use the PyTorch 2.4.1 CUDA 11.8 runtime accepted by the OpenRecon packager
- add a release smoke test for OpenRecon's CUDA ceiling

## Why

The first OpenRecon package build reached the image compatibility check and rejected the released TopoFit 0.2 image because its PyTorch runtime reports CUDA 12.4. OpenRecon currently requires CUDA 11.8 or earlier.

Failed downstream run: https://github.com/neurodesk/openrecon/actions/runs/33593427230

## Verification

- recipe validation passes
- Dockerfile generation resolves the BrainNet 0.2 wheel on the CUDA 11.8 base
- builder validation tests: 24 passed
- the candidate workflow will run the complete fulltest, including real TopoFit CPU inference and the new CUDA runtime assertion