### PR TITLE
Fix QSMxT automatic DICOM windowing

### DIFF
--- a/recipes/qsmxt/OpenReconREADME.md
+++ b/recipes/qsmxt/OpenReconREADME.md
@@ -47,14 +47,16 @@ window, and clipped-voxel count are included in the returned metadata.
 
 Derived maps set the MRD `RescaleSlope` and `RescaleIntercept` attributes. The
 OpenRecon DICOM writer maps these attributes to the standard DICOM fields.
-Because DICOM applies modality rescaling before its display window, a QSM window
-must also use physical units. Siemens MRD metadata represents standard window
-values as integers, which cannot encode a typical sub-unit ppm window. The
-bridge therefore removes `WindowCenter`, `WindowWidth`, and `VOILUTFunction`
-instead of supplying a misleading stored-pixel window. The intended physical
-window remains available as `QSMxTPhysicalWindowCenter` and
-`QSMxTPhysicalWindowWidth`, with `QSMxTWindowDomain=physical` documenting its
-domain. The scanner or DICOM viewer chooses the displayed window automatically.
+Siemens MRD metadata truncates sub-unit window values, so QSM DICOM values use
+parts per billion. One ppm equals 1000 ppb. This unit conversion preserves the
+quantitative values and lets the bridge publish integer `WindowCenter` and
+`WindowWidth` values for the robust display range.
+
+`QSMxTPhysicalWindowCenter` and `QSMxTPhysicalWindowWidth` retain the same
+window in ppm. The Enhanced MR object keeps `RescaleType=US` as required.
+`QSMxTWindowDomain=ppb` records the domain of the standard DICOM window fields.
+`QSMxTDisplayFormula` records how to recover the source ppm value from a stored
+pixel.
 
 Maps with a non-zero stored-value offset, including QSM, reserve stored code `0`.
 The bridge sends `PixelPaddingValue=0` and `PixelPaddingRangeLimit=0`, and native

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -277,21 +277,36 @@ tests:
       assert first_meta["ImageType"] == "DERIVED\\PRIMARY\\M\\QSMXT_CHIMAP"
       assert first_meta["QSMxTDisplayFormula"] == "ppm = (display - 2048) / 1000"
       assert first_meta["DataRole"] == ["Image", "Quantitative"]
-      assert float(first_meta["RescaleSlope"]) == 0.001
-      assert float(first_meta["RescaleIntercept"]) == -2.048
-      assert first_meta["RescaleType"] == "US"
       assert first_meta["PixelPaddingValue"] == "0"
-      if first_meta.get("QSMxTWindowDomain") == "stored":
+      window_domain = first_meta.get("QSMxTWindowDomain")
+      if window_domain == "ppb":
+          assert float(first_meta["RescaleSlope"]) == 1.0
+          assert float(first_meta["RescaleIntercept"]) == -2048.0
+          assert first_meta["RescaleType"] == "US"
+          assert float(first_meta["WindowCenter"]) == 1500.0
+          assert float(first_meta["WindowWidth"]) == 1000.0
+          assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
+          assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
+      elif window_domain == "stored":
+          assert float(first_meta["RescaleSlope"]) == 0.001
+          assert float(first_meta["RescaleIntercept"]) == -2.048
+          assert first_meta["RescaleType"] == "US"
           assert first_meta["PixelPaddingRangeLimit"] == "0"
           assert float(first_meta["WindowCenter"]) == 3548.0
           assert float(first_meta["WindowWidth"]) == 1000.0
           assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5
           assert float(first_meta["QSMxTPhysicalWindowWidth"]) == 1.0
       elif "WindowCenter" in first_meta:
+          assert float(first_meta["RescaleSlope"]) == 0.001
+          assert float(first_meta["RescaleIntercept"]) == -2.048
+          assert first_meta["RescaleType"] == "US"
           assert float(first_meta["WindowCenter"]) == 1.5
           assert float(first_meta["WindowWidth"]) == 1.0
       else:
-          assert first_meta["QSMxTWindowDomain"] == "physical"
+          assert float(first_meta["RescaleSlope"]) == 0.001
+          assert float(first_meta["RescaleIntercept"]) == -2.048
+          assert first_meta["RescaleType"] == "US"
+          assert window_domain == "physical"
           assert "WindowWidth" not in first_meta
           assert "VOILUTFunction" not in first_meta
           assert float(first_meta["QSMxTPhysicalWindowCenter"]) == 1.5

--- a/recipes/qsmxt/qsmxt.py
+++ b/recipes/qsmxt/qsmxt.py
@@ -108,6 +108,7 @@ T2STAR_SCALE_MIN_POSITIVE_VOXELS = 100
 QSM_WINDOW_LOW_PERCENTILE = 1.0
 QSM_WINDOW_HIGH_PERCENTILE = 99.0
 QSM_WINDOW_MIN_NONZERO_VOXELS = 100
+QSM_DICOM_PPB_PER_PPM = 1000.0
 DEFAULT_MASK_PRESET = "bet"
 DEFAULT_MASKING_INPUT = "magnitude"
 DEFAULT_BET_FRACTIONAL_INTENSITY = 0.5
@@ -2195,21 +2196,33 @@ def _output_meta(
     )
     meta["QSMxTPhysicalWindowCenter"] = f"{float(physical_center):.6g}"
     meta["QSMxTPhysicalWindowWidth"] = f"{float(physical_width):.6g}"
-    meta["QSMxTWindowDomain"] = "physical"
+    dicom_value_scale = (
+        QSM_DICOM_PPB_PER_PPM if output_id == "qsm" else 1.0
+    )
+    meta["QSMxTWindowDomain"] = (
+        "ppb" if output_id == "qsm" else "physical"
+    )
     meta["QSMxTDisplayMin"] = str(int(display_meta["display_min"]))
     meta["QSMxTDisplayMax"] = str(int(display_meta["display_max"]))
     meta["QSMxTDisplayClippedVoxels"] = str(int(display_meta["clipped_voxels"]))
     meta["RescaleSlope"] = _format_display_number(
-        display_meta["rescale_slope"]
+        display_meta["rescale_slope"] * dicom_value_scale
     )
     meta["RescaleIntercept"] = _format_display_number(
-        display_meta["rescale_intercept"]
+        display_meta["rescale_intercept"] * dicom_value_scale
     )
     meta["RescaleType"] = "US"
     if display_meta["padding_value"] is not None:
         meta["PixelPaddingValue"] = str(int(display_meta["padding_value"]))
         meta["PixelPaddingRangeLimit"] = str(
             int(display_meta["padding_value"])
+        )
+    if output_id == "qsm":
+        meta["WindowCenter"] = str(
+            int(np.rint(physical_center * dicom_value_scale))
+        )
+        meta["WindowWidth"] = str(
+            max(1, int(np.rint(physical_width * dicom_value_scale)))
         )
     meta.update(_header_geometry_meta(header))
     _strip_scanner_write_unsafe_meta(meta)
@@ -2279,9 +2292,17 @@ def _validate_output_images(output_images, input_images):
         display_offset = _meta_float(meta, "QSMxTDisplayOffset")
         rescale_slope = _meta_float(meta, "RescaleSlope")
         rescale_intercept = _meta_float(meta, "RescaleIntercept")
+        output_id = _meta_text(meta, "QSMxTOutput")
+        dicom_value_scale = (
+            QSM_DICOM_PPB_PER_PPM if output_id == "qsm" else 1.0
+        )
         if display_scale is not None and display_scale > 0.0:
-            expected_slope = 1.0 / display_scale
-            expected_intercept = -(display_offset or 0.0) / display_scale
+            expected_slope = dicom_value_scale / display_scale
+            expected_intercept = (
+                -(display_offset or 0.0)
+                * dicom_value_scale
+                / display_scale
+            )
             if rescale_slope is None or not np.isclose(
                 rescale_slope,
                 expected_slope,
@@ -2301,6 +2322,36 @@ def _validate_output_images(output_images, input_images):
                 )
         if _meta_text(meta, "RescaleType") != "US":
             errors.append(f"image {index} RescaleType is not US")
+
+        if output_id == "qsm":
+            window_center = _meta_float(meta, "WindowCenter")
+            window_width = _meta_float(meta, "WindowWidth")
+            physical_window_center = _meta_float(
+                meta,
+                "QSMxTPhysicalWindowCenter",
+            )
+            physical_window_width = _meta_float(
+                meta,
+                "QSMxTPhysicalWindowWidth",
+            )
+            if window_center is None:
+                errors.append(f"image {index} is missing WindowCenter")
+            elif physical_window_center is None or not np.isclose(
+                window_center,
+                np.rint(physical_window_center * dicom_value_scale),
+            ):
+                errors.append(
+                    f"image {index} WindowCenter does not match physical window"
+                )
+            if window_width is None or window_width < 1.0:
+                errors.append(f"image {index} has invalid WindowWidth")
+            elif physical_window_width is None or not np.isclose(
+                window_width,
+                max(1, np.rint(physical_window_width * dicom_value_scale)),
+            ):
+                errors.append(
+                    f"image {index} WindowWidth does not match physical window"
+                )
 
         padding_value = _meta_int(meta, "PixelPaddingValue")
         if display_offset:

--- a/recipes/qsmxt/test_qsmxt_openrecon.py
+++ b/recipes/qsmxt/test_qsmxt_openrecon.py
@@ -635,6 +635,54 @@ def test_scanner_display_volume_uses_robust_qsm_window_without_clipping_extrema(
     assert meta["window_input_max"] == pytest.approx(0.05)
 
 
+def test_output_meta_publishes_qsm_window_in_integer_ppb_domain():
+    source = _image(
+        1,
+        1,
+        "gre_qsm",
+        np.ones((1, 1, 3), dtype=np.float32),
+    )
+    physical = np.concatenate(
+        (
+            np.full(500, -0.05, dtype=np.float32),
+            np.full(500, 0.05, dtype=np.float32),
+            np.asarray([-0.4, 0.5], dtype=np.float32),
+        )
+    ).reshape(1, 1, -1)
+    display, display_meta = qsmxt._scanner_display_volume(
+        physical,
+        "qsm",
+        "ppm",
+    )
+
+    meta = qsmxt._output_meta(
+        source,
+        source.getHead(),
+        qsmxt.OUTPUT_SERIES_START,
+        "QSMxT QSM",
+        "QSMXT_CHIMAP",
+        "qsm",
+        "ppm",
+        physical,
+        Path("/tmp/qsm.nii.gz"),
+        0,
+        1,
+        display_meta,
+    )
+
+    assert meta["RescaleType"] == "US"
+    assert float(meta["RescaleSlope"]) == 1.0
+    assert float(meta["RescaleIntercept"]) == -2048.0
+    assert float(meta["WindowCenter"]) == 0.0
+    assert float(meta["WindowWidth"]) == 100.0
+    assert meta["QSMxTWindowDomain"] == "ppb"
+    decoded_ppb = (
+        display.astype(np.float64) * float(meta["RescaleSlope"])
+        + float(meta["RescaleIntercept"])
+    )
+    np.testing.assert_allclose(decoded_ppb, physical * 1000.0, atol=0.5)
+
+
 def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
     source = _image(
         1,
@@ -671,26 +719,30 @@ def test_output_meta_replaces_source_scaling_with_qsm_dicom_contract():
     )
 
     assert meta["DataRole"] == ["Image", "Quantitative"]
-    assert float(meta["RescaleSlope"]) == 0.00001
-    assert float(meta["RescaleIntercept"]) == -0.02048
+    assert float(meta["RescaleSlope"]) == 0.01
+    assert float(meta["RescaleIntercept"]) == -20.48
     assert meta["RescaleType"] == "US"
     assert meta["PixelPaddingValue"] == "0"
     assert meta["PixelPaddingRangeLimit"] == "0"
-    assert "WindowCenter" not in meta
-    assert "WindowWidth" not in meta
+    assert float(meta["WindowCenter"]) == 0.0
+    assert float(meta["WindowWidth"]) == 20.0
     assert "VOILUTFunction" not in meta
     assert float(meta["QSMxTPhysicalWindowCenter"]) == 0.0
     assert float(meta["QSMxTPhysicalWindowWidth"]) == 0.02
-    assert meta["QSMxTWindowDomain"] == "physical"
+    assert meta["QSMxTWindowDomain"] == "ppb"
     assert 0 not in display
 
-    decoded = (
+    decoded_ppb = (
         display.astype(np.float64) * float(meta["RescaleSlope"])
         + float(meta["RescaleIntercept"])
     )
-    center = float(meta["QSMxTPhysicalWindowCenter"])
-    width = float(meta["QSMxTPhysicalWindowWidth"])
-    rendered = np.clip((decoded - (center - width / 2.0)) / width, 0.0, 1.0)
+    center = float(meta["WindowCenter"])
+    width = float(meta["WindowWidth"])
+    rendered = np.clip(
+        (decoded_ppb - (center - width / 2.0)) / width,
+        0.0,
+        1.0,
+    )
     assert np.unique(rendered).size == 3
 
 
@@ -1043,16 +1095,17 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
     assert meta["QSMxTDisplayOffset"] == "2048"
     assert meta["QSMxTDisplayFormula"] == "ppm = (display - 2048) / 1000"
     assert meta["DataRole"] == ["Image", "Quantitative"]
-    assert float(meta["RescaleSlope"]) == 0.001
-    assert float(meta["RescaleIntercept"]) == -2.048
+    assert float(meta["RescaleSlope"]) == 1.0
+    assert float(meta["RescaleIntercept"]) == -2048.0
     assert meta["RescaleType"] == "US"
     assert meta["PixelPaddingValue"] == "0"
     assert meta["PixelPaddingRangeLimit"] == "0"
-    assert "WindowCenter" not in meta
-    assert "WindowWidth" not in meta
+    assert float(meta["WindowCenter"]) == 1500.0
+    assert float(meta["WindowWidth"]) == 1000.0
     assert "VOILUTFunction" not in meta
     assert float(meta["QSMxTPhysicalWindowCenter"]) == 1.5
     assert float(meta["QSMxTPhysicalWindowWidth"]) == 1.0
+    assert meta["QSMxTWindowDomain"] == "ppb"
     assert meta["QSMxTDisplayScaleInputMin"] == "1.5"
     assert meta["QSMxTDisplayScaleInputMax"] == "1.5"
     assert meta["QSMxTDisplayMin"] == "3548"


### PR DESCRIPTION
## Summary

- publish the robust QSM window through the standard MRD window fields
- express QSM DICOM rescale values and windows in integer-compatible ppb while retaining the source ppm formula
- validate the QSM rescale and window contract before sending images

## Why

The supplied distortion-corrected and non-distortion-corrected DICOM outputs both contained the fallback 0/2 ppm window. Their robust data windows were 0.022/0.220 ppm and 0.022/0.222 ppm. The previous private physical-window metadata did not reach the standard DICOM Frame VOI fields.

## Testing

- 38 focused QSMxT OpenRecon tests passed
- replayed both supplied DICOM pixel distributions through the corrected metadata path
- qsmxt recipe validation passed
- Dockerfile generation passed
- fulltest YAML parsed successfully
- git diff check passed