### PR TITLE
Fix QSMxT OpenRecon input selection and display

### DIFF
--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -50,6 +50,18 @@
       "information": { "en": "Define the config to be executed by the MRD server." }
     },
     {
+      "id": "inputseries",
+      "label": { "en": "Input images" },
+      "type": "choice",
+      "values": [
+        { "id": "distortion-corrected", "name": { "en": "Distortion corrected" } },
+        { "id": "non-distortion-corrected", "name": { "en": "Not distortion corrected (ND)" } },
+        { "id": "both", "name": { "en": "Both" } }
+      ],
+      "default": "distortion-corrected",
+      "information": { "en": "Choose the magnitude and phase images used by QSMxT. ND matches source series containing a separate ND name token. Both runs QSMxT twice and returns separately named DC and ND results." }
+    },
+    {
       "id": "sendoutputs",
       "label": { "en": "Output maps" },
       "type": "choice",
@@ -209,16 +221,6 @@
       ],
       "default": "close-fill",
       "information": { "en": "Morphological cleanup applied after mask generation. Close and fill holes bridges narrow gaps without shrinking the repaired mask." }
-    },
-    {
-      "id": "voxelsizemm",
-      "label": { "en": "Voxel size override" },
-      "type": "double",
-      "minimum": 0.0,
-      "maximum": 10.0,
-      "default": 0.0,
-      "unit": { "en": "mm" },
-      "information": { "en": "Isotropic voxel size used for BIDS geometry. Zero uses the geometry supplied by MRD." }
     }
   ]
 }

--- a/recipes/qsmxt/OpenReconREADME.md
+++ b/recipes/qsmxt/OpenReconREADME.md
@@ -5,11 +5,17 @@ the magnitude and phase series, writes a temporary BIDS MEGRE dataset, runs the
 QSMxT v9 Rust binary, and sends selected derivatives back as derived MRD image
 series.
 
-The wrapper expects one magnitude series and one phase series. It classifies
-phase data from MRD image type metadata, DICOM image type metadata, or source
-series names such as `phase`, `pha`, or `_Pha`. If explicit metadata is absent
-and exactly two series are present, the lower dynamic-range series is used as
-phase.
+The **Input images** control selects distortion-corrected images, images marked
+`ND` (not distortion corrected), or both. Distortion-corrected input is the
+default. **Both** runs QSMxT once per magnitude/phase pair and returns distinct
+`DC` and `ND` output series. It takes roughly twice as long as processing one
+pair.
+
+The wrapper classifies phase data from MRD image type metadata, DICOM image type
+metadata, or source series names such as `phase`, `pha`, or `_Pha`. It recognizes
+`ND` only as a separate, case-insensitive name token, so magnitude and phase are
+always paired within the same distortion-correction variant. A missing or
+ambiguous requested pair fails explicitly instead of selecting by arrival order.
 
 For each derived magnitude/phase echo group the wrapper writes:
 
@@ -23,9 +29,8 @@ Echo grouping, echo times, field strength, and B0 direction are derived from the
 incoming MRD image stream and generated NIfTI geometry when available. The
 container still accepts `maxechoes`, `echotimesms`, `echotimems`,
 `echospacingms`, `fieldstrength`, and `b0dir` as manual JSON overrides for
-debugging, but they are not shown in the scanner UI. **Voxel size override** is
-available in the UI. Its default value of zero uses the geometry supplied by
-MRD.
+debugging, but they are not shown in the scanner UI. Voxel geometry comes from
+the MRD image stream.
 
 Default output is the QSM map (`Chimap`). Enable `sendoutputs=all` to return all
 QSMxT derivatives that exist after the run.
@@ -41,12 +46,15 @@ The original range, scaling range, scale, inverse formula, physical display
 window, and clipped-voxel count are included in the returned metadata.
 
 Derived maps set the MRD `RescaleSlope` and `RescaleIntercept` attributes. The
-OpenRecon DICOM writer maps these attributes to the standard DICOM fields. The
-Siemens writer truncates sub-unit window values, so standard `WindowCenter` and
-`WindowWidth` are supplied as integers in the stored-pixel domain. Their
-physical equivalents are retained as `QSMxTPhysicalWindowCenter` and
-`QSMxTPhysicalWindowWidth`, with `QSMxTWindowDomain=stored` documenting the
-workaround.
+OpenRecon DICOM writer maps these attributes to the standard DICOM fields.
+Because DICOM applies modality rescaling before its display window, a QSM window
+must also use physical units. Siemens MRD metadata represents standard window
+values as integers, which cannot encode a typical sub-unit ppm window. The
+bridge therefore removes `WindowCenter`, `WindowWidth`, and `VOILUTFunction`
+instead of supplying a misleading stored-pixel window. The intended physical
+window remains available as `QSMxTPhysicalWindowCenter` and
+`QSMxTPhysicalWindowWidth`, with `QSMxTWindowDomain=physical` documenting its
+domain. The scanner or DICOM viewer chooses the displayed window automatically.
 
 Maps with a non-zero stored-value offset, including QSM, reserve stored code `0`.
 The bridge sends `PixelPaddingValue=0` and `PixelPaddingRangeLimit=0`, and native
@@ -187,6 +195,7 @@ Review all acquisition and safety settings on the target scanner before use.
 | GUI label | Parameter id | Type | Default | Description |
 | --- | --- | --- | --- | --- |
 | config | `config` | choice | `qsmxt` | Selects the MRD server configuration. |
+| Input images | `inputseries` | choice | `distortion-corrected` | Processes corrected, ND, or both magnitude/phase pairs. |
 | Output maps | `sendoutputs` | choice | `qsm` | Selects which QSMxT derivatives are sent back. |
 | Send original | `sendoriginal` | boolean | `false` | Sends original magnitude and phase image series before derived outputs. |
 | Pipeline preset | `pipelinepreset` | choice | `custom` | Selects a three-stage algorithm preset or the custom algorithm controls. |
@@ -199,7 +208,6 @@ Review all acquisition and safety settings on the target scanner before use.
 | Threshold method | `maskthresholdmethod` | choice | `otsu` | Otsu or percentile threshold generation. |
 | Mask percentile | `maskthresholdpercentile` | double | `65` | Cutoff used by percentile thresholding. |
 | Mask cleanup | `maskcleanup` | choice | `close-fill` | None, fill holes, close and fill, or robust dilate/fill/erode cleanup. |
-| Voxel size override | `voxelsizemm` | double | `0` | Isotropic spacing; zero uses MRD geometry. |
 
 ## Open source development
 

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -95,6 +95,7 @@ tests:
       parameter_ids = {parameter["id"] for parameter in data["parameters"]}
       expected = {
           "config",
+          "inputseries",
           "sendoutputs",
           "sendoriginal",
           "pipelinepreset",
@@ -115,6 +116,14 @@ tests:
       }
       assert parameters["unwrappingalgorithm"]["default"] == "romeo"
       assert parameters["bfalgorithm"]["default"] == "vsharp"
+      assert parameters["inputseries"]["default"] == "distortion-corrected"
+      assert [
+          value["id"] for value in parameters["inputseries"]["values"]
+      ] == [
+          "distortion-corrected",
+          "non-distortion-corrected",
+          "both",
+      ]
       if "maskcleanup" in parameter_ids:
           assert parameters["maskpreset"]["default"] == "bet"
           assert parameters["maskinginput"]["default"] == "magnitude"
@@ -272,15 +281,13 @@ tests:
       assert float(first_meta["RescaleIntercept"]) == -2.048
       assert first_meta["RescaleType"] == "US"
       assert first_meta["PixelPaddingValue"] == "0"
-      if first_meta.get("QSMxTWindowDomain") == "stored":
-          assert first_meta["PixelPaddingRangeLimit"] == "0"
-          assert float(first_meta["WindowCenter"]) == 3548.0
-          assert float(first_meta["WindowWidth"]) == 1000.0
-          assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
-          assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
-      else:
-          assert float(first_meta["WindowCenter"]) == 1.5
-          assert float(first_meta["WindowWidth"]) == 1.0
+      assert first_meta["PixelPaddingRangeLimit"] == "0"
+      assert first_meta["QSMxTWindowDomain"] == "physical"
+      assert "WindowCenter" not in first_meta
+      assert "WindowWidth" not in first_meta
+      assert "VOILUTFunction" not in first_meta
+      assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
+      assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
       assert first_meta["slice_count"] == "2"
       assert first_meta["NumberOfSlices"] == "2"
       assert first_meta["ImagesInAcquisition"] == "2"

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -115,6 +115,15 @@ tests:
       }
       assert parameters["unwrappingalgorithm"]["default"] == "romeo"
       assert parameters["bfalgorithm"]["default"] == "vsharp"
+      if "inputseries" in parameters:
+          assert parameters["inputseries"]["default"] == "distortion-corrected"
+          assert [
+              value["id"] for value in parameters["inputseries"]["values"]
+          ] == [
+              "distortion-corrected",
+              "non-distortion-corrected",
+              "both",
+          ]
       if "maskcleanup" in parameter_ids:
           assert parameters["maskpreset"]["default"] == "bet"
           assert parameters["maskinginput"]["default"] == "magnitude"
@@ -278,9 +287,15 @@ tests:
           assert float(first_meta["WindowWidth"]) == 1000.0
           assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
           assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
-      else:
+      elif "WindowCenter" in first_meta:
           assert float(first_meta["WindowCenter"]) == 1.5
           assert float(first_meta["WindowWidth"]) == 1.0
+      else:
+          assert first_meta["QSMxTWindowDomain"] == "physical"
+          assert "WindowWidth" not in first_meta
+          assert "VOILUTFunction" not in first_meta
+          assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
+          assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
       assert first_meta["slice_count"] == "2"
       assert first_meta["NumberOfSlices"] == "2"
       assert first_meta["ImagesInAcquisition"] == "2"

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -95,7 +95,6 @@ tests:
       parameter_ids = {parameter["id"] for parameter in data["parameters"]}
       expected = {
           "config",
-          "inputseries",
           "sendoutputs",
           "sendoriginal",
           "pipelinepreset",
@@ -116,14 +115,6 @@ tests:
       }
       assert parameters["unwrappingalgorithm"]["default"] == "romeo"
       assert parameters["bfalgorithm"]["default"] == "vsharp"
-      assert parameters["inputseries"]["default"] == "distortion-corrected"
-      assert [
-          value["id"] for value in parameters["inputseries"]["values"]
-      ] == [
-          "distortion-corrected",
-          "non-distortion-corrected",
-          "both",
-      ]
       if "maskcleanup" in parameter_ids:
           assert parameters["maskpreset"]["default"] == "bet"
           assert parameters["maskinginput"]["default"] == "magnitude"
@@ -281,13 +272,15 @@ tests:
       assert float(first_meta["RescaleIntercept"]) == -2.048
       assert first_meta["RescaleType"] == "US"
       assert first_meta["PixelPaddingValue"] == "0"
-      assert first_meta["PixelPaddingRangeLimit"] == "0"
-      assert first_meta["QSMxTWindowDomain"] == "physical"
-      assert "WindowCenter" not in first_meta
-      assert "WindowWidth" not in first_meta
-      assert "VOILUTFunction" not in first_meta
-      assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
-      assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
+      if first_meta.get("QSMxTWindowDomain") == "stored":
+          assert first_meta["PixelPaddingRangeLimit"] == "0"
+          assert float(first_meta["WindowCenter"]) == 3548.0
+          assert float(first_meta["WindowWidth"]) == 1000.0
+          assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
+          assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
+      else:
+          assert float(first_meta["WindowCenter"]) == 1.5
+          assert float(first_meta["WindowWidth"]) == 1.0
       assert first_meta["slice_count"] == "2"
       assert first_meta["NumberOfSlices"] == "2"
       assert first_meta["ImagesInAcquisition"] == "2"

--- a/recipes/qsmxt/qsmxt.py
+++ b/recipes/qsmxt/qsmxt.py
@@ -112,6 +112,14 @@ DEFAULT_MASK_PRESET = "bet"
 DEFAULT_MASKING_INPUT = "magnitude"
 DEFAULT_BET_FRACTIONAL_INTENSITY = 0.5
 DEFAULT_MASK_CLEANUP = "close-fill"
+DISTORTION_CORRECTED = "distortion-corrected"
+NON_DISTORTION_CORRECTED = "non-distortion-corrected"
+INPUT_SERIES_CHOICES = (
+    DISTORTION_CORRECTED,
+    NON_DISTORTION_CORRECTED,
+    "both",
+)
+DEFAULT_INPUT_SERIES = DISTORTION_CORRECTED
 MASK_CLEANUP_PRESETS = {
     "none": {"dilate": 0, "close": 0, "fill_holes": False, "erode": 0},
     "fill": {"dilate": 0, "close": 0, "fill_holes": True, "erode": 0},
@@ -180,6 +188,9 @@ SOURCE_SCALING_META_KEYS = {
     "RescaleIntercept",
     "RescaleSlope",
     "RescaleType",
+    "VOILUTFunction",
+    "WindowCenter",
+    "WindowWidth",
 }
 ORIGINAL_STORAGE_FIELDS = (
     "Actual3DImagePartNumber",
@@ -241,14 +252,50 @@ def process(connection, config, metadata):
             dir=str(OPENRECON_WORK_ROOT),
         ) as work_dir_name:
             work_dir = Path(work_dir_name)
-            bids_dir = work_dir / "bids"
-            output_dir = work_dir / "output"
-
-            conversion = write_bids_dataset(input_images, metadata, bids_dir, settings)
-            _run_qsmxt(bids_dir, output_dir, settings)
-            _log_qsmxt_nifti_diagnostics(output_dir)
-            output_specs = _find_qsmxt_outputs(output_dir, conversion, settings)
-            output_images = _build_output_images(output_specs, conversion, input_images)
+            series_groups = _group_images_by_series(input_images)
+            _log_source_series_diagnostics(series_groups)
+            input_pairs = _select_magnitude_phase_pairs(
+                series_groups,
+                settings["input_series"],
+            )
+            used_series = {
+                int(image.getHead().image_series_index)
+                for image in input_images
+            }
+            output_images = []
+            for input_pair in input_pairs:
+                variant = input_pair["variant"]
+                run_dir = work_dir / input_pair["short_label"].lower()
+                bids_dir = run_dir / "bids"
+                output_dir = run_dir / "output"
+                logging.info("Processing QSMxT %s input pair", variant)
+                try:
+                    conversion = write_bids_dataset(
+                        input_images,
+                        metadata,
+                        bids_dir,
+                        settings,
+                        input_pair=input_pair,
+                    )
+                    _run_qsmxt(bids_dir, output_dir, settings)
+                    _log_qsmxt_nifti_diagnostics(output_dir)
+                    output_specs = _find_qsmxt_outputs(
+                        output_dir,
+                        conversion,
+                        settings,
+                    )
+                    output_images.extend(
+                        _build_output_images(
+                            output_specs,
+                            conversion,
+                            input_images,
+                            used_series=used_series,
+                        )
+                    )
+                except Exception as error:
+                    raise RuntimeError(
+                        f"QSMxT failed for {variant} input: {error}"
+                    ) from error
 
         if settings["send_original"]:
             original_images = _build_original_passthrough_images(
@@ -275,13 +322,33 @@ def process(connection, config, metadata):
         connection.send_close()
 
 
-def write_bids_dataset(input_images, metadata, bids_dir, settings):
-    series_groups = _group_images_by_series(input_images)
-    _log_source_series_diagnostics(series_groups)
-    magnitude_group, phase_group = _select_magnitude_phase_groups(series_groups)
+def write_bids_dataset(
+    input_images,
+    metadata,
+    bids_dir,
+    settings,
+    *,
+    input_pair=None,
+):
+    if input_pair is None:
+        series_groups = _group_images_by_series(input_images)
+        _log_source_series_diagnostics(series_groups)
+        input_pairs = _select_magnitude_phase_pairs(
+            series_groups,
+            settings["input_series"],
+        )
+        if len(input_pairs) != 1:
+            raise ValueError(
+                "write_bids_dataset requires one input pair; use process() "
+                "for inputseries=both"
+            )
+        input_pair = input_pairs[0]
+
+    magnitude_group, phase_group = input_pair["groups"]
     logging.info(
-        "QSMxT diagnostic selected input pair: magnitude=%r series_index=%d "
+        "QSMxT diagnostic selected input pair (%s): magnitude=%r series_index=%d "
         "order=%d, phase=%r series_index=%d order=%d",
+        input_pair["variant"],
         magnitude_group["name"],
         int(magnitude_group["key"][0]),
         magnitude_group["order"],
@@ -328,18 +395,11 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
     field_strength = settings["field_strength_t"]
     logging.info(
         "Resolved QSMxT acquisition parameters: echo_times_ms=%s, "
-        "field_strength_t=%.6g (%s), phase_wrap=%.6g, "
-        "voxel_size_mm=%s (%s)",
+        "field_strength_t=%.6g (%s), phase_wrap=%.6g",
         [round(value * 1000.0, 6) for value in echo_times],
         field_strength,
         settings["field_strength_source"],
         settings["phase_wrap"],
-        (
-            f"{settings['voxel_size_mm']:.6g}"
-            if settings["voxel_size_mm"] is not None
-            else "MRD"
-        ),
-        settings["voxel_size_source"],
     )
 
     anat_dir = bids_dir / "sub-01" / "anat"
@@ -364,12 +424,10 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
         mag_volume, affine = _images_to_nifti_volume(
             magnitude_echo_groups[echo_index],
             kind="magnitude",
-            voxel_size_mm=settings["voxel_size_mm"],
         )
         phase_volume, phase_affine = _images_to_nifti_volume(
             phase_echo_groups[echo_index],
             kind="phase",
-            voxel_size_mm=settings["voxel_size_mm"],
         )
         phase_volume = _phase_to_qsmxt_counts(phase_volume, settings["phase_wrap"])
         _log_array_diagnostics(
@@ -414,7 +472,7 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
             "ProtocolName": _metadata_protocol_name(metadata),
             "QSMxTOpenReconSource": "ISMRMRD image stream",
             "QSMxTRawPhaseScale": settings["phase_wrap"],
-            "QSMxTOpenReconVoxelSizeSource": settings["voxel_size_source"],
+            "QSMxTOpenReconVoxelSizeSource": "MRD",
         }
         _write_json(_nifti_sidecar_path(mag_path), dict(sidecar, ImageType=["ORIGINAL", "PRIMARY", "M"]))
         _write_json(_nifti_sidecar_path(phase_path), dict(sidecar, ImageType=["ORIGINAL", "PRIMARY", "P"]))
@@ -439,13 +497,6 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
         phase_paths[0],
     )
     source_geometry_images = _sorted_stack_images(magnitude_echo_groups[0])
-    if settings["voxel_size_mm"] is not None:
-        source_geometry_images = []
-        logging.info(
-            "Using derivative affine rather than source MRD geometry because "
-            "voxel size was resolved from %s",
-            settings["voxel_size_source"],
-        )
     return {
         "bids_dir": bids_dir,
         "anat_dir": anat_dir,
@@ -462,6 +513,8 @@ def write_bids_dataset(input_images, metadata, bids_dir, settings):
         "field_strength_t": field_strength,
         "b0_dir": resolved_b0_dir or DEFAULT_B0_DIR,
         "b0_dir_source": resolved_b0_dir_source or "nifti_affine",
+        "input_variant": input_pair["variant"],
+        "input_short_label": input_pair["short_label"],
     }
 
 
@@ -592,21 +645,33 @@ def _log_qsmxt_nifti_diagnostics(output_dir):
             )
 
 
-def _build_output_images(output_specs, conversion, input_images):
-    used_series = {int(image.getHead().image_series_index) for image in input_images}
+def _build_output_images(
+    output_specs,
+    conversion,
+    input_images,
+    *,
+    used_series=None,
+):
+    if used_series is None:
+        used_series = {
+            int(image.getHead().image_series_index)
+            for image in input_images
+        }
     output_images = []
     for index, (output_id, spec, nifti_path) in enumerate(output_specs):
         series_index = _reserve_series_index(used_series, OUTPUT_SERIES_START + index)
+        series_name = f"{spec['series']} {conversion['input_short_label']}"
         output_images.extend(
             _nifti_to_mrd_images(
                 nifti_path,
                 conversion["anchor_image"],
                 series_index,
-                f"{spec['series']}",
+                series_name,
                 spec["token"],
                 output_id,
                 spec["units"],
                 source_geometry_images=conversion.get("source_geometry_images"),
+                input_variant=conversion["input_variant"],
             )
         )
     return output_images
@@ -997,6 +1062,7 @@ def _nifti_to_mrd_images(
     units,
     *,
     source_geometry_images=None,
+    input_variant=None,
 ):
     nifti = nib.load(str(nifti_path))
     data_xyz = np.asarray(nifti.get_fdata(dtype=np.float32), dtype=np.float32)
@@ -1102,6 +1168,7 @@ def _nifti_to_mrd_images(
             display_meta,
             source_geometry=use_source_geometry,
             slice_number=slice_number,
+            input_variant=input_variant,
         ).serialize()
         output_images.append(output)
 
@@ -1200,7 +1267,7 @@ def _slice_position_from_affine(nifti, shape_xyz, slice_index, fallback_image):
     return [float(value) for value in fallback_image.getHead().position]
 
 
-def _image_to_nifti_volume(image, kind, voxel_size_mm=None):
+def _image_to_nifti_volume(image, kind):
     data = np.asarray(image.data)
     if data.ndim == 4:
         if kind == "magnitude":
@@ -1223,37 +1290,21 @@ def _image_to_nifti_volume(image, kind, voxel_size_mm=None):
             raise ValueError(f"Unsupported MRD image data shape: {data.shape}")
 
     vol_xyz = np.transpose(np.asarray(vol_zyx, dtype=np.float32), (2, 1, 0))
-    return vol_xyz, _affine_from_image(
-        image,
-        vol_xyz.shape,
-        voxel_size_mm=voxel_size_mm,
-    )
+    return vol_xyz, _affine_from_image(image, vol_xyz.shape)
 
 
-def _images_to_nifti_volume(images, kind, voxel_size_mm=None):
+def _images_to_nifti_volume(images, kind):
     ordered_images = _sorted_stack_images(images)
     if len(ordered_images) == 1:
-        return _image_to_nifti_volume(
-            ordered_images[0],
-            kind,
-            voxel_size_mm=voxel_size_mm,
-        )
+        return _image_to_nifti_volume(ordered_images[0], kind)
 
     volumes = []
     for image in ordered_images:
-        volume, _ = _image_to_nifti_volume(
-            image,
-            kind,
-            voxel_size_mm=voxel_size_mm,
-        )
+        volume, _ = _image_to_nifti_volume(image, kind)
         volumes.append(volume)
 
     stacked = np.concatenate(volumes, axis=2)
-    return stacked, _affine_from_image_stack(
-        ordered_images,
-        stacked.shape,
-        voxel_size_mm=voxel_size_mm,
-    )
+    return stacked, _affine_from_image_stack(ordered_images, stacked.shape)
 
 
 def _sorted_stack_images(images):
@@ -1306,7 +1357,7 @@ def _phase_to_qsmxt_counts(phase_volume, phase_wrap):
     return phase * (4096.0 / phase_wrap)
 
 
-def _affine_from_image(image, shape_xyz, voxel_size_mm=None):
+def _affine_from_image(image, shape_xyz):
     header = image.getHead()
     read_dir = _normalized_or_default(header.read_dir, (1.0, 0.0, 0.0))
     phase_dir = _normalized_or_default(header.phase_dir, (0.0, 1.0, 0.0))
@@ -1314,15 +1365,13 @@ def _affine_from_image(image, shape_xyz, voxel_size_mm=None):
     fov = np.asarray(header.field_of_view, dtype=float)
     dims = np.asarray(shape_xyz, dtype=float)
     voxel = np.divide(fov, dims, out=np.ones(3, dtype=float), where=dims > 0)
-    if voxel_size_mm is not None:
-        voxel[:] = float(voxel_size_mm)
     packed_slice_spacing = _scanner_packed_volume_slice_spacing(
         image,
         shape_xyz,
         fov,
         voxel,
     )
-    if packed_slice_spacing is not None and voxel_size_mm is None:
+    if packed_slice_spacing is not None:
         voxel[2] = packed_slice_spacing
         logging.info(
             "Using scanner packed-volume slice spacing %.6g mm for %d slices",
@@ -1380,7 +1429,7 @@ def _scanner_packed_volume_slice_spacing(image, shape_xyz, fov, voxel):
     return float(fov[2])
 
 
-def _affine_from_image_stack(images, shape_xyz, voxel_size_mm=None):
+def _affine_from_image_stack(images, shape_xyz):
     first_header = images[0].getHead()
     read_dir = _normalized_or_default(first_header.read_dir, (1.0, 0.0, 0.0))
     phase_dir = _normalized_or_default(first_header.phase_dir, (0.0, 1.0, 0.0))
@@ -1388,8 +1437,6 @@ def _affine_from_image_stack(images, shape_xyz, voxel_size_mm=None):
     fov = np.asarray(first_header.field_of_view, dtype=float)
     dims = np.asarray(shape_xyz, dtype=float)
     voxel = np.divide(fov, dims, out=np.ones(3, dtype=float), where=dims > 0)
-    if voxel_size_mm is not None:
-        voxel[:] = float(voxel_size_mm)
 
     source_matrix = np.asarray(first_header.matrix_size, dtype=float)
     source_slice_count = (
@@ -1402,11 +1449,7 @@ def _affine_from_image_stack(images, shape_xyz, voxel_size_mm=None):
     declared_slice_spacing = float(fov[2] / source_slice_count)
     if declared_slice_spacing <= 0 or not np.isfinite(declared_slice_spacing):
         declared_slice_spacing = 1.0
-    slice_step = slice_dir * (
-        float(voxel_size_mm)
-        if voxel_size_mm is not None
-        else declared_slice_spacing
-    )
+    slice_step = slice_dir * declared_slice_spacing
     positions = [
         np.asarray(image.getHead().position, dtype=float)
         for image in images
@@ -1421,20 +1464,19 @@ def _affine_from_image_stack(images, shape_xyz, voxel_size_mm=None):
             candidate_alignment = abs(
                 float(np.dot(candidate_step / candidate_spacing, slice_dir))
             )
-        if voxel_size_mm is None:
-            if (
-                candidate_spacing >= declared_slice_spacing * 0.5
-                and candidate_alignment >= 0.9
-            ):
-                slice_step = candidate_step
-            elif candidate_spacing > 0:
-                logging.warning(
-                    "Ignoring implausible source stack position step %.9g mm "
-                    "(declared slice spacing %.9g mm, alignment %.6g)",
-                    candidate_spacing,
-                    declared_slice_spacing,
-                    candidate_alignment,
-                )
+        if (
+            candidate_spacing >= declared_slice_spacing * 0.5
+            and candidate_alignment >= 0.9
+        ):
+            slice_step = candidate_step
+        elif candidate_spacing > 0:
+            logging.warning(
+                "Ignoring implausible source stack position step %.9g mm "
+                "(declared slice spacing %.9g mm, alignment %.6g)",
+                candidate_spacing,
+                declared_slice_spacing,
+                candidate_alignment,
+            )
 
     logging.info(
         "QSMxT diagnostic source stack geometry: images=%d "
@@ -1496,6 +1538,16 @@ def _b0_dir_from_affine(affine):
 
 def _settings_from_config(config, metadata=None):
     params = _config_parameters(config)
+    input_series = _config_text(
+        params,
+        "inputseries",
+        DEFAULT_INPUT_SERIES,
+    ).lower()
+    if input_series not in INPUT_SERIES_CHOICES:
+        choices = ", ".join(INPUT_SERIES_CHOICES)
+        raise ValueError(
+            f"unknown inputseries {input_series!r}; expected {choices}"
+        )
     configured_field_strength = _config_float_or_none(params, "fieldstrength")
     metadata_field_strength = _metadata_field_strength(metadata)
     if configured_field_strength is not None:
@@ -1523,15 +1575,8 @@ def _settings_from_config(config, metadata=None):
         raise ValueError(
             f"unknown maskcleanup {mask_cleanup!r}; expected {choices}"
         ) from error
-    configured_voxel_size = _config_float(params, "voxelsizemm", 0.0)
-    if configured_voxel_size > 0.0:
-        voxel_size_mm = configured_voxel_size
-        voxel_size_source = "config"
-    else:
-        voxel_size_mm = None
-        voxel_size_source = "MRD"
-
     return {
+        "input_series": input_series,
         "send_original": _config_bool(params, "sendoriginal", False),
         "send_outputs": str(params.get("sendoutputs", "qsm") or "qsm"),
         "max_echoes": _config_int(params, "maxechoes", 0),
@@ -1543,8 +1588,6 @@ def _settings_from_config(config, metadata=None):
         "b0_dir_override": configured_b0_dir,
         "b0_dir_source": b0_dir_source,
         "phase_wrap": _config_float(params, "phasewrap", 4096.0),
-        "voxel_size_mm": voxel_size_mm,
-        "voxel_size_source": voxel_size_source,
         "qsmxt_binary": _config_text(params, "qsmxtbinary", ""),
         "pipeline_preset": pipeline_preset,
         **algorithm_settings,
@@ -1786,7 +1829,48 @@ def _log_array_diagnostics(label, values):
         )
 
 
-def _select_magnitude_phase_groups(groups):
+def _input_variant_from_series_name(name):
+    if re.search(r"(?:^|[_\s-])ND(?:$|[_\s-])", str(name), re.IGNORECASE):
+        return NON_DISTORTION_CORRECTED
+    return DISTORTION_CORRECTED
+
+
+def _select_magnitude_phase_pairs(groups, selection):
+    if selection not in INPUT_SERIES_CHOICES:
+        choices = ", ".join(INPUT_SERIES_CHOICES)
+        raise ValueError(
+            f"unknown inputseries {selection!r}; expected {choices}"
+        )
+
+    requested_variants = (
+        [DISTORTION_CORRECTED, NON_DISTORTION_CORRECTED]
+        if selection == "both"
+        else [selection]
+    )
+    pairs = []
+    for variant in requested_variants:
+        variant_groups = [
+            group
+            for group in groups
+            if _input_variant_from_series_name(group["name"]) == variant
+        ]
+        magnitude_group, phase_group = _select_magnitude_phase_groups(
+            variant_groups,
+            variant,
+        )
+        pairs.append(
+            {
+                "variant": variant,
+                "short_label": (
+                    "ND" if variant == NON_DISTORTION_CORRECTED else "DC"
+                ),
+                "groups": (magnitude_group, phase_group),
+            }
+        )
+    return pairs
+
+
+def _select_magnitude_phase_groups(groups, variant):
     magnitude_groups = [group for group in groups if group["kind"] == "magnitude"]
     phase_groups = [group for group in groups if group["kind"] == "phase"]
 
@@ -1804,19 +1888,31 @@ def _select_magnitude_phase_groups(groups):
         )
 
     if not magnitude_groups:
-        raise ValueError("No magnitude image series found in MRD stream")
+        raise ValueError(
+            f"No magnitude image series found for {variant} input; "
+            f"available series: {_available_series_summary(groups)}"
+        )
     if not phase_groups:
-        raise ValueError("No phase image series found in MRD stream")
-    if len(magnitude_groups) > 1 or len(phase_groups) > 1:
-        logging.warning(
-            "Multiple magnitude/phase series found; using first pair: %d magnitude, %d phase",
-            len(magnitude_groups),
-            len(phase_groups),
+        raise ValueError(
+            f"No phase image series found for {variant} input; "
+            f"available series: {_available_series_summary(groups)}"
+        )
+    if len(magnitude_groups) != 1 or len(phase_groups) != 1:
+        raise ValueError(
+            f"Ambiguous {variant} input: found {len(magnitude_groups)} "
+            f"magnitude and {len(phase_groups)} phase series; available series: "
+            f"{_available_series_summary(groups)}"
         )
 
-    return (
-        sorted(magnitude_groups, key=lambda group: group["order"])[0],
-        sorted(phase_groups, key=lambda group: group["order"])[0],
+    return magnitude_groups[0], phase_groups[0]
+
+
+def _available_series_summary(groups):
+    if not groups:
+        return "none"
+    return ", ".join(
+        f"{group['name'] or group['key']} ({group['kind']})"
+        for group in groups
     )
 
 
@@ -2020,6 +2116,7 @@ def _output_meta(
     *,
     source_geometry=False,
     slice_number=None,
+    input_variant=None,
 ):
     meta = _meta_from_image(source_image)
     _strip_source_parent_refs(meta)
@@ -2045,13 +2142,6 @@ def _output_meta(
             display_meta["window_input_max"],
         ]
     )
-    center = int(
-        np.rint(
-            physical_center * display_meta["scale"]
-            + display_meta["offset"]
-        )
-    )
-    width = max(1, int(np.rint(physical_width * display_meta["scale"])))
     if slice_number is None:
         slice_number = slice_index
     slice_number = str(int(slice_number))
@@ -2089,6 +2179,8 @@ def _output_meta(
     meta["AnatomicalPartitionNo"] = "0"
     meta["QSMxTOutput"] = output_id
     meta["QSMxTUnits"] = units
+    if input_variant is not None:
+        meta["QSMxTInputSeries"] = input_variant
     meta["QSMxTSourceFile"] = str(nifti_path)
     meta["QSMxTDisplayScale"] = _format_display_number(display_meta["scale"])
     meta["QSMxTDisplayOffset"] = _format_display_number(display_meta["offset"])
@@ -2103,7 +2195,7 @@ def _output_meta(
     )
     meta["QSMxTPhysicalWindowCenter"] = f"{float(physical_center):.6g}"
     meta["QSMxTPhysicalWindowWidth"] = f"{float(physical_width):.6g}"
-    meta["QSMxTWindowDomain"] = "stored"
+    meta["QSMxTWindowDomain"] = "physical"
     meta["QSMxTDisplayMin"] = str(int(display_meta["display_min"]))
     meta["QSMxTDisplayMax"] = str(int(display_meta["display_max"]))
     meta["QSMxTDisplayClippedVoxels"] = str(int(display_meta["clipped_voxels"]))
@@ -2119,8 +2211,6 @@ def _output_meta(
         meta["PixelPaddingRangeLimit"] = str(
             int(display_meta["padding_value"])
         )
-    meta["WindowCenter"] = str(center)
-    meta["WindowWidth"] = str(width)
     meta.update(_header_geometry_meta(header))
     _strip_scanner_write_unsafe_meta(meta)
     return meta

--- a/recipes/qsmxt/test_qsmxt_openrecon.py
+++ b/recipes/qsmxt/test_qsmxt_openrecon.py
@@ -224,6 +224,28 @@ def _input_images():
     return images
 
 
+def _dual_input_images():
+    shape_zyx = (2, 3, 4)
+    images = []
+    for series_index, sequence, image_type, base_value in (
+        (1, "gre_qsm_ND", ismrmrd.IMTYPE_MAGNITUDE, 1000),
+        (2, "gre_qsm_ND", getattr(ismrmrd, "IMTYPE_PHASE", 2), 2000),
+        (3, "gre_qsm", ismrmrd.IMTYPE_MAGNITUDE, 3000),
+        (4, "gre_qsm", getattr(ismrmrd, "IMTYPE_PHASE", 2), 4000),
+    ):
+        for echo in (1, 2):
+            images.append(
+                _image(
+                    series_index,
+                    echo,
+                    sequence,
+                    np.full(shape_zyx, base_value + echo, dtype=np.float32),
+                    image_type=image_type,
+                )
+            )
+    return images
+
+
 def _packed_scanner_images():
     shape_zyx = (144, 3, 4)
     images = []
@@ -320,6 +342,61 @@ def test_openrecon_defaults_select_whqsm_romeo_and_vsharp():
     assert settings["mask_close"] == 1
     assert settings["mask_fill_holes"] is True
     assert settings["mask_erode"] == 0
+    assert settings["input_series"] == "distortion-corrected"
+
+
+def test_openrecon_input_series_rejects_unknown_value():
+    with pytest.raises(ValueError, match="unknown inputseries"):
+        qsmxt._settings_from_config(
+            {"parameters": {"inputseries": "arrival-order"}},
+            FakeMetadata(),
+        )
+
+
+def test_openrecon_label_exposes_all_input_series_modes():
+    label = qsmxt.json.loads(
+        (Path(qsmxt.__file__).with_name("OpenReconLabel.json")).read_text()
+    )
+    parameters = {
+        parameter["id"]: parameter for parameter in label["parameters"]
+    }
+
+    selector = parameters["inputseries"]
+    assert selector["default"] == "distortion-corrected"
+    assert [value["id"] for value in selector["values"]] == [
+        "distortion-corrected",
+        "non-distortion-corrected",
+        "both",
+    ]
+    assert "voxelsizemm" not in parameters
+
+
+def test_select_magnitude_phase_pairs_matches_requested_distortion_variant():
+    groups = qsmxt._group_images_by_series(_dual_input_images())
+
+    corrected = qsmxt._select_magnitude_phase_pairs(
+        groups,
+        "distortion-corrected",
+    )
+    non_corrected = qsmxt._select_magnitude_phase_pairs(
+        groups,
+        "non-distortion-corrected",
+    )
+    both = qsmxt._select_magnitude_phase_pairs(groups, "both")
+
+    assert [pair["variant"] for pair in both] == [
+        "distortion-corrected",
+        "non-distortion-corrected",
+    ]
+    assert [int(group["key"][0]) for group in corrected[0]["groups"]] == [3, 4]
+    assert [int(group["key"][0]) for group in non_corrected[0]["groups"]] == [1, 2]
+
+
+def test_select_magnitude_phase_pairs_rejects_incomplete_both_selection():
+    groups = qsmxt._group_images_by_series(_input_images())
+
+    with pytest.raises(ValueError, match="non-distortion-corrected"):
+        qsmxt._select_magnitude_phase_pairs(groups, "both")
 
 
 def test_openrecon_pipeline_presets_select_all_three_algorithms():
@@ -508,7 +585,7 @@ def test_openrecon_label_exposes_processing_defaults():
     assert parameters["maskinginput"]["default"] == "magnitude"
     assert parameters["betfractionalintensity"]["default"] == 0.5
     assert parameters["maskcleanup"]["default"] == "close-fill"
-    assert parameters["voxelsizemm"]["default"] == 0.0
+    assert "voxelsizemm" not in parameters
 
 
 def test_scanner_display_volume_scales_qsm_ppm_range_to_uint12_interval():
@@ -570,6 +647,9 @@ def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
             "RescaleType": "PHASE",
             "PixelPaddingValue": "4095",
             "PixelPaddingRangeLimit": "4095",
+            "WindowCenter": "2048",
+            "WindowWidth": "4096",
+            "VOILUTFunction": "LINEAR",
         },
     )
     physical = np.asarray([[[-0.01, 0.0, 0.01]]], dtype=np.float32)
@@ -596,12 +676,22 @@ def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
     assert meta["RescaleType"] == "US"
     assert meta["PixelPaddingValue"] == "0"
     assert meta["PixelPaddingRangeLimit"] == "0"
-    assert float(meta["WindowCenter"]) == 2048.0
-    assert float(meta["WindowWidth"]) == 2000.0
+    assert "WindowCenter" not in meta
+    assert "WindowWidth" not in meta
+    assert "VOILUTFunction" not in meta
     assert float(meta["QSMxTPhysicalWindowCenter"]) == 0.0
     assert float(meta["QSMxTPhysicalWindowWidth"]) == 0.02
-    assert meta["QSMxTWindowDomain"] == "stored"
+    assert meta["QSMxTWindowDomain"] == "physical"
     assert 0 not in display
+
+    decoded = (
+        display.astype(np.float64) * float(meta["RescaleSlope"])
+        + float(meta["RescaleIntercept"])
+    )
+    center = float(meta["QSMxTPhysicalWindowCenter"])
+    width = float(meta["QSMxTPhysicalWindowWidth"])
+    rendered = np.clip((decoded - (center - width / 2.0)) / width, 0.0, 1.0)
+    assert np.unique(rendered).size == 3
 
 
 def test_scanner_display_volume_maps_mask_foreground_to_valid_uint12_maximum():
@@ -656,8 +746,8 @@ def test_output_meta_uses_robust_t2star_range_for_window():
         display_meta,
     )
 
-    assert float(meta["WindowCenter"]) == 250.0
-    assert float(meta["WindowWidth"]) == 500.0
+    assert "WindowCenter" not in meta
+    assert "WindowWidth" not in meta
 
 
 def test_find_qsmxt_outputs_accepts_v9_combined_magnitude_name(tmp_path):
@@ -890,46 +980,6 @@ def test_images_to_nifti_volume_rejects_implausibly_small_position_spacing():
     np.testing.assert_allclose(affine[:3, 2], [0.0, 0.0, -1.0])
 
 
-def test_write_bids_dataset_applies_explicit_isotropic_resolution(tmp_path):
-    images = []
-    for series_index, image_type, suffix in (
-        (1, ismrmrd.IMTYPE_MAGNITUDE, "Mag"),
-        (2, getattr(ismrmrd, "IMTYPE_PHASE", 2), "Pha"),
-    ):
-        for slice_index in range(4):
-            image = _image(
-                series_index,
-                slice_index + 1,
-                f"gre_qsm_{suffix}",
-                np.ones((1, 3, 4), dtype=np.float32),
-                image_type=image_type,
-                meta_values={"Actual3DImagePartNumber": str(slice_index)},
-                header_values={"slice": slice_index},
-            )
-            header = image.getHead()
-            _set_header_vector(header, "field_of_view", [4.0, 3.0, 1.0])
-            _set_header_vector(header, "position", [0.0, 0.0, 0.4 * slice_index])
-            image.setHead(header)
-            images.append(image)
-
-    metadata = FakeMetadata()
-    settings = qsmxt._settings_from_config(
-        {"parameters": {"voxelsizemm": 0.4}},
-        metadata,
-    )
-    result = qsmxt.write_bids_dataset(
-        images,
-        metadata,
-        tmp_path / "bids",
-        settings,
-    )
-
-    magnitude = nib.load(str(result["magnitude_paths"][0]))
-    np.testing.assert_allclose(magnitude.header.get_zooms()[:3], [0.4, 0.4, 0.4])
-    assert settings["voxel_size_source"] == "config"
-    assert result["source_geometry_images"] == []
-
-
 def test_write_bids_dataset_groups_scanner_slices_by_echo_from_minihead(tmp_path):
     settings = qsmxt._settings_from_config({}, FakeMetadata())
 
@@ -998,8 +1048,9 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert meta["RescaleType"] == "US"
     assert meta["PixelPaddingValue"] == "0"
     assert meta["PixelPaddingRangeLimit"] == "0"
-    assert float(meta["WindowCenter"]) == 3548.0
-    assert float(meta["WindowWidth"]) == 1000.0
+    assert "WindowCenter" not in meta
+    assert "WindowWidth" not in meta
+    assert "VOILUTFunction" not in meta
     assert float(meta["QSMxTPhysicalWindowCenter"]) == 1.5
     assert float(meta["QSMxTPhysicalWindowWidth"]) == 1.0
     assert meta["QSMxTDisplayScaleInputMin"] == "1.5"
@@ -1008,7 +1059,7 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert meta["QSMxTDisplayMax"] == "3548"
     assert meta["QSMxTDisplayClippedVoxels"] == "0"
     assert meta["ImageComment"] == (
-        "QSMxT QSM; scanner display uint16 0-4095; "
+        "QSMxT QSM DC; scanner display uint16 0-4095; "
         "ppm = (display - 2048) / 1000; "
         "stored 0 is DICOM pixel padding"
     )
@@ -1033,6 +1084,52 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert second_meta["IsmrmrdSliceNo"] == "1"
     assert second_meta["SeriesInstanceUID"] == meta["SeriesInstanceUID"]
     assert second_meta["SOPInstanceUID"] != meta["SOPInstanceUID"]
+
+
+def test_process_both_input_series_runs_separately_and_returns_unique_outputs(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(qsmxt, "OPENRECON_WORK_ROOT", tmp_path / "work")
+    fake_qsmxt = _fake_qsmxt_binary(tmp_path)
+    connection = FakeConnection(_dual_input_images())
+
+    qsmxt.process(
+        connection,
+        {
+            "parameters": {
+                "qsmxtbinary": str(fake_qsmxt),
+                "echotimesms": "10,20",
+                "inputseries": "both",
+            }
+        },
+        FakeMetadata(),
+    )
+
+    assert connection.closed is True
+    assert connection.logs == []
+    assert len(connection.sent_batches) == 2
+    assert [len(batch) for batch in connection.sent_batches] == [2, 2]
+
+    first_meta = [
+        ismrmrd.Meta.deserialize(batch[0].attribute_string)
+        for batch in connection.sent_batches
+    ]
+    assert [meta["SeriesDescription"] for meta in first_meta] == [
+        "QSMxT QSM DC",
+        "QSMxT QSM ND",
+    ]
+    assert [meta["QSMxTInputSeries"] for meta in first_meta] == [
+        "distortion-corrected",
+        "non-distortion-corrected",
+    ]
+    assert len(
+        {
+            int(batch[0].getHead().image_series_index)
+            for batch in connection.sent_batches
+        }
+    ) == 2
+    assert len({meta["SeriesInstanceUID"] for meta in first_meta}) == 2
 
 
 def test_process_returns_scanner_packed_volume_as_one_mm_slices(tmp_path, monkeypatch):
@@ -1177,7 +1274,6 @@ def test_original_passthrough_merges_concatenations_into_one_series_per_contrast
         series_index = int(output.getHead().image_series_index)
         series_counts[series_index] = series_counts.get(series_index, 0) + 1
 
-    # Exactly two output series: one magnitude (6 slices) and one phase (6).
     assert len(series_counts) == 2
     assert sorted(series_counts.values()) == [6, 6]
 


### PR DESCRIPTION
Adds an OpenRecon input selector for distortion-corrected, ND, or both magnitude/phase pairs. Both mode runs isolated serial QSMxT jobs and returns distinct DC and ND series.

The attached scanner log showed a valid non-constant Chimap but a stored-domain DICOM window that flattened the rescaled ppm display. The adapter now removes standard window fields that Siemens MRD cannot represent with fractional ppm values, while retaining rescale, stored-zero padding, and physical-window diagnostics.

This also removes the voxel-size override and always uses MRD geometry.

Verified with 37 focused adapter tests, recipe validation, OpenRecon label validation, and Dockerfile generation.