### PR TITLE
Allow SynthSeg fallback without MP2RAGE UNI-DEN

### DIFF
--- a/recipes/synthseg/OpenReconREADME.md
+++ b/recipes/synthseg/OpenReconREADME.md
@@ -20,8 +20,9 @@ Use this reconstruction pipeline on 3D brain image data. Any contrast works;
 no bias correction, skull stripping or intensity normalisation is required.
 For an MP2RAGE scan, only the denoised uniform (`UNI-DEN`) contrast is
 processed; INV1, INV2, UNI, and other contrasts in the same stream are ignored.
-An MP2RAGE stream without a `UNI-DEN` contrast is rejected rather than processed
-as a different anatomical contrast.
+If an MP2RAGE stream has no `UNI-DEN` contrast, the first magnitude image series
+is processed instead. Other sequences, including MPRAGE and GRE, are not
+filtered by contrast and each magnitude image series is processed normally.
 
 SynthSeg always segments at 1 mm isotropic internally. The wrapper always runs
 `mri_synthseg --keepgeom`, so the returned label map is resampled with nearest

--- a/recipes/synthseg/synthseg.py
+++ b/recipes/synthseg/synthseg.py
@@ -3307,7 +3307,7 @@ def _image_identity_values(image):
 
 
 def _select_anatomical_input_images(images):
-    """For an MP2RAGE stream, retain only its denoised uniform contrast."""
+    """Prefer MP2RAGE UNI-DEN, with the first magnitude series as a fallback."""
 
     images = list(images)
     identities = [
@@ -3323,9 +3323,21 @@ def _select_anatomical_input_images(images):
         if any("uniden" in value for value in values)
     ]
     if not selected:
-        raise ValueError(
-            "MP2RAGE input was detected, but no UNI-DEN contrast was received"
+        fallback_series_index = int(getattr(images[0], "image_series_index", 0))
+        selected = [
+            image
+            for image in images
+            if int(getattr(image, "image_series_index", 0))
+            == fallback_series_index
+        ]
+        logging.warning(
+            "MP2RAGE input was detected, but no UNI-DEN contrast was received; "
+            "processing the first magnitude image series instead "
+            "(image_series_index=%d, images=%d)",
+            fallback_series_index,
+            len(selected),
         )
+        return selected
     logging.info(
         "MP2RAGE input detected; selected %d UNI-DEN image(s) and ignored %d "
         "other MP2RAGE image(s)",

--- a/recipes/synthseg/test_synthseg_openrecon.py
+++ b/recipes/synthseg/test_synthseg_openrecon.py
@@ -319,8 +319,16 @@ def _mp2rage_selection_helpers():
     )
 
 
-def _selection_image(helpers, description, protocol="T1_MP2RAGE"):
+def _selection_image(
+    helpers,
+    description,
+    protocol="T1_MP2RAGE",
+    series_index=1,
+):
     image = helpers["FakeImage"](np.zeros((1, 1, 2, 2), dtype=np.int16))
+    head = image.getHead()
+    head.image_series_index = series_index
+    image.setHead(head)
     image.attribute_string = helpers["FakeMeta"](
         {
             "SeriesDescription": description,
@@ -344,26 +352,24 @@ def test_mp2rage_selection_keeps_only_uni_den_images():
     assert selected == images[1:3]
 
 
-def test_mp2rage_selection_fails_without_uni_den():
+def test_mp2rage_selection_uses_first_series_without_uni_den():
     helpers = _mp2rage_selection_helpers()
     images = [
-        _selection_image(helpers, "T1_MP2RAGE_INV1"),
-        _selection_image(helpers, "T1_MP2RAGE_UNI"),
+        _selection_image(helpers, "T1_MP2RAGE_INV1", series_index=4),
+        _selection_image(helpers, "T1_MP2RAGE_INV1", series_index=4),
+        _selection_image(helpers, "T1_MP2RAGE_UNI", series_index=5),
     ]
 
-    try:
-        helpers["_select_anatomical_input_images"](images)
-    except ValueError as error:
-        assert "no UNI-DEN contrast" in str(error)
-    else:
-        raise AssertionError("MP2RAGE input without UNI-DEN should fail closed")
+    selected = helpers["_select_anatomical_input_images"](images)
+
+    assert selected == images[:2]
 
 
 def test_non_mp2rage_selection_preserves_all_magnitude_images():
     helpers = _mp2rage_selection_helpers()
     images = [
         _selection_image(helpers, "MPRAGE_T1W", protocol="MPRAGE"),
-        _selection_image(helpers, "T2_SPACE", protocol="T2_SPACE"),
+        _selection_image(helpers, "GRE_T1W", protocol="GRE"),
     ]
 
     assert helpers["_select_anatomical_input_images"](images) == images


### PR DESCRIPTION
## Summary

- keep preferring UNI-DEN for MP2RAGE streams
- fall back to the first complete magnitude image series when UNI-DEN is absent
- document that MPRAGE, GRE, and other non-MP2RAGE sequences remain unfiltered

## Validation

- `pytest -q recipes/synthseg/test_synthseg_openrecon.py`
- `python3 builder/validation.py recipes/synthseg/build.yaml`
- `python3 -m builder generate synthseg --recreate`