### PR TITLE
Process only MP2RAGE UNI-DEN in SynthSeg and TopoFit

### DIFF
--- a/recipes/synthseg/OpenReconREADME.md
+++ b/recipes/synthseg/OpenReconREADME.md
@@ -18,6 +18,10 @@ photographs rather than MR images.
 
 Use this reconstruction pipeline on 3D brain image data. Any contrast works;
 no bias correction, skull stripping or intensity normalisation is required.
+For an MP2RAGE scan, only the denoised uniform (`UNI-DEN`) contrast is
+processed; INV1, INV2, UNI, and other contrasts in the same stream are ignored.
+An MP2RAGE stream without a `UNI-DEN` contrast is rejected rather than processed
+as a different anatomical contrast.
 
 SynthSeg always segments at 1 mm isotropic internally. The wrapper always runs
 `mri_synthseg --keepgeom`, so the returned label map is resampled with nearest

--- a/recipes/synthseg/synthseg.py
+++ b/recipes/synthseg/synthseg.py
@@ -32,6 +32,17 @@ OPENRECON_MODEL_DEFAULT = "synthseg"
 OPENRECON_MODEL_VALUES = ("synthseg", "robust", "v1")
 OPENRECON_SERIES_SUFFIX = "OR"
 OPENRECON_SEGMENT_SOURCE_GEOMETRY_SERIES_SUFFIX = "openrecon"
+MP2RAGE_IDENTITY_META_KEYS = (
+    "SeriesDescription",
+    "SequenceDescription",
+    "ProtocolName",
+    "SequenceName",
+    "ImageComments",
+    "ImageComment",
+    "ImageType",
+    "DicomImageType",
+    "ImageTypeValue4",
+)
 SYNTHSEG_OUTPUT_GEOMETRY_2D = "2d"
 SYNTHSEG_SEGMENT_SEND_ORDER = "after_originals"
 SYNTHSEG_SEGMENT_POSTPROCESSING_META_KEY = "SegmentPostProcessing"
@@ -3272,6 +3283,58 @@ def _as_image_list(images):
     return list(images)
 
 
+def _normalized_identity_text(value):
+    """Normalize scanner labels so UNI-DEN, UNI_DEN, and UNIDEN compare alike."""
+
+    if isinstance(value, (list, tuple)):
+        value = " ".join(str(item) for item in value)
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def _image_identity_values(image):
+    meta_obj = _meta_from_image(image)
+    values = []
+    for key in MP2RAGE_IDENTITY_META_KEYS:
+        try:
+            value = meta_obj.get(key)
+        except Exception:
+            continue
+        if isinstance(value, (list, tuple)):
+            values.extend(str(item) for item in value if item is not None)
+        elif value is not None:
+            values.append(str(value))
+    return values
+
+
+def _select_anatomical_input_images(images):
+    """For an MP2RAGE stream, retain only its denoised uniform contrast."""
+
+    images = list(images)
+    identities = [
+        [_normalized_identity_text(value) for value in _image_identity_values(image)]
+        for image in images
+    ]
+    if not any("mp2rage" in value for values in identities for value in values):
+        return images
+
+    selected = [
+        image
+        for image, values in zip(images, identities)
+        if any("uniden" in value for value in values)
+    ]
+    if not selected:
+        raise ValueError(
+            "MP2RAGE input was detected, but no UNI-DEN contrast was received"
+        )
+    logging.info(
+        "MP2RAGE input detected; selected %d UNI-DEN image(s) and ignored %d "
+        "other MP2RAGE image(s)",
+        len(selected),
+        len(images) - len(selected),
+    )
+    return selected
+
+
 def process(connection, config, metadata):
     logging.info("Config: \n%s", config)
 
@@ -3297,7 +3360,7 @@ def process(connection, config, metadata):
 
     # Continuously parse incoming data parsed from MRD messages
     acqGroup = []
-    imageGroups = {}
+    magnitudeImages = []
     skipped_passthrough_images = 0
     waveformGroup = []
     try:
@@ -3327,7 +3390,7 @@ def process(connection, config, metadata):
             elif isinstance(item, ismrmrd.Image):
                 # Only process magnitude images -- send phase images back without modification (fallback for images with unknown type)
                 if (item.image_type is ismrmrd.IMTYPE_MAGNITUDE) or (item.image_type == 0):
-                    imageGroups.setdefault(int(item.image_series_index), []).append(item)
+                    magnitudeImages.append(item)
                 else:
                     skipped_passthrough_images += 1
                     continue
@@ -3343,6 +3406,11 @@ def process(connection, config, metadata):
 
             else:
                 logging.error("Unsupported data type %s", type(item).__name__)
+
+        selectedImages = _select_anatomical_input_images(magnitudeImages)
+        imageGroups = {}
+        for item in selectedImages:
+            imageGroups.setdefault(int(item.image_series_index), []).append(item)
 
         logging.info(
             "Input stream drained before SynthSeg image processing: "

--- a/recipes/synthseg/test_synthseg_openrecon.py
+++ b/recipes/synthseg/test_synthseg_openrecon.py
@@ -307,6 +307,68 @@ def _synthseg_command_helpers():
     )
 
 
+def _mp2rage_selection_helpers():
+    return _load_runtime_helpers_for_test(
+        [
+            "_image_identity_values",
+            "_meta_from_image",
+            "_normalized_identity_text",
+            "_select_anatomical_input_images",
+        ],
+        assignments=["MP2RAGE_IDENTITY_META_KEYS"],
+    )
+
+
+def _selection_image(helpers, description, protocol="T1_MP2RAGE"):
+    image = helpers["FakeImage"](np.zeros((1, 1, 2, 2), dtype=np.int16))
+    image.attribute_string = helpers["FakeMeta"](
+        {
+            "SeriesDescription": description,
+            "ProtocolName": protocol,
+        }
+    ).serialize()
+    return image
+
+
+def test_mp2rage_selection_keeps_only_uni_den_images():
+    helpers = _mp2rage_selection_helpers()
+    images = [
+        _selection_image(helpers, "T1_MP2RAGE_INV1"),
+        _selection_image(helpers, "T1_MP2RAGE_UNI-DEN"),
+        _selection_image(helpers, "T1_MP2RAGE_UNI_DEN"),
+        _selection_image(helpers, "T1_MP2RAGE_INV2"),
+    ]
+
+    selected = helpers["_select_anatomical_input_images"](images)
+
+    assert selected == images[1:3]
+
+
+def test_mp2rage_selection_fails_without_uni_den():
+    helpers = _mp2rage_selection_helpers()
+    images = [
+        _selection_image(helpers, "T1_MP2RAGE_INV1"),
+        _selection_image(helpers, "T1_MP2RAGE_UNI"),
+    ]
+
+    try:
+        helpers["_select_anatomical_input_images"](images)
+    except ValueError as error:
+        assert "no UNI-DEN contrast" in str(error)
+    else:
+        raise AssertionError("MP2RAGE input without UNI-DEN should fail closed")
+
+
+def test_non_mp2rage_selection_preserves_all_magnitude_images():
+    helpers = _mp2rage_selection_helpers()
+    images = [
+        _selection_image(helpers, "MPRAGE_T1W", protocol="MPRAGE"),
+        _selection_image(helpers, "T2_SPACE", protocol="T2_SPACE"),
+    ]
+
+    assert helpers["_select_anatomical_input_images"](images) == images
+
+
 def test_synthseg_crop_options_are_mutually_exclusive_and_aligned():
     helpers = _synthseg_command_helpers()
     resolve = helpers["_resolve_synthseg_crop_options"]

--- a/recipes/topofit/OpenReconREADME.md
+++ b/recipes/topofit/OpenReconREADME.md
@@ -11,6 +11,10 @@ not run `recon-all`, cortical parcellation, or longitudinal processing.
 ## Input and output
 
 The input must be one reconstructed three-dimensional magnitude image series.
+For an MP2RAGE scan, only the denoised uniform (`UNI-DEN`) contrast is
+processed; INV1, INV2, UNI, and other contrasts in the same stream are ignored.
+An MP2RAGE stream without a `UNI-DEN` contrast is rejected rather than processed
+as a different anatomical contrast.
 The adapter sorts slices by physical position, converts center-based MRD/LPS
 geometry and reconstructed pixel directions to NIfTI RAS, and writes one
 NIfTI volume for BrainNet. By default, BrainNet conforms the data internally

--- a/recipes/topofit/test_topofit_openrecon.py
+++ b/recipes/topofit/test_topofit_openrecon.py
@@ -35,7 +35,13 @@ class RecordingConnection:
         self.closed = True
 
 
-def _mrd_volume(shape=(24, 20, 8)):
+def _mrd_volume(
+    shape=(24, 20, 8),
+    *,
+    series_description="MPRAGE_TEST",
+    protocol_name="MPRAGE_TEST",
+    series_index=7,
+):
     x_size, y_size, z_size = shape
     grid_y, grid_x = np.indices((y_size, x_size), dtype=np.float32)
     images = []
@@ -66,12 +72,13 @@ def _mrd_volume(shape=(24, 20, 8)):
             for index, value in enumerate(values):
                 field[index] = value
         header.image_type = ismrmrd.IMTYPE_MAGNITUDE
-        header.image_series_index = 7
+        header.image_series_index = series_index
         header.image_index = slice_index + 1
         header.slice = slice_index
         image.setHead(header)
         meta = ismrmrd.Meta()
-        meta["SeriesDescription"] = "MPRAGE_TEST"
+        meta["SeriesDescription"] = series_description
+        meta["ProtocolName"] = protocol_name
         meta["FrameOfReferenceUID"] = "1.2.826.0.1.3680043.10.999"
         meta["ImageRowDir"] = ["0.0", "1.0", "0.0"]
         meta["ImageColumnDir"] = ["-1.0", "0.0", "0.0"]
@@ -82,6 +89,76 @@ def _mrd_volume(shape=(24, 20, 8)):
 
 
 class TopoFitOpenReconTests(unittest.TestCase):
+    def test_mp2rage_processes_only_uni_den_contrast(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            topofit.WORKSPACE = Path(temporary_directory)
+            images = (
+                _mrd_volume(
+                    series_description="T1_MP2RAGE_INV1",
+                    protocol_name="T1_MP2RAGE",
+                    series_index=5,
+                )
+                + _mrd_volume(
+                    series_description="T1_MP2RAGE_UNI_DEN",
+                    protocol_name="T1_MP2RAGE",
+                    series_index=6,
+                )
+                + _mrd_volume(
+                    series_description="T1_MP2RAGE_INV2",
+                    protocol_name="T1_MP2RAGE",
+                    series_index=7,
+                )
+            )
+            connection = RecordingConnection(images)
+            config = {
+                "parameters": {
+                    "sendoriginal": False,
+                    "tfdevice": "cpu",
+                    "tfmodel": "t1w_1mm",
+                    "tfconform": True,
+                    "tfdebugmock": True,
+                }
+            }
+
+            topofit.process(connection, config, metadata=None)
+
+            errors = [
+                message
+                for level, message in connection.logs
+                if level == constants.MRD_LOGGING_ERROR
+            ]
+            self.assertEqual(errors, [])
+            outputs = [image for batch in connection.image_batches for image in batch]
+            self.assertEqual(len(outputs), 8)
+            self.assertEqual({int(image.image_series_index) for image in outputs}, {8})
+            output_meta = ismrmrd.Meta.deserialize(outputs[0].attribute_string)
+            self.assertEqual(
+                output_meta["SeriesDescription"],
+                "T1_MP2RAGE_UNI_DEN_topofit_qc",
+            )
+            manifests = list(Path(temporary_directory).glob("*/topofit_manifest.json"))
+            self.assertEqual(len(manifests), 1)
+
+    def test_mp2rage_without_uni_den_fails_closed(self):
+        connection = RecordingConnection(
+            _mrd_volume(
+                series_description="T1_MP2RAGE_INV2",
+                protocol_name="T1_MP2RAGE",
+            )
+        )
+
+        topofit.process(connection, {}, metadata=None)
+
+        self.assertTrue(connection.closed)
+        self.assertEqual(connection.image_batches, [])
+        errors = [
+            message
+            for level, message in connection.logs
+            if level == constants.MRD_LOGGING_ERROR
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no UNI-DEN contrast", errors[0])
+
     def test_mock_mrd_series_returns_source_grid_qc_and_manifest(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             topofit.WORKSPACE = Path(temporary_directory)

--- a/recipes/topofit/topofit.py
+++ b/recipes/topofit/topofit.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import traceback
 import uuid
 
@@ -37,6 +38,17 @@ DEFAULTS = {
     "tfconform": True,
     "tfdebugmock": False,
 }
+MP2RAGE_IDENTITY_META_KEYS = (
+    "SeriesDescription",
+    "SequenceDescription",
+    "ProtocolName",
+    "SequenceName",
+    "ImageComments",
+    "ImageComment",
+    "ImageType",
+    "DicomImageType",
+    "ImageTypeValue4",
+)
 
 
 def _config_value(config, key: str, default, value_type: str):
@@ -92,6 +104,58 @@ def _meta_text(meta: ismrmrd.Meta, key: str) -> str:
     if isinstance(value, (list, tuple)):
         value = value[0] if value else ""
     return str(value or "").strip()
+
+
+def _normalized_identity_text(value) -> str:
+    """Normalize scanner labels so UNI-DEN, UNI_DEN, and UNIDEN compare alike."""
+
+    if isinstance(value, (list, tuple)):
+        value = " ".join(str(item) for item in value)
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def _image_identity_values(image) -> list[str]:
+    meta = _meta_from_image(image)
+    values = []
+    for key in MP2RAGE_IDENTITY_META_KEYS:
+        try:
+            value = meta.get(key)
+        except Exception:
+            continue
+        if isinstance(value, (list, tuple)):
+            values.extend(str(item) for item in value if item is not None)
+        elif value is not None:
+            values.append(str(value))
+    return values
+
+
+def _select_anatomical_input_images(images):
+    """For an MP2RAGE stream, retain only its denoised uniform contrast."""
+
+    images = list(images)
+    identities = [
+        [_normalized_identity_text(value) for value in _image_identity_values(image)]
+        for image in images
+    ]
+    if not any("mp2rage" in value for values in identities for value in values):
+        return images
+
+    selected = [
+        image
+        for image, values in zip(images, identities)
+        if any("uniden" in value for value in values)
+    ]
+    if not selected:
+        raise ValueError(
+            "MP2RAGE input was detected, but no UNI-DEN contrast was received"
+        )
+    logging.info(
+        "MP2RAGE input detected; selected %d UNI-DEN image(s) and ignored %d "
+        "other MP2RAGE image(s)",
+        len(selected),
+        len(images) - len(selected),
+    )
+    return selected
 
 
 def _normalized(vector) -> np.ndarray | None:
@@ -418,7 +482,7 @@ def process(connection, config, metadata):
         send_original = _config_bool(
             config, "sendoriginal", DEFAULTS["sendoriginal"]
         )
-        image_groups: dict[int, list] = {}
+        magnitude_images = []
         skipped = 0
         for item in connection:
             if item is None:
@@ -429,17 +493,23 @@ def process(connection, config, metadata):
             if item.image_type not in (ismrmrd.IMTYPE_MAGNITUDE, 0):
                 skipped += 1
                 continue
-            image_groups.setdefault(int(item.image_series_index), []).append(item)
+            magnitude_images.append(item)
 
-        if not image_groups:
+        if not magnitude_images:
             raise ValueError("no magnitude MRD image series was received")
+        next_series_index = max(
+            int(image.image_series_index) for image in magnitude_images
+        ) + 1
+        selected_images = _select_anatomical_input_images(magnitude_images)
+        image_groups: dict[int, list] = {}
+        for image in selected_images:
+            image_groups.setdefault(int(image.image_series_index), []).append(image)
         logging.info(
             "TopoFit received %d series and skipped %d non-magnitude/non-image messages",
             len(image_groups),
             skipped,
         )
 
-        next_series_index = max(image_groups) + 1
         pending_output: list[tuple[str, list]] = []
         for source_series_index, images in sorted(image_groups.items()):
             ordered, volume_xyz, affine = _mrd_series_to_nifti(images)


### PR DESCRIPTION
## Summary

- detect MP2RAGE from scanner-visible MRD identity metadata
- restrict SynthSeg and TopoFit OpenRecon processing to UNI-DEN images
- fail closed when MP2RAGE is detected without a UNI-DEN contrast
- preserve existing behavior for non-MP2RAGE image streams
- add focused host and in-container regression coverage

## Verification

- SynthSeg focused helper tests: 9 passed
- SynthSeg mounted OpenRecon integration: mixed INV1/UNI-DEN/INV2 routed only UNI-DEN
- TopoFit mounted OpenRecon suite: 9 passed
- SynthSeg and TopoFit recipe validation passed
- SynthSeg and TopoFit Dockerfile generation passed
- clean local container rebuilds are in progress; candidate CI provides the release build gate