### PR TITLE
Release promotion lock before OpenRecon sync

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -674,12 +674,40 @@ jobs:
           done
           echo "::error::Release metadata push failed after three attempts; artifacts are already published."
           exit 1
+  sync_openrecon:
+    needs: [resolve, finalize]
+    if: >-
+      needs.resolve.outputs.should_promote == 'true' &&
+      needs.resolve.outputs.recipes != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout trusted main after metadata finalization
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install OpenRecon sync dependencies
+        run: pip install pyyaml
+      - name: Download finalized promotion metadata
+        uses: actions/download-artifact@v5
+        with:
+          pattern: promotion-metadata-*-${{ needs.resolve.outputs.head_sha }}
+          path: promotion-metadata
+          merge-multiple: true
       - name: Sync OpenRecon metadata
         env:
           GH_TOKEN: ${{ secrets.NEURODESK_GITHUB_TOKEN_ISSUE_AUTOMATION }}
         run: |
           set -euo pipefail
           gh auth setup-git
+          jq -s 'add' promotion-metadata/verified-manifest-*.json > verified-manifests.json
           jq -c '.[] | select(.architecture == "x86_64")' \
             verified-manifests.json | while IFS= read -r manifest; do
               recipe="$(echo "${manifest}" | jq -r '.recipe')"
@@ -689,7 +717,7 @@ jobs:
             done
 
   report_promotion:
-    needs: [resolve, await_candidate, publish, finalize]
+    needs: [resolve, await_candidate, publish, finalize, sync_openrecon]
     if: >-
       always() &&
       needs.resolve.outputs.should_promote == 'true' &&
@@ -705,6 +733,7 @@ jobs:
           AWAIT_RESULT: ${{ needs.await_candidate.result }}
           PUBLISH_RESULT: ${{ needs.publish.result }}
           FINALIZE_RESULT: ${{ needs.finalize.result }}
+          SYNC_RESULT: ${{ needs.sync_openrecon.result }}
         with:
           script: |
             const issue_number = Number(process.env.PR_NUMBER);
@@ -743,11 +772,12 @@ jobs:
             const awaitResult = process.env.AWAIT_RESULT;
             const publishResult = process.env.PUBLISH_RESULT;
             const finalizeResult = process.env.FINALIZE_RESULT;
-            const promotionResult = finalizeResult === 'success'
-              ? 'success'
-              : publishResult !== 'success'
-                ? publishResult
-                : finalizeResult;
+            const syncResult = process.env.SYNC_RESULT;
+            const promotionResult = publishResult !== 'success'
+              ? publishResult
+              : finalizeResult !== 'success'
+                ? finalizeResult
+                : syncResult;
             let heading;
             let action;
             if (promotionResult === 'success') {

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -111,7 +111,10 @@ def test_promotion_updates_the_existing_candidate_comment_in_place() -> None:
 
     report_job = workflow.split("  report_promotion:", 1)[1]
 
-    assert "needs: [resolve, await_candidate, publish, finalize]" in report_job
+    assert (
+        "needs: [resolve, await_candidate, publish, finalize, sync_openrecon]"
+        in report_job
+    )
     assert "always()" in report_job
     assert "pull-requests: write" in report_job
     assert "container-release-status:start" in report_job
@@ -214,6 +217,9 @@ def test_candidate_publication_is_parallel_and_only_finalization_is_locked() -> 
     pre_jobs, jobs = workflow.split("jobs:", 1)
     publish_job = jobs.split("  publish:", 1)[1].split("  finalize:", 1)[0]
     finalize_job = jobs.split("  finalize:", 1)[1].split(
+        "  sync_openrecon:", 1
+    )[0]
+    sync_job = jobs.split("  sync_openrecon:", 1)[1].split(
         "  report_promotion:", 1
     )[0]
 
@@ -229,6 +235,9 @@ def test_candidate_publication_is_parallel_and_only_finalization_is_locked() -> 
     assert "Finalize public Docker tags from staged manifests" not in publish_job
     assert "Finalize public Docker tags from staged manifests" in finalize_job
     assert "Finalize public SIF object names with server-side copies" in finalize_job
+    assert "Sync OpenRecon metadata" not in finalize_job
+    assert "concurrency:" not in sync_job
+    assert "needs: [resolve, finalize]" in sync_job
 
 
 def test_release_paths_dispatch_unchanged_openrecon_recipes() -> None:


### PR DESCRIPTION
## Summary

- move the OpenRecon follow-up sync to a separate unlocked job
- keep the concurrency lock limited to public tag/object finalization and the release metadata commit
- include post-finalization sync status in the existing promotion report

## Validation

- `pytest -q builder/tests` (267 passed)
- actionlint clean apart from its known `queue: max`/custom-runner schema gaps
- all workflow shell blocks pass `bash -n`
- `git diff --check`