### PR TITLE
Remove OpenRecon mock surfaces and accept anatomical GRE inputs

### DIFF
--- a/recipes/topofit/OpenReconLabel.json
+++ b/recipes/topofit/OpenReconLabel.json
@@ -54,7 +54,7 @@
       "label": { "en": "Keep original images" },
       "type": "boolean",
       "default": true,
-      "information": { "en": "Return a restamped copy of the input MPRAGE before the TopoFit QC series." }
+      "information": { "en": "Return a restamped copy of the selected anatomical input before the TopoFit QC series." }
     },
     {
       "id": "tfdevice",
@@ -133,13 +133,6 @@
       "default": 1,
       "unit": { "en": "vox" },
       "information": { "en": "Set the in-plane dilation radius in voxels. Zero draws the undilated projected vertices; one retains the previous width." }
-    },
-    {
-      "id": "tfdebugmock",
-      "label": { "en": "Mock surfaces" },
-      "type": "boolean",
-      "default": false,
-      "information": { "en": "Transport test only: generate small geometry-valid meshes without running the neural network. Never use mock output for analysis." }
     }
   ]
 }

--- a/recipes/topofit/OpenReconREADME.md
+++ b/recipes/topofit/OpenReconREADME.md
@@ -1,9 +1,9 @@
 # TopoFit OpenRecon
 
-This OpenRecon workflow runs BrainNet TopoFit on a reconstructed 3D MPRAGE
-during the scanner session. It generates bilateral white, pial, and spherical
-registration surfaces in FreeSurfer geometry format. It then returns a
-scanner-visible axial QC series on the exact source image grid.
+This OpenRecon workflow runs BrainNet TopoFit on a reconstructed 3D anatomical
+MR image during the scanner session. It generates bilateral white, pial, and
+spherical registration surfaces in FreeSurfer geometry format. It then returns
+a scanner-visible axial QC series on the exact source image grid.
 
 This is a research workflow, not a complete FreeSurfer reconstruction. It does
 not run `recon-all`, cortical parcellation, or longitudinal processing.
@@ -11,10 +11,13 @@ not run `recon-all`, cortical parcellation, or longitudinal processing.
 ## Input and output
 
 The input must be one reconstructed three-dimensional magnitude image series.
-For an MP2RAGE scan, only the denoised uniform (`UNI-DEN`) contrast is
-processed; INV1, INV2, UNI, and other contrasts in the same stream are ignored.
-An MP2RAGE stream without a `UNI-DEN` contrast is rejected rather than processed
-as a different anatomical contrast.
+MP2RAGE is not required. MPRAGE and other non-MP2RAGE 3D anatomical GRE series
+pass through the input selector unchanged. For an MP2RAGE scan, only the
+denoised uniform (`UNI-DEN`) contrast is processed; INV1, INV2, UNI, and other
+contrasts in the same stream are ignored. An MP2RAGE stream without a
+`UNI-DEN` contrast is rejected rather than processed as a different anatomical
+contrast.
+
 The adapter sorts slices by physical position, converts center-based MRD/LPS
 geometry and reconstructed pixel directions to NIfTI RAS, and writes one
 NIfTI volume for BrainNet. By default, BrainNet conforms the data internally
@@ -68,11 +71,6 @@ hemispheres; 3 marks overlap. The mask keeps the source shape and affine.
 | Find sulcal mid-depth voxels | `tfsulcalmiddepth` | `false` | Write a source-grid label mask for curvature-defined sulci at 50% cortical depth. |
 | Sulcal curvature threshold | `tfsulcalthreshold` | `0.1 mm^-1` | Set the minimum magnitude of negative mean curvature. |
 | Surface thickness | `tfoverlaythickness` | `1` voxel | Set the in-plane dilation radius from 0 to 3 voxels. |
-| Mock surfaces | `tfdebugmock` | `false` | Exercise MRD transport and geometry without neural inference. |
-
-The mock option follows the full scanner conversion, QC, metadata, and return
-path, but creates six tiny synthetic meshes. It is useful for a quick scanner
-integration test. Mock artifacts are not analysis results.
 
 ## Safety boundary
 

--- a/recipes/topofit/test_topofit_openrecon.py
+++ b/recipes/topofit/test_topofit_openrecon.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
+from unittest import mock
 
 import constants
 import ismrmrd
 import nibabel as nib
 import numpy as np
 import topofit
+from topofit_core import run_topofit_workflow
 
 
 class RecordingConnection:
@@ -86,7 +89,38 @@ def _mrd_volume(
     return images
 
 
+def _run_mock_workflow(input_path, run_dir, options):
+    return run_topofit_workflow(
+        input_path,
+        run_dir,
+        replace(options, mock=True),
+    )
+
+
 class TopoFitOpenReconTests(unittest.TestCase):
+    def test_openrecon_config_cannot_enable_mock_surfaces(self):
+        options = topofit._options_from_config(
+            {"parameters": {"tfdebugmock": True}}
+        )
+
+        self.assertFalse(options.mock)
+
+    def test_mprage_and_gre_inputs_are_not_filtered(self):
+        images = (
+            _mrd_volume(
+                series_description="MPRAGE_T1W",
+                protocol_name="MPRAGE",
+                series_index=5,
+            )
+            + _mrd_volume(
+                series_description="GRE_T1W",
+                protocol_name="GRE",
+                series_index=6,
+            )
+        )
+
+        self.assertEqual(topofit._select_anatomical_input_images(images), images)
+
     def test_mp2rage_processes_only_uni_den_contrast(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             topofit.WORKSPACE = Path(temporary_directory)
@@ -114,11 +148,15 @@ class TopoFitOpenReconTests(unittest.TestCase):
                     "tfdevice": "cpu",
                     "tfmodel": "t1w_1mm",
                     "tfconform": True,
-                    "tfdebugmock": True,
                 }
             }
 
-            topofit.process(connection, config, metadata=None)
+            with mock.patch.object(
+                topofit,
+                "run_topofit_workflow",
+                side_effect=_run_mock_workflow,
+            ):
+                topofit.process(connection, config, metadata=None)
 
             errors = [
                 message
@@ -157,7 +195,7 @@ class TopoFitOpenReconTests(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("no UNI-DEN contrast", errors[0])
 
-    def test_mock_mrd_series_returns_source_grid_qc_and_manifest(self):
+    def test_mrd_series_returns_source_grid_qc_and_manifest(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             topofit.WORKSPACE = Path(temporary_directory)
             connection = RecordingConnection(_mrd_volume())
@@ -167,7 +205,6 @@ class TopoFitOpenReconTests(unittest.TestCase):
                     "tfdevice": "cpu",
                     "tfmodel": "t1w_1mm",
                     "tfconform": True,
-                    "tfdebugmock": True,
                     "tfflatpatches": True,
                     "tfsulcalmiddepth": True,
                     "tfsulcalthreshold": 100.0,
@@ -175,7 +212,12 @@ class TopoFitOpenReconTests(unittest.TestCase):
                 }
             }
 
-            topofit.process(connection, config, metadata=None)
+            with mock.patch.object(
+                topofit,
+                "run_topofit_workflow",
+                side_effect=_run_mock_workflow,
+            ):
+                topofit.process(connection, config, metadata=None)
 
             self.assertTrue(connection.closed)
             errors = [

--- a/recipes/topofit/topofit.py
+++ b/recipes/topofit/topofit.py
@@ -35,7 +35,6 @@ DEFAULTS = {
     "tfdevice": "cuda",
     "tfmodel": "t1w_1mm",
     "tfconform": True,
-    "tfdebugmock": False,
     "tfflatpatches": False,
     "tfsulcalmiddepth": False,
     "tfsulcalthreshold": 0.1,
@@ -528,7 +527,6 @@ def _options_from_config(config) -> TopoFitOptions:
         .strip()
         .lower(),
         conform=_config_bool(config, "tfconform", DEFAULTS["tfconform"]),
-        mock=_config_bool(config, "tfdebugmock", DEFAULTS["tfdebugmock"]),
         find_flat_patches=_config_bool(
             config, "tfflatpatches", DEFAULTS["tfflatpatches"]
         ),


### PR DESCRIPTION
## Summary

- Remove the OpenRecon mock-surfaces configuration and documentation.
- Accept MPRAGE and other non-MP2RAGE anatomical GRE inputs.
- Preserve MP2RAGE UNI-DEN-only selection and update transport tests.

## Testing

- Added coverage for mock configuration rejection.
- Added coverage for MPRAGE and GRE input selection.
- Updated OpenRecon workflow tests to mock inference internally.