### PR TITLE
Add selectable TopoFit flat-patch analysis

### DIFF
--- a/recipes/topofit/OpenReconLabel.json
+++ b/recipes/topofit/OpenReconLabel.json
@@ -102,6 +102,23 @@
       "information": { "en": "Resample the input internally to the 1 mm RAS geometry expected by TopoFit while writing QC back on the source grid." }
     },
     {
+      "id": "tfflatpatches",
+      "label": { "en": "Find flat pial patches" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Find one locally planar pial-surface patch per hemisphere, draw each patch and outward normal, and append research-only LPS coordinates to the image comments." }
+    },
+    {
+      "id": "tfoverlaythickness",
+      "label": { "en": "Surface thickness" },
+      "type": "int",
+      "minimum": 0,
+      "maximum": 3,
+      "default": 1,
+      "unit": { "en": "vox" },
+      "information": { "en": "Set the in-plane dilation radius in voxels. Zero draws the undilated projected vertices; one retains the previous width." }
+    },
+    {
       "id": "tfdebugmock",
       "label": { "en": "Mock surfaces" },
       "type": "boolean",

--- a/recipes/topofit/OpenReconREADME.md
+++ b/recipes/topofit/OpenReconREADME.md
@@ -30,13 +30,22 @@ Each successful run writes these artifacts below `/tmp/share/topofit`:
 
 The QC volume preserves the input dimensions and affine. It displays the
 source anatomy with pial vertices at intensity 3500 and white vertices at
-intensity 4095. OpenRecon sends that volume back as
+intensity 4095. The surface thickness control sets the in-plane dilation
+radius. A value of zero keeps only the projected vertices. A value of one
+retains the previous width. OpenRecon sends that volume back as
 `<source>_topofit_qc`. When **Keep original images** is enabled, a restamped
 `<source>_original` series is sent first.
 
-Surface artifacts stay in the run workspace so a later in-container analysis
-stage can consume them. This first milestone does not export prescription
-coordinates.
+When **Find flat pial patches** is enabled, the workflow searches each pial
+mesh for the 10 mm-radius neighborhood with the lowest area-weighted plane-fit
+residual and coherent face normals. It draws both selected patches and their
+20 mm outward normals into the QC pixels. The result manifest stores the
+centers and normals in NIfTI world RAS. Each QC image comment also contains the
+centers in scanner patient-space LPS millimetres and the unit normals in LPS.
+
+Surface artifacts stay in the run workspace so later research analysis can
+consume them. Flat-patch coordinates are candidates only. They are not
+motion-cleared prescription coordinates.
 
 ## Parameters
 
@@ -46,6 +55,8 @@ coordinates.
 | Inference device | `tfdevice` | `cuda` | Run on the scanner GPU or use CPU for compatibility testing. |
 | TopoFit model | `tfmodel` | `t1w_1mm` | Select the T1w or synthetic pretrained model. |
 | Conform input | `tfconform` | `true` | Resample internally to the model grid. |
+| Find flat pial patches | `tfflatpatches` | `false` | Find one candidate per hemisphere, draw its patch and normal, and write LPS geometry into image comments. |
+| Surface thickness | `tfoverlaythickness` | `1` voxel | Set the in-plane dilation radius from 0 to 3 voxels. |
 | Mock surfaces | `tfdebugmock` | `false` | Exercise MRD transport and geometry without neural inference. |
 
 The mock option follows the full scanner conversion, QC, metadata, and return
@@ -58,9 +69,9 @@ Every QC image and manifest is marked:
 
 `RESEARCH ONLY - NOT MOTION-CLEARED - NOT FOR PRESCRIPTION`
 
-The manifest explicitly sets `prescription_coordinates` to `null`. A later
-stage must define the target, assess motion and surface quality, transform the
-result into the scanner frame, and pass independent validation before any
+The manifest explicitly keeps `prescription_coordinates` set to `null`, even
+when it records research-only flat-patch candidates. A later stage must assess
+motion and surface quality and pass independent validation before any
 coordinate can be actionable.
 
 The adapter fails closed: it buffers outputs until every required bilateral
@@ -74,10 +85,12 @@ The container exposes the same workflow as a command-line tool:
 ```bash
 topofit-openrecon mprage.nii.gz output --device cuda
 topofit-openrecon mprage.nii.gz transport-test --device cpu --mock
+topofit-openrecon mprage.nii.gz flat-patches --find-flat-patches --overlay-thickness 0
 ```
 
 The first command runs the real model. The second tests the artifact and QC
-path in seconds.
+path in seconds. The third enables flat-patch analysis and uses the thinnest
+surface trace.
 
 ## Citation
 

--- a/recipes/topofit/build.yaml
+++ b/recipes/topofit/build.yaml
@@ -1,5 +1,5 @@
 name: topofit
-version: "0.2.1"
+version: "0.3.0"
 
 copyright:
   - license: GPL-3.0-only
@@ -108,6 +108,10 @@ readme: |-
   The output directory contains FreeSurfer geometry files, a source-grid QC
   overlay, and a JSON manifest. The same workflow is available through the
   included OpenRecon image-to-image adapter for inline scanner testing.
+
+  Add `--find-flat-patches` to find one planar pial candidate per hemisphere,
+  draw its patch and outward normal, and record the geometry in the manifest.
+  `--overlay-thickness 0` produces the thinnest projected surface trace.
 
   The OpenRecon output is research-only. It does not emit actionable slice
   prescription coordinates and is marked as not motion-cleared.

--- a/recipes/topofit/fulltest.yaml
+++ b/recipes/topofit/fulltest.yaml
@@ -5,7 +5,7 @@
 # on CPU and can take several minutes on a CPU-only release runner.
 
 name: topofit
-version: "0.2.1"
+version: "0.3.0"
 
 required_files:
   - dataset: ds000001
@@ -101,7 +101,7 @@ tests:
   - name: Mock end-to-end NIfTI workflow
     description: Exercise the production artifact and QC path without neural inference.
     command: |
-      topofit-openrecon "${t1w}" "${output_dir}/mock" --device cpu --mock
+      topofit-openrecon "${t1w}" "${output_dir}/mock" --device cpu --mock --find-flat-patches --overlay-thickness 0
     validate:
       - output_exists: ${output_dir}/mock/topofit_manifest.json
       - output_exists: ${output_dir}/mock/topofit_qc.nii.gz
@@ -117,6 +117,9 @@ tests:
       assert manifest['status'] == 'SURFACE_READY_RESEARCH_ONLY'
       assert manifest['prescription_coordinates'] is None
       assert manifest['coordinate_status'] == 'WITHHELD_UNTIL_VALIDATED_ANALYSIS_STAGE'
+      assert manifest['flat_patch_status'] == 'CANDIDATES_REPORTED_RESEARCH_ONLY'
+      assert set(manifest['flat_patches']) == {'lh', 'rh'}
+      assert manifest['options']['overlay_thickness'] == 0
       print(manifest['warning'])
       "
     expected_output_contains: "NOT FOR PRESCRIPTION"
@@ -124,7 +127,7 @@ tests:
   - name: Real TopoFit CPU workflow
     description: Run the pinned BrainNet model from T1w input through validated surfaces and source-grid QC.
     command: |
-      topofit-openrecon "${t1w}" "${output_dir}/real" --device cpu
+      topofit-openrecon "${t1w}" "${output_dir}/real" --device cpu --find-flat-patches --overlay-thickness 0
     validate:
       - output_exists: ${output_dir}/real/topofit_manifest.json
       - output_exists: ${output_dir}/real/topofit_qc.nii.gz
@@ -146,6 +149,8 @@ tests:
       qc = nib.load('${output_dir}/real/topofit_qc.nii.gz')
       assert qc.shape == source.shape, (qc.shape, source.shape)
       np.testing.assert_allclose(qc.affine, source.affine)
+      manifest = __import__('json').load(open('${output_dir}/real/topofit_manifest.json'))
+      assert set(manifest['flat_patches']) == {'lh', 'rh'}
       for name in ('lh.white', 'rh.white', 'lh.pial', 'rh.pial', 'lh.registration', 'rh.registration'):
           vertices, faces = nib.freesurfer.read_geometry(str(Path('${output_dir}/real/surf') / name))
           assert vertices.shape[1] == 3 and faces.shape[1] == 3, name

--- a/recipes/topofit/test_topofit_core.py
+++ b/recipes/topofit/test_topofit_core.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import tempfile
 import unittest
+from pathlib import Path
 
 import nibabel as nib
 import numpy as np
-
 from topofit_core import (
     RESEARCH_WARNING,
     SURFACE_NAMES,
     TopoFitOptions,
+    _dilate_in_plane,
     build_brainnet_command,
+    find_flattest_patch,
     mrd_lps_to_nifti_ras_affine,
     run_topofit_workflow,
     validate_options,
@@ -72,6 +73,68 @@ class TopoFitCoreTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unknown model preset"):
             validate_options(TopoFitOptions(preset="t1w_random"))
 
+    def test_invalid_overlay_thickness_is_rejected_at_boundary(self):
+        for thickness in (-1, 4):
+            with (
+                self.subTest(thickness=thickness),
+                self.assertRaisesRegex(ValueError, "overlay thickness"),
+            ):
+                validate_options(TopoFitOptions(overlay_thickness=thickness))
+
+    def test_in_plane_dilation_is_configurable_without_edge_wrapping(self):
+        mask = np.zeros((5, 5, 3), dtype=bool)
+        mask[0, 0, 1] = True
+
+        thin = _dilate_in_plane(mask, 0)
+        current_width = _dilate_in_plane(mask, 1)
+
+        self.assertEqual(int(thin.sum()), 1)
+        self.assertEqual(int(current_width.sum()), 3)
+        self.assertFalse(current_width[-1, 0, 1])
+        self.assertFalse(current_width[0, -1, 1])
+
+    def test_flat_patch_finder_prefers_a_planar_neighborhood(self):
+        grid_x, grid_y = np.meshgrid(
+            np.linspace(-4.0, 4.0, 5),
+            np.linspace(-4.0, 4.0, 5),
+            indexing="ij",
+        )
+        plane = np.column_stack(
+            [grid_x.ravel(), grid_y.ravel(), np.full(grid_x.size, 8.0)]
+        )
+        curved = np.column_stack(
+            [
+                grid_x.ravel() + 20.0,
+                grid_y.ravel(),
+                0.18 * (grid_x.ravel() ** 2 + grid_y.ravel() ** 2),
+            ]
+        )
+        vertices = np.vstack([plane, curved])
+        faces = []
+        for offset in (0, plane.shape[0]):
+            for x_index in range(4):
+                for y_index in range(4):
+                    lower_left = offset + x_index * 5 + y_index
+                    faces.extend(
+                        [
+                            [lower_left, lower_left + 5, lower_left + 1],
+                            [lower_left + 1, lower_left + 5, lower_left + 6],
+                        ]
+                    )
+
+        detected = find_flattest_patch(
+            vertices,
+            np.asarray(faces, dtype=np.int32),
+            surface="lh.pial",
+            radius_mm=4.5,
+        )
+
+        self.assertLess(detected.patch.center_ras_mm[0], 10.0)
+        self.assertGreater(abs(detected.patch.normal_ras[2]), 0.99)
+        self.assertLess(detected.patch.rms_distance_mm, 1e-6)
+        self.assertGreater(detected.patch.area_mm2, 0.0)
+        self.assertGreater(detected.vertex_indices.size, 3)
+
     def test_mock_workflow_writes_surface_qc_and_non_actionable_manifest(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -97,12 +160,21 @@ class TopoFitCoreTests(unittest.TestCase):
             result = run_topofit_workflow(
                 input_path,
                 run_dir,
-                TopoFitOptions(device="cpu", mock=True),
+                TopoFitOptions(
+                    device="cpu",
+                    mock=True,
+                    find_flat_patches=True,
+                    overlay_thickness=0,
+                ),
             )
 
             self.assertEqual(result.status, "SURFACE_READY_RESEARCH_ONLY")
             self.assertEqual(result.warning, RESEARCH_WARNING)
             self.assertEqual(set(result.surfaces), set(SURFACE_NAMES))
+            self.assertEqual(set(result.flat_patches), {"lh", "rh"})
+            for patch in result.flat_patches.values():
+                self.assertAlmostEqual(np.linalg.norm(patch.normal_ras), 1.0)
+                self.assertGreater(patch.area_mm2, 0.0)
             for path in result.surfaces.values():
                 vertices, faces = nib.freesurfer.read_geometry(path)
                 self.assertEqual(vertices.shape[1], 3)
@@ -113,7 +185,21 @@ class TopoFitCoreTests(unittest.TestCase):
             np.testing.assert_allclose(qc.affine, affine)
             qc_data = np.asarray(qc.dataobj)
             self.assertEqual(int(qc_data.max()), 4095)
-            self.assertIn(3500, np.unique(qc_data))
+            self.assertIn(3800, np.unique(qc_data))
+            inverse_affine = np.linalg.inv(affine)
+            for patch in result.flat_patches.values():
+                center = np.asarray(patch.center_ras_mm)
+                normal = np.asarray(patch.normal_ras)
+                line = center + np.linspace(0.0, 20.0, 81)[:, None] * normal
+                voxels = np.rint(nib.affines.apply_affine(inverse_affine, line)).astype(
+                    int
+                )
+                inside = np.all(voxels >= 0, axis=1) & np.all(
+                    voxels < np.asarray(qc.shape), axis=1
+                )
+                self.assertGreater(int(inside.sum()), 1)
+                endpoint = voxels[np.flatnonzero(inside)[-1]]
+                self.assertEqual(int(qc_data[tuple(endpoint)]), 4095)
 
             manifest = json.loads(Path(result.manifest).read_text(encoding="utf-8"))
             self.assertIsNone(manifest["prescription_coordinates"])
@@ -121,6 +207,11 @@ class TopoFitCoreTests(unittest.TestCase):
                 manifest["coordinate_status"],
                 "WITHHELD_UNTIL_VALIDATED_ANALYSIS_STAGE",
             )
+            self.assertEqual(
+                manifest["flat_patch_status"],
+                "CANDIDATES_REPORTED_RESEARCH_ONLY",
+            )
+            self.assertEqual(set(manifest["flat_patches"]), {"lh", "rh"})
             self.assertTrue(manifest["options"]["mock"])
 
 

--- a/recipes/topofit/test_topofit_openrecon.py
+++ b/recipes/topofit/test_topofit_openrecon.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import tempfile
 import unittest
+from pathlib import Path
 
 import constants
 import ismrmrd
 import nibabel as nib
 import numpy as np
-
 import topofit
 
 
@@ -48,8 +47,7 @@ def _mrd_volume(
     for slice_index in range(z_size):
         radius = 5.0 + min(slice_index, z_size - 1 - slice_index)
         plane = np.where(
-            ((grid_x - (x_size - 1) / 2) ** 2)
-            + ((grid_y - (y_size - 1) / 2) ** 2)
+            ((grid_x - (x_size - 1) / 2) ** 2) + ((grid_y - (y_size - 1) / 2) ** 2)
             <= radius**2,
             900,
             20,
@@ -170,6 +168,8 @@ class TopoFitOpenReconTests(unittest.TestCase):
                     "tfmodel": "t1w_1mm",
                     "tfconform": True,
                     "tfdebugmock": True,
+                    "tfflatpatches": True,
+                    "tfoverlaythickness": 0,
                 }
             }
 
@@ -185,7 +185,9 @@ class TopoFitOpenReconTests(unittest.TestCase):
             outputs = [image for batch in connection.image_batches for image in batch]
             self.assertEqual(len(outputs), 8)
             self.assertEqual({int(image.image_series_index) for image in outputs}, {8})
-            self.assertTrue(all(image.data.shape == (1, 1, 20, 24) for image in outputs))
+            self.assertTrue(
+                all(image.data.shape == (1, 1, 20, 24) for image in outputs)
+            )
             self.assertEqual(max(int(np.max(image.data)) for image in outputs), 4095)
 
             output_meta = ismrmrd.Meta.deserialize(outputs[0].attribute_string)
@@ -197,12 +199,31 @@ class TopoFitOpenReconTests(unittest.TestCase):
                 output_meta["TopoFitStatus"], "SURFACE_READY_RESEARCH_ONLY"
             )
             self.assertEqual(output_meta["TopoFitPrescriptionStatus"], "WITHHELD")
+            self.assertEqual(output_meta["ImageComment"], output_meta["ImageComments"])
+            self.assertIn(
+                "TopoFit flat patch lh.pial LPS_mm", output_meta["ImageComments"]
+            )
+            self.assertIn(
+                "TopoFit flat patch rh.pial LPS_mm", output_meta["ImageComments"]
+            )
+            self.assertIn("normal=(", output_meta["ImageComments"])
 
             manifests = list(Path(temporary_directory).glob("*/topofit_manifest.json"))
             self.assertEqual(len(manifests), 1)
             manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
             self.assertIsNone(manifest["prescription_coordinates"])
             self.assertEqual(len(manifest["surfaces"]), 6)
+            self.assertEqual(set(manifest["flat_patches"]), {"lh", "rh"})
+            self.assertEqual(manifest["options"]["overlay_thickness"], 0)
+            for patch in manifest["flat_patches"].values():
+                center_lps = np.asarray(patch["center_ras_mm"]) * (-1.0, -1.0, 1.0)
+                normal_lps = np.asarray(patch["normal_ras"]) * (-1.0, -1.0, 1.0)
+                center_text = ",".join(f"{value:.2f}" for value in center_lps)
+                normal_text = ",".join(f"{value:.4f}" for value in normal_lps)
+                self.assertIn(
+                    f"center=({center_text}) normal=({normal_text})",
+                    output_meta["ImageComments"],
+                )
 
     def test_mrd_affine_uses_image_center_and_reconstructed_pixel_directions(self):
         images = _mrd_volume()

--- a/recipes/topofit/topofit.py
+++ b/recipes/topofit/topofit.py
@@ -5,29 +5,28 @@ from __future__ import annotations
 
 import argparse
 import copy
-from dataclasses import asdict
 import json
 import logging
 import os
-from pathlib import Path
 import re
 import traceback
 import uuid
+from dataclasses import asdict
+from pathlib import Path
 
 import constants
 import ismrmrd
+import mrdhelper
 import nibabel as nib
 import numpy as np
-
-import mrdhelper
 from topofit_core import (
     MODEL_PRESETS,
     RESEARCH_WARNING,
     TopoFitOptions,
     mrd_lps_to_nifti_ras_affine,
     run_topofit_workflow,
+    validate_options,
 )
-
 
 WORKSPACE = Path(os.environ.get("TOPOFIT_OPENRECON_WORKSPACE", "/tmp/share/topofit"))
 SEND_CHUNK_SIZE = 64
@@ -37,6 +36,8 @@ DEFAULTS = {
     "tfmodel": "t1w_1mm",
     "tfconform": True,
     "tfdebugmock": False,
+    "tfflatpatches": False,
+    "tfoverlaythickness": 1,
 }
 MP2RAGE_IDENTITY_META_KEYS = (
     "SeriesDescription",
@@ -71,6 +72,14 @@ def _config_bool(config, key: str, default: bool) -> bool:
     return bool(value)
 
 
+def _config_int(config, key: str, default: int) -> int:
+    value = _config_value(config, key, default, "int")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be an integer, got {value!r}") from None
+
+
 def _meta_from_image(image) -> ismrmrd.Meta:
     attribute_string = getattr(image, "attribute_string", "")
     if not attribute_string:
@@ -78,7 +87,9 @@ def _meta_from_image(image) -> ismrmrd.Meta:
     try:
         return ismrmrd.Meta.deserialize(attribute_string)
     except Exception:
-        logging.warning("Could not deserialize source MRD metadata; using a new Meta block")
+        logging.warning(
+            "Could not deserialize source MRD metadata; using a new Meta block"
+        )
         return ismrmrd.Meta()
 
 
@@ -200,11 +211,7 @@ def _image_directions(image) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     if meta_phase_dir is None:
         phase_dir = _normalized(header.phase_dir)
     slice_dir = _meta_vector(meta, "ImageSliceNormDir")
-    if (
-        slice_dir is None
-        and meta_read_dir is not None
-        and meta_phase_dir is not None
-    ):
+    if slice_dir is None and meta_read_dir is not None and meta_phase_dir is not None:
         slice_dir = _normalized(np.cross(read_dir, phase_dir))
     if slice_dir is None:
         slice_dir = _normalized(header.slice_dir)
@@ -272,13 +279,15 @@ def _mrd_series_to_nifti(images) -> tuple[list, np.ndarray, np.ndarray]:
             plane = np.abs(plane)
         if plane.ndim != 2:
             raise ValueError(
-                f"source image {index} must contain one 2D plane, got shape {plane.shape}"
+                f"source image {index} must contain one 2D plane, "
+                f"got shape {plane.shape}"
             )
         if expected_shape is None:
             expected_shape = plane.shape
         elif plane.shape != expected_shape:
             raise ValueError(
-                f"source image shapes differ: expected {expected_shape}, got {plane.shape}"
+                f"source image shapes differ: expected {expected_shape}, "
+                f"got {plane.shape}"
             )
         planes.append(np.asarray(plane, dtype=np.float32))
 
@@ -286,7 +295,9 @@ def _mrd_series_to_nifti(images) -> tuple[list, np.ndarray, np.ndarray]:
     matrix = np.asarray(header.matrix_size, dtype=float)
     field_of_view = np.asarray(header.field_of_view, dtype=float)
     if matrix.shape != (3,) or field_of_view.shape != (3,):
-        raise ValueError("MRD matrix_size and field_of_view must each have three values")
+        raise ValueError(
+            "MRD matrix_size and field_of_view must each have three values"
+        )
     if (
         matrix[0] <= 0
         or matrix[1] <= 0
@@ -360,6 +371,7 @@ def _stamp_output(
     series_description: str,
     processing_history: list[str],
     warning: str = "",
+    details: str = "",
 ) -> None:
     header = copy.copy(source.getHead())
     header.data_type = output.data_type
@@ -377,7 +389,9 @@ def _stamp_output(
     meta["SeriesDescription"] = series_description[:64]
     meta["SequenceDescriptionAdditional"] = "TopoFit"
     if warning:
-        meta["ImageComments"] = warning
+        comment = f"{warning}; {details}" if details else warning
+        meta["ImageComment"] = comment
+        meta["ImageComments"] = comment
         meta["TopoFitStatus"] = "SURFACE_READY_RESEARCH_ONLY"
         meta["TopoFitPrescriptionStatus"] = "WITHHELD"
         meta["WindowCenter"] = "2048"
@@ -394,7 +408,9 @@ def _clone_original_series(images, series_index: int) -> list:
     description = f"{_series_description(images[0], 'mprage')}_original"
     output = []
     for index, source in enumerate(images):
-        clone = ismrmrd.Image.from_array(np.array(source.data, copy=True), transpose=False)
+        clone = ismrmrd.Image.from_array(
+            np.array(source.data, copy=True), transpose=False
+        )
         _stamp_output(
             clone,
             source,
@@ -408,7 +424,29 @@ def _clone_original_series(images, series_index: int) -> list:
     return output
 
 
-def _qc_mrd_images(qc_path: Path, source_images, series_index: int) -> list:
+def _format_flat_patch_comment(flat_patches) -> str:
+    parts = []
+    for hemisphere in ("lh", "rh"):
+        patch = flat_patches.get(hemisphere)
+        if patch is None:
+            continue
+        center_lps = np.asarray(patch.center_ras_mm, dtype=float) * (-1.0, -1.0, 1.0)
+        normal_lps = np.asarray(patch.normal_ras, dtype=float) * (-1.0, -1.0, 1.0)
+        center = ",".join(f"{value:.2f}" for value in center_lps)
+        normal = ",".join(f"{value:.4f}" for value in normal_lps)
+        parts.append(
+            f"TopoFit flat patch {patch.surface} LPS_mm center=({center}) "
+            f"normal=({normal})"
+        )
+    return "; ".join(parts)
+
+
+def _qc_mrd_images(
+    qc_path: Path,
+    source_images,
+    series_index: int,
+    flat_patches=None,
+) -> list:
     image = nib.load(str(qc_path))
     volume_xyz = np.asarray(image.get_fdata(dtype=np.float32))
     if volume_xyz.shape != (
@@ -424,6 +462,7 @@ def _qc_mrd_images(qc_path: Path, source_images, series_index: int) -> list:
     volume_yxz = np.rint(volume_xyz.transpose((1, 0, 2))).astype(np.int16)
     series_uid = _new_series_uid()
     description = f"{_series_description(source_images[0], 'mprage')}_topofit_qc"
+    patch_comment = _format_flat_patch_comment(flat_patches or {})
     output = []
     for index, source in enumerate(source_images):
         plane = np.ascontiguousarray(volume_yxz[:, :, index])
@@ -439,6 +478,7 @@ def _qc_mrd_images(qc_path: Path, source_images, series_index: int) -> list:
             description,
             ["PYTHON", "BRAINNET", "TOPOFIT", "SURFACE_QC"],
             RESEARCH_WARNING,
+            patch_comment,
         )
         output.append(derived)
     return output
@@ -459,17 +499,24 @@ def _send_images(connection, images, label: str) -> None:
 
 def _options_from_config(config) -> TopoFitOptions:
     options = TopoFitOptions(
-        device=str(
-            _config_value(config, "tfdevice", DEFAULTS["tfdevice"], "str")
-        ).strip().lower(),
-        preset=str(
-            _config_value(config, "tfmodel", DEFAULTS["tfmodel"], "str")
-        ).strip().lower(),
+        device=str(_config_value(config, "tfdevice", DEFAULTS["tfdevice"], "str"))
+        .strip()
+        .lower(),
+        preset=str(_config_value(config, "tfmodel", DEFAULTS["tfmodel"], "str"))
+        .strip()
+        .lower(),
         conform=_config_bool(config, "tfconform", DEFAULTS["tfconform"]),
         mock=_config_bool(config, "tfdebugmock", DEFAULTS["tfdebugmock"]),
+        find_flat_patches=_config_bool(
+            config, "tfflatpatches", DEFAULTS["tfflatpatches"]
+        ),
+        overlay_thickness=_config_int(
+            config,
+            "tfoverlaythickness",
+            DEFAULTS["tfoverlaythickness"],
+        ),
     )
-    if options.preset not in MODEL_PRESETS:
-        raise ValueError(f"unsupported TopoFit model preset: {options.preset}")
+    validate_options(options)
     return options
 
 
@@ -479,9 +526,7 @@ def process(connection, config, metadata):
     del metadata
     try:
         options = _options_from_config(config)
-        send_original = _config_bool(
-            config, "sendoriginal", DEFAULTS["sendoriginal"]
-        )
+        send_original = _config_bool(config, "sendoriginal", DEFAULTS["sendoriginal"])
         magnitude_images = []
         skipped = 0
         for item in connection:
@@ -497,15 +542,16 @@ def process(connection, config, metadata):
 
         if not magnitude_images:
             raise ValueError("no magnitude MRD image series was received")
-        next_series_index = max(
-            int(image.image_series_index) for image in magnitude_images
-        ) + 1
+        next_series_index = (
+            max(int(image.image_series_index) for image in magnitude_images) + 1
+        )
         selected_images = _select_anatomical_input_images(magnitude_images)
         image_groups: dict[int, list] = {}
         for image in selected_images:
             image_groups.setdefault(int(image.image_series_index), []).append(image)
         logging.info(
-            "TopoFit received %d series and skipped %d non-magnitude/non-image messages",
+            "TopoFit received %d series and skipped %d "
+            "non-magnitude/non-image messages",
             len(image_groups),
             skipped,
         )
@@ -530,7 +576,10 @@ def process(connection, config, metadata):
 
             result = run_topofit_workflow(input_path, run_dir, options)
             qc_images = _qc_mrd_images(
-                Path(result.qc_image), ordered, next_series_index
+                Path(result.qc_image),
+                ordered,
+                next_series_index,
+                result.flat_patches,
             )
             pending_output.append(("TopoFit QC", qc_images))
             next_series_index += 1
@@ -567,9 +616,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("input", type=Path, help="Input 3D MRI in NIfTI format")
     parser.add_argument("output_dir", type=Path, help="Directory for surfaces and QC")
     parser.add_argument("--device", choices=("cuda", "cpu"), default="cuda")
-    parser.add_argument(
-        "--model", choices=tuple(MODEL_PRESETS), default="t1w_1mm"
-    )
+    parser.add_argument("--model", choices=tuple(MODEL_PRESETS), default="t1w_1mm")
     parser.add_argument(
         "--no-conform",
         dest="conform",
@@ -580,6 +627,19 @@ def _parse_args() -> argparse.Namespace:
         "--mock",
         action="store_true",
         help="Generate geometry-valid test surfaces without running BrainNet",
+    )
+    parser.add_argument(
+        "--find-flat-patches",
+        action="store_true",
+        help="Find and draw one flat pial-surface patch per hemisphere",
+    )
+    parser.add_argument(
+        "--overlay-thickness",
+        type=int,
+        choices=range(4),
+        default=1,
+        metavar="VOXELS",
+        help="In-plane surface dilation radius; 0 draws the undilated trace",
     )
     parser.set_defaults(conform=True)
     return parser.parse_args()
@@ -593,6 +653,8 @@ def main() -> int:
         preset=args.model,
         conform=args.conform,
         mock=args.mock,
+        find_flat_patches=args.find_flat_patches,
+        overlay_thickness=args.overlay_thickness,
     )
     result = run_topofit_workflow(args.input, args.output_dir, options)
     print(json.dumps(asdict(result), indent=2))

--- a/recipes/topofit/topofit_core.py
+++ b/recipes/topofit/topofit_core.py
@@ -7,17 +7,17 @@ without a scanner connection.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
 import json
 import logging
-from pathlib import Path
 import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from time import perf_counter
 from typing import Callable, Sequence
 
 import nibabel as nib
 import numpy as np
-
+from scipy.spatial import cKDTree
 
 RESEARCH_WARNING = "RESEARCH ONLY - NOT MOTION-CLEARED - NOT FOR PRESCRIPTION"
 SURFACE_NAMES = (
@@ -33,6 +33,10 @@ MODEL_PRESETS = {
     "synth_1mm": ("synth", "1mm"),
     "synth_random": ("synth", "random"),
 }
+FLAT_PATCH_RADIUS_MM = 10.0
+FLAT_PATCH_NORMAL_LENGTH_MM = 20.0
+MAX_OVERLAY_THICKNESS = 3
+MAX_PATCH_CANDIDATES = 64
 
 
 @dataclass(frozen=True)
@@ -43,6 +47,29 @@ class TopoFitOptions:
     preset: str = "t1w_1mm"
     conform: bool = True
     mock: bool = False
+    find_flat_patches: bool = False
+    overlay_thickness: int = 1
+
+
+@dataclass(frozen=True)
+class FlatPatch:
+    """One locally planar pial-surface candidate in NIfTI world RAS."""
+
+    surface: str
+    center_ras_mm: tuple[float, float, float]
+    normal_ras: tuple[float, float, float]
+    radius_mm: float
+    area_mm2: float
+    rms_distance_mm: float
+    vertex_count: int
+
+
+@dataclass(frozen=True)
+class _DetectedFlatPatch:
+    """Flat-patch measurements plus private mesh support for the QC renderer."""
+
+    patch: FlatPatch
+    vertex_indices: np.ndarray
 
 
 @dataclass(frozen=True)
@@ -55,6 +82,7 @@ class TopoFitResult:
     qc_image: str
     manifest: str
     surfaces: dict[str, str]
+    flat_patches: dict[str, FlatPatch]
     elapsed_seconds: float
     warning: str = RESEARCH_WARNING
 
@@ -64,11 +92,21 @@ def validate_options(options: TopoFitOptions) -> tuple[str, str]:
 
     if options.device not in {"cuda", "cpu"}:
         raise ValueError("device must be 'cuda' or 'cpu'")
+    if (
+        not isinstance(options.overlay_thickness, int)
+        or isinstance(options.overlay_thickness, bool)
+        or not 0 <= options.overlay_thickness <= MAX_OVERLAY_THICKNESS
+    ):
+        raise ValueError(
+            f"overlay thickness must be an integer from 0 to {MAX_OVERLAY_THICKNESS}"
+        )
     try:
         return MODEL_PRESETS[options.preset]
     except KeyError:
         valid = ", ".join(sorted(MODEL_PRESETS))
-        raise ValueError(f"unknown model preset {options.preset!r}; choose {valid}") from None
+        raise ValueError(
+            f"unknown model preset {options.preset!r}; choose {valid}"
+        ) from None
 
 
 def build_brainnet_command(
@@ -119,15 +157,25 @@ def mrd_lps_to_nifti_ras_affine(
     if position_array.shape != (3,) or any(
         item.shape != (3,) for item in raw_directions
     ):
-        raise ValueError("MRD position and direction vectors must each have three values")
+        raise ValueError(
+            "MRD position and direction vectors must each have three values"
+        )
     if not np.all(np.isfinite(position_array)) or any(
         not np.all(np.isfinite(item)) for item in raw_directions
     ):
         raise ValueError("MRD position and direction vectors must be finite")
-    if spacing.shape != (3,) or not np.all(np.isfinite(spacing)) or np.any(spacing <= 0):
-        raise ValueError(f"voxel size must contain three positive values, got {spacing}")
+    if (
+        spacing.shape != (3,)
+        or not np.all(np.isfinite(spacing))
+        or np.any(spacing <= 0)
+    ):
+        raise ValueError(
+            f"voxel size must contain three positive values, got {spacing}"
+        )
     if shape.shape != (2,) or np.any(shape < 2):
-        raise ValueError(f"in-plane shape must contain two values greater than one, got {shape}")
+        raise ValueError(
+            f"in-plane shape must contain two values greater than one, got {shape}"
+        )
 
     norms = [float(np.linalg.norm(item)) for item in raw_directions]
     if any(norm < 1e-8 for norm in norms):
@@ -153,7 +201,10 @@ def mrd_lps_to_nifti_ras_affine(
         [lps_to_ras @ direction * step for direction, step in zip(directions, spacing)]
     )
     affine[:3, 3] = lps_to_ras @ origin_lps
-    if not np.all(np.isfinite(affine)) or abs(float(np.linalg.det(affine[:3, :3]))) < 1e-8:
+    if (
+        not np.all(np.isfinite(affine))
+        or abs(float(np.linalg.det(affine[:3, :3]))) < 1e-8
+    ):
         raise ValueError("MRD geometry produced a singular or non-finite NIfTI affine")
     return affine
 
@@ -248,7 +299,9 @@ def validate_surface_outputs(surface_dir: Path) -> dict[str, Path]:
             raise RuntimeError(f"TopoFit did not produce required surface {name}")
         vertices, faces = nib.freesurfer.read_geometry(str(path))
         if vertices.ndim != 2 or vertices.shape[1] != 3 or vertices.shape[0] < 4:
-            raise RuntimeError(f"surface {name} has invalid vertices shape {vertices.shape}")
+            raise RuntimeError(
+                f"surface {name} has invalid vertices shape {vertices.shape}"
+            )
         if faces.ndim != 2 or faces.shape[1] != 3 or faces.shape[0] < 4:
             raise RuntimeError(f"surface {name} has invalid faces shape {faces.shape}")
         if not np.all(np.isfinite(vertices)):
@@ -257,6 +310,212 @@ def validate_surface_outputs(surface_dir: Path) -> dict[str, Path]:
             raise RuntimeError(f"surface {name} contains out-of-range face indices")
         outputs[name] = path
     return outputs
+
+
+def _face_geometry(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    triangles = vertices[faces]
+    cross_products = np.cross(
+        triangles[:, 1] - triangles[:, 0],
+        triangles[:, 2] - triangles[:, 0],
+    )
+    twice_area = np.linalg.norm(cross_products, axis=1)
+    valid = twice_area > 1e-8
+    if int(valid.sum()) < 3:
+        raise ValueError(
+            "flat-patch analysis requires at least three non-degenerate faces"
+        )
+
+    valid_faces = faces[valid]
+    centers = triangles[valid].mean(axis=1)
+    areas = twice_area[valid] * 0.5
+    normals = cross_products[valid] / twice_area[valid, np.newaxis]
+
+    mesh_center = vertices.mean(axis=0)
+    orientation = np.sum(areas * np.einsum("ij,ij->i", normals, centers - mesh_center))
+    if orientation < 0:
+        normals = -normals
+    return valid_faces, centers, normals, areas
+
+
+def _fit_face_patch(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    normals: np.ndarray,
+    areas: np.ndarray,
+    face_indices: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, float, float, float]:
+    selected_faces = faces[face_indices]
+    selected_areas = areas[face_indices]
+    points = vertices[selected_faces].reshape(-1, 3)
+    weights = np.repeat(selected_areas / 3.0, 3)
+    total_area = float(selected_areas.sum())
+    center = np.average(points, axis=0, weights=weights)
+    centered = points - center
+    covariance = (centered * weights[:, np.newaxis]).T @ centered / weights.sum()
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    normal = eigenvectors[:, int(np.argmin(eigenvalues))]
+
+    mean_normal = np.sum(normals[face_indices] * selected_areas[:, np.newaxis], axis=0)
+    if float(np.dot(normal, mean_normal)) < 0:
+        normal = -normal
+    normal /= np.linalg.norm(normal)
+    residuals = centered @ normal
+    rms_distance = float(np.sqrt(np.average(residuals**2, weights=weights)))
+    coherence = float(
+        np.average(
+            np.abs(normals[face_indices] @ normal),
+            weights=selected_areas,
+        )
+    )
+    return center, normal, rms_distance, total_area, coherence
+
+
+def _candidate_face_indices(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    normals: np.ndarray,
+    areas: np.ndarray,
+    centers: np.ndarray,
+    radius_mm: float,
+) -> list[int]:
+    vertex_normal_sums = np.zeros_like(vertices, dtype=float)
+    weighted_normals = normals * areas[:, np.newaxis]
+    for corner in range(3):
+        np.add.at(vertex_normal_sums, faces[:, corner], weighted_normals)
+    magnitudes = np.linalg.norm(vertex_normal_sums, axis=1)
+    valid = magnitudes > 1e-8
+    vertex_normal_sums[valid] /= magnitudes[valid, np.newaxis]
+    alignment = np.einsum("ij,ikj->ik", normals, vertex_normal_sums[faces])
+    local_bending = 1.0 - np.mean(np.clip(alignment, -1.0, 1.0), axis=1)
+    ranked = np.lexsort((np.arange(faces.shape[0]), local_bending))
+    if ranked.size <= MAX_PATCH_CANDIDATES:
+        return [int(index) for index in ranked]
+
+    selected: list[int] = []
+    minimum_separation = radius_mm * 0.5
+    for index in ranked:
+        point = centers[index]
+        if all(
+            float(np.linalg.norm(point - centers[other])) >= minimum_separation
+            for other in selected
+        ):
+            selected.append(int(index))
+            if len(selected) == MAX_PATCH_CANDIDATES:
+                break
+    if not selected:
+        selected.append(int(ranked[0]))
+    return selected
+
+
+def _connected_face_component(
+    faces: np.ndarray,
+    face_indices: np.ndarray,
+    seed_index: int,
+) -> np.ndarray:
+    """Keep the vertex-connected part of a local neighborhood containing its seed."""
+
+    face_set = {int(index) for index in face_indices}
+    if seed_index not in face_set:
+        face_set.add(seed_index)
+    vertex_faces: dict[int, list[int]] = {}
+    for face_index in face_set:
+        for vertex_index in faces[face_index]:
+            vertex_faces.setdefault(int(vertex_index), []).append(face_index)
+
+    connected = {seed_index}
+    pending = [seed_index]
+    while pending:
+        face_index = pending.pop()
+        for vertex_index in faces[face_index]:
+            for neighbor in vertex_faces[int(vertex_index)]:
+                if neighbor not in connected:
+                    connected.add(neighbor)
+                    pending.append(neighbor)
+    return np.asarray(sorted(connected), dtype=np.int64)
+
+
+def find_flattest_patch(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    surface: str,
+    radius_mm: float = FLAT_PATCH_RADIUS_MM,
+) -> _DetectedFlatPatch:
+    """Find the lowest-residual fixed-radius planar neighborhood on one mesh."""
+
+    vertices = np.asarray(vertices, dtype=float)
+    faces = np.asarray(faces, dtype=np.int64)
+    if vertices.ndim != 2 or vertices.shape[1] != 3:
+        raise ValueError("flat-patch vertices must have shape (n, 3)")
+    if faces.ndim != 2 or faces.shape[1] != 3:
+        raise ValueError("flat-patch faces must have shape (n, 3)")
+    if not np.isfinite(radius_mm) or radius_mm <= 0:
+        raise ValueError("flat-patch radius must be positive")
+
+    valid_faces, centers, normals, areas = _face_geometry(vertices, faces)
+    candidate_indices = _candidate_face_indices(
+        vertices,
+        valid_faces,
+        normals,
+        areas,
+        centers,
+        radius_mm,
+    )
+    tree = cKDTree(centers)
+    target_area = np.pi * radius_mm**2 * 0.25
+    best = None
+    for seed_index in candidate_indices:
+        neighborhood = np.asarray(
+            tree.query_ball_point(centers[seed_index], radius_mm), dtype=np.int64
+        )
+        neighborhood = _connected_face_component(valid_faces, neighborhood, seed_index)
+        if neighborhood.size < 3:
+            neighborhood = np.asarray([seed_index], dtype=np.int64)
+        center, normal, rms, area, coherence = _fit_face_patch(
+            vertices, valid_faces, normals, areas, neighborhood
+        )
+        aligned = neighborhood[
+            np.abs(normals[neighborhood] @ normal) >= np.cos(np.deg2rad(45.0))
+        ]
+        if aligned.size >= 3 and aligned.size != neighborhood.size:
+            neighborhood = aligned
+            center, normal, rms, area, coherence = _fit_face_patch(
+                vertices, valid_faces, normals, areas, neighborhood
+            )
+        coverage_penalty = max(0.0, target_area - area) / target_area * radius_mm
+        score = rms + radius_mm * (1.0 - coherence) + coverage_penalty
+        candidate = (score, seed_index, neighborhood, center, normal, rms, area)
+        if best is None or candidate[:2] < best[:2]:
+            best = candidate
+
+    assert best is not None
+    _, _, support_faces, center, normal, rms, area = best
+    vertex_indices = np.unique(valid_faces[support_faces].reshape(-1))
+    patch = FlatPatch(
+        surface=surface,
+        center_ras_mm=tuple(float(value) for value in center),
+        normal_ras=tuple(float(value) for value in normal),
+        radius_mm=float(radius_mm),
+        area_mm2=area,
+        rms_distance_mm=rms,
+        vertex_count=int(vertex_indices.size),
+    )
+    return _DetectedFlatPatch(patch=patch, vertex_indices=vertex_indices)
+
+
+def find_flat_patches(
+    surfaces: dict[str, Path],
+) -> dict[str, _DetectedFlatPatch]:
+    """Find one fixed-radius flat pial candidate per hemisphere."""
+
+    detected = {}
+    for hemisphere in ("lh", "rh"):
+        surface = f"{hemisphere}.pial"
+        vertices, faces = nib.freesurfer.read_geometry(str(surfaces[surface]))
+        detected[hemisphere] = find_flattest_patch(vertices, faces, surface)
+    return detected
 
 
 def _scaled_anatomy(image: nib.spatialimages.SpatialImage) -> np.ndarray:
@@ -274,47 +533,113 @@ def _scaled_anatomy(image: nib.spatialimages.SpatialImage) -> np.ndarray:
     return np.rint(scaled * 3000.0).astype(np.int16)
 
 
-def _surface_voxel_mask(
+def _dilate_in_plane(mask: np.ndarray, radius: int) -> np.ndarray:
+    """Expand a mask in image axes 0 and 1 without wrapping at the edges."""
+
+    dilated = mask.copy()
+    for _ in range(radius):
+        expanded = dilated.copy()
+        expanded[1:, :, :] |= dilated[:-1, :, :]
+        expanded[:-1, :, :] |= dilated[1:, :, :]
+        expanded[:, 1:, :] |= dilated[:, :-1, :]
+        expanded[:, :-1, :] |= dilated[:, 1:, :]
+        dilated = expanded
+    return dilated
+
+
+def _world_points_voxel_mask(
     image: nib.spatialimages.SpatialImage,
-    paths: Sequence[Path],
+    world_points: np.ndarray,
+    thickness: int,
 ) -> np.ndarray:
     mask = np.zeros(image.shape, dtype=bool)
     inverse_affine = np.linalg.inv(image.affine)
+    voxel_points = np.rint(
+        nib.affines.apply_affine(inverse_affine, world_points)
+    ).astype(int)
+    inside = np.all(voxel_points >= 0, axis=1) & np.all(
+        voxel_points < np.asarray(image.shape), axis=1
+    )
+    voxel_points = voxel_points[inside]
+    if voxel_points.size:
+        mask[tuple(voxel_points.T)] = True
+    return _dilate_in_plane(mask, thickness)
+
+
+def _surface_voxel_mask(
+    image: nib.spatialimages.SpatialImage,
+    paths: Sequence[Path],
+    thickness: int,
+) -> np.ndarray:
+    mask = np.zeros(image.shape, dtype=bool)
     for path in paths:
         vertices, _ = nib.freesurfer.read_geometry(str(path))
-        voxel_vertices = np.rint(
-            nib.affines.apply_affine(inverse_affine, vertices)
-        ).astype(int)
-        inside = np.all(voxel_vertices >= 0, axis=1) & np.all(
-            voxel_vertices < np.asarray(image.shape), axis=1
-        )
-        voxel_vertices = voxel_vertices[inside]
-        if voxel_vertices.size:
-            mask[tuple(voxel_vertices.T)] = True
+        mask |= _world_points_voxel_mask(image, vertices, 0)
+    return _dilate_in_plane(mask, thickness)
 
-    dilated = mask.copy()
-    for axis in (0, 1):
-        dilated |= np.roll(mask, 1, axis=axis)
-        dilated |= np.roll(mask, -1, axis=axis)
-    return dilated
+
+def _flat_patch_masks(
+    image: nib.spatialimages.SpatialImage,
+    surfaces: dict[str, Path],
+    detections: dict[str, _DetectedFlatPatch],
+    thickness: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    patch_mask = np.zeros(image.shape, dtype=bool)
+    normal_mask = np.zeros(image.shape, dtype=bool)
+    sample_step = max(min(image.header.get_zooms()[:3]) * 0.5, 0.1)
+    sample_count = int(np.ceil(FLAT_PATCH_NORMAL_LENGTH_MM / sample_step)) + 1
+    distances = np.linspace(0.0, FLAT_PATCH_NORMAL_LENGTH_MM, sample_count)
+    for detection in detections.values():
+        vertices, _ = nib.freesurfer.read_geometry(
+            str(surfaces[detection.patch.surface])
+        )
+        patch_mask |= _world_points_voxel_mask(
+            image,
+            vertices[detection.vertex_indices],
+            thickness,
+        )
+        center = np.asarray(detection.patch.center_ras_mm)
+        normal = np.asarray(detection.patch.normal_ras)
+        line_points = center + distances[:, np.newaxis] * normal
+        normal_mask |= _world_points_voxel_mask(
+            image,
+            line_points,
+            thickness,
+        )
+    return patch_mask, normal_mask
 
 
 def write_qc_overlay(
     image: nib.spatialimages.SpatialImage,
     surfaces: dict[str, Path],
     output_path: Path,
+    overlay_thickness: int = 1,
+    flat_patches: dict[str, _DetectedFlatPatch] | None = None,
 ) -> Path:
     """Rasterize white and pial vertices onto the source voxel grid."""
 
     output = _scaled_anatomy(image)
     pial_mask = _surface_voxel_mask(
-        image, [surfaces["lh.pial"], surfaces["rh.pial"]]
+        image,
+        [surfaces["lh.pial"], surfaces["rh.pial"]],
+        overlay_thickness,
     )
     white_mask = _surface_voxel_mask(
-        image, [surfaces["lh.white"], surfaces["rh.white"]]
+        image,
+        [surfaces["lh.white"], surfaces["rh.white"]],
+        overlay_thickness,
     )
     output[pial_mask] = 3500
     output[white_mask] = 4095
+    if flat_patches:
+        patch_mask, normal_mask = _flat_patch_masks(
+            image,
+            surfaces,
+            flat_patches,
+            overlay_thickness,
+        )
+        output[patch_mask] = 3800
+        output[normal_mask] = 4095
 
     header = image.header.copy()
     header.set_data_dtype(np.int16)
@@ -370,9 +695,22 @@ def run_topofit_workflow(
         _run_command(command, runner)
 
     surfaces = validate_surface_outputs(surface_dir)
-    qc_path = write_qc_overlay(image, surfaces, run_dir / "topofit_qc.nii.gz")
+    detected_flat_patches = (
+        find_flat_patches(surfaces) if options.find_flat_patches else {}
+    )
+    qc_path = write_qc_overlay(
+        image,
+        surfaces,
+        run_dir / "topofit_qc.nii.gz",
+        overlay_thickness=options.overlay_thickness,
+        flat_patches=detected_flat_patches,
+    )
     elapsed = perf_counter() - started
     manifest_path = run_dir / "topofit_manifest.json"
+    flat_patches = {
+        hemisphere: detection.patch
+        for hemisphere, detection in detected_flat_patches.items()
+    }
     result = TopoFitResult(
         status="SURFACE_READY_RESEARCH_ONLY",
         run_dir=str(run_dir.resolve()),
@@ -380,6 +718,7 @@ def run_topofit_workflow(
         qc_image=str(qc_path.resolve()),
         manifest=str(manifest_path.resolve()),
         surfaces={name: str(path.resolve()) for name, path in surfaces.items()},
+        flat_patches=flat_patches,
         elapsed_seconds=round(elapsed, 3),
     )
     manifest = asdict(result)
@@ -387,5 +726,8 @@ def run_topofit_workflow(
     manifest["brainnet_command"] = command
     manifest["prescription_coordinates"] = None
     manifest["coordinate_status"] = "WITHHELD_UNTIL_VALIDATED_ANALYSIS_STAGE"
+    manifest["flat_patch_status"] = (
+        "CANDIDATES_REPORTED_RESEARCH_ONLY" if flat_patches else "DISABLED"
+    )
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     return result


### PR DESCRIPTION
Adds selectable flat-patch analysis and configurable QC surface thickness to TopoFit 0.3.0.

What changes

- Finds one 10 mm-radius pial candidate per hemisphere with a connected, area-weighted plane fit.
- Writes patch centers and unit normals into QC image comments in scanner LPS coordinates.
- Draws each patch and its 20 mm outward normal in the QC pixels.
- Adds a 0 to 3 voxel surface-thickness control. Zero draws the undilated trace.
- Keeps prescription coordinates unset and marks candidates as research-only.

Local verification

- 12 focused TopoFit core and MRD tests pass, including the existing MP2RAGE UNI-DEN path.
- 15 OpenRecon schema and synchronization tests pass.
- Recipe validation, lint, spelling, and Dockerfile generation pass.

The required container candidate workflow will build and run the real CPU BrainNet fulltest before merge.