### PR TITLE
Add TopoFit sulcal mid-depth analysis

### DIFF
--- a/recipes/topofit/OpenReconLabel.json
+++ b/recipes/topofit/OpenReconLabel.json
@@ -13,7 +13,7 @@
       "manufacture_date": "2026/09/02",
       "material_number": "topofit_VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "gtin": "00860000171212",
-      "udi": "(01)00860000171212(21)1.3.0",
+      "udi": "(01)00860000171212(21)VERSION_WILL_BE_REPLACED_BY_SCRIPT",
       "safety_advices": "Research use only. The output is not motion-cleared and must not be used directly for slice prescription.",
       "special_operating_instructions": "OpenRecon TopoFit cortical surface workflow",
       "additional_relevant_information": "The scanner receives a source-grid QC overlay. Surface files remain in the run workspace for downstream research analysis."
@@ -107,6 +107,22 @@
       "type": "boolean",
       "default": false,
       "information": { "en": "Find one locally planar pial-surface patch per hemisphere, draw each patch and outward normal, and append research-only LPS coordinates to the image comments." }
+    },
+    {
+      "id": "tfsulcalmiddepth",
+      "label": { "en": "Find sulcal mid-depth voxels" },
+      "type": "boolean",
+      "default": false,
+      "information": { "en": "Classify concave pial regions by signed mean curvature and write the source-grid voxels intersected at 50% cortical depth." }
+    },
+    {
+      "id": "tfsulcalthreshold",
+      "label": { "en": "Sulcal curvature threshold" },
+      "type": "double",
+      "minimum": 0.1,
+      "maximum": 1.0,
+      "default": 0.1,
+      "information": { "en": "Set the minimum magnitude of negative, concave mean curvature used to classify sulcal vertices." }
     },
     {
       "id": "tfoverlaythickness",

--- a/recipes/topofit/OpenReconREADME.md
+++ b/recipes/topofit/OpenReconREADME.md
@@ -26,6 +26,7 @@ Each successful run writes these artifacts below `/tmp/share/topofit`:
 - `surf/lh.pial` and `surf/rh.pial`
 - `surf/lh.registration` and `surf/rh.registration`
 - `topofit_qc.nii.gz`
+- `topofit_sulcal_middepth_mask.nii.gz` when sulcal analysis is enabled
 - `topofit_manifest.json`
 
 The QC volume preserves the input dimensions and affine. It displays the
@@ -47,6 +48,14 @@ Surface artifacts stay in the run workspace so later research analysis can
 consume them. Flat-patch coordinates are candidates only. They are not
 motion-cleared prescription coordinates.
 
+When **Find sulcal mid-depth voxels** is enabled, the workflow computes signed
+cotangent mean curvature on each pial mesh. Negative curvature is concave and
+sulcal. Faces whose three vertices meet the configured threshold are moved to
+50% cortical depth using the corresponding white and pial vertices. The
+workflow writes every source-grid voxel cell intersected by those faces to
+`topofit_sulcal_middepth_mask.nii.gz`. Labels 1 and 2 mark the left and right
+hemispheres; 3 marks overlap. The mask keeps the source shape and affine.
+
 ## Parameters
 
 | GUI label | Parameter | Default | Meaning |
@@ -56,6 +65,8 @@ motion-cleared prescription coordinates.
 | TopoFit model | `tfmodel` | `t1w_1mm` | Select the T1w or synthetic pretrained model. |
 | Conform input | `tfconform` | `true` | Resample internally to the model grid. |
 | Find flat pial patches | `tfflatpatches` | `false` | Find one candidate per hemisphere, draw its patch and normal, and write LPS geometry into image comments. |
+| Find sulcal mid-depth voxels | `tfsulcalmiddepth` | `false` | Write a source-grid label mask for curvature-defined sulci at 50% cortical depth. |
+| Sulcal curvature threshold | `tfsulcalthreshold` | `0.1 mm^-1` | Set the minimum magnitude of negative mean curvature. |
 | Surface thickness | `tfoverlaythickness` | `1` voxel | Set the in-plane dilation radius from 0 to 3 voxels. |
 | Mock surfaces | `tfdebugmock` | `false` | Exercise MRD transport and geometry without neural inference. |
 
@@ -86,6 +97,7 @@ The container exposes the same workflow as a command-line tool:
 topofit-openrecon mprage.nii.gz output --device cuda
 topofit-openrecon mprage.nii.gz transport-test --device cpu --mock
 topofit-openrecon mprage.nii.gz flat-patches --find-flat-patches --overlay-thickness 0
+topofit-openrecon mprage.nii.gz sulci --find-sulcal-middepth --sulcal-curvature-threshold 0.1
 ```
 
 The first command runs the real model. The second tests the artifact and QC

--- a/recipes/topofit/build.yaml
+++ b/recipes/topofit/build.yaml
@@ -1,5 +1,5 @@
 name: topofit
-version: "0.3.0"
+version: "0.4.0"
 
 copyright:
   - license: GPL-3.0-only
@@ -48,9 +48,11 @@ build:
 
     - run:
         - install -m 0644 {{ get_file("topofit_core.py") }} /opt/code/python-ismrmrd-server/topofit_core.py
+        - install -m 0644 {{ get_file("topofit_geometry.py") }} /opt/code/python-ismrmrd-server/topofit_geometry.py
         - install -m 0755 {{ get_file("topofit.py") }} /opt/code/python-ismrmrd-server/topofit.py
         - install -m 0755 {{ get_file("topofit-openrecon") }} /usr/local/bin/topofit-openrecon
         - install -m 0644 {{ get_file("test_topofit_core.py") }} /opt/code/python-ismrmrd-server/test_topofit_core.py
+        - install -m 0644 {{ get_file("test_topofit_geometry.py") }} /opt/code/python-ismrmrd-server/test_topofit_geometry.py
         - install -m 0644 {{ get_file("test_topofit_openrecon.py") }} /opt/code/python-ismrmrd-server/test_topofit_openrecon.py
         - install -m 0644 {{ get_file("OpenReconLabel.json") }} /opt/code/python-ismrmrd-server/OpenReconLabel.json
         - install -m 0644 {{ get_file("OpenReconREADME.md") }} /opt/code/python-ismrmrd-server/OpenReconREADME.md
@@ -78,12 +80,16 @@ files:
     url: "{{ context.cortech_wheel_url }}"
   - name: topofit_core.py
     filename: topofit_core.py
+  - name: topofit_geometry.py
+    filename: topofit_geometry.py
   - name: topofit.py
     filename: topofit.py
   - name: topofit-openrecon
     filename: topofit-openrecon
   - name: test_topofit_core.py
     filename: test_topofit_core.py
+  - name: test_topofit_geometry.py
+    filename: test_topofit_geometry.py
   - name: test_topofit_openrecon.py
     filename: test_topofit_openrecon.py
   - name: OpenReconLabel.json
@@ -111,6 +117,9 @@ readme: |-
 
   Add `--find-flat-patches` to find one planar pial candidate per hemisphere,
   draw its patch and outward normal, and record the geometry in the manifest.
+  Add `--find-sulcal-middepth` to classify concave pial regions by mean
+  curvature and write the intersecting middle-cortical-depth voxels as a
+  source-grid label image.
   `--overlay-thickness 0` produces the thinnest projected surface trace.
 
   The OpenRecon output is research-only. It does not emit actionable slice

--- a/recipes/topofit/fulltest.yaml
+++ b/recipes/topofit/fulltest.yaml
@@ -5,7 +5,7 @@
 # on CPU and can take several minutes on a CPU-only release runner.
 
 name: topofit
-version: "0.3.0"
+version: "0.4.0"
 
 required_files:
   - dataset: ds000001
@@ -92,6 +92,12 @@ tests:
       bash -lc 'cd /opt/code/python-ismrmrd-server && PYTHONPATH=. python3 -m unittest -v test_topofit_core.py'
     expected_output_contains: "OK"
 
+  - name: Curvature and voxel intersection unit tests
+    description: Exercise signed curvature, cortical mid-depth, and triangle-to-voxel selection.
+    command: |
+      bash -lc 'cd /opt/code/python-ismrmrd-server && PYTHONPATH=. python3 -m unittest -v test_topofit_geometry.py'
+    expected_output_contains: "OK"
+
   - name: OpenRecon mock transport test
     description: Send real MRD images through the adapter and verify source-grid QC, metadata, and manifest output.
     command: |
@@ -101,10 +107,11 @@ tests:
   - name: Mock end-to-end NIfTI workflow
     description: Exercise the production artifact and QC path without neural inference.
     command: |
-      topofit-openrecon "${t1w}" "${output_dir}/mock" --device cpu --mock --find-flat-patches --overlay-thickness 0
+      topofit-openrecon "${t1w}" "${output_dir}/mock" --device cpu --mock --find-flat-patches --find-sulcal-middepth --overlay-thickness 0
     validate:
       - output_exists: ${output_dir}/mock/topofit_manifest.json
       - output_exists: ${output_dir}/mock/topofit_qc.nii.gz
+      - output_exists: ${output_dir}/mock/topofit_sulcal_middepth_mask.nii.gz
       - output_exists: ${output_dir}/mock/surf/lh.white
       - output_exists: ${output_dir}/mock/surf/rh.pial
 
@@ -118,6 +125,8 @@ tests:
       assert manifest['prescription_coordinates'] is None
       assert manifest['coordinate_status'] == 'WITHHELD_UNTIL_VALIDATED_ANALYSIS_STAGE'
       assert manifest['flat_patch_status'] == 'CANDIDATES_REPORTED_RESEARCH_ONLY'
+      assert manifest['sulcal_middepth_status'] == 'VOXELS_REPORTED_RESEARCH_ONLY'
+      assert set(manifest['sulci']) == {'lh', 'rh'}
       assert set(manifest['flat_patches']) == {'lh', 'rh'}
       assert manifest['options']['overlay_thickness'] == 0
       print(manifest['warning'])
@@ -127,10 +136,11 @@ tests:
   - name: Real TopoFit CPU workflow
     description: Run the pinned BrainNet model from T1w input through validated surfaces and source-grid QC.
     command: |
-      topofit-openrecon "${t1w}" "${output_dir}/real" --device cpu --find-flat-patches --overlay-thickness 0
+      topofit-openrecon "${t1w}" "${output_dir}/real" --device cpu --find-flat-patches --find-sulcal-middepth --overlay-thickness 0
     validate:
       - output_exists: ${output_dir}/real/topofit_manifest.json
       - output_exists: ${output_dir}/real/topofit_qc.nii.gz
+      - output_exists: ${output_dir}/real/topofit_sulcal_middepth_mask.nii.gz
       - output_exists: ${output_dir}/real/surf/lh.white
       - output_exists: ${output_dir}/real/surf/rh.white
       - output_exists: ${output_dir}/real/surf/lh.pial
@@ -151,6 +161,10 @@ tests:
       np.testing.assert_allclose(qc.affine, source.affine)
       manifest = __import__('json').load(open('${output_dir}/real/topofit_manifest.json'))
       assert set(manifest['flat_patches']) == {'lh', 'rh'}
+      sulcal = nib.load('${output_dir}/real/topofit_sulcal_middepth_mask.nii.gz')
+      assert sulcal.shape == source.shape
+      np.testing.assert_allclose(sulcal.affine, source.affine)
+      assert set(np.unique(np.asarray(sulcal.dataobj))).issubset({0, 1, 2, 3})
       for name in ('lh.white', 'rh.white', 'lh.pial', 'rh.pial', 'lh.registration', 'rh.registration'):
           vertices, faces = nib.freesurfer.read_geometry(str(Path('${output_dir}/real/surf') / name))
           assert vertices.shape[1] == 3 and faces.shape[1] == 3, name

--- a/recipes/topofit/test_topofit_core.py
+++ b/recipes/topofit/test_topofit_core.py
@@ -81,6 +81,16 @@ class TopoFitCoreTests(unittest.TestCase):
             ):
                 validate_options(TopoFitOptions(overlay_thickness=thickness))
 
+    def test_invalid_sulcal_curvature_threshold_is_rejected_at_boundary(self):
+        for threshold in (0.0, -0.1, float("nan")):
+            with (
+                self.subTest(threshold=threshold),
+                self.assertRaisesRegex(ValueError, "sulcal curvature threshold"),
+            ):
+                validate_options(
+                    TopoFitOptions(sulcal_curvature_threshold_mm_inv=threshold)
+                )
+
     def test_in_plane_dilation_is_configurable_without_edge_wrapping(self):
         mask = np.zeros((5, 5, 3), dtype=bool)
         mask[0, 0, 1] = True
@@ -164,6 +174,8 @@ class TopoFitCoreTests(unittest.TestCase):
                     device="cpu",
                     mock=True,
                     find_flat_patches=True,
+                    find_sulcal_middepth=True,
+                    sulcal_curvature_threshold_mm_inv=100.0,
                     overlay_thickness=0,
                 ),
             )
@@ -186,6 +198,11 @@ class TopoFitCoreTests(unittest.TestCase):
             qc_data = np.asarray(qc.dataobj)
             self.assertEqual(int(qc_data.max()), 4095)
             self.assertIn(3800, np.unique(qc_data))
+            self.assertIsNotNone(result.sulcal_middepth_mask)
+            sulcal_mask = nib.load(result.sulcal_middepth_mask)
+            self.assertEqual(sulcal_mask.shape, data.shape)
+            np.testing.assert_allclose(sulcal_mask.affine, affine)
+            self.assertEqual(sulcal_mask.get_data_dtype(), np.dtype(np.uint8))
             inverse_affine = np.linalg.inv(affine)
             for patch in result.flat_patches.values():
                 center = np.asarray(patch.center_ras_mm)
@@ -213,6 +230,14 @@ class TopoFitCoreTests(unittest.TestCase):
             )
             self.assertEqual(set(manifest["flat_patches"]), {"lh", "rh"})
             self.assertTrue(manifest["options"]["mock"])
+            self.assertEqual(
+                manifest["sulcal_middepth_status"],
+                "VOXELS_REPORTED_RESEARCH_ONLY",
+            )
+            self.assertEqual(set(manifest["sulci"]), {"lh", "rh"})
+            self.assertEqual(
+                manifest["sulcal_middepth_definition"]["depth_fraction"], 0.5
+            )
 
 
 if __name__ == "__main__":

--- a/recipes/topofit/test_topofit_geometry.py
+++ b/recipes/topofit/test_topofit_geometry.py
@@ -1,0 +1,80 @@
+"""Deterministic tests for TopoFit curvature and voxel intersection."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from topofit_geometry import signed_mean_curvature, triangle_voxel_mask
+
+
+class TopoFitGeometryTests(unittest.TestCase):
+    def test_outward_convex_surface_has_positive_curvature(self):
+        pial = np.asarray(
+            [
+                [-1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, -1.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        white = pial * 0.8
+        faces = np.asarray(
+            [
+                [0, 2, 4], [2, 1, 4], [1, 3, 4], [3, 0, 4],
+                [2, 0, 5], [1, 2, 5], [3, 1, 5], [0, 3, 5],
+            ]
+        )
+
+        curvature, _, _ = signed_mean_curvature(white, faces, pial, faces)
+
+        self.assertTrue(np.all(curvature > 0.0), curvature)
+
+    def test_concave_center_has_negative_curvature_and_midpoint_depth(self):
+        x, y = np.meshgrid(np.arange(3.0), np.arange(3.0), indexing="ij")
+        pial = np.column_stack((x.ravel(), y.ravel(), np.zeros(9)))
+        pial[4, 2] = -1.0
+        white = pial.copy()
+        white[:, 2] -= 2.0
+        faces = []
+        for i in range(2):
+            for j in range(2):
+                lower = i * 3 + j
+                faces.extend(
+                    ([lower, lower + 3, lower + 1], [lower + 1, lower + 3, lower + 4])
+                )
+        faces = np.asarray(faces, dtype=np.int32)
+
+        curvature, middle, returned_faces = signed_mean_curvature(
+            white, faces, pial, faces
+        )
+
+        self.assertLess(curvature[4], 0.0)
+        np.testing.assert_allclose(middle, (white + pial) / 2.0)
+        np.testing.assert_array_equal(returned_faces, faces)
+
+    def test_triangle_marks_voxel_even_when_no_vertex_rounds_into_it(self):
+        vertices = np.asarray(
+            [[-0.49, 0.49, 0.0], [1.49, 0.49, 0.0], [0.5, 1.49, 0.0]]
+        )
+        faces = np.asarray([[0, 1, 2]], dtype=np.int32)
+
+        mask = triangle_voxel_mask((3, 3, 2), np.eye(4), vertices, faces)
+
+        self.assertTrue(mask[0, 0, 0])
+        self.assertTrue(mask[1, 0, 0])
+        self.assertTrue(mask[0, 1, 0])
+
+    def test_surface_correspondence_is_required(self):
+        vertices = np.asarray(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        faces = np.asarray([[0, 1, 2], [0, 3, 1], [0, 2, 3], [1, 3, 2]])
+        with self.assertRaisesRegex(ValueError, "identical face topology"):
+            signed_mean_curvature(vertices, faces, vertices, faces[::-1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/recipes/topofit/test_topofit_openrecon.py
+++ b/recipes/topofit/test_topofit_openrecon.py
@@ -169,6 +169,8 @@ class TopoFitOpenReconTests(unittest.TestCase):
                     "tfconform": True,
                     "tfdebugmock": True,
                     "tfflatpatches": True,
+                    "tfsulcalmiddepth": True,
+                    "tfsulcalthreshold": 100.0,
                     "tfoverlaythickness": 0,
                 }
             }
@@ -207,6 +209,10 @@ class TopoFitOpenReconTests(unittest.TestCase):
                 "TopoFit flat patch rh.pial LPS_mm", output_meta["ImageComments"]
             )
             self.assertIn("normal=(", output_meta["ImageComments"])
+            self.assertIn(
+                "TopoFit sulcal mid-depth research voxels: lh=0, rh=0",
+                output_meta["ImageComments"],
+            )
 
             manifests = list(Path(temporary_directory).glob("*/topofit_manifest.json"))
             self.assertEqual(len(manifests), 1)
@@ -215,6 +221,13 @@ class TopoFitOpenReconTests(unittest.TestCase):
             self.assertEqual(len(manifest["surfaces"]), 6)
             self.assertEqual(set(manifest["flat_patches"]), {"lh", "rh"})
             self.assertEqual(manifest["options"]["overlay_thickness"], 0)
+            self.assertEqual(
+                manifest["options"]["sulcal_curvature_threshold_mm_inv"], 100.0
+            )
+            self.assertEqual(
+                manifest["sulcal_middepth_status"],
+                "VOXELS_REPORTED_RESEARCH_ONLY",
+            )
             for patch in manifest["flat_patches"].values():
                 center_lps = np.asarray(patch["center_ras_mm"]) * (-1.0, -1.0, 1.0)
                 normal_lps = np.asarray(patch["normal_ras"]) * (-1.0, -1.0, 1.0)

--- a/recipes/topofit/topofit.py
+++ b/recipes/topofit/topofit.py
@@ -37,6 +37,8 @@ DEFAULTS = {
     "tfconform": True,
     "tfdebugmock": False,
     "tfflatpatches": False,
+    "tfsulcalmiddepth": False,
+    "tfsulcalthreshold": 0.1,
     "tfoverlaythickness": 1,
 }
 MP2RAGE_IDENTITY_META_KEYS = (
@@ -78,6 +80,14 @@ def _config_int(config, key: str, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         raise ValueError(f"{key} must be an integer, got {value!r}") from None
+
+
+def _config_float(config, key: str, default: float) -> float:
+    value = _config_value(config, key, default, "float")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be a number, got {value!r}") from None
 
 
 def _meta_from_image(image) -> ismrmrd.Meta:
@@ -441,11 +451,22 @@ def _format_flat_patch_comment(flat_patches) -> str:
     return "; ".join(parts)
 
 
+def _format_sulcal_middepth_comment(sulci) -> str:
+    if not sulci:
+        return ""
+    counts = ", ".join(
+        f"{hemisphere}={sulci[hemisphere]['intersecting_voxel_count']}"
+        for hemisphere in ("lh", "rh")
+    )
+    return f"TopoFit sulcal mid-depth research voxels: {counts}"
+
+
 def _qc_mrd_images(
     qc_path: Path,
     source_images,
     series_index: int,
     flat_patches=None,
+    sulci=None,
 ) -> list:
     image = nib.load(str(qc_path))
     volume_xyz = np.asarray(image.get_fdata(dtype=np.float32))
@@ -463,6 +484,7 @@ def _qc_mrd_images(
     series_uid = _new_series_uid()
     description = f"{_series_description(source_images[0], 'mprage')}_topofit_qc"
     patch_comment = _format_flat_patch_comment(flat_patches or {})
+    sulcal_comment = _format_sulcal_middepth_comment(sulci or {})
     output = []
     for index, source in enumerate(source_images):
         plane = np.ascontiguousarray(volume_yxz[:, :, index])
@@ -478,7 +500,7 @@ def _qc_mrd_images(
             description,
             ["PYTHON", "BRAINNET", "TOPOFIT", "SURFACE_QC"],
             RESEARCH_WARNING,
-            patch_comment,
+            "; ".join(part for part in (patch_comment, sulcal_comment) if part),
         )
         output.append(derived)
     return output
@@ -509,6 +531,12 @@ def _options_from_config(config) -> TopoFitOptions:
         mock=_config_bool(config, "tfdebugmock", DEFAULTS["tfdebugmock"]),
         find_flat_patches=_config_bool(
             config, "tfflatpatches", DEFAULTS["tfflatpatches"]
+        ),
+        find_sulcal_middepth=_config_bool(
+            config, "tfsulcalmiddepth", DEFAULTS["tfsulcalmiddepth"]
+        ),
+        sulcal_curvature_threshold_mm_inv=_config_float(
+            config, "tfsulcalthreshold", DEFAULTS["tfsulcalthreshold"]
         ),
         overlay_thickness=_config_int(
             config,
@@ -580,6 +608,7 @@ def process(connection, config, metadata):
                 ordered,
                 next_series_index,
                 result.flat_patches,
+                result.sulci,
             )
             pending_output.append(("TopoFit QC", qc_images))
             next_series_index += 1
@@ -634,6 +663,18 @@ def _parse_args() -> argparse.Namespace:
         help="Find and draw one flat pial-surface patch per hemisphere",
     )
     parser.add_argument(
+        "--find-sulcal-middepth",
+        action="store_true",
+        help="Identify concave pial regions and select their mid-depth voxels",
+    )
+    parser.add_argument(
+        "--sulcal-curvature-threshold",
+        type=float,
+        default=0.1,
+        metavar="MM^-1",
+        help="Minimum concave mean curvature for sulcal selection (default: 0.1)",
+    )
+    parser.add_argument(
         "--overlay-thickness",
         type=int,
         choices=range(4),
@@ -654,6 +695,8 @@ def main() -> int:
         conform=args.conform,
         mock=args.mock,
         find_flat_patches=args.find_flat_patches,
+        find_sulcal_middepth=args.find_sulcal_middepth,
+        sulcal_curvature_threshold_mm_inv=args.sulcal_curvature_threshold,
         overlay_thickness=args.overlay_thickness,
     )
     result = run_topofit_workflow(args.input, args.output_dir, options)

--- a/recipes/topofit/topofit_core.py
+++ b/recipes/topofit/topofit_core.py
@@ -18,6 +18,13 @@ from typing import Callable, Sequence
 import nibabel as nib
 import numpy as np
 from scipy.spatial import cKDTree
+from topofit_geometry import (
+    CURVATURE_SIGN_CONVENTION,
+    MIDDLE_DEPTH_FRACTION,
+    SulcalHemisphere,
+    identify_sulcal_middepth,
+    triangle_voxel_mask,
+)
 
 RESEARCH_WARNING = "RESEARCH ONLY - NOT MOTION-CLEARED - NOT FOR PRESCRIPTION"
 SURFACE_NAMES = (
@@ -37,6 +44,7 @@ FLAT_PATCH_RADIUS_MM = 10.0
 FLAT_PATCH_NORMAL_LENGTH_MM = 20.0
 MAX_OVERLAY_THICKNESS = 3
 MAX_PATCH_CANDIDATES = 64
+DEFAULT_SULCAL_CURVATURE_THRESHOLD_MM_INV = 0.1
 
 
 @dataclass(frozen=True)
@@ -48,6 +56,10 @@ class TopoFitOptions:
     conform: bool = True
     mock: bool = False
     find_flat_patches: bool = False
+    find_sulcal_middepth: bool = False
+    sulcal_curvature_threshold_mm_inv: float = (
+        DEFAULT_SULCAL_CURVATURE_THRESHOLD_MM_INV
+    )
     overlay_thickness: int = 1
 
 
@@ -83,6 +95,8 @@ class TopoFitResult:
     manifest: str
     surfaces: dict[str, str]
     flat_patches: dict[str, FlatPatch]
+    sulcal_middepth_mask: str | None
+    sulci: dict[str, dict[str, float | int | str]]
     elapsed_seconds: float
     warning: str = RESEARCH_WARNING
 
@@ -100,6 +114,13 @@ def validate_options(options: TopoFitOptions) -> tuple[str, str]:
         raise ValueError(
             f"overlay thickness must be an integer from 0 to {MAX_OVERLAY_THICKNESS}"
         )
+    if (
+        not isinstance(options.sulcal_curvature_threshold_mm_inv, (int, float))
+        or isinstance(options.sulcal_curvature_threshold_mm_inv, bool)
+        or not np.isfinite(options.sulcal_curvature_threshold_mm_inv)
+        or options.sulcal_curvature_threshold_mm_inv <= 0
+    ):
+        raise ValueError("sulcal curvature threshold must be a positive finite value")
     try:
         return MODEL_PRESETS[options.preset]
     except KeyError:
@@ -609,12 +630,65 @@ def _flat_patch_masks(
     return patch_mask, normal_mask
 
 
+def _find_sulcal_middepth(
+    image: nib.spatialimages.SpatialImage,
+    surfaces: dict[str, Path],
+    threshold_mm_inv: float,
+) -> tuple[dict[str, SulcalHemisphere], dict[str, np.ndarray]]:
+    detections = {}
+    masks = {}
+    for hemisphere in ("lh", "rh"):
+        white_vertices, white_faces = nib.freesurfer.read_geometry(
+            str(surfaces[f"{hemisphere}.white"])
+        )
+        pial_vertices, pial_faces = nib.freesurfer.read_geometry(
+            str(surfaces[f"{hemisphere}.pial"])
+        )
+        detection = identify_sulcal_middepth(
+            hemisphere,
+            white_vertices,
+            white_faces,
+            pial_vertices,
+            pial_faces,
+            threshold_mm_inv,
+        )
+        detections[hemisphere] = detection
+        masks[hemisphere] = triangle_voxel_mask(
+            tuple(int(value) for value in image.shape),
+            image.affine,
+            detection.middle_vertices_ras_mm,
+            detection.selected_faces,
+        )
+    return detections, masks
+
+
+def write_sulcal_middepth_mask(
+    image: nib.spatialimages.SpatialImage,
+    masks: dict[str, np.ndarray],
+    output_path: Path,
+) -> Path:
+    """Write a bilateral label image on the source voxel grid."""
+
+    labels = np.zeros(image.shape, dtype=np.uint8)
+    labels[masks["lh"]] |= 1
+    labels[masks["rh"]] |= 2
+    header = image.header.copy()
+    header.set_data_dtype(np.uint8)
+    header["descrip"] = b"TopoFit sulcal mid-depth research mask"
+    output = nib.Nifti1Image(labels, image.affine, header=header)
+    output.set_qform(image.affine, code=1)
+    output.set_sform(image.affine, code=1)
+    nib.save(output, str(output_path))
+    return output_path
+
+
 def write_qc_overlay(
     image: nib.spatialimages.SpatialImage,
     surfaces: dict[str, Path],
     output_path: Path,
     overlay_thickness: int = 1,
     flat_patches: dict[str, _DetectedFlatPatch] | None = None,
+    sulcal_middepth_masks: dict[str, np.ndarray] | None = None,
 ) -> Path:
     """Rasterize white and pial vertices onto the source voxel grid."""
 
@@ -630,6 +704,8 @@ def write_qc_overlay(
         overlay_thickness,
     )
     output[pial_mask] = 3500
+    if sulcal_middepth_masks:
+        output[sulcal_middepth_masks["lh"] | sulcal_middepth_masks["rh"]] = 3650
     output[white_mask] = 4095
     if flat_patches:
         patch_mask, normal_mask = _flat_patch_masks(
@@ -698,18 +774,45 @@ def run_topofit_workflow(
     detected_flat_patches = (
         find_flat_patches(surfaces) if options.find_flat_patches else {}
     )
+    sulcal_detections, sulcal_masks = (
+        _find_sulcal_middepth(
+            image, surfaces, options.sulcal_curvature_threshold_mm_inv
+        )
+        if options.find_sulcal_middepth
+        else ({}, {})
+    )
+    sulcal_mask_path = (
+        write_sulcal_middepth_mask(
+            image, sulcal_masks, run_dir / "topofit_sulcal_middepth_mask.nii.gz"
+        )
+        if sulcal_masks
+        else None
+    )
     qc_path = write_qc_overlay(
         image,
         surfaces,
         run_dir / "topofit_qc.nii.gz",
         overlay_thickness=options.overlay_thickness,
         flat_patches=detected_flat_patches,
+        sulcal_middepth_masks=sulcal_masks,
     )
     elapsed = perf_counter() - started
     manifest_path = run_dir / "topofit_manifest.json"
     flat_patches = {
         hemisphere: detection.patch
         for hemisphere, detection in detected_flat_patches.items()
+    }
+    sulci = {
+        hemisphere: {
+            "hemisphere": detection.hemisphere,
+            "threshold_mm_inv": detection.threshold_mm_inv,
+            "selected_vertex_count": detection.selected_vertex_count,
+            "selected_face_count": detection.selected_face_count,
+            "intersecting_voxel_count": int(sulcal_masks[hemisphere].sum()),
+            "curvature_min_mm_inv": detection.curvature_min_mm_inv,
+            "curvature_median_mm_inv": detection.curvature_median_mm_inv,
+        }
+        for hemisphere, detection in sulcal_detections.items()
     }
     result = TopoFitResult(
         status="SURFACE_READY_RESEARCH_ONLY",
@@ -719,6 +822,10 @@ def run_topofit_workflow(
         manifest=str(manifest_path.resolve()),
         surfaces={name: str(path.resolve()) for name, path in surfaces.items()},
         flat_patches=flat_patches,
+        sulcal_middepth_mask=(
+            str(sulcal_mask_path.resolve()) if sulcal_mask_path else None
+        ),
+        sulci=sulci,
         elapsed_seconds=round(elapsed, 3),
     )
     manifest = asdict(result)
@@ -729,5 +836,17 @@ def run_topofit_workflow(
     manifest["flat_patch_status"] = (
         "CANDIDATES_REPORTED_RESEARCH_ONLY" if flat_patches else "DISABLED"
     )
+    manifest["sulcal_middepth_status"] = (
+        "VOXELS_REPORTED_RESEARCH_ONLY" if sulcal_mask_path else "DISABLED"
+    )
+    manifest["sulcal_middepth_definition"] = {
+        "depth_fraction": MIDDLE_DEPTH_FRACTION,
+        "curvature_surface": "pial",
+        "curvature_method": "cotangent_mean_curvature",
+        "curvature_units": "mm^-1",
+        "curvature_sign_convention": CURVATURE_SIGN_CONVENTION,
+        "face_selection": "all_vertices_at_or_below_negative_threshold",
+        "mask_labels": {"1": "left", "2": "right", "3": "bilateral_overlap"},
+    }
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     return result

--- a/recipes/topofit/topofit_geometry.py
+++ b/recipes/topofit/topofit_geometry.py
@@ -1,0 +1,182 @@
+"""Curvature and source-grid geometry for TopoFit cortical surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import nibabel as nib
+import numpy as np
+
+
+CURVATURE_SIGN_CONVENTION = "positive_convex_negative_sulcal"
+MIDDLE_DEPTH_FRACTION = 0.5
+
+
+@dataclass(frozen=True)
+class SulcalHemisphere:
+    """Measurements and mesh support for one hemisphere's sulcal selection."""
+
+    hemisphere: str
+    threshold_mm_inv: float
+    selected_vertex_count: int
+    selected_face_count: int
+    curvature_min_mm_inv: float
+    curvature_median_mm_inv: float
+    middle_vertices_ras_mm: np.ndarray
+    selected_faces: np.ndarray
+
+
+def _validated_surface_pair(
+    white_vertices: np.ndarray,
+    white_faces: np.ndarray,
+    pial_vertices: np.ndarray,
+    pial_faces: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    white = np.asarray(white_vertices, dtype=float)
+    pial = np.asarray(pial_vertices, dtype=float)
+    white_topology = np.asarray(white_faces, dtype=np.int64)
+    pial_topology = np.asarray(pial_faces, dtype=np.int64)
+    if white.ndim != 2 or white.shape[1] != 3 or pial.shape != white.shape:
+        raise ValueError("white and pial surfaces must have corresponding (n, 3) vertices")
+    if white_topology.ndim != 2 or white_topology.shape[1] != 3:
+        raise ValueError("white and pial surfaces must have triangular faces")
+    if not np.array_equal(white_topology, pial_topology):
+        raise ValueError("white and pial surfaces must have identical face topology")
+    if not np.all(np.isfinite(white)) or not np.all(np.isfinite(pial)):
+        raise ValueError("white and pial surfaces must contain finite vertices")
+    return white, pial, pial_topology
+
+
+def _outward_vertex_normals(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    cortical_directions: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    triangles = vertices[faces]
+    face_vectors = np.cross(
+        triangles[:, 1] - triangles[:, 0], triangles[:, 2] - triangles[:, 0]
+    )
+    twice_area = np.linalg.norm(face_vectors, axis=1)
+    if np.any(twice_area <= 1e-8):
+        raise ValueError("curvature analysis does not support degenerate faces")
+    normals = np.zeros_like(vertices)
+    for corner in range(3):
+        np.add.at(normals, faces[:, corner], face_vectors)
+    lengths = np.linalg.norm(normals, axis=1)
+    if np.any(lengths <= 1e-8):
+        raise ValueError("curvature analysis found a vertex without a valid normal")
+    normals /= lengths[:, np.newaxis]
+    if float(np.median(np.einsum("ij,ij->i", normals, cortical_directions))) < 0:
+        normals = -normals
+    return normals, twice_area * 0.5
+
+
+def signed_mean_curvature(
+    white_vertices: np.ndarray,
+    white_faces: np.ndarray,
+    pial_vertices: np.ndarray,
+    pial_faces: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return convex-positive cotangent mean curvature and the mid-depth mesh."""
+
+    white, pial, faces = _validated_surface_pair(
+        white_vertices, white_faces, pial_vertices, pial_faces
+    )
+    normals, face_areas = _outward_vertex_normals(pial, faces, pial - white)
+    vertex_areas = np.zeros(pial.shape[0], dtype=float)
+    for corner in range(3):
+        np.add.at(vertex_areas, faces[:, corner], face_areas / 3.0)
+    if np.any(vertex_areas <= 1e-12):
+        raise ValueError("curvature analysis found a vertex without surface area")
+
+    laplacian = np.zeros_like(pial)
+    for opposite, first, second in ((0, 1, 2), (1, 2, 0), (2, 0, 1)):
+        a = pial[faces[:, first]] - pial[faces[:, opposite]]
+        b = pial[faces[:, second]] - pial[faces[:, opposite]]
+        cotangent = np.einsum("ij,ij->i", a, b) / np.linalg.norm(
+            np.cross(a, b), axis=1
+        )
+        i = faces[:, first]
+        j = faces[:, second]
+        contribution = cotangent[:, np.newaxis] * (pial[j] - pial[i])
+        np.add.at(laplacian, i, contribution)
+        np.add.at(laplacian, j, -contribution)
+    laplacian /= 2.0 * vertex_areas[:, np.newaxis]
+    curvature = -0.5 * np.einsum("ij,ij->i", laplacian, normals)
+    middle = white + MIDDLE_DEPTH_FRACTION * (pial - white)
+    return curvature, middle, faces
+
+
+def identify_sulcal_middepth(
+    hemisphere: str,
+    white_vertices: np.ndarray,
+    white_faces: np.ndarray,
+    pial_vertices: np.ndarray,
+    pial_faces: np.ndarray,
+    threshold_mm_inv: float,
+) -> SulcalHemisphere:
+    """Select concave pial faces and place them at middle cortical depth."""
+
+    if not np.isfinite(threshold_mm_inv) or threshold_mm_inv <= 0:
+        raise ValueError("sulcal curvature threshold must be a positive finite value")
+    curvature, middle, faces = signed_mean_curvature(
+        white_vertices, white_faces, pial_vertices, pial_faces
+    )
+    selected_vertices = curvature <= -threshold_mm_inv
+    selected_faces = faces[np.all(selected_vertices[faces], axis=1)]
+    values = curvature[selected_vertices]
+    return SulcalHemisphere(
+        hemisphere=hemisphere,
+        threshold_mm_inv=float(threshold_mm_inv),
+        selected_vertex_count=int(selected_vertices.sum()),
+        selected_face_count=int(selected_faces.shape[0]),
+        curvature_min_mm_inv=float(curvature.min()),
+        curvature_median_mm_inv=float(np.median(values)) if values.size else 0.0,
+        middle_vertices_ras_mm=middle,
+        selected_faces=selected_faces,
+    )
+
+
+def _triangle_intersects_unit_box(triangle: np.ndarray, center: np.ndarray) -> bool:
+    shifted = triangle - center
+    edges = (shifted[1] - shifted[0], shifted[2] - shifted[1], shifted[0] - shifted[2])
+    axes = [np.eye(3)[axis] for axis in range(3)]
+    axes.append(np.cross(edges[0], edges[1]))
+    for edge in edges:
+        axes.extend(np.cross(edge, np.eye(3)[axis]) for axis in range(3))
+    for axis in axes:
+        if float(np.dot(axis, axis)) <= 1e-16:
+            continue
+        projections = shifted @ axis
+        radius = 0.5 * float(np.abs(axis).sum())
+        if float(projections.min()) > radius or float(projections.max()) < -radius:
+            return False
+    return True
+
+
+def triangle_voxel_mask(
+    shape: tuple[int, int, int],
+    affine: np.ndarray,
+    vertices_ras_mm: np.ndarray,
+    faces: np.ndarray,
+) -> np.ndarray:
+    """Mark source-grid voxel cells intersected by any selected mesh triangle."""
+
+    mask = np.zeros(shape, dtype=bool)
+    if faces.size == 0:
+        return mask
+    voxel_vertices = np.asarray(
+        nib.affines.apply_affine(np.linalg.inv(affine), vertices_ras_mm)
+    )
+    upper = np.asarray(shape) - 1
+    for face in faces:
+        triangle = voxel_vertices[face]
+        lower_bound = np.maximum(np.ceil(triangle.min(axis=0) - 0.5), 0).astype(int)
+        upper_bound = np.minimum(np.floor(triangle.max(axis=0) + 0.5), upper).astype(int)
+        for i in range(lower_bound[0], upper_bound[0] + 1):
+            for j in range(lower_bound[1], upper_bound[1] + 1):
+                for k in range(lower_bound[2], upper_bound[2] + 1):
+                    index = np.asarray((i, j, k))
+                    if _triangle_intersects_unit_box(triangle, index):
+                        mask[i, j, k] = True
+    return mask

--- a/recipes/topofit/topofit_geometry.py
+++ b/recipes/topofit/topofit_geometry.py
@@ -137,21 +137,34 @@ def identify_sulcal_middepth(
     )
 
 
-def _triangle_intersects_unit_box(triangle: np.ndarray, center: np.ndarray) -> bool:
-    shifted = triangle - center
-    edges = (shifted[1] - shifted[0], shifted[2] - shifted[1], shifted[0] - shifted[2])
-    axes = [np.eye(3)[axis] for axis in range(3)]
-    axes.append(np.cross(edges[0], edges[1]))
-    for edge in edges:
-        axes.extend(np.cross(edge, np.eye(3)[axis]) for axis in range(3))
-    for axis in axes:
-        if float(np.dot(axis, axis)) <= 1e-16:
-            continue
-        projections = shifted @ axis
-        radius = 0.5 * float(np.abs(axis).sum())
-        if float(projections.min()) > radius or float(projections.max()) < -radius:
-            return False
-    return True
+def _triangles_intersect_unit_boxes(
+    triangles: np.ndarray,
+    centers: np.ndarray,
+) -> np.ndarray:
+    """Test triangle-box pairs in one vectorized separating-axis pass."""
+
+    shifted = triangles - centers[:, np.newaxis, :]
+    edges = np.stack(
+        (
+            shifted[:, 1] - shifted[:, 0],
+            shifted[:, 2] - shifted[:, 1],
+            shifted[:, 0] - shifted[:, 2],
+        ),
+        axis=1,
+    )
+    box_axes = np.broadcast_to(np.eye(3), (triangles.shape[0], 3, 3))
+    face_normals = np.cross(edges[:, 0], edges[:, 1])[:, np.newaxis, :]
+    edge_axes = np.cross(edges[:, :, np.newaxis, :], np.eye(3)[np.newaxis, :, :])
+    axes = np.concatenate(
+        (box_axes, face_normals, edge_axes.reshape(-1, 9, 3)), axis=1
+    )
+    projections = np.einsum("mva,mka->mvk", shifted, axes)
+    radii = 0.5 * np.abs(axes).sum(axis=2)
+    separated = (projections.min(axis=1) > radii) | (
+        projections.max(axis=1) < -radii
+    )
+    nonzero_axes = np.einsum("mka,mka->mk", axes, axes) > 1e-16
+    return ~np.any(separated & nonzero_axes, axis=1)
 
 
 def triangle_voxel_mask(
@@ -168,15 +181,34 @@ def triangle_voxel_mask(
     voxel_vertices = np.asarray(
         nib.affines.apply_affine(np.linalg.inv(affine), vertices_ras_mm)
     )
+    triangles = voxel_vertices[faces]
     upper = np.asarray(shape) - 1
-    for face in faces:
-        triangle = voxel_vertices[face]
-        lower_bound = np.maximum(np.ceil(triangle.min(axis=0) - 0.5), 0).astype(int)
-        upper_bound = np.minimum(np.floor(triangle.max(axis=0) + 0.5), upper).astype(int)
-        for i in range(lower_bound[0], upper_bound[0] + 1):
-            for j in range(lower_bound[1], upper_bound[1] + 1):
-                for k in range(lower_bound[2], upper_bound[2] + 1):
-                    index = np.asarray((i, j, k))
-                    if _triangle_intersects_unit_box(triangle, index):
-                        mask[i, j, k] = True
+    lower_bounds = np.maximum(np.ceil(triangles.min(axis=1) - 0.5), 0).astype(int)
+    upper_bounds = np.minimum(
+        np.floor(triangles.max(axis=1) + 0.5), upper
+    ).astype(int)
+    candidate_centers = []
+    candidate_faces = []
+    for face_index, (lower, candidate_upper) in enumerate(
+        zip(lower_bounds, upper_bounds)
+    ):
+        if np.any(candidate_upper < lower):
+            continue
+        grid = np.indices(tuple(candidate_upper - lower + 1)).reshape(3, -1).T
+        candidate_centers.append(grid + lower)
+        candidate_faces.append(np.full(grid.shape[0], face_index, dtype=np.int64))
+    if not candidate_centers:
+        return mask
+
+    centers = np.concatenate(candidate_centers)
+    face_indices = np.concatenate(candidate_faces)
+    chunk_size = 100_000
+    for start in range(0, centers.shape[0], chunk_size):
+        stop = min(start + chunk_size, centers.shape[0])
+        chunk_centers = centers[start:stop]
+        intersects = _triangles_intersect_unit_boxes(
+            triangles[face_indices[start:stop]], chunk_centers
+        )
+        selected = chunk_centers[intersects]
+        mask[tuple(selected.T)] = True
     return mask


### PR DESCRIPTION
## Summary

- bump TopoFit to 0.4.0
- classify sulci from signed pial-surface mean curvature
- select source-grid voxels intersected at 50% cortical depth
- expose the analysis through the CLI and OpenRecon controls
- add a bilateral label mask, manifest metadata, and focused geometry tests

## Verification

- `PYTHONPATH=recipes/topofit python3 -m unittest -q recipes/topofit/test_topofit_geometry.py recipes/topofit/test_topofit_core.py`
- `python3 workflows/validate_openrecon_labels.py recipes/topofit/OpenReconLabel.json`
- `python3 builder/validation.py recipes/topofit/build.yaml`
- `python3 -m builder generate topofit --recreate`