### PR TITLE
Split spinalcordtoolbox into CPU and GPU containers

### DIFF
--- a/recipes/spinalcordtoolbox/OpenReconLabel.gpu.json
+++ b/recipes/spinalcordtoolbox/OpenReconLabel.gpu.json
@@ -1,10 +1,10 @@
 {
   "general": {
-    "name": { "en": "spinalcordtoolbox" },
+    "name": { "en": "spinalcordtoolbox GPU" },
     "version": "VERSION_WILL_BE_REPLACED_BY_SCRIPT",
     "vendor": "neurodesk",
-    "information": { "en": "spinalcordtoolbox" },
-    "id": "spinalcordtoolbox",
+    "information": { "en": "spinalcordtoolbox GPU" },
+    "id": "spinalcordtoolbox_gpu",
     "regulatory_information": {
       "device_trade_name":"spinalcordtoolbox",
       "production_identifier":"VERSION_WILL_BE_REPLACED_BY_SCRIPT",
@@ -28,9 +28,9 @@
     "emitter": "image",
     "injector": "image",
     "can_process_adjustment_data": false,
-    "can_use_gpu": false,
-    "min_count_required_gpus": 0,
-    "min_required_gpu_memory": 0,
+    "can_use_gpu": true,
+    "min_count_required_gpus": 1,
+    "min_required_gpu_memory": 10048,
     "min_required_memory": 40096,
     "min_count_required_cpu_cores": 32,
     "content_qualification_type": "RESEARCH"

--- a/recipes/spinalcordtoolbox/build.yaml
+++ b/recipes/spinalcordtoolbox/build.yaml
@@ -5,6 +5,15 @@ copyright:
     url: https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/LICENSE
 architectures:
   - x86_64
+options:
+  gpu:
+    description: Install SCT with CUDA-enabled PyTorch
+    default: false
+variants:
+  gpu:
+    architecture: x86_64
+    options:
+      gpu: true
 variables:
   upstream_version: "7.3"
 build:
@@ -35,14 +44,22 @@ build:
     - run:
         - chmod a+rwx /opt/spinalcordtoolbox-{{ context.version }}/ -R
     - user: spinalcordtoolbox
-    - run:
+    - condition: not context.options.gpu
+      run:
+        - ./install_sct -i -y -c
+        - rm -rf /home/spinalcordtoolbox/.cache /opt/spinalcordtoolbox-{{ context.version }}/python/pkgs
+    - condition: context.options.gpu
+      run:
         - ./install_sct -i -y -g -c
         - rm -rf /home/spinalcordtoolbox/.cache /opt/spinalcordtoolbox-{{ context.version }}/python/pkgs
     - environment:
         PATH: /opt/spinalcordtoolbox-{{ context.version }}/bin/:$PATH
         SCT_DIR: /opt/spinalcordtoolbox-{{ context.version }}
+    - condition: context.options.gpu
+      environment:
         SCT_USE_GPU: "1"
-    - run:
+    - condition: context.options.gpu
+      run:
         - /opt/spinalcordtoolbox-{{ context.version }}/python/envs/venv_sct/bin/python -c 'import os, torch; assert torch.version.cuda; assert os.environ.get("SCT_USE_GPU") == "1"; print(torch.__version__, torch.version.cuda)'
     - run:
         - sct_deepseg spinalcord -install
@@ -63,10 +80,14 @@ build:
         - sct_deepseg rootlets -install
         - sct_deepseg sc_canal_t2 -install
         - sct_deepseg spine -install
+        - rm -rf /home/spinalcordtoolbox/.cache
+    - condition: not context.options.gpu
+      run:
+        - sct_check_dependencies
     - user: root
     - copy: spinalcordtoolbox.py /opt/code/python-ismrmrd-server/spinalcordtoolbox.py
     - copy: nifti2mrd.py /opt/code/python-ismrmrd-server/nifti2mrd.py
-    - copy: OpenReconLabel.json /opt/code/python-ismrmrd-server/OpenReconLabel.json
+    - copy: openrecon_label /opt/code/python-ismrmrd-server/OpenReconLabel.json
     - copy: OpenReconREADME.md /opt/code/python-ismrmrd-server/OpenReconREADME.md
     - deploy:
           bins:
@@ -75,8 +96,13 @@ build:
             - /opt/spinalcordtoolbox-{{ context.version }}/bin/
 readme: |-
   ----------------------------------
-  ## spinalcordtoolbox/{{ context.version }} ##
+  ## {{ context.name }}/{{ context.version }} ##
   This packages upstream SCT {{ context.upstream_version }}.
+  {% if context.options.gpu %}
+  This variant installs SCT's CUDA-enabled PyTorch environment.
+  {% else %}
+  This is the CPU-only variant. Use spinalcordtoolbox_gpu for CUDA support.
+  {% endif %}
 
   SCT tools process MRI data (NIfTI files) and can do fully automatic tasks such as:
   - Segmentation of the spinal cord and gray matter
@@ -97,7 +123,7 @@ readme: |-
 
   More documentation can be found here: https://spinalcordtoolbox.com/en/latest/user_section/getting-started.html
 
-  To run container outside of this environment: ml spinalcordtoolbox/{{ context.version }}
+  To run container outside of this environment: ml {{ context.name }}/{{ context.version }}
 
   license: LGPLv3 (https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/LICENSE)
 
@@ -109,3 +135,9 @@ icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNS
 files:
   - name: downloaded_tar_file
     url: https://github.com/spinalcordtoolbox/spinalcordtoolbox/archive/refs/tags/{{ context.upstream_version }}.tar.gz
+  - name: openrecon_label
+    filename: OpenReconLabel.json
+    condition: not context.options.gpu
+  - name: openrecon_label
+    filename: OpenReconLabel.gpu.json
+    condition: context.options.gpu

--- a/recipes/spinalcordtoolbox/fulltest.yaml
+++ b/recipes/spinalcordtoolbox/fulltest.yaml
@@ -54,10 +54,25 @@ tests:
     command: sct_version
     expected_output_contains: "${upstream_version}"
 
-  - name: CUDA-enabled PyTorch build
-    description: Verify SCT's isolated Python environment contains a CUDA-enabled PyTorch build
-    command: /opt/spinalcordtoolbox-${version}/python/envs/venv_sct/bin/python -c 'import os, torch; assert torch.version.cuda; assert os.environ.get("SCT_USE_GPU") == "1"; print(f"cuda={torch.version.cuda}")'
-    expected_output_contains: "cuda="
+  - name: OpenRecon GPU declaration matches PyTorch
+    description: Verify the staged OpenRecon label matches the installed PyTorch build
+    command: |
+      /opt/spinalcordtoolbox-${version}/python/envs/venv_sct/bin/python - <<'PY'
+      import json
+      from pathlib import Path
+
+      import torch
+
+      label = json.loads(
+          Path("/opt/code/python-ismrmrd-server/OpenReconLabel.json").read_text()
+      )
+      reconstruction = label["reconstruction"]
+      has_cuda = torch.version.cuda is not None
+      assert reconstruction["can_use_gpu"] is has_cuda
+      assert reconstruction["min_count_required_gpus"] == (1 if has_cuda else 0)
+      assert reconstruction["min_required_gpu_memory"] == (10048 if has_cuda else 0)
+      PY
+    expected_exit_code: 0
 
   # ==========================================================================
   # IMAGE CONVERSION (sct_convert)

--- a/recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py
+++ b/recipes/spinalcordtoolbox/test_spinalcordtoolbox_openrecon.py
@@ -16,6 +16,7 @@ import pytest
 RECIPE_DIR = Path(__file__).resolve().parent
 WRAPPER_PATH = RECIPE_DIR / "spinalcordtoolbox.py"
 LABEL_PATH = RECIPE_DIR / "OpenReconLabel.json"
+GPU_LABEL_PATH = RECIPE_DIR / "OpenReconLabel.gpu.json"
 NIFTI2MRD_PATH = RECIPE_DIR / "nifti2mrd.py"
 
 
@@ -394,6 +395,43 @@ def test_openrecon_exposes_all_supported_deepseg_tasks():
     for analysis_id in EXPECTED_HIDDEN_ANALYSIS_CHOICES:
         assert analysis_id not in choices
     assert "sct_label_vertebrae" in choices
+
+
+def test_cpu_and_gpu_labels_only_differ_in_identity_and_gpu_requirements():
+    cpu_label = json.loads(LABEL_PATH.read_text())
+    gpu_label = json.loads(GPU_LABEL_PATH.read_text())
+
+    assert cpu_label["parameters"] == gpu_label["parameters"]
+    assert cpu_label["general"]["regulatory_information"] == gpu_label["general"][
+        "regulatory_information"
+    ]
+
+    cpu_general = copy.deepcopy(cpu_label["general"])
+    gpu_general = copy.deepcopy(gpu_label["general"])
+    for field in ("name", "information", "id"):
+        cpu_general.pop(field)
+        gpu_general.pop(field)
+    assert cpu_general == gpu_general
+    assert cpu_label["general"]["id"] == "spinalcordtoolbox"
+    assert gpu_label["general"]["id"] == "spinalcordtoolbox_gpu"
+
+    cpu_reconstruction = copy.deepcopy(cpu_label["reconstruction"])
+    gpu_reconstruction = copy.deepcopy(gpu_label["reconstruction"])
+    gpu_fields = (
+        "can_use_gpu",
+        "min_count_required_gpus",
+        "min_required_gpu_memory",
+    )
+    for field in gpu_fields:
+        cpu_reconstruction.pop(field)
+        gpu_reconstruction.pop(field)
+    assert cpu_reconstruction == gpu_reconstruction
+    assert cpu_label["reconstruction"]["can_use_gpu"] is False
+    assert cpu_label["reconstruction"]["min_count_required_gpus"] == 0
+    assert cpu_label["reconstruction"]["min_required_gpu_memory"] == 0
+    assert gpu_label["reconstruction"]["can_use_gpu"] is True
+    assert gpu_label["reconstruction"]["min_count_required_gpus"] == 1
+    assert gpu_label["reconstruction"]["min_required_gpu_memory"] == 10048
 
 
 def test_openrecon_exposes_combined_analysis_bundles():


### PR DESCRIPTION
The default `spinalcordtoolbox` container now installs CPU-only PyTorch. The named `gpu` variant publishes as `spinalcordtoolbox_gpu` and installs SCT's CUDA-enabled PyTorch environment. Both variants install all 18 model families.

The CPU image no longer carries the CUDA stack. Both builds clear SCT installer packages and model-download caches. Separate OpenRecon labels describe each image's actual accelerator requirement, and the shared full test checks that the staged label matches the installed PyTorch build.

Checks run locally:

- recipe validation for 7.3.3
- generated and staged both concrete variants
- confirmed identical 18-model install lists
- validated both OpenRecon labels
- 264 builder tests
- 65 spinalcordtoolbox OpenRecon tests
