### PR TITLE
Allow large candidate promotions to finish

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -205,6 +205,7 @@ jobs:
       needs.resolve.outputs.should_promote == 'true' &&
       needs.resolve.outputs.recipes != '[]'
     runs-on: neurodesk-syd-arcrunner-neurocontainers
+    timeout-minutes: 720
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
## Summary

- give the self-hosted candidate promotion job a 12-hour timeout
- retain the default timeouts for the GitHub-hosted planning and candidate-gate jobs

## Why

Promotion run 33704369038 downloaded and checksum-verified the two spinalcordtoolbox variants, then GitHub cancelled the job at the default six-hour limit during serial multi-registry publication. Large all-model variants need more than the default job window.

## Verification

- `pytest -q builder/tests` (265 passed)
- parsed the workflow YAML and verified `jobs.promote.timeout-minutes == 720`