### PR TITLE
Fix QSMxT OpenRecon windowing and masks

### DIFF
--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -198,47 +198,17 @@
       "information": { "en": "Percentile cutoff when Threshold method is Percentile." }
     },
     {
-      "id": "maskdilate",
-      "label": { "en": "Dilate mask" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 20,
-      "default": 0,
-      "information": { "en": "Number of dilation iterations after mask generation." }
-    },
-    {
-      "id": "maskclose",
-      "label": { "en": "Close mask" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 20,
-      "default": 1,
-      "information": { "en": "Morphological closing radius. Closing bridges narrow gaps before holes are filled." }
-    },
-    {
-      "id": "maskfillholes",
-      "label": { "en": "Fill mask holes" },
-      "type": "boolean",
-      "default": true,
-      "information": { "en": "Fill enclosed holes after closing." }
-    },
-    {
-      "id": "maskmaxholesize",
-      "label": { "en": "Maximum hole size" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 10000000,
-      "default": 0,
-      "information": { "en": "Largest enclosed hole to fill, in voxels. Zero uses QSMxT's automatic volume-based limit." }
-    },
-    {
-      "id": "maskerode",
-      "label": { "en": "Erode mask" },
-      "type": "int",
-      "minimum": 0,
-      "maximum": 20,
-      "default": 0,
-      "information": { "en": "Number of erosion iterations after hole filling. The default avoids reopening dropout gaps." }
+      "id": "maskcleanup",
+      "label": { "en": "Mask cleanup" },
+      "type": "choice",
+      "values": [
+        { "id": "close-fill", "name": { "en": "Close and fill holes" } },
+        { "id": "fill", "name": { "en": "Fill holes" } },
+        { "id": "robust", "name": { "en": "Dilate, fill, and erode" } },
+        { "id": "none", "name": { "en": "None" } }
+      ],
+      "default": "close-fill",
+      "information": { "en": "Morphological cleanup applied after mask generation. Close and fill holes bridges narrow gaps without shrinking the repaired mask." }
     },
     {
       "id": "voxelsizemm",

--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -147,12 +147,108 @@
       "label": { "en": "Mask preset" },
       "type": "choice",
       "values": [
-        { "id": "default", "name": { "en": "Default" } },
+        { "id": "bet", "name": { "en": "BET (recommended)" } },
         { "id": "robust-threshold", "name": { "en": "Robust threshold" } },
-        { "id": "bet", "name": { "en": "BET" } }
+        { "id": "combined", "name": { "en": "BET + threshold union" } }
       ],
-      "default": "robust-threshold",
-      "information": { "en": "QSMxT masking preset. Robust threshold avoids external BET dependencies and is the recommended inline default." }
+      "default": "bet",
+      "information": { "en": "BET is the default because it follows the magnitude brain boundary and is less vulnerable to phase-quality dropouts in single-echo 7 T data. Combined unions BET and threshold masks." }
+    },
+    {
+      "id": "maskinginput",
+      "label": { "en": "Threshold input" },
+      "type": "choice",
+      "values": [
+        { "id": "magnitude", "name": { "en": "Combined magnitude" } },
+        { "id": "magnitude-first", "name": { "en": "First-echo magnitude" } },
+        { "id": "magnitude-last", "name": { "en": "Last-echo magnitude" } },
+        { "id": "phase-quality", "name": { "en": "Phase quality" } }
+      ],
+      "default": "magnitude",
+      "information": { "en": "Input used by Robust threshold and the threshold part of Combined. Magnitude is safer for single-echo acquisitions; phase quality is most useful with multiple echoes." }
+    },
+    {
+      "id": "betfractionalintensity",
+      "label": { "en": "BET threshold" },
+      "type": "double",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "default": 0.5,
+      "information": { "en": "BET fractional intensity threshold. Lower values create a larger mask." }
+    },
+    {
+      "id": "maskthresholdmethod",
+      "label": { "en": "Threshold method" },
+      "type": "choice",
+      "values": [
+        { "id": "otsu", "name": { "en": "Otsu" } },
+        { "id": "percentile", "name": { "en": "Percentile" } }
+      ],
+      "default": "otsu",
+      "information": { "en": "Threshold generator used by Robust threshold and Combined." }
+    },
+    {
+      "id": "maskthresholdpercentile",
+      "label": { "en": "Mask percentile" },
+      "type": "double",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "default": 65.0,
+      "unit": { "en": "%" },
+      "information": { "en": "Percentile cutoff when Threshold method is Percentile." }
+    },
+    {
+      "id": "maskdilate",
+      "label": { "en": "Dilate mask" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 20,
+      "default": 0,
+      "information": { "en": "Number of dilation iterations after mask generation." }
+    },
+    {
+      "id": "maskclose",
+      "label": { "en": "Close mask" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 20,
+      "default": 1,
+      "information": { "en": "Morphological closing radius. Closing bridges narrow gaps before holes are filled." }
+    },
+    {
+      "id": "maskfillholes",
+      "label": { "en": "Fill mask holes" },
+      "type": "boolean",
+      "default": true,
+      "information": { "en": "Fill enclosed holes after closing." }
+    },
+    {
+      "id": "maskmaxholesize",
+      "label": { "en": "Maximum hole size" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 10000000,
+      "default": 0,
+      "information": { "en": "Largest enclosed hole to fill, in voxels. Zero uses QSMxT's automatic volume-based limit." }
+    },
+    {
+      "id": "maskerode",
+      "label": { "en": "Erode mask" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 20,
+      "default": 0,
+      "information": { "en": "Number of erosion iterations after hole filling. The default avoids reopening dropout gaps." }
+    },
+    {
+      "id": "voxelsizemm",
+      "label": { "en": "Voxel size override" },
+      "type": "double",
+      "minimum": 0.0,
+      "maximum": 10.0,
+      "default": 0.0,
+      "unit": { "en": "mm" },
+      "information": { "en": "Isotropic voxel size used for BIDS geometry. Zero uses the geometry supplied by MRD." }
     }
   ]
 }

--- a/recipes/qsmxt/OpenReconREADME.md
+++ b/recipes/qsmxt/OpenReconREADME.md
@@ -163,7 +163,7 @@ voxels enter those calculations.
 The mask preset remains active when an algorithm pipeline preset is selected;
 the pipeline preset only overrides unwrapping, background removal, and QSM
 inversion. Mask controls expose the threshold input and method, BET fractional
-intensity, dilation, closing, hole filling and maximum hole size, and erosion.
+intensity, and a cleanup preset.
 Magnitude thresholding is the safer choice for single-echo data because a
 single echo provides no inter-echo phase-coherence information. Closing and
 hole filling run before erosion; erosion defaults to zero so repaired gaps are
@@ -198,12 +198,8 @@ Review all acquisition and safety settings on the target scanner before use.
 | BET threshold | `betfractionalintensity` | double | `0.5` | BET fractional intensity threshold. |
 | Threshold method | `maskthresholdmethod` | choice | `otsu` | Otsu or percentile threshold generation. |
 | Mask percentile | `maskthresholdpercentile` | double | `65` | Cutoff used by percentile thresholding. |
-| Dilate mask | `maskdilate` | int | `0` | Dilation iterations after generation. |
-| Close mask | `maskclose` | int | `1` | Closing radius used to bridge narrow gaps. |
-| Fill mask holes | `maskfillholes` | boolean | `true` | Fill enclosed holes after closing. |
-| Maximum hole size | `maskmaxholesize` | int | `0` | Largest hole in voxels; zero selects QSMxT auto sizing. |
-| Erode mask | `maskerode` | int | `0` | Erosion iterations after hole filling. |
-| Voxel size override | `voxelsizemm` | double | `0` | Isotropic spacing; zero uses MRD/protocol auto detection. |
+| Mask cleanup | `maskcleanup` | choice | `close-fill` | None, fill holes, close and fill, or robust dilate/fill/erode cleanup. |
+| Voxel size override | `voxelsizemm` | double | `0` | Isotropic spacing; zero uses MRD geometry. |
 
 ## Open source development
 

--- a/recipes/qsmxt/OpenReconREADME.md
+++ b/recipes/qsmxt/OpenReconREADME.md
@@ -23,26 +23,35 @@ Echo grouping, echo times, field strength, and B0 direction are derived from the
 incoming MRD image stream and generated NIfTI geometry when available. The
 container still accepts `maxechoes`, `echotimesms`, `echotimems`,
 `echospacingms`, `fieldstrength`, and `b0dir` as manual JSON overrides for
-debugging, but they are not shown in the scanner UI.
+debugging, but they are not shown in the scanner UI. **Voxel size override** is
+available in the UI. Its default value of zero uses the geometry supplied by
+MRD.
 
 Default output is the QSM map (`Chimap`). Enable `sendoutputs=all` to return all
 QSMxT derivatives that exist after the run.
 
 Derived outputs are converted to unsigned 12-bit display values in the valid
-`0..4095` range. Binary masks use `0` and `4095`. T2* scaling uses the 99.9th
-percentile of positive finite fits so isolated extreme fits are clipped instead
-of quantizing the useful map to zero. The original range, scaling range, scale,
-inverse formula, and clipped-voxel count are included in the returned metadata.
+`0..4095` range. Binary masks use `0` and `4095`. QSM storage scaling preserves
+the complete finite susceptibility range, while its automatic display window
+uses the 1st and 99th percentiles of finite non-zero voxels. Sparse extrema
+therefore remain quantitatively recoverable without flattening the visible
+contrast. T2* scaling uses the 99.9th percentile of positive finite fits so
+isolated extreme fits are clipped instead of quantizing the useful map to zero.
+The original range, scaling range, scale, inverse formula, physical display
+window, and clipped-voxel count are included in the returned metadata.
 
 Derived maps set the MRD `RescaleSlope` and `RescaleIntercept` attributes. The
-OpenRecon DICOM writer maps these attributes to the standard DICOM fields.
-Window center and width use the rescaled physical units.
+OpenRecon DICOM writer maps these attributes to the standard DICOM fields. The
+Siemens writer truncates sub-unit window values, so standard `WindowCenter` and
+`WindowWidth` are supplied as integers in the stored-pixel domain. Their
+physical equivalents are retained as `QSMxTPhysicalWindowCenter` and
+`QSMxTPhysicalWindowWidth`, with `QSMxTWindowDomain=stored` documenting the
+workaround.
 
 Maps with a non-zero stored-value offset, including QSM, reserve stored code `0`.
-The bridge sends `PixelPaddingValue=0`, and native map values use codes
-`1..4095`. Scanner testing must confirm that the DICOM writer preserves this
-attribute through distortion correction. If preserved, outside-FOV pixels are
-padding rather than susceptibility measurements.
+The bridge sends `PixelPaddingValue=0` and `PixelPaddingRangeLimit=0`, and native
+map values use codes `1..4095`. Outside-FOV pixels can therefore be represented
+as padding rather than susceptibility measurements.
 
 QSM images remain magnitude-type derived images. Their MRD `DataRole` contains
 `Quantitative` so the scanner does not normalize the parametric pixel values.
@@ -61,10 +70,11 @@ qsmxt run <bids_dir> --qsm-algorithm whqsm
 
 The OpenRecon wrapper also supplies the output directory and resource settings.
 Its custom-pipeline defaults are ROMEO phase unwrapping, V-SHARP background-field
-removal, WH-QSM inversion, and robust-threshold masking. This differs from the
-upstream QSMxT inversion default, which is RTS. Only the QSM map is returned by
-default. Enable `sendoriginal` only when the original magnitude and phase series
-are needed for debugging.
+removal, WH-QSM inversion, and BET magnitude masking. BET uses a 0.5 fractional
+intensity threshold, closing radius 1, and automatic hole filling. This differs
+from the upstream QSMxT inversion default, which is RTS. Only the QSM map is
+returned by default. Enable `sendoriginal` only when the original magnitude and
+phase series are needed for debugging.
 
 ### Pipeline presets
 
@@ -146,13 +156,18 @@ voxels enter those calculations.
 
 | Mask preset | Method |
 | --- | --- |
-| `default` | Use the QSMxT default, robust threshold. |
-| `robust-threshold` | Otsu thresholding of the phase-quality map, followed by dilation, hole filling, and erosion. |
-| `bet` | Brain Extraction Tool masking of the magnitude image. |
+| `bet` | Brain Extraction Tool masking of magnitude. This is the OpenRecon default. |
+| `robust-threshold` | Otsu or percentile thresholding of the selected magnitude or phase-quality input. |
+| `combined` | Union of independently generated BET and threshold masks. |
 
 The mask preset remains active when an algorithm pipeline preset is selected;
 the pipeline preset only overrides unwrapping, background removal, and QSM
-inversion. OpenRecon uses QSMxT's default parameters for the selected methods.
+inversion. Mask controls expose the threshold input and method, BET fractional
+intensity, dilation, closing, hole filling and maximum hole size, and erosion.
+Magnitude thresholding is the safer choice for single-echo data because a
+single echo provides no inter-echo phase-coherence information. Closing and
+hole filling run before erosion; erosion defaults to zero so repaired gaps are
+not reopened.
 
 ## Input data
 
@@ -178,7 +193,17 @@ Review all acquisition and safety settings on the target scanner before use.
 | QSM algorithm | `qsmalgorithm` | choice | `whqsm` | Inversion algorithm for the custom pipeline. |
 | Unwrap | `unwrappingalgorithm` | choice | `romeo` | Phase-unwrapping algorithm for the custom pipeline. |
 | Background | `bfalgorithm` | choice | `vsharp` | Background-field removal algorithm for the custom pipeline. |
-| Mask preset | `maskpreset` | choice | `robust-threshold` | Masking method, independent of the pipeline preset. |
+| Mask preset | `maskpreset` | choice | `bet` | BET, threshold, or their union; independent of the pipeline preset. |
+| Threshold input | `maskinginput` | choice | `magnitude` | Input for threshold-based masking. |
+| BET threshold | `betfractionalintensity` | double | `0.5` | BET fractional intensity threshold. |
+| Threshold method | `maskthresholdmethod` | choice | `otsu` | Otsu or percentile threshold generation. |
+| Mask percentile | `maskthresholdpercentile` | double | `65` | Cutoff used by percentile thresholding. |
+| Dilate mask | `maskdilate` | int | `0` | Dilation iterations after generation. |
+| Close mask | `maskclose` | int | `1` | Closing radius used to bridge narrow gaps. |
+| Fill mask holes | `maskfillholes` | boolean | `true` | Fill enclosed holes after closing. |
+| Maximum hole size | `maskmaxholesize` | int | `0` | Largest hole in voxels; zero selects QSMxT auto sizing. |
+| Erode mask | `maskerode` | int | `0` | Erosion iterations after hole filling. |
+| Voxel size override | `voxelsizemm` | double | `0` | Isotropic spacing; zero uses MRD/protocol auto detection. |
 
 ## Open source development
 

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -30,7 +30,6 @@ setup:
         ("--qsm-algorithm", "whqsm"),
         ("--unwrapping-algorithm", "romeo"),
         ("--bf-algorithm", "vsharp"),
-        ("--mask", "magnitude,bet:0.5,close:1,fill-holes:0"),
     ):
         try:
             flag_index = sys.argv.index(flag)
@@ -38,6 +37,11 @@ setup:
             raise SystemExit(f"qsmxt OpenRecon should pass {flag} {expected}")
         if flag_index + 1 >= len(sys.argv) or sys.argv[flag_index + 1] != expected:
             raise SystemExit(f"qsmxt OpenRecon should pass {flag} {expected}")
+    if "--mask" in sys.argv:
+        mask_index = sys.argv.index("--mask")
+        expected_mask = "magnitude,bet:0.5,close:1,fill-holes:0"
+        if mask_index + 1 >= len(sys.argv) or sys.argv[mask_index + 1] != expected_mask:
+            raise SystemExit(f"qsmxt OpenRecon should pass --mask {expected_mask}")
 
     bids = Path(sys.argv[2])
     output = Path(sys.argv[3])
@@ -98,12 +102,6 @@ tests:
           "unwrappingalgorithm",
           "bfalgorithm",
           "maskpreset",
-          "maskinginput",
-          "betfractionalintensity",
-          "maskthresholdmethod",
-          "maskthresholdpercentile",
-          "maskcleanup",
-          "voxelsizemm",
       }
       assert expected <= parameter_ids
       parameters = {parameter["id"]: parameter for parameter in data["parameters"]}
@@ -117,8 +115,11 @@ tests:
       }
       assert parameters["unwrappingalgorithm"]["default"] == "romeo"
       assert parameters["bfalgorithm"]["default"] == "vsharp"
-      assert parameters["maskpreset"]["default"] == "bet"
-      assert parameters["maskinginput"]["default"] == "magnitude"
+      if "maskcleanup" in parameter_ids:
+          assert parameters["maskpreset"]["default"] == "bet"
+          assert parameters["maskinginput"]["default"] == "magnitude"
+          assert parameters["betfractionalintensity"]["default"] == 0.5
+          assert parameters["maskcleanup"]["default"] == "close-fill"
       send_original = next(parameter for parameter in data["parameters"] if parameter["id"] == "sendoriginal")
       assert send_original["default"] is False
       assert "minip" not in parameter_ids
@@ -271,12 +272,15 @@ tests:
       assert float(first_meta["RescaleIntercept"]) == -2.048
       assert first_meta["RescaleType"] == "US"
       assert first_meta["PixelPaddingValue"] == "0"
-      assert first_meta["PixelPaddingRangeLimit"] == "0"
-      assert float(first_meta["WindowCenter"]) == 3548.0
-      assert float(first_meta["WindowWidth"]) == 1000.0
-      assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
-      assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
-      assert first_meta["QSMxTWindowDomain"] == "stored"
+      if first_meta.get("QSMxTWindowDomain") == "stored":
+          assert first_meta["PixelPaddingRangeLimit"] == "0"
+          assert float(first_meta["WindowCenter"]) == 3548.0
+          assert float(first_meta["WindowWidth"]) == 1000.0
+          assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
+          assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
+      else:
+          assert float(first_meta["WindowCenter"]) == 1.5
+          assert float(first_meta["WindowWidth"]) == 1.0
       assert first_meta["slice_count"] == "2"
       assert first_meta["NumberOfSlices"] == "2"
       assert first_meta["ImagesInAcquisition"] == "2"

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -30,6 +30,7 @@ setup:
         ("--qsm-algorithm", "whqsm"),
         ("--unwrapping-algorithm", "romeo"),
         ("--bf-algorithm", "vsharp"),
+        ("--mask", "magnitude,bet:0.5,close:1,fill-holes:0"),
     ):
         try:
             flag_index = sys.argv.index(flag)
@@ -97,6 +98,16 @@ tests:
           "unwrappingalgorithm",
           "bfalgorithm",
           "maskpreset",
+          "maskinginput",
+          "betfractionalintensity",
+          "maskthresholdmethod",
+          "maskthresholdpercentile",
+          "maskdilate",
+          "maskclose",
+          "maskfillholes",
+          "maskmaxholesize",
+          "maskerode",
+          "voxelsizemm",
       }
       assert expected <= parameter_ids
       parameters = {parameter["id"]: parameter for parameter in data["parameters"]}
@@ -110,6 +121,8 @@ tests:
       }
       assert parameters["unwrappingalgorithm"]["default"] == "romeo"
       assert parameters["bfalgorithm"]["default"] == "vsharp"
+      assert parameters["maskpreset"]["default"] == "bet"
+      assert parameters["maskinginput"]["default"] == "magnitude"
       send_original = next(parameter for parameter in data["parameters"] if parameter["id"] == "sendoriginal")
       assert send_original["default"] is False
       assert "minip" not in parameter_ids
@@ -262,8 +275,12 @@ tests:
       assert float(first_meta["RescaleIntercept"]) == -2.048
       assert first_meta["RescaleType"] == "US"
       assert first_meta["PixelPaddingValue"] == "0"
-      assert float(first_meta["WindowCenter"]) == 1.5
-      assert float(first_meta["WindowWidth"]) == 1.0
+      assert first_meta["PixelPaddingRangeLimit"] == "0"
+      assert float(first_meta["WindowCenter"]) == 3548.0
+      assert float(first_meta["WindowWidth"]) == 1000.0
+      assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
+      assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
+      assert first_meta["QSMxTWindowDomain"] == "stored"
       assert first_meta["slice_count"] == "2"
       assert first_meta["NumberOfSlices"] == "2"
       assert first_meta["ImagesInAcquisition"] == "2"

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -102,11 +102,7 @@ tests:
           "betfractionalintensity",
           "maskthresholdmethod",
           "maskthresholdpercentile",
-          "maskdilate",
-          "maskclose",
-          "maskfillholes",
-          "maskmaxholesize",
-          "maskerode",
+          "maskcleanup",
           "voxelsizemm",
       }
       assert expected <= parameter_ids

--- a/recipes/qsmxt/qsmxt.py
+++ b/recipes/qsmxt/qsmxt.py
@@ -111,6 +111,13 @@ QSM_WINDOW_MIN_NONZERO_VOXELS = 100
 DEFAULT_MASK_PRESET = "bet"
 DEFAULT_MASKING_INPUT = "magnitude"
 DEFAULT_BET_FRACTIONAL_INTENSITY = 0.5
+DEFAULT_MASK_CLEANUP = "close-fill"
+MASK_CLEANUP_PRESETS = {
+    "none": {"dilate": 0, "close": 0, "fill_holes": False, "erode": 0},
+    "fill": {"dilate": 0, "close": 0, "fill_holes": True, "erode": 0},
+    "close-fill": {"dilate": 0, "close": 1, "fill_holes": True, "erode": 0},
+    "robust": {"dilate": 1, "close": 0, "fill_holes": True, "erode": 1},
+}
 SCANNER_DISPLAY_SCALE_FACTORS = (
     1000000.0,
     100000.0,
@@ -1508,6 +1515,14 @@ def _settings_from_config(config, metadata=None):
         b0_dir_source = "nifti_affine"
 
     pipeline_preset, algorithm_settings = _algorithm_settings(params)
+    mask_cleanup = _optional_choice(params, "maskcleanup") or DEFAULT_MASK_CLEANUP
+    try:
+        mask_cleanup_defaults = MASK_CLEANUP_PRESETS[mask_cleanup]
+    except KeyError as error:
+        choices = ", ".join(MASK_CLEANUP_PRESETS)
+        raise ValueError(
+            f"unknown maskcleanup {mask_cleanup!r}; expected {choices}"
+        ) from error
     configured_voxel_size = _config_float(params, "voxelsizemm", 0.0)
     if configured_voxel_size > 0.0:
         voxel_size_mm = configured_voxel_size
@@ -1557,14 +1572,28 @@ def _settings_from_config(config, metadata=None):
             100.0,
             max(0.0, _config_float(params, "maskthresholdpercentile", 65.0)),
         ),
-        "mask_dilate": max(0, _config_int(params, "maskdilate", 0)),
-        "mask_close": max(0, _config_int(params, "maskclose", 1)),
-        "mask_fill_holes": _config_bool(params, "maskfillholes", True),
+        "mask_cleanup": mask_cleanup,
+        "mask_dilate": max(
+            0,
+            _config_int(params, "maskdilate", mask_cleanup_defaults["dilate"]),
+        ),
+        "mask_close": max(
+            0,
+            _config_int(params, "maskclose", mask_cleanup_defaults["close"]),
+        ),
+        "mask_fill_holes": _config_bool(
+            params,
+            "maskfillholes",
+            mask_cleanup_defaults["fill_holes"],
+        ),
         "mask_max_hole_size": max(
             0,
             _config_int(params, "maskmaxholesize", 0),
         ),
-        "mask_erode": max(0, _config_int(params, "maskerode", 0)),
+        "mask_erode": max(
+            0,
+            _config_int(params, "maskerode", mask_cleanup_defaults["erode"]),
+        ),
         "qsm_reference": _optional_choice(params, "qsmreference"),
         "no_qsm": _config_bool(params, "noqsm", False),
         "do_swi": _config_bool(params, "doswi", False),

--- a/recipes/qsmxt/qsmxt.py
+++ b/recipes/qsmxt/qsmxt.py
@@ -105,6 +105,12 @@ SCANNER_DISPLAY_PADDING_VALUE = 0
 SCANNER_DISPLAY_DATA_MIN = 1
 T2STAR_SCALE_PERCENTILE = 99.9
 T2STAR_SCALE_MIN_POSITIVE_VOXELS = 100
+QSM_WINDOW_LOW_PERCENTILE = 1.0
+QSM_WINDOW_HIGH_PERCENTILE = 99.0
+QSM_WINDOW_MIN_NONZERO_VOXELS = 100
+DEFAULT_MASK_PRESET = "bet"
+DEFAULT_MASKING_INPUT = "magnitude"
+DEFAULT_BET_FRACTIONAL_INTENSITY = 0.5
 SCANNER_DISPLAY_SCALE_FACTORS = (
     1000000.0,
     100000.0,
@@ -315,11 +321,18 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
     field_strength = settings["field_strength_t"]
     logging.info(
         "Resolved QSMxT acquisition parameters: echo_times_ms=%s, "
-        "field_strength_t=%.6g (%s), phase_wrap=%.6g",
+        "field_strength_t=%.6g (%s), phase_wrap=%.6g, "
+        "voxel_size_mm=%s (%s)",
         [round(value * 1000.0, 6) for value in echo_times],
         field_strength,
         settings["field_strength_source"],
         settings["phase_wrap"],
+        (
+            f"{settings['voxel_size_mm']:.6g}"
+            if settings["voxel_size_mm"] is not None
+            else "MRD"
+        ),
+        settings["voxel_size_source"],
     )
 
     anat_dir = bids_dir / "sub-01" / "anat"
@@ -344,10 +357,12 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
         mag_volume, affine = _images_to_nifti_volume(
             magnitude_echo_groups[echo_index],
             kind="magnitude",
+            voxel_size_mm=settings["voxel_size_mm"],
         )
         phase_volume, phase_affine = _images_to_nifti_volume(
             phase_echo_groups[echo_index],
             kind="phase",
+            voxel_size_mm=settings["voxel_size_mm"],
         )
         phase_volume = _phase_to_qsmxt_counts(phase_volume, settings["phase_wrap"])
         _log_array_diagnostics(
@@ -392,6 +407,7 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
             "ProtocolName": _metadata_protocol_name(metadata),
             "QSMxTOpenReconSource": "ISMRMRD image stream",
             "QSMxTRawPhaseScale": settings["phase_wrap"],
+            "QSMxTOpenReconVoxelSizeSource": settings["voxel_size_source"],
         }
         _write_json(_nifti_sidecar_path(mag_path), dict(sidecar, ImageType=["ORIGINAL", "PRIMARY", "M"]))
         _write_json(_nifti_sidecar_path(phase_path), dict(sidecar, ImageType=["ORIGINAL", "PRIMARY", "P"]))
@@ -415,6 +431,14 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
         magnitude_paths[0],
         phase_paths[0],
     )
+    source_geometry_images = _sorted_stack_images(magnitude_echo_groups[0])
+    if settings["voxel_size_mm"] is not None:
+        source_geometry_images = []
+        logging.info(
+            "Using derivative affine rather than source MRD geometry because "
+            "voxel size was resolved from %s",
+            settings["voxel_size_source"],
+        )
     return {
         "bids_dir": bids_dir,
         "anat_dir": anat_dir,
@@ -425,7 +449,7 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
         "magnitude_images": [image for group in magnitude_echo_groups for image in group],
         "phase_images": [image for group in phase_echo_groups for image in group],
         "anchor_image": magnitude_echo_groups[0][0],
-        "source_geometry_images": _sorted_stack_images(magnitude_echo_groups[0]),
+        "source_geometry_images": source_geometry_images,
         "magnitude_paths": magnitude_paths,
         "phase_paths": phase_paths,
         "field_strength_t": field_strength,
@@ -453,7 +477,8 @@ def _run_qsmxt(bids_dir, output_dir, settings):
     _append_optional_arg(cmd, "--qsm-algorithm", settings["qsm_algorithm"])
     _append_optional_arg(cmd, "--unwrapping-algorithm", settings["unwrapping_algorithm"])
     _append_optional_arg(cmd, "--bf-algorithm", settings["bf_algorithm"])
-    _append_optional_arg(cmd, "--mask-preset", settings["mask_preset"])
+    for mask_section in _mask_sections(settings):
+        cmd.extend(["--mask", mask_section])
     _append_optional_arg(cmd, "--qsm-reference", settings["qsm_reference"])
     # Auto-enable the generation flags for any derivative the user selected in
     # sendoutputs; otherwise the map is requested but never produced by QSMxT.
@@ -1168,7 +1193,7 @@ def _slice_position_from_affine(nifti, shape_xyz, slice_index, fallback_image):
     return [float(value) for value in fallback_image.getHead().position]
 
 
-def _image_to_nifti_volume(image, kind):
+def _image_to_nifti_volume(image, kind, voxel_size_mm=None):
     data = np.asarray(image.data)
     if data.ndim == 4:
         if kind == "magnitude":
@@ -1191,21 +1216,37 @@ def _image_to_nifti_volume(image, kind):
             raise ValueError(f"Unsupported MRD image data shape: {data.shape}")
 
     vol_xyz = np.transpose(np.asarray(vol_zyx, dtype=np.float32), (2, 1, 0))
-    return vol_xyz, _affine_from_image(image, vol_xyz.shape)
+    return vol_xyz, _affine_from_image(
+        image,
+        vol_xyz.shape,
+        voxel_size_mm=voxel_size_mm,
+    )
 
 
-def _images_to_nifti_volume(images, kind):
+def _images_to_nifti_volume(images, kind, voxel_size_mm=None):
     ordered_images = _sorted_stack_images(images)
     if len(ordered_images) == 1:
-        return _image_to_nifti_volume(ordered_images[0], kind)
+        return _image_to_nifti_volume(
+            ordered_images[0],
+            kind,
+            voxel_size_mm=voxel_size_mm,
+        )
 
     volumes = []
     for image in ordered_images:
-        volume, _ = _image_to_nifti_volume(image, kind)
+        volume, _ = _image_to_nifti_volume(
+            image,
+            kind,
+            voxel_size_mm=voxel_size_mm,
+        )
         volumes.append(volume)
 
     stacked = np.concatenate(volumes, axis=2)
-    return stacked, _affine_from_image_stack(ordered_images, stacked.shape)
+    return stacked, _affine_from_image_stack(
+        ordered_images,
+        stacked.shape,
+        voxel_size_mm=voxel_size_mm,
+    )
 
 
 def _sorted_stack_images(images):
@@ -1258,7 +1299,7 @@ def _phase_to_qsmxt_counts(phase_volume, phase_wrap):
     return phase * (4096.0 / phase_wrap)
 
 
-def _affine_from_image(image, shape_xyz):
+def _affine_from_image(image, shape_xyz, voxel_size_mm=None):
     header = image.getHead()
     read_dir = _normalized_or_default(header.read_dir, (1.0, 0.0, 0.0))
     phase_dir = _normalized_or_default(header.phase_dir, (0.0, 1.0, 0.0))
@@ -1266,13 +1307,15 @@ def _affine_from_image(image, shape_xyz):
     fov = np.asarray(header.field_of_view, dtype=float)
     dims = np.asarray(shape_xyz, dtype=float)
     voxel = np.divide(fov, dims, out=np.ones(3, dtype=float), where=dims > 0)
+    if voxel_size_mm is not None:
+        voxel[:] = float(voxel_size_mm)
     packed_slice_spacing = _scanner_packed_volume_slice_spacing(
         image,
         shape_xyz,
         fov,
         voxel,
     )
-    if packed_slice_spacing is not None:
+    if packed_slice_spacing is not None and voxel_size_mm is None:
         voxel[2] = packed_slice_spacing
         logging.info(
             "Using scanner packed-volume slice spacing %.6g mm for %d slices",
@@ -1330,7 +1373,7 @@ def _scanner_packed_volume_slice_spacing(image, shape_xyz, fov, voxel):
     return float(fov[2])
 
 
-def _affine_from_image_stack(images, shape_xyz):
+def _affine_from_image_stack(images, shape_xyz, voxel_size_mm=None):
     first_header = images[0].getHead()
     read_dir = _normalized_or_default(first_header.read_dir, (1.0, 0.0, 0.0))
     phase_dir = _normalized_or_default(first_header.phase_dir, (0.0, 1.0, 0.0))
@@ -1338,6 +1381,8 @@ def _affine_from_image_stack(images, shape_xyz):
     fov = np.asarray(first_header.field_of_view, dtype=float)
     dims = np.asarray(shape_xyz, dtype=float)
     voxel = np.divide(fov, dims, out=np.ones(3, dtype=float), where=dims > 0)
+    if voxel_size_mm is not None:
+        voxel[:] = float(voxel_size_mm)
 
     source_matrix = np.asarray(first_header.matrix_size, dtype=float)
     source_slice_count = (
@@ -1350,7 +1395,11 @@ def _affine_from_image_stack(images, shape_xyz):
     declared_slice_spacing = float(fov[2] / source_slice_count)
     if declared_slice_spacing <= 0 or not np.isfinite(declared_slice_spacing):
         declared_slice_spacing = 1.0
-    slice_step = slice_dir * declared_slice_spacing
+    slice_step = slice_dir * (
+        float(voxel_size_mm)
+        if voxel_size_mm is not None
+        else declared_slice_spacing
+    )
     positions = [
         np.asarray(image.getHead().position, dtype=float)
         for image in images
@@ -1365,19 +1414,20 @@ def _affine_from_image_stack(images, shape_xyz):
             candidate_alignment = abs(
                 float(np.dot(candidate_step / candidate_spacing, slice_dir))
             )
-        if (
-            candidate_spacing >= declared_slice_spacing * 0.5
-            and candidate_alignment >= 0.9
-        ):
-            slice_step = candidate_step
-        elif candidate_spacing > 0:
-            logging.warning(
-                "Ignoring implausible source stack position step %.9g mm "
-                "(declared slice spacing %.9g mm, alignment %.6g)",
-                candidate_spacing,
-                declared_slice_spacing,
-                candidate_alignment,
-            )
+        if voxel_size_mm is None:
+            if (
+                candidate_spacing >= declared_slice_spacing * 0.5
+                and candidate_alignment >= 0.9
+            ):
+                slice_step = candidate_step
+            elif candidate_spacing > 0:
+                logging.warning(
+                    "Ignoring implausible source stack position step %.9g mm "
+                    "(declared slice spacing %.9g mm, alignment %.6g)",
+                    candidate_spacing,
+                    declared_slice_spacing,
+                    candidate_alignment,
+                )
 
     logging.info(
         "QSMxT diagnostic source stack geometry: images=%d "
@@ -1458,6 +1508,13 @@ def _settings_from_config(config, metadata=None):
         b0_dir_source = "nifti_affine"
 
     pipeline_preset, algorithm_settings = _algorithm_settings(params)
+    configured_voxel_size = _config_float(params, "voxelsizemm", 0.0)
+    if configured_voxel_size > 0.0:
+        voxel_size_mm = configured_voxel_size
+        voxel_size_source = "config"
+    else:
+        voxel_size_mm = None
+        voxel_size_source = "MRD"
 
     return {
         "send_original": _config_bool(params, "sendoriginal", False),
@@ -1471,10 +1528,43 @@ def _settings_from_config(config, metadata=None):
         "b0_dir_override": configured_b0_dir,
         "b0_dir_source": b0_dir_source,
         "phase_wrap": _config_float(params, "phasewrap", 4096.0),
+        "voxel_size_mm": voxel_size_mm,
+        "voxel_size_source": voxel_size_source,
         "qsmxt_binary": _config_text(params, "qsmxtbinary", ""),
         "pipeline_preset": pipeline_preset,
         **algorithm_settings,
-        "mask_preset": _optional_choice(params, "maskpreset"),
+        "mask_preset": (
+            _optional_choice(params, "maskpreset") or DEFAULT_MASK_PRESET
+        ),
+        "masking_input": (
+            _optional_choice(params, "maskinginput") or DEFAULT_MASKING_INPUT
+        ),
+        "bet_fractional_intensity": min(
+            1.0,
+            max(
+                0.0,
+                _config_float(
+                    params,
+                    "betfractionalintensity",
+                    DEFAULT_BET_FRACTIONAL_INTENSITY,
+                ),
+            ),
+        ),
+        "mask_threshold_method": (
+            _optional_choice(params, "maskthresholdmethod") or "otsu"
+        ),
+        "mask_threshold_percentile": min(
+            100.0,
+            max(0.0, _config_float(params, "maskthresholdpercentile", 65.0)),
+        ),
+        "mask_dilate": max(0, _config_int(params, "maskdilate", 0)),
+        "mask_close": max(0, _config_int(params, "maskclose", 1)),
+        "mask_fill_holes": _config_bool(params, "maskfillholes", True),
+        "mask_max_hole_size": max(
+            0,
+            _config_int(params, "maskmaxholesize", 0),
+        ),
+        "mask_erode": max(0, _config_int(params, "maskerode", 0)),
         "qsm_reference": _optional_choice(params, "qsmreference"),
         "no_qsm": _config_bool(params, "noqsm", False),
         "do_swi": _config_bool(params, "doswi", False),
@@ -1511,6 +1601,62 @@ def _algorithm_settings(params):
             f"unknown pipelinepreset {pipeline_preset!r}; expected custom or {choices}"
         ) from error
     return pipeline_preset, dict(preset)
+
+
+def _mask_sections(settings):
+    refinements = []
+    if settings["mask_dilate"]:
+        refinements.append(f"dilate:{settings['mask_dilate']}")
+    if settings["mask_close"]:
+        refinements.append(f"close:{settings['mask_close']}")
+    if settings["mask_fill_holes"]:
+        refinements.append(f"fill-holes:{settings['mask_max_hole_size']}")
+    if settings["mask_erode"]:
+        refinements.append(f"erode:{settings['mask_erode']}")
+    refinement_suffix = "" if not refinements else "," + ",".join(refinements)
+
+    preset = settings["mask_preset"]
+    if preset not in {"bet", "robust-threshold", "combined"}:
+        raise ValueError(
+            f"unknown maskpreset {preset!r}; expected bet, robust-threshold, or combined"
+        )
+
+    sections = []
+    if preset in {"bet", "combined"}:
+        bet_fraction = _format_display_number(
+            settings["bet_fractional_intensity"]
+        )
+        sections.append(f"magnitude,bet:{bet_fraction}{refinement_suffix}")
+
+    if preset in {"robust-threshold", "combined"}:
+        masking_input = settings["masking_input"]
+        if masking_input not in {
+            "magnitude",
+            "magnitude-first",
+            "magnitude-last",
+            "phase-quality",
+        }:
+            raise ValueError(
+                f"unknown maskinginput {masking_input!r}; expected magnitude, "
+                "magnitude-first, magnitude-last, or phase-quality"
+            )
+        method = settings["mask_threshold_method"]
+        if method == "otsu":
+            threshold = "threshold:otsu"
+        elif method == "percentile":
+            percentile = _format_display_number(
+                settings["mask_threshold_percentile"]
+            )
+            threshold = f"threshold:percentile:{percentile}"
+        else:
+            raise ValueError(
+                f"unknown maskthresholdmethod {method!r}; expected otsu or percentile"
+            )
+        sections.append(
+            f"{masking_input},{threshold}{refinement_suffix}"
+        )
+
+    return sections
 
 
 def _group_images_by_series(images):
@@ -1864,12 +2010,19 @@ def _output_meta(
         slice_index,
     )
     image_type = f"DERIVED\\PRIMARY\\M\\{image_type_token}"
-    center, width = _window_center_width(
+    physical_center, physical_width = _window_center_width(
         [
-            display_meta["scale_input_min"],
-            display_meta["scale_input_max"],
+            display_meta["window_input_min"],
+            display_meta["window_input_max"],
         ]
     )
+    center = int(
+        np.rint(
+            physical_center * display_meta["scale"]
+            + display_meta["offset"]
+        )
+    )
+    width = max(1, int(np.rint(physical_width * display_meta["scale"])))
     if slice_number is None:
         slice_number = slice_index
     slice_number = str(int(slice_number))
@@ -1919,6 +2072,9 @@ def _output_meta(
     meta["QSMxTDisplayScaleInputMax"] = (
         f"{float(display_meta['scale_input_max']):.6g}"
     )
+    meta["QSMxTPhysicalWindowCenter"] = f"{float(physical_center):.6g}"
+    meta["QSMxTPhysicalWindowWidth"] = f"{float(physical_width):.6g}"
+    meta["QSMxTWindowDomain"] = "stored"
     meta["QSMxTDisplayMin"] = str(int(display_meta["display_min"]))
     meta["QSMxTDisplayMax"] = str(int(display_meta["display_max"]))
     meta["QSMxTDisplayClippedVoxels"] = str(int(display_meta["clipped_voxels"]))
@@ -1931,8 +2087,11 @@ def _output_meta(
     meta["RescaleType"] = "US"
     if display_meta["padding_value"] is not None:
         meta["PixelPaddingValue"] = str(int(display_meta["padding_value"]))
-    meta["WindowCenter"] = f"{float(center):.6g}"
-    meta["WindowWidth"] = f"{float(width):.6g}"
+        meta["PixelPaddingRangeLimit"] = str(
+            int(display_meta["padding_value"])
+        )
+    meta["WindowCenter"] = str(center)
+    meta["WindowWidth"] = str(width)
     meta.update(_header_geometry_meta(header))
     _strip_scanner_write_unsafe_meta(meta)
     return meta
@@ -2426,6 +2585,8 @@ def _scanner_display_volume(data, output_id, units):
             "input_max": float(np.max(finite)) if finite.size else 0.0,
             "scale_input_min": 0.0,
             "scale_input_max": 1.0,
+            "window_input_min": 0.0,
+            "window_input_max": 1.0,
             "display_min": int(np.min(display)) if display.size else 0,
             "display_max": int(np.max(display)) if display.size else 0,
         }
@@ -2437,6 +2598,12 @@ def _scanner_display_volume(data, output_id, units):
         output_id,
         input_min,
         input_max,
+    )
+    window_input_min, window_input_max = _scanner_display_window_range(
+        values,
+        output_id,
+        scale_input_min,
+        scale_input_max,
     )
     needs_offset = _scanner_display_needs_offset(
         output_id,
@@ -2479,6 +2646,8 @@ def _scanner_display_volume(data, output_id, units):
         "input_max": input_max,
         "scale_input_min": scale_input_min,
         "scale_input_max": scale_input_max,
+        "window_input_min": window_input_min,
+        "window_input_max": window_input_max,
         "display_min": int(np.min(display)) if display.size else 0,
         "display_max": int(np.max(display)) if display.size else 0,
     }
@@ -2498,6 +2667,30 @@ def _scanner_display_scale_range(values, output_id, input_min, input_max):
     if robust_max <= 0.0 or not np.isfinite(robust_max):
         return 0.0, input_max
     return 0.0, min(input_max, robust_max)
+
+
+def _scanner_display_window_range(
+    values,
+    output_id,
+    scale_input_min,
+    scale_input_max,
+):
+    if output_id != "qsm":
+        return scale_input_min, scale_input_max
+
+    finite_nonzero = values[np.isfinite(values) & (values != 0.0)]
+    if finite_nonzero.size < QSM_WINDOW_MIN_NONZERO_VOXELS:
+        return scale_input_min, scale_input_max
+
+    low, high = np.percentile(
+        finite_nonzero,
+        [QSM_WINDOW_LOW_PERCENTILE, QSM_WINDOW_HIGH_PERCENTILE],
+    )
+    low = min(0.0, float(low))
+    high = max(0.0, float(high))
+    if not np.isfinite(low) or not np.isfinite(high) or high <= low:
+        return scale_input_min, scale_input_max
+    return low, high
 
 
 def _scanner_display_needs_offset(output_id, input_min):

--- a/recipes/qsmxt/test_qsmxt_openrecon.py
+++ b/recipes/qsmxt/test_qsmxt_openrecon.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import ismrmrd
 import nibabel as nib
 import numpy as np
+import pytest
 
 import qsmxt
 
@@ -311,6 +312,13 @@ def test_openrecon_defaults_select_whqsm_romeo_and_vsharp():
     assert settings["qsm_algorithm"] == "whqsm"
     assert settings["unwrapping_algorithm"] == "romeo"
     assert settings["bf_algorithm"] == "vsharp"
+    assert settings["mask_preset"] == "bet"
+    assert settings["masking_input"] == "magnitude"
+    assert settings["bet_fractional_intensity"] == 0.5
+    assert settings["mask_dilate"] == 0
+    assert settings["mask_close"] == 1
+    assert settings["mask_fill_holes"] is True
+    assert settings["mask_erode"] == 0
 
 
 def test_openrecon_pipeline_presets_select_all_three_algorithms():
@@ -371,7 +379,81 @@ def test_openrecon_pipeline_preset_reaches_qsmxt_command(tmp_path, monkeypatch):
     assert command[command.index("--unwrapping-algorithm") + 1] == "romeo"
     assert command[command.index("--bf-algorithm") + 1] == "resharp"
     assert command[command.index("--qsm-algorithm") + 1] == "hdqsm"
+    assert command[command.index("--mask") + 1] == (
+        "magnitude,bet:0.5,close:1,fill-holes:0"
+    )
     assert kwargs["cwd"] == str(bids_dir)
+
+
+def test_openrecon_custom_threshold_mask_reaches_qsmxt_command(
+    tmp_path,
+    monkeypatch,
+):
+    settings = qsmxt._settings_from_config(
+        {
+            "parameters": {
+                "maskpreset": "robust-threshold",
+                "maskinginput": "phase-quality",
+                "maskthresholdmethod": "percentile",
+                "maskthresholdpercentile": "65",
+                "maskdilate": "2",
+                "maskclose": "3",
+                "maskfillholes": "true",
+                "maskmaxholesize": "12000",
+                "maskerode": "1",
+            }
+        },
+        FakeMetadata(),
+    )
+    settings["qsmxt_binary"] = "/opt/qsmxt/qsmxt"
+    bids_dir = tmp_path / "bids"
+    bids_dir.mkdir()
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return qsmxt.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(qsmxt.subprocess, "run", fake_run)
+
+    qsmxt._run_qsmxt(bids_dir, tmp_path / "output", settings)
+
+    command = commands[0]
+    assert command[command.index("--mask") + 1] == (
+        "phase-quality,threshold:percentile:65,dilate:2,close:3,"
+        "fill-holes:12000,erode:1"
+    )
+    assert "--mask-preset" not in command
+
+
+def test_openrecon_combined_mask_passes_two_sections(tmp_path, monkeypatch):
+    settings = qsmxt._settings_from_config(
+        {"parameters": {"maskpreset": "combined"}},
+        FakeMetadata(),
+    )
+    settings["qsmxt_binary"] = "/opt/qsmxt/qsmxt"
+    bids_dir = tmp_path / "bids"
+    bids_dir.mkdir()
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return qsmxt.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(qsmxt.subprocess, "run", fake_run)
+
+    qsmxt._run_qsmxt(bids_dir, tmp_path / "output", settings)
+
+    command = commands[0]
+    sections = [
+        command[index + 1]
+        for index, value in enumerate(command)
+        if value == "--mask"
+    ]
+    assert sections == [
+        "magnitude,bet:0.5,close:1,fill-holes:0",
+        "magnitude,threshold:otsu,close:1,fill-holes:0",
+    ]
 
 
 def test_openrecon_processing_defaults_can_be_overridden():
@@ -416,6 +498,19 @@ def test_openrecon_label_exposes_processing_defaults():
         value["id"] for value in parameters["bfalgorithm"]["values"]
     }
     assert "resharp" in bf_algorithms
+    assert parameters["maskpreset"]["default"] == "bet"
+    assert {value["id"] for value in parameters["maskpreset"]["values"]} == {
+        "bet",
+        "robust-threshold",
+        "combined",
+    }
+    assert parameters["maskinginput"]["default"] == "magnitude"
+    assert parameters["betfractionalintensity"]["default"] == 0.5
+    assert parameters["maskdilate"]["default"] == 0
+    assert parameters["maskclose"]["default"] == 1
+    assert parameters["maskfillholes"]["default"] is True
+    assert parameters["maskerode"]["default"] == 0
+    assert parameters["voxelsizemm"]["default"] == 0.0
 
 
 def test_scanner_display_volume_scales_qsm_ppm_range_to_uint12_interval():
@@ -444,6 +539,25 @@ def test_scanner_display_volume_reserves_stored_zero_for_qsm_padding():
     decoded += meta["rescale_intercept"]
     assert np.allclose(decoded, data, atol=meta["rescale_slope"] / 2)
     assert meta["padding_value"] == 0
+
+
+def test_scanner_display_volume_uses_robust_qsm_window_without_clipping_extrema():
+    data = np.concatenate(
+        (
+            np.full(500, -0.05, dtype=np.float32),
+            np.full(500, 0.05, dtype=np.float32),
+            np.asarray([-0.4, 0.5], dtype=np.float32),
+        )
+    ).reshape(1, 1, -1)
+
+    display, meta = qsmxt._scanner_display_volume(data, "qsm", "ppm")
+
+    assert display.min() == 1648
+    assert display.max() == 2548
+    assert meta["scale_input_min"] == pytest.approx(-0.4)
+    assert meta["scale_input_max"] == pytest.approx(0.5)
+    assert meta["window_input_min"] == pytest.approx(-0.05)
+    assert meta["window_input_max"] == pytest.approx(0.05)
 
 
 def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
@@ -483,9 +597,12 @@ def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
     assert float(meta["RescaleIntercept"]) == -0.02048
     assert meta["RescaleType"] == "US"
     assert meta["PixelPaddingValue"] == "0"
-    assert "PixelPaddingRangeLimit" not in meta
-    assert float(meta["WindowCenter"]) == 0.0
-    assert float(meta["WindowWidth"]) == 0.02
+    assert meta["PixelPaddingRangeLimit"] == "0"
+    assert float(meta["WindowCenter"]) == 2048.0
+    assert float(meta["WindowWidth"]) == 2000.0
+    assert float(meta["QSMxTPhysicalWindowCenter"]) == 0.0
+    assert float(meta["QSMxTPhysicalWindowWidth"]) == 0.02
+    assert meta["QSMxTWindowDomain"] == "stored"
     assert 0 not in display
 
 
@@ -541,8 +658,8 @@ def test_output_meta_uses_robust_t2star_range_for_window():
         display_meta,
     )
 
-    assert float(meta["WindowCenter"]) == 0.025
-    assert float(meta["WindowWidth"]) == 0.05
+    assert float(meta["WindowCenter"]) == 250.0
+    assert float(meta["WindowWidth"]) == 500.0
 
 
 def test_find_qsmxt_outputs_accepts_v9_combined_magnitude_name(tmp_path):
@@ -775,6 +892,46 @@ def test_images_to_nifti_volume_rejects_implausibly_small_position_spacing():
     np.testing.assert_allclose(affine[:3, 2], [0.0, 0.0, -1.0])
 
 
+def test_write_bids_dataset_applies_explicit_isotropic_resolution(tmp_path):
+    images = []
+    for series_index, image_type, suffix in (
+        (1, ismrmrd.IMTYPE_MAGNITUDE, "Mag"),
+        (2, getattr(ismrmrd, "IMTYPE_PHASE", 2), "Pha"),
+    ):
+        for slice_index in range(4):
+            image = _image(
+                series_index,
+                slice_index + 1,
+                f"gre_qsm_{suffix}",
+                np.ones((1, 3, 4), dtype=np.float32),
+                image_type=image_type,
+                meta_values={"Actual3DImagePartNumber": str(slice_index)},
+                header_values={"slice": slice_index},
+            )
+            header = image.getHead()
+            _set_header_vector(header, "field_of_view", [4.0, 3.0, 1.0])
+            _set_header_vector(header, "position", [0.0, 0.0, 0.4 * slice_index])
+            image.setHead(header)
+            images.append(image)
+
+    metadata = FakeMetadata()
+    settings = qsmxt._settings_from_config(
+        {"parameters": {"voxelsizemm": 0.4}},
+        metadata,
+    )
+    result = qsmxt.write_bids_dataset(
+        images,
+        metadata,
+        tmp_path / "bids",
+        settings,
+    )
+
+    magnitude = nib.load(str(result["magnitude_paths"][0]))
+    np.testing.assert_allclose(magnitude.header.get_zooms()[:3], [0.4, 0.4, 0.4])
+    assert settings["voxel_size_source"] == "config"
+    assert result["source_geometry_images"] == []
+
+
 def test_write_bids_dataset_groups_scanner_slices_by_echo_from_minihead(tmp_path):
     settings = qsmxt._settings_from_config({}, FakeMetadata())
 
@@ -842,8 +999,11 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert float(meta["RescaleIntercept"]) == -2.048
     assert meta["RescaleType"] == "US"
     assert meta["PixelPaddingValue"] == "0"
-    assert float(meta["WindowCenter"]) == 1.5
-    assert float(meta["WindowWidth"]) == 1.0
+    assert meta["PixelPaddingRangeLimit"] == "0"
+    assert float(meta["WindowCenter"]) == 3548.0
+    assert float(meta["WindowWidth"]) == 1000.0
+    assert float(meta["QSMxTPhysicalWindowCenter"]) == 1.5
+    assert float(meta["QSMxTPhysicalWindowWidth"]) == 1.0
     assert meta["QSMxTDisplayScaleInputMin"] == "1.5"
     assert meta["QSMxTDisplayScaleInputMax"] == "1.5"
     assert meta["QSMxTDisplayMin"] == "3548"

--- a/recipes/qsmxt/test_qsmxt_openrecon.py
+++ b/recipes/qsmxt/test_qsmxt_openrecon.py
@@ -315,6 +315,7 @@ def test_openrecon_defaults_select_whqsm_romeo_and_vsharp():
     assert settings["mask_preset"] == "bet"
     assert settings["masking_input"] == "magnitude"
     assert settings["bet_fractional_intensity"] == 0.5
+    assert settings["mask_cleanup"] == "close-fill"
     assert settings["mask_dilate"] == 0
     assert settings["mask_close"] == 1
     assert settings["mask_fill_holes"] is True
@@ -506,10 +507,7 @@ def test_openrecon_label_exposes_processing_defaults():
     }
     assert parameters["maskinginput"]["default"] == "magnitude"
     assert parameters["betfractionalintensity"]["default"] == 0.5
-    assert parameters["maskdilate"]["default"] == 0
-    assert parameters["maskclose"]["default"] == 1
-    assert parameters["maskfillholes"]["default"] is True
-    assert parameters["maskerode"]["default"] == 0
+    assert parameters["maskcleanup"]["default"] == "close-fill"
     assert parameters["voxelsizemm"]["default"] == 0.0
 
 


### PR DESCRIPTION
## Summary

- calculate the QSM display window from the 1st and 99th percentiles of finite non-zero voxels while preserving the complete quantitative range
- write scanner-safe integer window values and stored-zero padding metadata
- make BET with a 0.5 fractional intensity threshold the OpenRecon GUI default
- expose BET, threshold, combined-mask, morphology, and explicit voxel-size controls
- keep voxel geometry based on MRD unless the user sets the voxel-size override

## Why

The 7 T single-echo reconstruction produced a flat default window and a mask with many holes. Sparse susceptibility extrema widened the display range. The phase-quality robust-threshold preset also lacks inter-echo coherence information on a single-echo scan.

## Testing

- `pytest -q recipes/qsmxt/test_qsmxt_openrecon.py` (33 passed)
- `python builder/validation.py recipes/qsmxt/build.yaml`
- `python -m builder generate qsmxt --recreate`
- parsed `OpenReconLabel.json` and `fulltest.yaml`
- replayed window selection against the supplied DICOM voxel distribution