### PR TITLE
Rebuild Meica OpenRecon container

### DIFF
--- a/recipes/meica/OpenReconLabel.json
+++ b/recipes/meica/OpenReconLabel.json
@@ -10,7 +10,7 @@
       "production_identifier": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "manufacturer_address": "Erlangen, Germany",
       "made_in": "DE",
-      "manufacture_date": "2026/07/14",
+      "manufacture_date": "2026/09/02",
       "material_number": "meica_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "gtin": "00860000171212",
       "udi": "(01)00860000171212(21)VERSION_WILL_BE_REPLACED_BY_SCRIPT",


### PR DESCRIPTION
Rebuild the Meica 4.0.1 container and publish a fresh OpenRecon package.

The OpenRecon manufacture date now matches this rebuild. The container candidate gate will build and run the existing Meica deploy and fulltest checks before merge.

Local checks:
- `python3 builder/validation.py recipes/meica/build.yaml --verbose`
- `python3 workflows/validate_openrecon_labels.py`
- `python3 -m unittest builder.tests.test_openrecon_label_validation`
- `python3 -m builder generate meica --recreate`
- `python3 tools/one_pr_release.py detect --base origin/main --head HEAD`