### PR TITLE
Fix Metabody OpenRecon config metadata

### DIFF
--- a/recipes/metabody/OpenReconLabel.json
+++ b/recipes/metabody/OpenReconLabel.json
@@ -37,6 +37,19 @@
   },
   "parameters": [
     {
+      "id": "config",
+      "label": { "en": "Configuration" },
+      "type": "choice",
+      "values": [
+        {
+          "id": "metabody",
+          "name": { "en": "metabody" }
+        }
+      ],
+      "default": "metabody",
+      "information": { "en": "MRD server configuration to run." }
+    },
+    {
       "id": "sendOriginal",
       "label": { "en": "Send original images" },
       "type": "boolean",

--- a/recipes/metabody/OpenReconREADME.md
+++ b/recipes/metabody/OpenReconREADME.md
@@ -17,6 +17,7 @@ foot, right foot, left hand, right hand, and tongue contrasts.
 
 | GUI label | Parameter id | Type | Default | Description |
 | --- | --- | --- | --- | --- |
+| Configuration | `config` | choice | `metabody` | Run the Metabody MRD server configuration. |
 | Send original images | `sendOriginal` | boolean | `true` | Return copies of the input images as series 99 before the statistical maps. |
 | Colormap name | `colormap` | choice | `seismic` | Apply a Matplotlib colormap to the statistical maps. Select `none` for grayscale output. |
 


### PR DESCRIPTION
## Summary

- restore the required `config` choice in the Metabody OpenRecon label
- document the configuration parameter
- make Neurocontainers validation enforce the downstream OpenRecon packaging contract
- add a regression test for missing `config` metadata

## Verification

- `uv run --with pytest --with jsonschema pytest -q builder/tests/test_openrecon_label_validation.py`
- `python3 workflows/validate_openrecon_labels.py`
- targeted Ruff and codespell checks

This fixes the OpenRecon build failure from neurodesk/openrecon/actions/runs/33641734806.