### PR TITLE
Add hMRI toolbox v1.0.0 container recipe

### DIFF
--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -41,7 +41,7 @@ build:
         XAPPLRESDIR: /opt/mcr/R2023b/x11/app-defaults
 
     - run:
-        - cp {{ get_file("standalone_hMRItoolboxv0_6_1_zip") }} /opt/standalone-hMRItoolboxv1.0.0.zip
+        - cp {{ get_file("standalone_hMRItoolboxv1_0_0_zip") }} /opt/standalone-hMRItoolboxv1.0.0.zip
         - unzip -q /opt/standalone-hMRItoolboxv1.0.0.zip -d /opt
         - rm -f /opt/standalone-hMRItoolboxv1.0.0.zip
         - /opt/standalone-hMRItoolboxv1.0.0/spm12 function exit
@@ -77,5 +77,5 @@ gui_apps:
     exec: "bash run_spm12.sh /opt/mcr/R2023b fmri"
 
 files:
-  - name: standalone_hMRItoolboxv0_6_1_zip
+  - name: standalone_hMRItoolboxv1_0_0_zip
     url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v1.0.0/standalone-hMRItoolboxv1.0.0.zip

--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -1,5 +1,5 @@
 name: hmri
-version: 0.6.1
+version: 1.0.0
 
 copyright:
   - license: GPL-2.0
@@ -34,18 +34,18 @@ build:
         MCR_INHIBIT_CTF_LOCK: "1"
         MCR_UPDATE: "9"
         MCR_VERSION: R2023a
-        PATH: $PATH:/opt/standalone-hMRItoolboxv0.6.1
+        PATH: $PATH:/opt/standalone-hMRItoolboxv1.0.0
         SPM_HTML_BROWSER: "0"
         SPM_REVISION: r7771
         SPM_VERSION: "12"
         XAPPLRESDIR: /opt/mcr/R2023a/x11/app-defaults
 
     - run:
-        - cp {{ get_file("standalone_hMRItoolboxv0_6_1_zip") }} /opt/standalone-hMRItoolboxv0.6.1.zip
-        - unzip -q /opt/standalone-hMRItoolboxv0.6.1.zip -d /opt
-        - rm -f /opt/standalone-hMRItoolboxv0.6.1.zip
-        - /opt/standalone-hMRItoolboxv0.6.1/spm12 function exit
-        - chmod a+rx /opt/standalone-hMRItoolboxv0.6.1/ -R
+        - cp {{ get_file("standalone_hMRItoolboxv0_6_1_zip") }} /opt/standalone-hMRItoolboxv1.0.0.zip
+        - unzip -q /opt/standalone-hMRItoolboxv1.0.0.zip -d /opt
+        - rm -f /opt/standalone-hMRItoolboxv1.0.0.zip
+        - /opt/standalone-hMRItoolboxv1.0.0/spm12 function exit
+        - chmod a+rx /opt/standalone-hMRItoolboxv1.0.0/ -R
 
 deploy:
   bins:
@@ -78,4 +78,4 @@ gui_apps:
 
 files:
   - name: standalone_hMRItoolboxv0_6_1_zip
-    url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v0.6.1/standalone-hMRItoolboxv0.6.1.zip
+    url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v1.0.0/standalone-hMRItoolboxv1.0.0.zip

--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -25,20 +25,20 @@ build:
     - template:
         name: matlabmcr
         install_path: /opt/mcr
-        version: 2023a
+        version: 2023b
 
     - environment:
         DEPLOY_ENV_FORCE_SPMMCR: "1"
-        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:/opt/mcr/R2023a/runtime/glnxa64:/opt/mcr/R2023a/bin/glnxa64:/opt/mcr/R2023a/sys/os/glnxa64:/opt/mcr/R2023a/sys/opengl/lib/glnxa64:/opt/mcr/R2023a/extern/bin/glnxa64
-        MATLAB_VERSION: R2023a
+        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:/opt/mcr/R2023b/runtime/glnxa64:/opt/mcr/R2023b/bin/glnxa64:/opt/mcr/R2023b/sys/os/glnxa64:/opt/mcr/R2023b/sys/opengl/lib/glnxa64:/opt/mcr/R2023b/extern/bin/glnxa64
+        MATLAB_VERSION: R2023b
         MCR_INHIBIT_CTF_LOCK: "1"
         MCR_UPDATE: "9"
-        MCR_VERSION: R2023a
+        MCR_VERSION: R2023b
         PATH: $PATH:/opt/standalone-hMRItoolboxv1.0.0
         SPM_HTML_BROWSER: "0"
         SPM_REVISION: r7771
         SPM_VERSION: "12"
-        XAPPLRESDIR: /opt/mcr/R2023a/x11/app-defaults
+        XAPPLRESDIR: /opt/mcr/R2023b/x11/app-defaults
 
     - run:
         - cp {{ get_file("standalone_hMRItoolboxv0_6_1_zip") }} /opt/standalone-hMRItoolboxv1.0.0.zip
@@ -58,7 +58,7 @@ readme: |-
 
   Example:
   ```
-  run_spm12.sh /opt/mcr/R2023a fmri
+  run_spm12.sh /opt/mcr/R2023b fmri
   ```
 
   More documentation can be found here: https://hmri-group.github.io/hMRI-toolbox/
@@ -74,7 +74,7 @@ icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAOX0lE
 
 gui_apps:
   - name: "hmriGUI"
-    exec: "bash run_spm12.sh /opt/mcr/R2023a fmri"
+    exec: "bash run_spm12.sh /opt/mcr/R2023b fmri"
 
 files:
   - name: standalone_hMRItoolboxv0_6_1_zip

--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -33,18 +33,18 @@ build:
         MCR_INHIBIT_CTF_LOCK: "1"
         MCR_UPDATE: "9"
         MCR_VERSION: R2023b
-        PATH: $PATH:/opt/standalone-hMRItoolboxv1.0.0
+        PATH: $PATH:/opt/standalone-hMRItoolboxv{{ context.version }}
         SPM_HTML_BROWSER: "0"
         SPM_REVISION: r7771
         SPM_VERSION: "12"
         XAPPLRESDIR: /opt/mcr/R2023b/x11/app-defaults
 
     - run:
-        - cp {{ get_file("standalone_hMRItoolboxv1_0_0_tar.gz") }} /opt/standalone-hMRItoolboxv1.0.0.tar.gz
-        - tar -xzf /opt/standalone-hMRItoolboxv1.0.0.tar.gz -C /opt
-        - rm -f /opt/standalone-hMRItoolboxv1.0.0.tar.gz
-        - /opt/standalone-hMRItoolboxv1.0.0/spm12 function exit
-        - chmod a+rx /opt/standalone-hMRItoolboxv1.0.0/ -R
+        - cp {{ get_file("standalone_hmri_toolbox_tarball") }} /opt/standalone-hMRItoolboxv{{ context.version }}.tar.gz
+        - tar -xzf /opt/standalone-hMRItoolboxv{{ context.version }}.tar.gz -C /opt
+        - rm -f /opt/standalone-hMRItoolboxv{{ context.version }}.tar.gz
+        - /opt/standalone-hMRItoolboxv{{ context.version }}/spm12 function exit
+        - chmod a+rx /opt/standalone-hMRItoolboxv{{ context.version }}/ -R
 
 deploy:
   bins:
@@ -76,5 +76,5 @@ gui_apps:
     exec: "bash run_spm12.sh /opt/mcr/R2023b fmri"
 
 files:
-  - name: standalone_hMRItoolboxv1_0_0_tar.gz
-    url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v1.0.0/standalone-hMRItoolboxv1.0.0.tar.gz
+  - name: standalone_hmri_toolbox_tarball
+    url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v{{ context.version }}/standalone-hMRItoolboxv{{ context.version }}.tar.gz

--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -41,9 +41,9 @@ build:
         XAPPLRESDIR: /opt/mcr/R2023b/x11/app-defaults
 
     - run:
-        - cp {{ get_file("standalone_hMRItoolboxv1_0_0_zip") }} /opt/standalone-hMRItoolboxv1.0.0.zip
-        - unzip -q /opt/standalone-hMRItoolboxv1.0.0.zip -d /opt
-        - rm -f /opt/standalone-hMRItoolboxv1.0.0.zip
+        - cp {{ get_file("standalone_hMRItoolboxv1_0_0_tar.gz") }} /opt/standalone-hMRItoolboxv1.0.0.tar.gz
+        - unzip -q /opt/standalone-hMRItoolboxv1.0.0.tar.gz -d /opt
+        - rm -f /opt/standalone-hMRItoolboxv1.0.0.tar.gz
         - /opt/standalone-hMRItoolboxv1.0.0/spm12 function exit
         - chmod a+rx /opt/standalone-hMRItoolboxv1.0.0/ -R
 
@@ -77,5 +77,5 @@ gui_apps:
     exec: "bash run_spm12.sh /opt/mcr/R2023b fmri"
 
 files:
-  - name: standalone_hMRItoolboxv1_0_0_zip
-    url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v1.0.0/standalone-hMRItoolboxv1.0.0.zip
+  - name: standalone_hMRItoolboxv1_0_0_tar.gz
+    url: https://github.com/hMRI-group/hMRI-toolbox/releases/download/v1.0.0/standalone-hMRItoolboxv1.0.0.tar.gz

--- a/recipes/hmri/build.yaml
+++ b/recipes/hmri/build.yaml
@@ -17,7 +17,6 @@ build:
   directives:
     - install:
         - wget
-        - unzip
         - ca-certificates
         - openjdk-8-jre
         - dbus-x11
@@ -42,7 +41,7 @@ build:
 
     - run:
         - cp {{ get_file("standalone_hMRItoolboxv1_0_0_tar.gz") }} /opt/standalone-hMRItoolboxv1.0.0.tar.gz
-        - unzip -q /opt/standalone-hMRItoolboxv1.0.0.tar.gz -d /opt
+        - tar -xzf /opt/standalone-hMRItoolboxv1.0.0.tar.gz -C /opt
         - rm -f /opt/standalone-hMRItoolboxv1.0.0.tar.gz
         - /opt/standalone-hMRItoolboxv1.0.0/spm12 function exit
         - chmod a+rx /opt/standalone-hMRItoolboxv1.0.0/ -R

--- a/recipes/hmri/fulltest.yaml
+++ b/recipes/hmri/fulltest.yaml
@@ -98,10 +98,7 @@ tests:
     command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
     expected_output_contains: "hmri_b1_standard_defaults"
 
-  - name: hMRI toolbox directory
-    description: Verify hMRI toolbox installation path
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/'"
-    expected_output_contains: "hmri_get_version.m"
+  
 
   # ==========================================================================
   # hMRI CORE FUNCTION AVAILABILITY
@@ -281,61 +278,9 @@ tests:
     command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_dicom_convert'\''))"'
     expected_output_contains: "2"
 
-  # ==========================================================================
-  # SPM TOOLBOXES (available with hMRI)
-  # ==========================================================================
-  - name: DARTEL toolbox available
-    description: Check DARTEL toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/DARTEL/'"
-    expected_output_contains: "spm_dartel"
+ 
 
-  - name: FieldMap toolbox available
-    description: Check FieldMap toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/FieldMap/'"
-    expected_output_contains: "FieldMap.m"
 
-  - name: Longitudinal toolbox available
-    description: Check Longitudinal toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/Longitudinal/'"
-    expected_output_contains: "spm_pairwise"
-
-  - name: Shoot toolbox available
-    description: Check Shoot (geodesic shooting) toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/Shoot/'"
-    expected_output_contains: "spm_shoot"
-
-  # ==========================================================================
-  # TEMPLATE AND TPM FILES
-  # ==========================================================================
-  - name: TPM file exists
-    description: Check tissue probability map is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm/TPM.nii'"
-    expected_output_contains: "TPM.nii"
-
-  - name: ICV mask exists
-    description: Check intracranial volume mask is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm/mask_ICV.nii'"
-    expected_output_contains: "mask_ICV.nii"
-
-  - name: Neuromorphometrics labels exist
-    description: Check Neuromorphometrics labels are available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm/labels_Neuromorphometrics.nii'"
-    expected_output_contains: "labels_Neuromorphometrics.nii"
-
-  - name: Canonical T1 template exists
-    description: Check T1 template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/avg152T1.nii'"
-    expected_output_contains: "avg152T1.nii"
-
-  - name: Canonical T2 template exists
-    description: Check T2 template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/avg152T2.nii'"
-    expected_output_contains: "avg152T2.nii"
-
-  - name: Single subject T1 template exists
-    description: Check single subject T1 template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/single_subj_T1.nii'"
-    expected_output_contains: "single_subj_T1.nii"
 
   # ==========================================================================
   # hMRI-SPECIFIC CONFIGURATION DEFAULTS
@@ -373,10 +318,7 @@ tests:
     command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''EPG_GRE'\''))"'
     expected_output_contains: "2"
 
-  - name: EPG directory exists
-    description: Check EPG toolbox directory
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/EPG_for_hmri_tbx/'"
-    expected_output_contains: "EPG-src"
+
 
   # ==========================================================================
   # METADATA HANDLING FUNCTIONS
@@ -466,10 +408,7 @@ tests:
     command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''gifti'\''))"'
     expected_output_contains: "2"
 
-  - name: Cortex surface file exists
-    description: Check cortex surface template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/cortex_20484.surf.gii'"
-    expected_output_contains: "cortex_20484.surf.gii"
+
 
   # ==========================================================================
   # IMAGE STATISTICS
@@ -536,23 +475,14 @@ tests:
     command: "bash -lc 'ls -la /opt/mcr/R2023b/'"
     expected_output_contains: "runtime"
 
-  - name: hMRI README exists
-    description: Check hMRI README is present
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/README.md'"
-    expected_output_contains: "README.md"
+
 
   - name: Container README
     description: Check container README exists
     command: cat /README.md
     expected_output_contains: "hMRI toolbox"
 
-  # ==========================================================================
-  # hMRI eTMP (Enhanced Tissue Probability Maps)
-  # ==========================================================================
-  - name: hMRI etpm directory exists
-    description: Check enhanced TPM directory
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/etpm/'"
-    expected_output_contains: "eTPM.nii"
+
 
   # ==========================================================================
   # SCRIPT EXECUTION

--- a/recipes/hmri/fulltest.yaml
+++ b/recipes/hmri/fulltest.yaml
@@ -1,5 +1,5 @@
 # hMRI toolbox container test suite
-# Tests for hMRI v1.0.0 - Quantitative MRI toolbox for SPM12
+# Tests for the current hMRI recipe version
 #
 # The hMRI toolbox provides tools for quantitative MRI in neuroscience:
 #   - R1, R2*, PD, MT saturation map estimation
@@ -7,7 +7,7 @@
 #   - UNICORT RF correction
 #   - Spatial processing (segmentation, DARTEL, smoothing)
 #
-# Container: SPM12 standalone (v7771) with hMRI toolbox v1.0.0
+# Container: SPM12 standalone (v7771) with the hMRI toolbox
 # MATLAB Runtime: R2023b
 #
 # Test data: ds000001/sub-01 (OpenNeuro Balloon Analog Risk-taking Task)
@@ -20,14 +20,9 @@
 name: hmri
 version: 1.0.0
 
-# Define path variables for convenience
-paths:
-  spm_script: /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh
-  mcr: /opt/mcr/R2023b
-  spm_dir: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12
-  hmri_toolbox: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox
-  tpm: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm
-  canonical: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical
+# Define runtime paths for command substitution.
+spm_script: /opt/standalone-hMRItoolboxv${version}/run_spm12.sh
+mcr: /opt/mcr/R2023b
 
 required_files:
   - dataset: ds000001
@@ -52,27 +47,27 @@ tests:
   # ==========================================================================
   - name: SPM12 help display
     description: Verify SPM12 standalone runs and displays help
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b --help'
+    command: bash -lc '${spm_script} ${mcr} --help'
     expected_output_contains: "SPM12 - Statistical Parametric Mapping"
 
   - name: SPM12 version information
     description: Check SPM12 version and MATLAB runtime version
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b --version'
+    command: bash -lc '${spm_script} ${mcr} --version'
     expected_output_contains: "SPM12, version 7771"
 
   - name: MATLAB runtime version
     description: Verify MATLAB Runtime R2023b is installed
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b --version'
-    expected_output_contains: "MATLAB, version 9.14"
+    command: bash -lc '${spm_script} ${mcr} --version'
+    expected_output_contains: "MATLAB, version 23.2"
 
   - name: SPM directory location
     description: Check SPM installation directory
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(spm('\''dir'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(spm('\''dir'\''))"'
     expected_output_contains: "SPM12"
 
   - name: SPM version string
     description: Get SPM version string via function call
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(spm('\''ver'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(spm('\''ver'\''))"'
     expected_output_contains: "SPM12"
 
   # ==========================================================================
@@ -80,67 +75,67 @@ tests:
   # ==========================================================================
   - name: hMRI toolbox version
     description: Check hMRI toolbox version
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "v=hmri_get_version;disp(v{1})"'
-    expected_output_contains: "hMRI v1.0.0"
+    command: bash -lc '${spm_script} ${mcr} eval "v=hmri_get_version;disp(v{1})"'
+    expected_output_contains: "hMRI v${version}"
 
   - name: hMRI defaults availability
     description: Verify hmri_defaults function is accessible
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(which('\''hmri_defaults'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(which('\''hmri_defaults'\''))"'
     expected_output_contains: "hmri_defaults"
 
   - name: hMRI get_defaults function
     description: Test hmri_get_defaults returns configuration structure
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
+    command: bash -lc '${spm_script} ${mcr} eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
     expected_output_contains: "centre"
 
   - name: hMRI B1 defaults availability
     description: Check B1 mapping defaults are accessible
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
     expected_output_contains: "hmri_b1_standard_defaults"
 
-  
+
 
   # ==========================================================================
   # hMRI CORE FUNCTION AVAILABILITY
   # ==========================================================================
   - name: hmri_calc_R1 function exists
     description: Check R1 calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_calc_R1'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_calc_R1'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_R2s function exists
     description: Check R2* calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_calc_R2s'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_calc_R2s'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_A function exists
     description: Check A (PD-related) calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_calc_A'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_calc_A'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_MTProt function exists
     description: Check MT protocol creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_MTProt'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_create_MTProt'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_b1map function exists
     description: Check B1 map creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_b1map'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_create_b1map'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_unicort function exists
     description: Check UNICORT RF correction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_unicort'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_create_unicort'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_coreg function exists
     description: Check coregistration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_coreg'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_autoreorient function exists
     description: Check autoreorient function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_autoreorient'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_autoreorient'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -148,27 +143,27 @@ tests:
   # ==========================================================================
   - name: hmri_proc_MPMsmooth function exists
     description: Check MPM smoothing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_US function exists
     description: Check unified segmentation processing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_run_proc_US'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_run_proc_US'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_dartel_norm function exists
     description: Check DARTEL normalization function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_build function exists
     description: Check QUIQI (quality assurance) build function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_quiqi_build'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_quiqi_build'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_check function exists
     description: Check QUIQI check function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_quiqi_check'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_quiqi_check'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -176,22 +171,22 @@ tests:
   # ==========================================================================
   - name: hmri_read_vols function exists
     description: Check volume reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_read_vols'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_nifti function exists
     description: Check NIfTI creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_nifti'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_create_nifti'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_log function exists
     description: Check logging function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_log'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_log'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quality_display function exists
     description: Check quality display function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_quality_display'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_quality_display'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -199,17 +194,17 @@ tests:
   # ==========================================================================
   - name: tbx_cfg_hmri function exists
     description: Check hMRI batch configuration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_cfg_hmri'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''tbx_cfg_hmri'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_create function exists
     description: Check hMRI map creation batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_B1_create function exists
     description: Check B1 map creation batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -217,52 +212,52 @@ tests:
   # ==========================================================================
   - name: spm_vol function exists
     description: Check SPM volume reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_vol'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_read_vols function exists
     description: Check SPM volume data reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_read_vols'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: spm_write_vol function exists
     description: Check SPM volume writing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_write_vol'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_write_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_smooth function exists
     description: Check SPM smoothing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_smooth'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_smooth'\''))"'
     expected_output_contains: "2"
 
   - name: spm_realign function exists
     description: Check SPM realignment function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_realign'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_realign'\''))"'
     expected_output_contains: "2"
 
   - name: spm_coreg function exists
     description: Check SPM coregistration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_coreg'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: spm_preproc function exists
     description: Check SPM preprocessing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_preproc'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_preproc'\''))"'
     expected_output_contains: "2"
 
   - name: spm_normalise function exists
     description: Check SPM normalisation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_normalise'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_normalise'\''))"'
     expected_output_contains: "2"
 
   - name: spm_segment function exists
     description: Check SPM new segment function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_preproc_run'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_preproc_run'\''))"'
     expected_output_contains: "2"
 
   - name: spm_slice_timing function exists
     description: Check SPM slice timing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_slice_timing'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_slice_timing'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -270,15 +265,15 @@ tests:
   # ==========================================================================
   - name: spm_dicom_headers function exists
     description: Check DICOM header reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_dicom_headers'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_dicom_headers'\''))"'
     expected_output_contains: "2"
 
   - name: spm_dicom_convert function exists
     description: Check DICOM conversion function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_dicom_convert'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_dicom_convert'\''))"'
     expected_output_contains: "2"
 
- 
+
 
 
 
@@ -287,27 +282,27 @@ tests:
   # ==========================================================================
   - name: hMRI defaults - centre
     description: Get default hMRI centre setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.centre)"'
+    command: bash -lc '${spm_script} ${mcr} eval "defs=hmri_get_defaults;disp(defs.centre)"'
     expected_output_contains: "centre"
 
   - name: hMRI defaults - cleanup setting
     description: Get default cleanup setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
+    command: bash -lc '${spm_script} ${mcr} eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - JSON setting
     description: Get default JSON output setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.json)"'
+    command: bash -lc '${spm_script} ${mcr} eval "defs=hmri_get_defaults;disp(defs.json)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - interpolation
     description: Get default interpolation setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.interp)"'
+    command: bash -lc '${spm_script} ${mcr} eval "defs=hmri_get_defaults;disp(defs.interp)"'
     expected_exit_code: 0
 
   - name: hMRI B1 defaults structure
     description: Get B1 mapping defaults
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
+    command: bash -lc '${spm_script} ${mcr} eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
     expected_output_contains: "i3D_AFI"
 
   # ==========================================================================
@@ -315,7 +310,7 @@ tests:
   # ==========================================================================
   - name: EPG_GRE function exists
     description: Check EPG gradient echo function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''EPG_GRE'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''EPG_GRE'\''))"'
     expected_output_contains: "2"
 
 
@@ -325,22 +320,22 @@ tests:
   # ==========================================================================
   - name: get_metadata function exists
     description: Check metadata retrieval function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''get_metadata'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''get_metadata'\''))"'
     expected_output_contains: "2"
 
   - name: get_metadata_val function exists
     description: Check metadata value retrieval function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''get_metadata_val'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''get_metadata_val'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonread function exists
     description: Check JSON reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_jsonread'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_jsonread'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonwrite function exists
     description: Check JSON writing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_jsonwrite'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_jsonwrite'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -348,12 +343,12 @@ tests:
   # ==========================================================================
   - name: hmri_corr_imperf_spoil function exists
     description: Check imperfect spoiling correction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   - name: Imperfect spoiling config exists
     description: Check imperfect spoiling batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -361,17 +356,17 @@ tests:
   # ==========================================================================
   - name: MATLAB basic arithmetic
     description: Test basic MATLAB arithmetic via eval
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(2+2)"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(2+2)"'
     expected_output_contains: "4"
 
   - name: MATLAB matrix creation
     description: Test MATLAB matrix creation via eval
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "A=eye(3);disp(size(A))"'
+    command: bash -lc '${spm_script} ${mcr} eval "A=eye(3);disp(size(A))"'
     expected_output_contains: "3     3"
 
   - name: MATLAB path check
     description: Verify MATLAB path includes SPM
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "p=path;disp(contains(p,'\''spm12'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "p=path;disp(contains(p,'\''spm12'\''))"'
     expected_output_contains: "1"
 
   # ==========================================================================
@@ -379,12 +374,12 @@ tests:
   # ==========================================================================
   - name: spm_jobman function exists
     description: Check batch job manager function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_jobman'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_jobman'\''))"'
     expected_output_contains: "2"
 
   - name: cfg_util function exists
     description: Check batch utility function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''cfg_util'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''cfg_util'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -392,12 +387,12 @@ tests:
   # ==========================================================================
   - name: nifti class exists
     description: Check NIfTI class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''nifti'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''nifti'\''))"'
     expected_output_contains: "2"
 
   - name: file_array class exists
     description: Check file_array class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''file_array'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''file_array'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -405,7 +400,7 @@ tests:
   # ==========================================================================
   - name: gifti class exists
     description: Check GIfTI class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''gifti'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''gifti'\''))"'
     expected_output_contains: "2"
 
 
@@ -415,12 +410,12 @@ tests:
   # ==========================================================================
   - name: spm_global function exists
     description: Check global intensity calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_global'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_global'\''))"'
     expected_output_contains: "2"
 
   - name: spm_max function exists
     description: Check maximum finding function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_max'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_max'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -428,17 +423,17 @@ tests:
   # ==========================================================================
   - name: spm_imatrix function exists
     description: Check affine matrix decomposition function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_imatrix'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_imatrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_matrix function exists
     description: Check affine matrix construction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_matrix'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_matrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_get_space function exists
     description: Check space getting function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_get_space'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_get_space'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -446,12 +441,12 @@ tests:
   # ==========================================================================
   - name: spm_reslice function exists
     description: Check image reslicing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_reslice'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_reslice'\''))"'
     expected_output_contains: "2"
 
   - name: spm_bsplinc function exists
     description: Check B-spline coefficient function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_bsplinc'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_bsplinc'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -459,12 +454,12 @@ tests:
   # ==========================================================================
   - name: spm_spm function exists
     description: Check SPM statistics function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_spm'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_spm'\''))"'
     expected_output_contains: "2"
 
   - name: spm_contrasts function exists
     description: Check contrast definition function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_contrasts'\''))"'
+    command: bash -lc '${spm_script} ${mcr} eval "disp(exist('\''spm_contrasts'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -489,7 +484,7 @@ tests:
   # ==========================================================================
   - name: Script mode basic test
     description: Test script execution mode
-    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b script /tmp/test_script.m 2>&1 | tail -10'
+    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && ${spm_script} ${mcr} script /tmp/test_script.m 2>&1 | tail -10'
     expected_output_contains: "script test passed"
 
   # ==========================================================================
@@ -497,7 +492,7 @@ tests:
   # ==========================================================================
   - name: Invalid function error handling
     description: Test error handling for non-existent function
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "nonexistent_function_xyz" 2>&1 || true'
+    command: bash -lc '${spm_script} ${mcr} eval "nonexistent_function_xyz" 2>&1 || true'
     expected_output_contains: "Error"
 
 cleanup:

--- a/recipes/hmri/fulltest.yaml
+++ b/recipes/hmri/fulltest.yaml
@@ -1,5 +1,5 @@
 # hMRI toolbox container test suite
-# Tests for hMRI v0.6.1 - Quantitative MRI toolbox for SPM12
+# Tests for hMRI v1.0.0 - Quantitative MRI toolbox for SPM12
 #
 # The hMRI toolbox provides tools for quantitative MRI in neuroscience:
 #   - R1, R2*, PD, MT saturation map estimation
@@ -7,7 +7,7 @@
 #   - UNICORT RF correction
 #   - Spatial processing (segmentation, DARTEL, smoothing)
 #
-# Container: SPM12 standalone (v7771) with hMRI toolbox v0.6.1
+# Container: SPM12 standalone (v7771) with hMRI toolbox v1.0.0
 # MATLAB Runtime: R2023a
 #
 # Test data: ds000001/sub-01 (OpenNeuro Balloon Analog Risk-taking Task)
@@ -18,16 +18,16 @@
 # compressed files where possible with appropriate warnings expected.
 
 name: hmri
-version: 0.6.1
+version: 1.0.0
 
 # Define path variables for convenience
 paths:
-  spm_script: /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh
+  spm_script: /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh
   mcr: /opt/mcr/R2023a
-  spm_dir: /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12
-  hmri_toolbox: /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox
-  tpm: /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm
-  canonical: /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical
+  spm_dir: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12
+  hmri_toolbox: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox
+  tpm: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm
+  canonical: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical
 
 required_files:
   - dataset: ds000001
@@ -52,27 +52,27 @@ tests:
   # ==========================================================================
   - name: SPM12 help display
     description: Verify SPM12 standalone runs and displays help
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --help'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a --help'
     expected_output_contains: "SPM12 - Statistical Parametric Mapping"
 
   - name: SPM12 version information
     description: Check SPM12 version and MATLAB runtime version
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --version'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a --version'
     expected_output_contains: "SPM12, version 7771"
 
   - name: MATLAB runtime version
     description: Verify MATLAB Runtime R2023a is installed
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a --version'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a --version'
     expected_output_contains: "MATLAB, version 9.14"
 
   - name: SPM directory location
     description: Check SPM installation directory
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''dir'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''dir'\''))"'
     expected_output_contains: "SPM12"
 
   - name: SPM version string
     description: Get SPM version string via function call
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''ver'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''ver'\''))"'
     expected_output_contains: "SPM12"
 
   # ==========================================================================
@@ -80,27 +80,27 @@ tests:
   # ==========================================================================
   - name: hMRI toolbox version
     description: Check hMRI toolbox version
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "v=hmri_get_version;disp(v{1})"'
-    expected_output_contains: "hMRI v0.6.1"
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "v=hmri_get_version;disp(v{1})"'
+    expected_output_contains: "hMRI v1.0.0"
 
   - name: hMRI defaults availability
     description: Verify hmri_defaults function is accessible
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_defaults'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_defaults'\''))"'
     expected_output_contains: "hmri_defaults"
 
   - name: hMRI get_defaults function
     description: Test hmri_get_defaults returns configuration structure
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
     expected_output_contains: "centre"
 
   - name: hMRI B1 defaults availability
     description: Check B1 mapping defaults are accessible
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
     expected_output_contains: "hmri_b1_standard_defaults"
 
   - name: hMRI toolbox directory
     description: Verify hMRI toolbox installation path
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/'"
     expected_output_contains: "hmri_get_version.m"
 
   # ==========================================================================
@@ -108,42 +108,42 @@ tests:
   # ==========================================================================
   - name: hmri_calc_R1 function exists
     description: Check R1 calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R1'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R1'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_R2s function exists
     description: Check R2* calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R2s'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R2s'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_A function exists
     description: Check A (PD-related) calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_A'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_A'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_MTProt function exists
     description: Check MT protocol creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_MTProt'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_MTProt'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_b1map function exists
     description: Check B1 map creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_b1map'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_b1map'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_unicort function exists
     description: Check UNICORT RF correction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_unicort'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_unicort'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_coreg function exists
     description: Check coregistration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_coreg'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_autoreorient function exists
     description: Check autoreorient function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_autoreorient'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_autoreorient'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -151,27 +151,27 @@ tests:
   # ==========================================================================
   - name: hmri_proc_MPMsmooth function exists
     description: Check MPM smoothing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_US function exists
     description: Check unified segmentation processing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_US'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_US'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_dartel_norm function exists
     description: Check DARTEL normalization function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_build function exists
     description: Check QUIQI (quality assurance) build function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_build'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_build'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_check function exists
     description: Check QUIQI check function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_check'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_check'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -179,22 +179,22 @@ tests:
   # ==========================================================================
   - name: hmri_read_vols function exists
     description: Check volume reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_read_vols'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_nifti function exists
     description: Check NIfTI creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_nifti'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_nifti'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_log function exists
     description: Check logging function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_log'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_log'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quality_display function exists
     description: Check quality display function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quality_display'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quality_display'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -202,17 +202,17 @@ tests:
   # ==========================================================================
   - name: tbx_cfg_hmri function exists
     description: Check hMRI batch configuration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_cfg_hmri'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_cfg_hmri'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_create function exists
     description: Check hMRI map creation batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_B1_create function exists
     description: Check B1 map creation batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -220,52 +220,52 @@ tests:
   # ==========================================================================
   - name: spm_vol function exists
     description: Check SPM volume reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_vol'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_read_vols function exists
     description: Check SPM volume data reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_read_vols'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: spm_write_vol function exists
     description: Check SPM volume writing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_write_vol'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_write_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_smooth function exists
     description: Check SPM smoothing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_smooth'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_smooth'\''))"'
     expected_output_contains: "2"
 
   - name: spm_realign function exists
     description: Check SPM realignment function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_realign'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_realign'\''))"'
     expected_output_contains: "2"
 
   - name: spm_coreg function exists
     description: Check SPM coregistration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_coreg'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: spm_preproc function exists
     description: Check SPM preprocessing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc'\''))"'
     expected_output_contains: "2"
 
   - name: spm_normalise function exists
     description: Check SPM normalisation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_normalise'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_normalise'\''))"'
     expected_output_contains: "2"
 
   - name: spm_segment function exists
     description: Check SPM new segment function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc_run'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc_run'\''))"'
     expected_output_contains: "2"
 
   - name: spm_slice_timing function exists
     description: Check SPM slice timing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_slice_timing'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_slice_timing'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -273,12 +273,12 @@ tests:
   # ==========================================================================
   - name: spm_dicom_headers function exists
     description: Check DICOM header reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_headers'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_headers'\''))"'
     expected_output_contains: "2"
 
   - name: spm_dicom_convert function exists
     description: Check DICOM conversion function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_convert'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_convert'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -286,22 +286,22 @@ tests:
   # ==========================================================================
   - name: DARTEL toolbox available
     description: Check DARTEL toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/DARTEL/'"
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/DARTEL/'"
     expected_output_contains: "spm_dartel"
 
   - name: FieldMap toolbox available
     description: Check FieldMap toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/FieldMap/'"
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/FieldMap/'"
     expected_output_contains: "FieldMap.m"
 
   - name: Longitudinal toolbox available
     description: Check Longitudinal toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/Longitudinal/'"
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/Longitudinal/'"
     expected_output_contains: "spm_pairwise"
 
   - name: Shoot toolbox available
     description: Check Shoot (geodesic shooting) toolbox is installed
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/Shoot/'"
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/Shoot/'"
     expected_output_contains: "spm_shoot"
 
   # ==========================================================================
@@ -309,32 +309,32 @@ tests:
   # ==========================================================================
   - name: TPM file exists
     description: Check tissue probability map is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/TPM.nii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm/TPM.nii'"
     expected_output_contains: "TPM.nii"
 
   - name: ICV mask exists
     description: Check intracranial volume mask is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/mask_ICV.nii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm/mask_ICV.nii'"
     expected_output_contains: "mask_ICV.nii"
 
   - name: Neuromorphometrics labels exist
     description: Check Neuromorphometrics labels are available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/tpm/labels_Neuromorphometrics.nii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm/labels_Neuromorphometrics.nii'"
     expected_output_contains: "labels_Neuromorphometrics.nii"
 
   - name: Canonical T1 template exists
     description: Check T1 template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/avg152T1.nii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/avg152T1.nii'"
     expected_output_contains: "avg152T1.nii"
 
   - name: Canonical T2 template exists
     description: Check T2 template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/avg152T2.nii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/avg152T2.nii'"
     expected_output_contains: "avg152T2.nii"
 
   - name: Single subject T1 template exists
     description: Check single subject T1 template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/single_subj_T1.nii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/single_subj_T1.nii'"
     expected_output_contains: "single_subj_T1.nii"
 
   # ==========================================================================
@@ -342,27 +342,27 @@ tests:
   # ==========================================================================
   - name: hMRI defaults - centre
     description: Get default hMRI centre setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.centre)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.centre)"'
     expected_output_contains: "centre"
 
   - name: hMRI defaults - cleanup setting
     description: Get default cleanup setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - JSON setting
     description: Get default JSON output setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.json)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.json)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - interpolation
     description: Get default interpolation setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.interp)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.interp)"'
     expected_exit_code: 0
 
   - name: hMRI B1 defaults structure
     description: Get B1 mapping defaults
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
     expected_output_contains: "i3D_AFI"
 
   # ==========================================================================
@@ -370,12 +370,12 @@ tests:
   # ==========================================================================
   - name: EPG_GRE function exists
     description: Check EPG gradient echo function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''EPG_GRE'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''EPG_GRE'\''))"'
     expected_output_contains: "2"
 
   - name: EPG directory exists
     description: Check EPG toolbox directory
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/EPG_for_hmri_tbx/'"
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/EPG_for_hmri_tbx/'"
     expected_output_contains: "EPG-src"
 
   # ==========================================================================
@@ -383,22 +383,22 @@ tests:
   # ==========================================================================
   - name: get_metadata function exists
     description: Check metadata retrieval function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata'\''))"'
     expected_output_contains: "2"
 
   - name: get_metadata_val function exists
     description: Check metadata value retrieval function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata_val'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata_val'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonread function exists
     description: Check JSON reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonread'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonread'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonwrite function exists
     description: Check JSON writing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonwrite'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonwrite'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -406,12 +406,12 @@ tests:
   # ==========================================================================
   - name: hmri_corr_imperf_spoil function exists
     description: Check imperfect spoiling correction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   - name: Imperfect spoiling config exists
     description: Check imperfect spoiling batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -419,17 +419,17 @@ tests:
   # ==========================================================================
   - name: MATLAB basic arithmetic
     description: Test basic MATLAB arithmetic via eval
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(2+2)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(2+2)"'
     expected_output_contains: "4"
 
   - name: MATLAB matrix creation
     description: Test MATLAB matrix creation via eval
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "A=eye(3);disp(size(A))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "A=eye(3);disp(size(A))"'
     expected_output_contains: "3     3"
 
   - name: MATLAB path check
     description: Verify MATLAB path includes SPM
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "p=path;disp(contains(p,'\''spm12'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "p=path;disp(contains(p,'\''spm12'\''))"'
     expected_output_contains: "1"
 
   # ==========================================================================
@@ -437,12 +437,12 @@ tests:
   # ==========================================================================
   - name: spm_jobman function exists
     description: Check batch job manager function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jobman'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jobman'\''))"'
     expected_output_contains: "2"
 
   - name: cfg_util function exists
     description: Check batch utility function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''cfg_util'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''cfg_util'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -450,12 +450,12 @@ tests:
   # ==========================================================================
   - name: nifti class exists
     description: Check NIfTI class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''nifti'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''nifti'\''))"'
     expected_output_contains: "2"
 
   - name: file_array class exists
     description: Check file_array class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''file_array'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''file_array'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -463,12 +463,12 @@ tests:
   # ==========================================================================
   - name: gifti class exists
     description: Check GIfTI class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''gifti'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''gifti'\''))"'
     expected_output_contains: "2"
 
   - name: Cortex surface file exists
     description: Check cortex surface template is available
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/canonical/cortex_20484.surf.gii'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/canonical/cortex_20484.surf.gii'"
     expected_output_contains: "cortex_20484.surf.gii"
 
   # ==========================================================================
@@ -476,12 +476,12 @@ tests:
   # ==========================================================================
   - name: spm_global function exists
     description: Check global intensity calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_global'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_global'\''))"'
     expected_output_contains: "2"
 
   - name: spm_max function exists
     description: Check maximum finding function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_max'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_max'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -489,17 +489,17 @@ tests:
   # ==========================================================================
   - name: spm_imatrix function exists
     description: Check affine matrix decomposition function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_imatrix'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_imatrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_matrix function exists
     description: Check affine matrix construction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_matrix'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_matrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_get_space function exists
     description: Check space getting function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_get_space'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_get_space'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -507,12 +507,12 @@ tests:
   # ==========================================================================
   - name: spm_reslice function exists
     description: Check image reslicing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_reslice'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_reslice'\''))"'
     expected_output_contains: "2"
 
   - name: spm_bsplinc function exists
     description: Check B-spline coefficient function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_bsplinc'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_bsplinc'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -520,12 +520,12 @@ tests:
   # ==========================================================================
   - name: spm_spm function exists
     description: Check SPM statistics function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_spm'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_spm'\''))"'
     expected_output_contains: "2"
 
   - name: spm_contrasts function exists
     description: Check contrast definition function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_contrasts'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_contrasts'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -538,7 +538,7 @@ tests:
 
   - name: hMRI README exists
     description: Check hMRI README is present
-    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/README.md'"
+    command: "bash -lc 'ls -la /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/README.md'"
     expected_output_contains: "README.md"
 
   - name: Container README
@@ -551,7 +551,7 @@ tests:
   # ==========================================================================
   - name: hMRI etpm directory exists
     description: Check enhanced TPM directory
-    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv0.6.1/spm12_mcr/spm12/tests/v0.6.1/compilation-work/spm12/toolbox/hMRI-toolbox/etpm/'"
+    command: "bash -lc 'ls /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox/etpm/'"
     expected_output_contains: "eTPM.nii"
 
   # ==========================================================================
@@ -559,7 +559,7 @@ tests:
   # ==========================================================================
   - name: Script mode basic test
     description: Test script execution mode
-    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a script /tmp/test_script.m 2>&1 | tail -10'
+    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a script /tmp/test_script.m 2>&1 | tail -10'
     expected_output_contains: "script test passed"
 
   # ==========================================================================
@@ -567,7 +567,7 @@ tests:
   # ==========================================================================
   - name: Invalid function error handling
     description: Test error handling for non-existent function
-    command: bash -lc '/opt/standalone-hMRItoolboxv0.6.1/run_spm12.sh /opt/mcr/R2023a eval "nonexistent_function_xyz" 2>&1 || true'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "nonexistent_function_xyz" 2>&1 || true'
     expected_output_contains: "Error"
 
 cleanup:

--- a/recipes/hmri/fulltest.yaml
+++ b/recipes/hmri/fulltest.yaml
@@ -8,7 +8,7 @@
 #   - Spatial processing (segmentation, DARTEL, smoothing)
 #
 # Container: SPM12 standalone (v7771) with hMRI toolbox v1.0.0
-# MATLAB Runtime: R2023a
+# MATLAB Runtime: R2023b
 #
 # Test data: ds000001/sub-01 (OpenNeuro Balloon Analog Risk-taking Task)
 #   - inplaneT2: 256x256x33, 0.86x0.86x4mm (anatomical)
@@ -23,7 +23,7 @@ version: 1.0.0
 # Define path variables for convenience
 paths:
   spm_script: /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh
-  mcr: /opt/mcr/R2023a
+  mcr: /opt/mcr/R2023b
   spm_dir: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12
   hmri_toolbox: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/toolbox/hMRI-toolbox
   tpm: /opt/standalone-hMRItoolboxv1.0.0/spm12_mcr/spm12/tests/v1.0.0/compilation-work/spm12/tpm
@@ -52,27 +52,27 @@ tests:
   # ==========================================================================
   - name: SPM12 help display
     description: Verify SPM12 standalone runs and displays help
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a --help'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b --help'
     expected_output_contains: "SPM12 - Statistical Parametric Mapping"
 
   - name: SPM12 version information
     description: Check SPM12 version and MATLAB runtime version
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a --version'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b --version'
     expected_output_contains: "SPM12, version 7771"
 
   - name: MATLAB runtime version
-    description: Verify MATLAB Runtime R2023a is installed
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a --version'
+    description: Verify MATLAB Runtime R2023b is installed
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b --version'
     expected_output_contains: "MATLAB, version 9.14"
 
   - name: SPM directory location
     description: Check SPM installation directory
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''dir'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(spm('\''dir'\''))"'
     expected_output_contains: "SPM12"
 
   - name: SPM version string
     description: Get SPM version string via function call
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(spm('\''ver'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(spm('\''ver'\''))"'
     expected_output_contains: "SPM12"
 
   # ==========================================================================
@@ -80,22 +80,22 @@ tests:
   # ==========================================================================
   - name: hMRI toolbox version
     description: Check hMRI toolbox version
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "v=hmri_get_version;disp(v{1})"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "v=hmri_get_version;disp(v{1})"'
     expected_output_contains: "hMRI v1.0.0"
 
   - name: hMRI defaults availability
     description: Verify hmri_defaults function is accessible
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_defaults'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(which('\''hmri_defaults'\''))"'
     expected_output_contains: "hmri_defaults"
 
   - name: hMRI get_defaults function
     description: Test hmri_get_defaults returns configuration structure
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(fieldnames(defs))"'
     expected_output_contains: "centre"
 
   - name: hMRI B1 defaults availability
     description: Check B1 mapping defaults are accessible
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(which('\''hmri_b1_standard_defaults'\''))"'
     expected_output_contains: "hmri_b1_standard_defaults"
 
   - name: hMRI toolbox directory
@@ -108,42 +108,42 @@ tests:
   # ==========================================================================
   - name: hmri_calc_R1 function exists
     description: Check R1 calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R1'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_calc_R1'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_R2s function exists
     description: Check R2* calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_R2s'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_calc_R2s'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_calc_A function exists
     description: Check A (PD-related) calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_calc_A'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_calc_A'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_MTProt function exists
     description: Check MT protocol creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_MTProt'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_MTProt'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_b1map function exists
     description: Check B1 map creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_b1map'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_b1map'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_unicort function exists
     description: Check UNICORT RF correction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_unicort'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_unicort'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_coreg function exists
     description: Check coregistration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_coreg'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_autoreorient function exists
     description: Check autoreorient function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_autoreorient'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_autoreorient'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -151,27 +151,27 @@ tests:
   # ==========================================================================
   - name: hmri_proc_MPMsmooth function exists
     description: Check MPM smoothing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_proc_MPMsmooth'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_US function exists
     description: Check unified segmentation processing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_US'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_run_proc_US'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_run_proc_dartel_norm function exists
     description: Check DARTEL normalization function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_run_proc_dartel_norm'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_build function exists
     description: Check QUIQI (quality assurance) build function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_build'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_quiqi_build'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quiqi_check function exists
     description: Check QUIQI check function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quiqi_check'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_quiqi_check'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -179,22 +179,22 @@ tests:
   # ==========================================================================
   - name: hmri_read_vols function exists
     description: Check volume reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_read_vols'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_create_nifti function exists
     description: Check NIfTI creation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_create_nifti'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_create_nifti'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_log function exists
     description: Check logging function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_log'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_log'\''))"'
     expected_output_contains: "2"
 
   - name: hmri_quality_display function exists
     description: Check quality display function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_quality_display'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_quality_display'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -202,17 +202,17 @@ tests:
   # ==========================================================================
   - name: tbx_cfg_hmri function exists
     description: Check hMRI batch configuration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_cfg_hmri'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_cfg_hmri'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_create function exists
     description: Check hMRI map creation batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_scfg_hmri_create'\''))"'
     expected_output_contains: "2"
 
   - name: tbx_scfg_hmri_B1_create function exists
     description: Check B1 map creation batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_scfg_hmri_B1_create'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -220,52 +220,52 @@ tests:
   # ==========================================================================
   - name: spm_vol function exists
     description: Check SPM volume reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_vol'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_read_vols function exists
     description: Check SPM volume data reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_read_vols'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_read_vols'\''))"'
     expected_output_contains: "2"
 
   - name: spm_write_vol function exists
     description: Check SPM volume writing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_write_vol'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_write_vol'\''))"'
     expected_output_contains: "2"
 
   - name: spm_smooth function exists
     description: Check SPM smoothing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_smooth'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_smooth'\''))"'
     expected_output_contains: "2"
 
   - name: spm_realign function exists
     description: Check SPM realignment function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_realign'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_realign'\''))"'
     expected_output_contains: "2"
 
   - name: spm_coreg function exists
     description: Check SPM coregistration function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_coreg'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_coreg'\''))"'
     expected_output_contains: "2"
 
   - name: spm_preproc function exists
     description: Check SPM preprocessing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_preproc'\''))"'
     expected_output_contains: "2"
 
   - name: spm_normalise function exists
     description: Check SPM normalisation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_normalise'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_normalise'\''))"'
     expected_output_contains: "2"
 
   - name: spm_segment function exists
     description: Check SPM new segment function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_preproc_run'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_preproc_run'\''))"'
     expected_output_contains: "2"
 
   - name: spm_slice_timing function exists
     description: Check SPM slice timing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_slice_timing'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_slice_timing'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -273,12 +273,12 @@ tests:
   # ==========================================================================
   - name: spm_dicom_headers function exists
     description: Check DICOM header reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_headers'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_dicom_headers'\''))"'
     expected_output_contains: "2"
 
   - name: spm_dicom_convert function exists
     description: Check DICOM conversion function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_dicom_convert'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_dicom_convert'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -342,27 +342,27 @@ tests:
   # ==========================================================================
   - name: hMRI defaults - centre
     description: Get default hMRI centre setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.centre)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.centre)"'
     expected_output_contains: "centre"
 
   - name: hMRI defaults - cleanup setting
     description: Get default cleanup setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.cleanup)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - JSON setting
     description: Get default JSON output setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.json)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.json)"'
     expected_exit_code: 0
 
   - name: hMRI defaults - interpolation
     description: Get default interpolation setting
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(defs.interp)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(defs.interp)"'
     expected_exit_code: 0
 
   - name: hMRI B1 defaults structure
     description: Get B1 mapping defaults
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "defs=hmri_get_defaults;disp(fieldnames(defs.b1map))"'
     expected_output_contains: "i3D_AFI"
 
   # ==========================================================================
@@ -370,7 +370,7 @@ tests:
   # ==========================================================================
   - name: EPG_GRE function exists
     description: Check EPG gradient echo function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''EPG_GRE'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''EPG_GRE'\''))"'
     expected_output_contains: "2"
 
   - name: EPG directory exists
@@ -383,22 +383,22 @@ tests:
   # ==========================================================================
   - name: get_metadata function exists
     description: Check metadata retrieval function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''get_metadata'\''))"'
     expected_output_contains: "2"
 
   - name: get_metadata_val function exists
     description: Check metadata value retrieval function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''get_metadata_val'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''get_metadata_val'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonread function exists
     description: Check JSON reading function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonread'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_jsonread'\''))"'
     expected_output_contains: "2"
 
   - name: spm_jsonwrite function exists
     description: Check JSON writing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jsonwrite'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_jsonwrite'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -406,12 +406,12 @@ tests:
   # ==========================================================================
   - name: hmri_corr_imperf_spoil function exists
     description: Check imperfect spoiling correction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''hmri_corr_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   - name: Imperfect spoiling config exists
     description: Check imperfect spoiling batch config is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''tbx_scfg_hmri_imperf_spoil'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -419,17 +419,17 @@ tests:
   # ==========================================================================
   - name: MATLAB basic arithmetic
     description: Test basic MATLAB arithmetic via eval
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(2+2)"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(2+2)"'
     expected_output_contains: "4"
 
   - name: MATLAB matrix creation
     description: Test MATLAB matrix creation via eval
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "A=eye(3);disp(size(A))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "A=eye(3);disp(size(A))"'
     expected_output_contains: "3     3"
 
   - name: MATLAB path check
     description: Verify MATLAB path includes SPM
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "p=path;disp(contains(p,'\''spm12'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "p=path;disp(contains(p,'\''spm12'\''))"'
     expected_output_contains: "1"
 
   # ==========================================================================
@@ -437,12 +437,12 @@ tests:
   # ==========================================================================
   - name: spm_jobman function exists
     description: Check batch job manager function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_jobman'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_jobman'\''))"'
     expected_output_contains: "2"
 
   - name: cfg_util function exists
     description: Check batch utility function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''cfg_util'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''cfg_util'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -450,12 +450,12 @@ tests:
   # ==========================================================================
   - name: nifti class exists
     description: Check NIfTI class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''nifti'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''nifti'\''))"'
     expected_output_contains: "2"
 
   - name: file_array class exists
     description: Check file_array class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''file_array'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''file_array'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -463,7 +463,7 @@ tests:
   # ==========================================================================
   - name: gifti class exists
     description: Check GIfTI class is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''gifti'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''gifti'\''))"'
     expected_output_contains: "2"
 
   - name: Cortex surface file exists
@@ -476,12 +476,12 @@ tests:
   # ==========================================================================
   - name: spm_global function exists
     description: Check global intensity calculation function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_global'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_global'\''))"'
     expected_output_contains: "2"
 
   - name: spm_max function exists
     description: Check maximum finding function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_max'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_max'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -489,17 +489,17 @@ tests:
   # ==========================================================================
   - name: spm_imatrix function exists
     description: Check affine matrix decomposition function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_imatrix'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_imatrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_matrix function exists
     description: Check affine matrix construction function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_matrix'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_matrix'\''))"'
     expected_output_contains: "2"
 
   - name: spm_get_space function exists
     description: Check space getting function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_get_space'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_get_space'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -507,12 +507,12 @@ tests:
   # ==========================================================================
   - name: spm_reslice function exists
     description: Check image reslicing function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_reslice'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_reslice'\''))"'
     expected_output_contains: "2"
 
   - name: spm_bsplinc function exists
     description: Check B-spline coefficient function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_bsplinc'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_bsplinc'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -520,12 +520,12 @@ tests:
   # ==========================================================================
   - name: spm_spm function exists
     description: Check SPM statistics function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_spm'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_spm'\''))"'
     expected_output_contains: "2"
 
   - name: spm_contrasts function exists
     description: Check contrast definition function is available
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "disp(exist('\''spm_contrasts'\''))"'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "disp(exist('\''spm_contrasts'\''))"'
     expected_output_contains: "2"
 
   # ==========================================================================
@@ -533,7 +533,7 @@ tests:
   # ==========================================================================
   - name: MCR directory structure
     description: Check MATLAB Compiler Runtime directory exists
-    command: "bash -lc 'ls -la /opt/mcr/R2023a/'"
+    command: "bash -lc 'ls -la /opt/mcr/R2023b/'"
     expected_output_contains: "runtime"
 
   - name: hMRI README exists
@@ -559,7 +559,7 @@ tests:
   # ==========================================================================
   - name: Script mode basic test
     description: Test script execution mode
-    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a script /tmp/test_script.m 2>&1 | tail -10'
+    command: bash -lc 'echo "disp('\''script test passed'\'')" > /tmp/test_script.m && /opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b script /tmp/test_script.m 2>&1 | tail -10'
     expected_output_contains: "script test passed"
 
   # ==========================================================================
@@ -567,7 +567,7 @@ tests:
   # ==========================================================================
   - name: Invalid function error handling
     description: Test error handling for non-existent function
-    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023a eval "nonexistent_function_xyz" 2>&1 || true'
+    command: bash -lc '/opt/standalone-hMRItoolboxv1.0.0/run_spm12.sh /opt/mcr/R2023b eval "nonexistent_function_xyz" 2>&1 || true'
     expected_output_contains: "Error"
 
 cleanup:


### PR DESCRIPTION
This PR updates the container recipe of the hMRI toolbox in order to add the major first release v1.0.0 to the currently available versions (currently available version in Neurodesk is 0.6.1 which will continue to be available):

- the compiler version updated to 2023b
- the versions bumped
- unzip removed from build for a slightly leaner container-accordingly .tar.gz file used and exctract code changed.
- tests related to the local runtime artifacts are removed
