### PR TITLE
Validate required OpenRecon config metadata

### DIFF
--- a/builder/tests/test_openrecon_label_validation.py
+++ b/builder/tests/test_openrecon_label_validation.py
@@ -1,5 +1,7 @@
 import json
+import tempfile
 import unittest
+from pathlib import Path
 
 from workflows.validate_openrecon_labels import (
     SCHEMA_PATH,
@@ -51,6 +53,28 @@ class OpenReconLabelValidationTests(unittest.TestCase):
                 {str(path): errors for path, errors in failures.items()},
                 indent=2,
             ),
+        )
+
+    def test_label_without_config_parameter_is_rejected(self):
+        source_path = (
+            SCHEMA_PATH.parents[1] / "recipes" / "b0map" / "OpenReconLabel.json"
+        )
+        label = json.loads(source_path.read_text(encoding="utf-8"))
+        label["parameters"] = [
+            parameter
+            for parameter in label["parameters"]
+            if parameter.get("id") != "config"
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            label_path = Path(temp_dir) / "OpenReconLabel.json"
+            label_path.write_text(json.dumps(label), encoding="utf-8")
+
+            errors = validate_label(label_path)
+
+        self.assertIn(
+            'parameters: must contain exactly one parameter with id "config"; found 0',
+            errors,
         )
 
 

--- a/workflows/validate_openrecon_labels.py
+++ b/workflows/validate_openrecon_labels.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from jsonschema import Draft7Validator, ValidationError
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RECIPES_DIR = REPO_ROOT / "recipes"
@@ -56,6 +56,31 @@ def format_validation_error(error: ValidationError) -> str:
     return f"{path}: {error.message}"
 
 
+def validate_packaging_metadata(label: dict[str, Any]) -> list[str]:
+    """Validate metadata required by the downstream OpenRecon packager."""
+    parameters = label.get("parameters", [])
+    config_parameters = [
+        parameter for parameter in parameters if parameter.get("id") == "config"
+    ]
+    if len(config_parameters) != 1:
+        return [
+            (
+                "parameters: must contain exactly one parameter with id "
+                f'"config"; found {len(config_parameters)}'
+            )
+        ]
+
+    errors = []
+    config_parameter = config_parameters[0]
+    if config_parameter.get("type") != "choice":
+        errors.append('parameters: parameter "config" must have type "choice"')
+    if not config_parameter.get("values"):
+        errors.append(
+            'parameters: parameter "config" must define at least one choice value'
+        )
+    return errors
+
+
 def validate_label(
     label_path: Path,
     schema_path: Path = SCHEMA_PATH,
@@ -65,7 +90,8 @@ def validate_label(
     label = prepare_label_for_validation(load_json(label_path))
     validator = Draft7Validator(schema)
     errors = sorted(validator.iter_errors(label), key=lambda error: list(error.path))
-    return [format_validation_error(error) for error in errors]
+    schema_errors = [format_validation_error(error) for error in errors]
+    return schema_errors + validate_packaging_metadata(label)
 
 
 def validate_labels(


### PR DESCRIPTION
## Summary

- enforce the downstream OpenRecon packaging requirement for exactly one `config` choice
- add a regression test proving labels without that parameter are rejected

## Verification

- `uv run --with pytest --with jsonschema pytest -q builder/tests/test_openrecon_label_validation.py`
- `python3 workflows/validate_openrecon_labels.py`
- targeted Ruff and codespell checks

This prevents the contract mismatch that caused OpenRecon build run 33641734806 to fail.