### PR TITLE
Fix OpenRecon sync imports in promotion

### DIFF
--- a/builder/tests/test_sync_openrecon.py
+++ b/builder/tests/test_sync_openrecon.py
@@ -1,10 +1,32 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from tools import sync_openrecon
+
+
+def test_sync_openrecon_runs_as_workflow_script(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "tools" / "sync_openrecon.py"
+    isolated_runner = (
+        "import runpy, sys, types; "
+        "sys.modules['yaml'] = types.ModuleType('yaml'); "
+        "sys.argv = ['sync_openrecon.py', '--help']; "
+        f"runpy.run_path({str(script)!r}, run_name='__main__')"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", isolated_runner],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def write_source_recipe(root: Path, recipe: str = "demo") -> None:

--- a/tools/sync_openrecon.py
+++ b/tools/sync_openrecon.py
@@ -8,11 +8,16 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Sequence
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(SCRIPT_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_REPO_ROOT))
 
 import yaml
 


### PR DESCRIPTION
## Summary

- add the repository root to `sys.path` before importing `builder.variants`
- cover the exact workflow script invocation in an isolated subprocess

## Why

Promotion run `33698825453` published the tested container, then failed OpenRecon synchronization because `python tools/sync_openrecon.py` could not import `builder`. The promotion job installs dependencies but does not install this repository as a package.

## Verification

- `uv run pytest -q builder/tests/test_sync_openrecon.py`
- `uv run pytest -q builder/tests` (265 passed)