### PR TITLE
Release TopoFit 0.5.1 with cortical patch and normal QC

### DIFF
--- a/recipes/topofit/OpenReconLabel.json
+++ b/recipes/topofit/OpenReconLabel.json
@@ -103,10 +103,45 @@
     },
     {
       "id": "tfflatpatches",
-      "label": { "en": "Find flat pial patches" },
+      "label": { "en": "Find cortical patches" },
       "type": "boolean",
       "default": false,
-      "information": { "en": "Find one locally planar pial-surface patch per hemisphere, draw each patch and outward normal, and append research-only LPS coordinates to the image comments." }
+      "information": { "en": "Find ranked, non-overlapping cortical patches with visible IDs and normals. Default: up to three per hemisphere at 50% depth. Automatic candidates are not lesion ROIs or matched controls." }
+    },
+    {
+      "id": "tfpatchcount", "label": { "en": "Maximum patches per hemisphere" },
+      "type": "int", "minimum": 1, "maximum": 10, "default": 3,
+      "information": { "en": "Return up to this many distinct patches in each selected hemisphere. Fewer are returned when quality criteria cannot be met." }
+    },
+    {
+      "id": "tfpatchradius", "label": { "en": "Cortical patch radius" },
+      "type": "double", "minimum": 5.0, "maximum": 20.0, "default": 10.0,
+      "unit": { "en": "mm" },
+      "information": { "en": "Grow neighborhoods along cortical mesh edges, not by straight-line distance through the brain." }
+    },
+    {
+      "id": "tfpatchhemisphere", "label": { "en": "Patch hemisphere" },
+      "type": "choice", "default": "both",
+      "values": [
+        { "id": "both", "name": { "en": "Both" } },
+        { "id": "lh", "name": { "en": "Left" } },
+        { "id": "rh", "name": { "en": "Right" } }
+      ],
+      "information": { "en": "Restrict cortical patch search to the selected hemisphere. Surface reconstruction remains bilateral." }
+    },
+    {
+      "id": "tfpatchregion", "label": { "en": "Patch search region" },
+      "type": "choice", "default": "cortex",
+      "values": [
+        { "id": "cortex", "name": { "en": "Whole eligible cortex" } },
+        { "id": "roi", "name": { "en": "Native-space ROI" } }
+      ],
+      "information": { "en": "ROI mode requires a supplied NIfTI mask on the source image grid. It never falls back to whole-brain search." }
+    },
+    {
+      "id": "tfpatchroi", "label": { "en": "Native-space ROI path" },
+      "type": "string", "default": "",
+      "information": { "en": "Container-visible path to a NIfTI mask, for example /data/roi.nii.gz. Used only in ROI mode. The mask must already be registered to the input image." }
     },
     {
       "id": "tfsulcalmiddepth",

--- a/recipes/topofit/OpenReconREADME.md
+++ b/recipes/topofit/OpenReconREADME.md
@@ -3,7 +3,7 @@
 This OpenRecon workflow runs BrainNet TopoFit on a reconstructed 3D anatomical
 MR image during the scanner session. It generates bilateral white, pial, and
 spherical registration surfaces in FreeSurfer geometry format. It then returns
-a scanner-visible axial QC series on the exact source image grid.
+scanner-visible QC series on the exact source image grid.
 
 This is a research workflow, not a complete FreeSurfer reconstruction. It does
 not run `recon-all`, cortical parcellation, or longitudinal processing.
@@ -29,6 +29,8 @@ Each successful run writes these artifacts below `/tmp/share/topofit`:
 - `surf/lh.pial` and `surf/rh.pial`
 - `surf/lh.registration` and `surf/rh.registration`
 - `topofit_qc.nii.gz`
+- `topofit_patch_qc.nii.gz` when flat-patch analysis is enabled
+- `topofit_patch_geometry.npz` with selected ribbon coordinates and local normals
 - `topofit_sulcal_middepth_mask.nii.gz` when sulcal analysis is enabled
 - `topofit_manifest.json`
 
@@ -40,12 +42,68 @@ retains the previous width. OpenRecon sends that volume back as
 `<source>_topofit_qc`. When **Keep original images** is enabled, a restamped
 `<source>_original` series is sent first.
 
-When **Find flat pial patches** is enabled, the workflow searches each pial
-mesh for the 10 mm-radius neighborhood with the lowest area-weighted plane-fit
-residual and coherent face normals. It draws both selected patches and their
-20 mm outward normals into the QC pixels. The result manifest stores the
-centers and normals in NIfTI world RAS. Each QC image comment also contains the
-centers in scanner patient-space LPS millimetres and the unit normals in LPS.
+When **Find cortical patches** is enabled, the workflow searches the middle
+of the cortical ribbon: `white + 0.5 * (pial - white)`.
+It maps the fsaverage cortex labels through TopoFit's registration spheres,
+excludes a 5 mm mesh-edge margin around the medial-wall closure, and rejects
+white-to-pial separations below 0.5 mm. These conservative eligibility guards
+are not validated tissue-classification or cortical-thickness thresholds.
+They do not exclude all medial cortex by a midline coordinate cutoff.
+
+Candidates grow along mesh edges within the configured radius, default 10 mm.
+The default search returns up to three non-overlapping patches per hemisphere.
+It evaluates up to `max(64, 32 * requested_count)` seeds per hemisphere.
+This is a heuristic search, not an exhaustive count of all suitable cortex.
+Accepted patches have area-weighted plane-fit RMS at most 0.5 mm, area at least
+`0.25 * pi * radius^2`, and signed normal coherence at least 0.9. The default
+minimum area is 78.5 mm². RMS and area cutoffs are configurable research settings,
+not clinically validated thresholds. Scoring combines RMS and normal coherence.
+Ranked candidates that share any mesh vertex with an accepted patch are removed.
+Fewer patches, or none, are returned if the criteria cannot be met. A failed
+quality search produces `NO_PATCH_MEETS_CRITERIA`, not a relaxed fallback.
+An orientation filter retains a connected part of one cortical bank. The
+reported center is an actual mid-surface vertex, not a centroid in CSF.
+The workflow returns a separate
+`<source>_topofit_patch_qc` series with each selected patch filled on the source
+grid (intensity 3000), its white boundary (2400), and its pial boundary (2700).
+A center ring shows the true in-plane normal component at physical scale (4095).
+A dot means that the normal points toward increasing slice positions. A cross
+means that it points toward decreasing slice positions. This convention keeps
+a through-plane normal visible without drawing a false in-plane arrow. The
+result manifest stores the centers and normals in NIfTI world RAS. Each QC
+image comment also contains the centers and unit normals in scanner
+patient-space LPS.
+
+Patch IDs such as `LH01` and `RH03` appear beside their normal glyphs. They are
+ranked within each hemisphere for that run, not longitudinal anatomical labels.
+All patches share one source-grid QC series. The JSON manifest records accepted
+counts, IDs, scores, areas, RMS errors, normal coherence, and local geometry paths.
+The offline preview groups the patches into a ranked contact sheet with cortex zooms.
+
+`topofit_patch_geometry.npz` contains `<patch_id>_vertex_indices`, local triangle
+indices in `<patch_id>_faces`, and paired `<patch_id>_white_ras_mm`,
+`<patch_id>_mid_ras_mm`, and `<patch_id>_pial_ras_mm` arrays. The
+`<patch_id>_normals_ras` array contains unit, area-weighted local mid-surface
+normals oriented from white matter toward pial. Diffusion analysis needs these
+local normals, not the single representative plane normal drawn for QC.
+
+`--patch-roi roi.nii.gz` restricts selection to positive mask values on the
+input NIfTI grid. The affine and shape must match the scan. The OpenRecon
+configuration uses `tfpatchregion=roi` and the container-side path `tfpatchroi`.
+Whole-cortex mode ignores a previously supplied ROI path. The package does not
+upload or register a mask; it must be supplied through a container volume mount.
+A unilateral mask returns only that hemisphere. An empty cortical ROI fails
+without falling back to whole-brain selection.
+
+McNab et al. (2013), *Surface based analysis of diffusion orientation for
+identifying architectonic domains in the in vivo human cortex*, Tian et al.'s
+OHBM 2017 poster *In Vivo Identification of Granular Cortices using Whole-brain
+Cortical Diffusion MRI Analysis*, and the supplied 2026 FCD draft motivate
+ribbon sampling and local normals. This workflow provides the
+structural geometry, not a reproduction of their diffusion results. It does
+not identify FCD, register diffusion or FLAIR, compute radiality or directional
+ADC, or generate matched contralateral controls. Without an ROI, the
+automatic patches are independent candidates and need anatomical review.
 
 Surface artifacts stay in the run workspace so later research analysis can
 consume them. Flat-patch coordinates are candidates only. They are not
@@ -53,7 +111,8 @@ motion-cleared prescription coordinates.
 
 When **Find sulcal mid-depth voxels** is enabled, the workflow computes signed
 cotangent mean curvature on each pial mesh. Negative curvature is concave and
-sulcal. Faces whose three vertices meet the configured threshold are moved to
+sulcal. The same cortical eligibility mask excludes the medial-wall transition
+and collapsed ribbon. Faces whose three vertices meet the threshold are moved to
 50% cortical depth using the corresponding white and pial vertices. The
 workflow writes every source-grid voxel cell intersected by those faces to
 `topofit_sulcal_middepth_mask.nii.gz`. Labels 1 and 2 mark the left and right
@@ -67,12 +126,25 @@ hemispheres; 3 marks overlap. The mask keeps the source shape and affine.
 | Inference device | `tfdevice` | `cuda` | Run on the scanner GPU or use CPU for compatibility testing. |
 | TopoFit model | `tfmodel` | `t1w_1mm` | Select the T1w or synthetic pretrained model. |
 | Conform input | `tfconform` | `true` | Resample internally to the model grid. |
-| Find flat pial patches | `tfflatpatches` | `false` | Find one candidate per hemisphere, draw its patch and normal, and write LPS geometry into image comments. |
+| Find cortical patches | `tfflatpatches` | `false` | Find connected mid-cortical candidates and return patch-and-normal QC with LPS geometry in image comments. |
+| Maximum patches per hemisphere | `tfpatchcount` | `3` | Return up to 1–10 accepted patches per selected hemisphere. |
+| Cortical patch radius | `tfpatchradius` | `10 mm` | Mesh-edge radius, 5–20 mm. |
+| Patch hemisphere | `tfpatchhemisphere` | `both` | Both, `lh`, or `rh`. Reconstruction remains bilateral. |
+| Patch search region | `tfpatchregion` | `cortex` | Whole eligible cortex or `roi`. |
+| Native-space ROI path | `tfpatchroi` | empty | Container-visible NIfTI mask path, used only in ROI mode. |
+| Configuration-only maximum plane-fit error | `tfpatchmaxrms` | `0.5 mm` | Advanced acceptance cutoff, 0.01–2 mm RMS. |
+| Configuration-only minimum area fraction | `tfpatchminarea` | `0.25` | Advanced area cutoff as a fraction of `pi * radius^2`, 0.1–1. |
 | Find sulcal mid-depth voxels | `tfsulcalmiddepth` | `false` | Write a source-grid label mask for curvature-defined sulci at 50% cortical depth. |
 | Sulcal curvature threshold | `tfsulcalthreshold` | `0.1 mm^-1` | Set the minimum magnitude of negative mean curvature. |
 | Surface thickness | `tfoverlaythickness` | `1` voxel | Set the in-plane dilation radius from 0 to 3 voxels. |
 
 ## Safety boundary
+
+The scanner label uses all 14 parameter slots allowed by OpenRecon schema 1.1.0.
+The existing controls are retained. `tfpatchmaxrms` and `tfpatchminarea` are
+advanced JSON configuration or CLI options, not additional scanner controls.
+The schema permits only 0.1 steps for doubles, so it cannot represent an area
+fraction of 0.25 as a numeric control without changing the parameter's units.
 
 Every QC image and manifest is marked:
 
@@ -95,12 +167,27 @@ The container exposes the same workflow as a command-line tool:
 topofit-openrecon mprage.nii.gz output --device cuda
 topofit-openrecon mprage.nii.gz transport-test --device cpu --mock
 topofit-openrecon mprage.nii.gz flat-patches --find-flat-patches --overlay-thickness 0
+topofit-openrecon mprage.nii.gz multiple-patches --find-flat-patches --patch-count 3 --patch-radius 10 --patch-max-rms 0.5 --patch-min-area 0.25
+topofit-openrecon mprage.nii.gz roi-patch --find-flat-patches --patch-roi roi.nii.gz
 topofit-openrecon mprage.nii.gz sulci --find-sulcal-middepth --sulcal-curvature-threshold 0.1
 ```
 
 The first command runs the real model. The second tests the artifact and QC
 path in seconds. The third enables flat-patch analysis and uses the thinnest
 surface trace.
+
+The repository includes two offline verification scripts. `verify_dicom.py`
+reads one Enhanced MR volume, creates MRD frames, and runs the real adapter.
+It verifies the returned geometry and pixels before exporting a derived QC
+DICOM. It does not test the scanner connection or replace the scanner's DICOM
+converter. `preview_patch_qc.py` renders the selected geometry over source
+anatomy in a contact sheet with one selected plane and cortex zoom per patch.
+It requires Pillow.
+
+The multi-patch manifest uses schema version 2 in `flat_patch_definition`.
+Its `flat_patches` dictionary and NPZ arrays are keyed by patch ID rather than
+hemisphere. The default count is three when analysis is enabled. A count of one
+restores the previous output count without restoring the old manifest schema.
 
 ## Citation
 

--- a/recipes/topofit/build.yaml
+++ b/recipes/topofit/build.yaml
@@ -1,5 +1,5 @@
 name: topofit
-version: "0.4.0"
+version: "0.5.1"
 
 copyright:
   - license: GPL-3.0-only
@@ -8,6 +8,8 @@ copyright:
     url: https://github.com/simnibs/brainsynth/blob/v{{ context.brainsynth_version }}/LICENSE
   - license: GPL-3.0-only
     url: https://github.com/simnibs/cortech/blob/v{{ context.cortech_version }}/LICENSE
+  - license: LicenseRef-FreeSurfer
+    url: https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
 
 architectures:
   - x86_64
@@ -41,10 +43,20 @@ build:
     - include: macros/openrecon/neurodocker.yaml
 
     - run:
-        - python3 -m pip install --no-cache-dir "numpy==2.1.3" "scipy==1.15.1" "nibabel==5.3.2" "numba==0.61.0" "pytorch-ignite==0.5.2" "tqdm==4.67.1"
+        - python3 -m pip install --no-cache-dir "numpy==2.1.3" "scipy==1.15.1" "nibabel==5.3.2" "numba==0.61.0" "pytorch-ignite==0.5.2" "tqdm==4.67.1" "pillow==11.0.0"
         - python3 -m pip install --no-cache-dir --no-deps {{ get_file("cortech_wheel") }} {{ get_file("brainsynth_wheel") }} {{ get_file("brainnet_wheel") }}
         - python3 -c "import brainnet, brainsynth, cortech, torch; print('BrainNet imports with torch', torch.__version__)"
         - python3 -c "from importlib.resources import files; assert files('brainnet').joinpath('resources/models/topofit/t1w_1mm_state.pt').is_file()"
+
+    - run:
+        - mkdir -p /opt/topofit-atlas
+        - install -m 0644 {{ get_file("fsaverage_sphere") }} /opt/topofit-atlas/lh.sphere.reg
+        - install -m 0644 {{ get_file("fsaverage_sphere") }} /opt/topofit-atlas/rh.sphere.reg
+        - install -m 0644 {{ get_file("lh_cortex") }} /opt/topofit-atlas/lh.cortex.label
+        - install -m 0644 {{ get_file("rh_cortex") }} /opt/topofit-atlas/rh.cortex.label
+        - echo 'fddcf0eeecc6e0f62142164f7c0ac24fda1f0be8cb653d3f037970184c5ba98f  /opt/topofit-atlas/lh.sphere.reg' | sha256sum -c -
+        - echo 'e08216c1a840f0c192ac63c212fbbe12efc7e9731faa64a45083a098746b928a  /opt/topofit-atlas/lh.cortex.label' | sha256sum -c -
+        - echo '432e9ce95e095c066dae2ed2fb3e6c0c67af6e77d8f52ba2d3b560b4fc50b87f  /opt/topofit-atlas/rh.cortex.label' | sha256sum -c -
 
     - run:
         - install -m 0644 {{ get_file("topofit_core.py") }} /opt/code/python-ismrmrd-server/topofit_core.py
@@ -72,6 +84,12 @@ categories:
   - machine learning
 
 files:
+  - name: fsaverage_sphere
+    url: https://www.freesurfer.net/pub/dist/freesurfer/tutorial_versions_centos6/freesurfer/subjects/fsaverage/surf/lh.sphere.reg
+  - name: lh_cortex
+    url: https://www.freesurfer.net/pub/dist/freesurfer/tutorial_versions_centos6/freesurfer/subjects/fsaverage/label/lh.cortex.label
+  - name: rh_cortex
+    url: https://www.freesurfer.net/pub/dist/freesurfer/tutorial_versions_centos6/freesurfer/subjects/fsaverage/label/rh.cortex.label
   - name: brainnet_wheel
     url: "{{ context.brainnet_wheel_url }}"
   - name: brainsynth_wheel
@@ -112,11 +130,18 @@ readme: |-
   ```
 
   The output directory contains FreeSurfer geometry files, a source-grid QC
-  overlay, and a JSON manifest. The same workflow is available through the
+  overlay, and a JSON manifest. Flat-patch analysis also writes a dedicated
+  source-grid patch illustration. The same workflow is available through the
   included OpenRecon image-to-image adapter for inline scanner testing.
 
-  Add `--find-flat-patches` to find one planar pial candidate per hemisphere,
-  draw its patch and outward normal, and record the geometry in the manifest.
+  Add `--find-flat-patches` to find up to three distinct mid-cortical candidates per hemisphere,
+  draw its patch and outward normal in `topofit_patch_qc.nii.gz`, and record the
+  geometry in the manifest and paired ribbon coordinates/local normals in an NPZ.
+  The selector excludes the mapped fsaverage medial wall and collapsed ribbon.
+  Use `--patch-roi roi.nii.gz` to restrict selection to a native-grid ROI;
+  automatic candidates are not lesion labels or matched contralateral controls.
+  `--patch-count`, `--patch-radius`, `--patch-max-rms`, `--patch-min-area`, and
+  `--patch-hemisphere` control the candidate count, size, acceptance, and search side.
   Add `--find-sulcal-middepth` to classify concave pial regions by mean
   curvature and write the intersecting middle-cortical-depth voxels as a
   source-grid label image.

--- a/recipes/topofit/fulltest.yaml
+++ b/recipes/topofit/fulltest.yaml
@@ -5,7 +5,7 @@
 # on CPU and can take several minutes on a CPU-only release runner.
 
 name: topofit
-version: "0.4.0"
+version: "0.5.1"
 
 required_files:
   - dataset: ds000001
@@ -23,6 +23,21 @@ setup:
     mkdir -p "${output_dir}"
 
 tests:
+  - name: Cortical eligibility atlas installed
+    description: Verify the runtime atlas contains both cortex labels and usable registration spheres.
+    command: |
+      PYTHONPATH=/opt/code/python-ismrmrd-server python3 -c "
+      from pathlib import Path
+      import nibabel as nib
+      from topofit_core import mapped_cortex_mask
+      for hemisphere in ('lh', 'rh'):
+          sphere, _ = nib.freesurfer.read_geometry(str(Path('/opt/topofit-atlas') / (hemisphere + '.sphere.reg')))
+          mask = mapped_cortex_mask(sphere, hemisphere)
+          assert 0.8 < mask.mean() < 0.99
+      print('cortex atlas ok')
+      "
+    expected_output_contains: "cortex atlas ok"
+
   - name: OpenRecon-compatible CUDA runtime
     description: Verify PyTorch stays within the CUDA ceiling enforced by the OpenRecon packager.
     command: |
@@ -111,6 +126,7 @@ tests:
     validate:
       - output_exists: ${output_dir}/mock/topofit_manifest.json
       - output_exists: ${output_dir}/mock/topofit_qc.nii.gz
+      - output_exists: ${output_dir}/mock/topofit_patch_qc.nii.gz
       - output_exists: ${output_dir}/mock/topofit_sulcal_middepth_mask.nii.gz
       - output_exists: ${output_dir}/mock/surf/lh.white
       - output_exists: ${output_dir}/mock/surf/rh.pial
@@ -127,7 +143,7 @@ tests:
       assert manifest['flat_patch_status'] == 'CANDIDATES_REPORTED_RESEARCH_ONLY'
       assert manifest['sulcal_middepth_status'] == 'VOXELS_REPORTED_RESEARCH_ONLY'
       assert set(manifest['sulci']) == {'lh', 'rh'}
-      assert set(manifest['flat_patches']) == {'lh', 'rh'}
+      assert all(1 <= manifest['patch_counts'][h] <= 3 for h in ('lh', 'rh'))
       assert manifest['options']['overlay_thickness'] == 0
       print(manifest['warning'])
       "
@@ -140,6 +156,7 @@ tests:
     validate:
       - output_exists: ${output_dir}/real/topofit_manifest.json
       - output_exists: ${output_dir}/real/topofit_qc.nii.gz
+      - output_exists: ${output_dir}/real/topofit_patch_qc.nii.gz
       - output_exists: ${output_dir}/real/topofit_sulcal_middepth_mask.nii.gz
       - output_exists: ${output_dir}/real/surf/lh.white
       - output_exists: ${output_dir}/real/surf/rh.white
@@ -151,20 +168,46 @@ tests:
   - name: Real surfaces and QC geometry are valid
     description: Parse every mesh and prove the QC volume remains on the source grid.
     command: |
-      python3 -c "
+      PYTHONPATH=/opt/code/python-ismrmrd-server python3 -c "
       from pathlib import Path
       import nibabel as nib
       import numpy as np
+      from topofit_core import mapped_cortex_mask, erode_cortex_mask, cortical_ribbon_mask
       source = nib.load('${t1w}')
       qc = nib.load('${output_dir}/real/topofit_qc.nii.gz')
       assert qc.shape == source.shape, (qc.shape, source.shape)
       np.testing.assert_allclose(qc.affine, source.affine)
       manifest = __import__('json').load(open('${output_dir}/real/topofit_manifest.json'))
-      assert set(manifest['flat_patches']) == {'lh', 'rh'}
-      sulcal = nib.load('${output_dir}/real/topofit_sulcal_middepth_mask.nii.gz')
-      assert sulcal.shape == source.shape
-      np.testing.assert_allclose(sulcal.affine, source.affine)
-      assert set(np.unique(np.asarray(sulcal.dataobj))).issubset({0, 1, 2, 3})
+      assert all(1 <= manifest['patch_counts'][h] <= 3 for h in ('lh', 'rh'))
+      geometry = np.load('${output_dir}/real/topofit_patch_geometry.npz')
+      for hemisphere in ('lh', 'rh'):
+          root = Path('${output_dir}/real/surf')
+          white, faces = nib.freesurfer.read_geometry(str(root / (hemisphere + '.white')))
+          pial, _ = nib.freesurfer.read_geometry(str(root / (hemisphere + '.pial')))
+          sphere, _ = nib.freesurfer.read_geometry(str(root / (hemisphere + '.registration')))
+          cortex = erode_cortex_mask((white + pial) / 2, faces, mapped_cortex_mask(sphere, hemisphere))
+          eligible = cortical_ribbon_mask(white, pial, cortex)
+          used = set()
+          for patch_id, patch in manifest['flat_patches'].items():
+              if patch['surface'] != hemisphere + '.mid':
+                  continue
+              indices = geometry[patch_id + '_vertex_indices']
+              assert patch_id == patch['patch_id']
+              assert used.isdisjoint(indices)
+              used.update(indices)
+              assert eligible[indices].all()
+              assert patch['rms_distance_mm'] <= manifest['options']['patch_max_rms_mm']
+              assert patch['area_mm2'] >= manifest['flat_patch_definition']['minimum_area_mm2']
+              assert patch['normal_coherence'] >= 0.9
+              np.testing.assert_allclose(geometry[patch_id + '_mid_ras_mm'], (white[indices] + pial[indices]) / 2)
+              normals = geometry[patch_id + '_normals_ras']
+              np.testing.assert_allclose(np.linalg.norm(normals, axis=1), 1)
+              assert np.all(np.einsum('ij,ij->i', normals, pial[indices] - white[indices]) >= 0)
+      if manifest['options']['find_sulcal_middepth']:
+          sulcal = nib.load('${output_dir}/real/topofit_sulcal_middepth_mask.nii.gz')
+          assert sulcal.shape == source.shape
+          np.testing.assert_allclose(sulcal.affine, source.affine)
+          assert set(np.unique(np.asarray(sulcal.dataobj))).issubset({0, 1, 2, 3})
       for name in ('lh.white', 'rh.white', 'lh.pial', 'rh.pial', 'lh.registration', 'rh.registration'):
           vertices, faces = nib.freesurfer.read_geometry(str(Path('${output_dir}/real/surf') / name))
           assert vertices.shape[1] == 3 and faces.shape[1] == 3, name

--- a/recipes/topofit/preview_patch_qc.py
+++ b/recipes/topofit/preview_patch_qc.py
@@ -1,0 +1,106 @@
+"""Render a ranked cortical-patch contact sheet from actual run geometry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+from topofit_geometry import triangle_voxel_mask
+
+
+def render_preview(input_path: Path, run_dir: Path, output_path: Path) -> None:
+    image = nib.as_closest_canonical(nib.load(input_path))
+    data = np.asarray(image.dataobj, dtype=float)
+    lo, hi = np.percentile(data[data > 0], (1, 99.5))
+    gray = np.uint8(np.clip((data - lo) / max(hi - lo, 1), 0, 1) * 210)
+    manifest = json.loads((run_dir / "topofit_manifest.json").read_text())
+    patches = manifest["flat_patches"]
+    geometry = np.load(run_dir / "topofit_patch_geometry.npz")
+    rows = max(1, (len(patches) + 2) // 3)
+    canvas = Image.new("RGB", (1500, 125 + rows * 520), (12, 15, 21))
+    draw = ImageDraw.Draw(canvas)
+    font = ImageFont.load_default(size=18)
+    small = ImageFont.load_default(size=15)
+    draw.text((20, 12), f"TopoFit: {len(patches)} distinct cortical patches at 50% depth", font=font)
+    draw.text((20, 42), "Green: white boundary. Red: pial boundary. Yellow: mid-cortex. Cyan: projected normal, 12 mm.", font=font)
+    draw.text((20, 72), "Actual scan, source-grid views with cortex zooms. Research candidates, not matched controls or prescription coordinates.", font=font)
+    inverse = np.linalg.inv(image.affine)
+    masks = {name: np.zeros(image.shape, dtype=bool) for name in ("white", "pial", "mid")}
+    centers = {}
+    for patch_id, patch in patches.items():
+        centers[patch_id] = nib.affines.apply_affine(inverse, patch["center_ras_mm"])
+        for boundary in masks:
+            masks[boundary] |= triangle_voxel_mask(
+                image.shape, image.affine, geometry[f"{patch_id}_{boundary}_ras_mm"],
+                geometry[f"{patch_id}_faces"],
+            )
+    if not patches:
+        draw.text((30, 160), "No cortical patches passed the quality criteria.", font=font)
+    for number, (patch_id, patch) in enumerate(patches.items()):
+        center = centers[patch_id]
+        normal = np.asarray(patch["normal_ras"])
+        voxel_normal = inverse[:3, :3] @ normal
+        axis = int(np.argmin(abs(voxel_normal / np.linalg.norm(voxel_normal))))
+        remaining = [a for a in range(3) if a != axis]
+        index = int(np.clip(round(center[axis]), 0, image.shape[axis] - 1))
+        plane = np.repeat(np.take(gray, index, axis=axis)[..., None], 3, axis=-1)
+        for boundary, color in (("white", (40, 230, 100)), ("pial", (255, 80, 80)), ("mid", (255, 225, 40))):
+            plane[np.take(masks[boundary], index, axis=axis)] = color
+        plane = Image.fromarray(np.rot90(plane))
+        spacing = nib.affines.voxel_sizes(image.affine)[remaining]
+        scale = min(470 / (plane.width * spacing[0]), 410 / (plane.height * spacing[1]))
+        size = (round(plane.width * spacing[0] * scale), round(plane.height * spacing[1] * scale))
+        plane = plane.resize(size, Image.Resampling.NEAREST)
+        overlay = ImageDraw.Draw(plane)
+
+        def point(voxel):
+            return np.asarray((
+                voxel[remaining[0]] * size[0] / image.shape[remaining[0]],
+                (image.shape[remaining[1]] - 1 - voxel[remaining[1]]) * size[1] / image.shape[remaining[1]],
+            ))
+
+        for other_id, other in patches.items():
+            other_center = centers[other_id]
+            if other_id != patch_id and abs(other_center[axis] - index) > 0.75:
+                continue
+            endpoint = nib.affines.apply_affine(inverse,
+                np.asarray(other["center_ras_mm"]) + 12 * np.asarray(other["normal_ras"]))
+            start, end = point(other_center), point(endpoint)
+            delta = end - start
+            if np.linalg.norm(delta) > 3:
+                direction = delta / np.linalg.norm(delta)
+                side = np.asarray((-direction[1], direction[0]))
+                overlay.line((tuple(start), tuple(end)), fill=(40, 220, 255), width=2)
+                overlay.polygon([tuple(end), tuple(end - 7 * direction + 3 * side),
+                                 tuple(end - 7 * direction - 3 * side)], fill=(40, 220, 255))
+        col, row = number % 3, number // 3
+        xbase, ybase = col * 500, 120 + row * 520
+        draw.text((xbase + 16, ybase),
+                  f"{patch_id}   {patch['area_mm2']:.0f} mm^2   RMS {patch['rms_distance_mm']:.3f} mm", font=font)
+        draw.text((xbase + 16, ybase + 26),
+                  f"{('Sagittal', 'Coronal', 'Axial')[axis]} view; ribbon {patch['median_ribbon_separation_mm']:.2f} mm", font=small)
+        xoff, yoff = xbase + (500 - size[0]) // 2, ybase + 55
+        canvas.paste(plane, (xoff, yoff))
+        cx, cy = point(center)
+        half = max(24, round(15 * scale))
+        crop = plane.crop((round(cx - half), round(cy - half), round(cx + half), round(cy + half)))
+        crop = crop.resize((150, 150), Image.Resampling.NEAREST)
+        zx, zy = xbase + 335, ybase + 337
+        canvas.paste(crop, (zx, zy))
+        draw.rectangle((zx, zy, zx + 150, zy + 150), outline=(150, 160, 180), width=1)
+        draw.text((zx, zy - 20), f"{patch_id} cortex zoom", font=small)
+    canvas.save(output_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("run_dir", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    render_preview(args.input, args.run_dir, args.output)

--- a/recipes/topofit/test_topofit_core.py
+++ b/recipes/topofit/test_topofit_core.py
@@ -6,16 +6,18 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 import nibabel as nib
 import numpy as np
+import topofit_core
 from topofit_core import (
     RESEARCH_WARNING,
     SURFACE_NAMES,
     TopoFitOptions,
     _dilate_in_plane,
     build_brainnet_command,
-    find_flattest_patch,
+    find_ranked_patches,
     mrd_lps_to_nifti_ras_affine,
     run_topofit_workflow,
     validate_options,
@@ -23,6 +25,141 @@ from topofit_core import (
 
 
 class TopoFitCoreTests(unittest.TestCase):
+    def test_multiple_patches_are_ranked_disjoint_and_quality_limited(self):
+        x, y = np.meshgrid(np.arange(41.), np.arange(21.), indexing="ij")
+        vertices = np.column_stack((x.ravel(), y.ravel(), np.zeros(x.size)))
+        faces = []
+        for i in range(40):
+            for j in range(20):
+                k = i * 21 + j
+                faces.extend(((k, k + 21, k + 1), (k + 1, k + 21, k + 22)))
+        faces = np.asarray(faces)
+        patches = topofit_core.find_ranked_patches(
+            vertices, faces, "lh.mid", count=3, radius_mm=5,
+        )
+        self.assertEqual(len(patches), 3)
+        used = set()
+        for detection in patches:
+            indices = set(detection.vertex_indices)
+            self.assertTrue(used.isdisjoint(indices))
+            used.update(indices)
+            self.assertLessEqual(detection.patch.rms_distance_mm, 0.5)
+            self.assertGreaterEqual(detection.patch.area_mm2, 0.25 * np.pi * 5**2)
+        poor = vertices.copy()
+        poor[:, 2] = 0.03 * (x.ravel() - 20)**2 + 0.02 * (y.ravel() - 10)**2
+        self.assertEqual(topofit_core.find_ranked_patches(
+            poor, faces, "lh.mid", count=3, radius_mm=5, max_rms_mm=1e-8,
+        ), [])
+
+    def test_patch_parameters_are_validated(self):
+        from dataclasses import replace
+        defaults = TopoFitOptions()
+        for field, value in (("patch_count", 0), ("patch_count", 11),
+                             ("patch_radius_mm", 0), ("patch_max_rms_mm", float("nan")),
+                             ("patch_min_area_fraction", 1.1), ("patch_hemisphere", "bad")):
+            with self.subTest(field=field), self.assertRaises(ValueError):
+                validate_options(replace(defaults, **{field: value}))
+
+    def test_mock_mesh_has_local_neighborhoods_on_full_size_scan(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image = nib.Nifti1Image(np.zeros((256, 256, 192), dtype=np.uint8), np.eye(4))
+            topofit_core.write_mock_surfaces(image, root)
+            surfaces = topofit_core.validate_surface_outputs(root)
+            detections = topofit_core.find_flat_patches(surfaces, mock=True)
+            self.assertTrue(detections)
+            self.assertEqual({d.patch.surface for d in detections.values()}, {"lh.mid", "rh.mid"})
+
+    def test_medial_wall_margin_follows_surface_distance(self):
+        x, y = np.meshgrid(np.arange(12.0), np.arange(3.0), indexing="ij")
+        vertices = np.column_stack((np.zeros(x.size), x.ravel(), y.ravel()))
+        faces = []
+        for i in range(11):
+            for j in range(2):
+                k = i * 3 + j
+                faces.extend(((k, k + 3, k + 1), (k + 1, k + 3, k + 4)))
+        cortex = x.ravel() > 0
+        result = topofit_core.erode_cortex_mask(vertices, np.asarray(faces), cortex)
+        np.testing.assert_array_equal(result, x.ravel() > 5)
+        self.assertTrue(result[-1])  # Genuine medial cortex at RAS x=0 survives.
+
+    def test_atlas_label_mapping_uses_registration_not_vertex_order(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sphere = np.asarray([[1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, 0, 1.]])
+            nib.freesurfer.write_geometry(str(root / "lh.sphere.reg"), sphere,
+                                         np.asarray([[0, 1, 3], [1, 2, 3]]))
+            (root / "lh.cortex.label").write_text(
+                "#!ascii label\n2\n0 0 0 0 0\n3 0 0 0 0\n"
+            )
+            mapped = topofit_core.mapped_cortex_mask(sphere[[3, 1, 0, 2]] * 100, "lh", root)
+            np.testing.assert_array_equal(mapped, [True, False, True, False])
+
+    def test_roi_restricts_geometry_and_empty_roi_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image = nib.Nifti1Image(np.ones((32, 32, 32), dtype=np.float32), np.eye(4))
+            topofit_core.write_mock_surfaces(image, root / "surf")
+            surfaces = topofit_core.validate_surface_outputs(root / "surf")
+            mask = np.zeros(image.shape, dtype=np.uint8)
+            mask[:16] = 1
+            roi = nib.Nifti1Image(mask, image.affine)
+            options = TopoFitOptions(patch_count=1, patch_radius_mm=5, patch_min_area_fraction=0.1)
+            detections = topofit_core.find_flat_patches(surfaces, options, roi=roi, mock=True)
+            self.assertEqual(set(detections), {"LH01"})
+            detection = detections["LH01"]
+            self.assertTrue(np.all(topofit_core._roi_membership(
+                detection.vertices[detection.vertex_indices], roi
+            )))
+            empty = nib.Nifti1Image(np.zeros_like(mask), image.affine)
+            with self.assertRaisesRegex(ValueError, "ROI contains no eligible cortical"):
+                topofit_core.find_flat_patches(surfaces, roi=empty, mock=True)
+
+    def test_cortical_selection_rejects_flat_collapsed_closure(self):
+        x, y = np.meshgrid(np.arange(9.0), np.arange(9.0), indexing="ij")
+        closure = np.column_stack((x.ravel(), y.ravel(), np.zeros(x.size)))
+        cortex = closure + (20.0, 0.0, 2.0)
+        cortex[:, 2] += 0.02 * (x.ravel() - 4.0) ** 2
+        white = np.vstack((closure, cortex))
+        pial = white + np.vstack((
+            np.tile((0.0, 0.0, 0.1), (81, 1)),
+            np.tile((0.0, 0.0, 3.0), (81, 1)),
+        ))
+        faces = []
+        for offset in (0, 81):
+            for i in range(8):
+                for j in range(8):
+                    k = offset + i * 9 + j
+                    faces.extend(((k, k + 9, k + 1), (k + 1, k + 9, k + 10)))
+        faces = np.asarray(faces)
+        # Even a mislabeled closure must be rejected by the ribbon check.
+        eligible = topofit_core.cortical_ribbon_mask(
+            white, pial, np.ones(len(white), dtype=bool)
+        )
+        result = find_ranked_patches(
+            (white + pial) / 2, faces, "lh.mid", radius_mm=4.5,
+            eligible_vertices=eligible, count=1,
+        )[0]
+        self.assertTrue(np.all(result.vertex_indices >= 81))
+        self.assertGreater(result.patch.center_ras_mm[0], 20.0)
+        self.assertGreater(result.patch.center_ras_mm[2], 3.4)
+
+    def test_cortex_mask_preserves_medial_cortex_and_rejects_closure(self):
+        white = np.asarray([[0, 0, 0], [0, 5, 0], [20, 0, 0]], dtype=float)
+        pial = white + [[0, 0, 3], [0, 0, 0.1], [0, 0, 3]]
+        mask = topofit_core.cortical_ribbon_mask(
+            white, pial, np.asarray([True, True, False])
+        )
+        np.testing.assert_array_equal(mask, [True, False, False])
+
+    def test_no_eligible_cortex_does_not_fall_back_to_whole_mesh(self):
+        with self.assertRaisesRegex(ValueError, "eligible cortical"):
+            find_ranked_patches(
+                np.asarray([[0., 0., 0.], [1., 0., 0.], [0., 1., 0.]]),
+                np.asarray([[0, 1, 2]]), "lh.mid",
+                eligible_vertices=np.zeros(3, dtype=bool),
+            )
+
     def test_command_uses_pinned_cli_contract(self):
         command = build_brainnet_command(
             Path("/data/input.nii.gz"),
@@ -132,18 +269,92 @@ class TopoFitCoreTests(unittest.TestCase):
                         ]
                     )
 
-        detected = find_flattest_patch(
+        detected = find_ranked_patches(
             vertices,
             np.asarray(faces, dtype=np.int32),
             surface="lh.pial",
-            radius_mm=4.5,
-        )
+            radius_mm=4.5, count=1,
+        )[0]
 
         self.assertLess(detected.patch.center_ras_mm[0], 10.0)
         self.assertGreater(abs(detected.patch.normal_ras[2]), 0.99)
         self.assertLess(detected.patch.rms_distance_mm, 1e-6)
         self.assertGreater(detected.patch.area_mm2, 0.0)
         self.assertGreater(detected.vertex_indices.size, 3)
+
+    def test_patch_qc_makes_through_plane_normal_visible_on_patch_slice(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            image = nib.Nifti1Image(
+                np.full((32, 32, 7), 500.0, dtype=np.float32),
+                np.eye(4),
+            )
+            vertices = np.asarray(
+                [
+                    [10.0, 10.0, 3.2],
+                    [22.0, 10.0, 3.2],
+                    [22.0, 22.0, 3.2],
+                    [10.0, 22.0, 3.2],
+                ],
+                dtype=np.float32,
+            )
+            faces = np.asarray([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+            surface_path = root / "lh.pial"
+            nib.freesurfer.write_geometry(str(surface_path), vertices, faces)
+            white_path = root / "lh.white"
+            nib.freesurfer.write_geometry(str(white_path), vertices - (0, 0, 2), faces)
+
+            def render(normal, name):
+                patch = topofit_core.FlatPatch(
+                    surface="lh.pial",
+                    center_ras_mm=(16.0, 16.0, 3.2),
+                    normal_ras=normal,
+                    radius_mm=10.0,
+                    area_mm2=144.0,
+                    rms_distance_mm=0.0,
+                    vertex_count=4,
+                )
+                detection = SimpleNamespace(patch=patch, faces=faces, vertices=vertices)
+                output_path = root / name
+                topofit_core.write_patch_qc(
+                    image,
+                    {"lh.pial": surface_path, "lh.white": white_path},
+                    {"lh": detection},
+                    output_path,
+                )
+                return nib.load(output_path)
+
+            positive = render((0.0, 0.0, 1.0), "positive.nii.gz")
+            negative = render((0.0, 0.0, -1.0), "negative.nii.gz")
+            positive_data = np.asarray(positive.dataobj)
+            negative_data = np.asarray(negative.dataobj)
+
+            self.assertEqual(positive.shape, image.shape)
+            np.testing.assert_allclose(positive.affine, image.affine)
+            self.assertEqual(
+                int(positive_data[14, 16, 3]),
+                topofit_core.PATCH_QC_PATCH_INTENSITY,
+            )
+            self.assertEqual(
+                int(positive_data[16, 16, 3]),
+                topofit_core.PATCH_QC_NORMAL_INTENSITY,
+            )
+            self.assertLessEqual(
+                int(positive_data[:, :, (0, 1, 2, 4, 5, 6)].max()),
+                2700,  # White/pial boundaries, but no mid-patch or normal glyph.
+            )
+
+            # A center dot means increasing slice position. Diagonal strokes
+            # mean decreasing slice position. Both remain visible in this one
+            # acquired plane even though the physical ray is through-plane.
+            self.assertNotEqual(
+                int(positive_data[18, 18, 3]),
+                topofit_core.PATCH_QC_NORMAL_INTENSITY,
+            )
+            self.assertEqual(
+                int(negative_data[18, 18, 3]),
+                topofit_core.PATCH_QC_NORMAL_INTENSITY,
+            )
 
     def test_mock_workflow_writes_surface_qc_and_non_actionable_manifest(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -174,6 +385,9 @@ class TopoFitCoreTests(unittest.TestCase):
                     device="cpu",
                     mock=True,
                     find_flat_patches=True,
+                    patch_count=1,
+                    patch_radius_mm=5,
+                    patch_min_area_fraction=0.1,
                     find_sulcal_middepth=True,
                     sulcal_curvature_threshold_mm_inv=100.0,
                     overlay_thickness=0,
@@ -183,7 +397,7 @@ class TopoFitCoreTests(unittest.TestCase):
             self.assertEqual(result.status, "SURFACE_READY_RESEARCH_ONLY")
             self.assertEqual(result.warning, RESEARCH_WARNING)
             self.assertEqual(set(result.surfaces), set(SURFACE_NAMES))
-            self.assertEqual(set(result.flat_patches), {"lh", "rh"})
+            self.assertEqual(set(result.flat_patches), {"LH01", "RH01"})
             for patch in result.flat_patches.values():
                 self.assertAlmostEqual(np.linalg.norm(patch.normal_ras), 1.0)
                 self.assertGreater(patch.area_mm2, 0.0)
@@ -198,12 +412,34 @@ class TopoFitCoreTests(unittest.TestCase):
             qc_data = np.asarray(qc.dataobj)
             self.assertEqual(int(qc_data.max()), 4095)
             self.assertIn(3800, np.unique(qc_data))
+            self.assertIsNotNone(result.patch_qc_image)
+            with np.load(result.patch_geometry) as geometry:
+                for hemisphere in result.flat_patches:
+                    white = geometry[f"{hemisphere}_white_ras_mm"]
+                    pial = geometry[f"{hemisphere}_pial_ras_mm"]
+                    middle = geometry[f"{hemisphere}_mid_ras_mm"]
+                    normals = geometry[f"{hemisphere}_normals_ras"]
+                    np.testing.assert_allclose(middle, (white + pial) / 2)
+                    np.testing.assert_allclose(np.linalg.norm(normals, axis=1), 1)
+                    self.assertTrue(np.all(np.einsum("ij,ij->i", normals, pial - white) >= 0))
+            patch_qc = nib.load(result.patch_qc_image)
+            self.assertEqual(patch_qc.shape, data.shape)
+            np.testing.assert_allclose(patch_qc.affine, affine)
+            patch_qc_data = np.asarray(patch_qc.dataobj)
+            self.assertIn(
+                topofit_core.PATCH_QC_PATCH_INTENSITY,
+                np.unique(patch_qc_data),
+            )
+            self.assertIn(
+                topofit_core.PATCH_QC_NORMAL_INTENSITY,
+                np.unique(patch_qc_data),
+            )
             self.assertIsNotNone(result.sulcal_middepth_mask)
             sulcal_mask = nib.load(result.sulcal_middepth_mask)
             self.assertEqual(sulcal_mask.shape, data.shape)
             np.testing.assert_allclose(sulcal_mask.affine, affine)
             self.assertEqual(sulcal_mask.get_data_dtype(), np.dtype(np.uint8))
-            inverse_affine = np.linalg.inv(affine)
+            inverse_affine = np.linalg.inv(qc.affine)
             for patch in result.flat_patches.values():
                 center = np.asarray(patch.center_ras_mm)
                 normal = np.asarray(patch.normal_ras)
@@ -215,8 +451,10 @@ class TopoFitCoreTests(unittest.TestCase):
                     voxels < np.asarray(qc.shape), axis=1
                 )
                 self.assertGreater(int(inside.sum()), 1)
-                endpoint = voxels[np.flatnonzero(inside)[-1]]
-                self.assertEqual(int(qc_data[tuple(endpoint)]), 4095)
+                ray_values = qc_data[tuple(voxels[inside].T)]
+                self.assertGreater(np.count_nonzero(ray_values == 4095), 1)
+                if inside[-1]:
+                    self.assertEqual(int(qc_data[tuple(voxels[-1])]), 4095)
 
             manifest = json.loads(Path(result.manifest).read_text(encoding="utf-8"))
             self.assertIsNone(manifest["prescription_coordinates"])
@@ -228,7 +466,7 @@ class TopoFitCoreTests(unittest.TestCase):
                 manifest["flat_patch_status"],
                 "CANDIDATES_REPORTED_RESEARCH_ONLY",
             )
-            self.assertEqual(set(manifest["flat_patches"]), {"lh", "rh"})
+            self.assertEqual(set(manifest["flat_patches"]), {"LH01", "RH01"})
             self.assertTrue(manifest["options"]["mock"])
             self.assertEqual(
                 manifest["sulcal_middepth_status"],

--- a/recipes/topofit/test_topofit_openrecon.py
+++ b/recipes/topofit/test_topofit_openrecon.py
@@ -93,11 +93,30 @@ def _run_mock_workflow(input_path, run_dir, options):
     return run_topofit_workflow(
         input_path,
         run_dir,
-        replace(options, mock=True),
+        replace(options, mock=True, patch_count=1, patch_radius_mm=5, patch_min_area_fraction=0.1),
     )
 
 
 class TopoFitOpenReconTests(unittest.TestCase):
+    def test_scanner_label_defaults_and_patch_controls_reach_core_options(self):
+        from topofit_core import TopoFitOptions
+        label = json.loads(Path(__file__).with_name("OpenReconLabel.json").read_text())
+        parameters = {p["id"]: p["default"] for p in label["parameters"]}
+        self.assertEqual(topofit._options_from_config({"parameters": parameters}), TopoFitOptions())
+        parameters.update(tfflatpatches=True, tfpatchcount=5, tfpatchradius=7.5,
+                          tfpatchmaxrms=0.3, tfpatchminarea=0.4,
+                          tfpatchhemisphere="lh", tfpatchregion="roi",
+                          tfpatchroi="/data/roi.nii.gz")
+        options = topofit._options_from_config({"parameters": parameters})
+        self.assertEqual(options.patch_count, 5)
+        self.assertEqual(options.patch_radius_mm, 7.5)
+        self.assertEqual(options.patch_max_rms_mm, 0.3)
+        self.assertEqual(options.patch_min_area_fraction, 0.4)
+        self.assertEqual(options.patch_hemisphere, "lh")
+        self.assertEqual(options.patch_roi, "/data/roi.nii.gz")
+        parameters["tfpatchregion"] = "cortex"
+        self.assertIsNone(topofit._options_from_config({"parameters": parameters}).patch_roi)
+
     def test_openrecon_config_cannot_enable_mock_surfaces(self):
         options = topofit._options_from_config(
             {"parameters": {"tfdebugmock": True}}
@@ -198,7 +217,7 @@ class TopoFitOpenReconTests(unittest.TestCase):
     def test_mrd_series_returns_source_grid_qc_and_manifest(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             topofit.WORKSPACE = Path(temporary_directory)
-            connection = RecordingConnection(_mrd_volume())
+            connection = RecordingConnection(_mrd_volume(shape=(32, 32, 32)))
             config = {
                 "parameters": {
                     "sendoriginal": False,
@@ -227,14 +246,25 @@ class TopoFitOpenReconTests(unittest.TestCase):
             ]
             self.assertEqual(errors, [])
             outputs = [image for batch in connection.image_batches for image in batch]
-            self.assertEqual(len(outputs), 8)
-            self.assertEqual({int(image.image_series_index) for image in outputs}, {8})
+            self.assertEqual(len(outputs), 64)
+            self.assertEqual(
+                {int(image.image_series_index) for image in outputs},
+                {8, 9},
+            )
             self.assertTrue(
-                all(image.data.shape == (1, 1, 20, 24) for image in outputs)
+                all(image.data.shape == (1, 1, 32, 32) for image in outputs)
             )
             self.assertEqual(max(int(np.max(image.data)) for image in outputs), 4095)
 
-            output_meta = ismrmrd.Meta.deserialize(outputs[0].attribute_string)
+            surface_outputs = [
+                image for image in outputs if int(image.image_series_index) == 8
+            ]
+            patch_outputs = [
+                image for image in outputs if int(image.image_series_index) == 9
+            ]
+            output_meta = ismrmrd.Meta.deserialize(
+                surface_outputs[0].attribute_string
+            )
             self.assertEqual(
                 output_meta["FrameOfReferenceUID"],
                 "1.2.826.0.1.3680043.10.999",
@@ -245,23 +275,37 @@ class TopoFitOpenReconTests(unittest.TestCase):
             self.assertEqual(output_meta["TopoFitPrescriptionStatus"], "WITHHELD")
             self.assertEqual(output_meta["ImageComment"], output_meta["ImageComments"])
             self.assertIn(
-                "TopoFit flat patch lh.pial LPS_mm", output_meta["ImageComments"]
+                "TopoFit patch LH01 lh.mid LPS_mm", output_meta["ImageComments"]
             )
             self.assertIn(
-                "TopoFit flat patch rh.pial LPS_mm", output_meta["ImageComments"]
+                "TopoFit patch RH01 rh.mid LPS_mm", output_meta["ImageComments"]
             )
             self.assertIn("normal=(", output_meta["ImageComments"])
             self.assertIn(
                 "TopoFit sulcal mid-depth research voxels: lh=0, rh=0",
                 output_meta["ImageComments"],
             )
+            patch_meta = ismrmrd.Meta.deserialize(
+                patch_outputs[0].attribute_string
+            )
+            self.assertEqual(
+                patch_meta["SeriesDescription"],
+                "MPRAGE_TEST_topofit_patch_qc",
+            )
+            self.assertEqual(patch_meta["BurnedInAnnotation"], "YES")
+            self.assertIn("dot=increasing slice position", patch_meta["ImageComments"])
+            patch_values = np.unique(
+                np.stack([np.squeeze(image.data) for image in patch_outputs])
+            )
+            self.assertIn(3000, patch_values)
+            self.assertIn(4095, patch_values)
 
             manifests = list(Path(temporary_directory).glob("*/topofit_manifest.json"))
             self.assertEqual(len(manifests), 1)
             manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
             self.assertIsNone(manifest["prescription_coordinates"])
             self.assertEqual(len(manifest["surfaces"]), 6)
-            self.assertEqual(set(manifest["flat_patches"]), {"lh", "rh"})
+            self.assertEqual(set(manifest["flat_patches"]), {"LH01", "RH01"})
             self.assertEqual(manifest["options"]["overlay_thickness"], 0)
             self.assertEqual(
                 manifest["options"]["sulcal_curvature_threshold_mm_inv"], 100.0

--- a/recipes/topofit/topofit.py
+++ b/recipes/topofit/topofit.py
@@ -403,6 +403,7 @@ def _stamp_output(
         meta["ImageComments"] = comment
         meta["TopoFitStatus"] = "SURFACE_READY_RESEARCH_ONLY"
         meta["TopoFitPrescriptionStatus"] = "WITHHELD"
+        meta["BurnedInAnnotation"] = "YES"
         meta["WindowCenter"] = "2048"
         meta["WindowWidth"] = "4096"
     output.attribute_string = meta.serialize()
@@ -435,17 +436,14 @@ def _clone_original_series(images, series_index: int) -> list:
 
 def _format_flat_patch_comment(flat_patches) -> str:
     parts = []
-    for hemisphere in ("lh", "rh"):
-        patch = flat_patches.get(hemisphere)
-        if patch is None:
-            continue
+    for patch_id, patch in flat_patches.items():
         center_lps = np.asarray(patch.center_ras_mm, dtype=float) * (-1.0, -1.0, 1.0)
         normal_lps = np.asarray(patch.normal_ras, dtype=float) * (-1.0, -1.0, 1.0)
         center = ",".join(f"{value:.2f}" for value in center_lps)
         normal = ",".join(f"{value:.4f}" for value in normal_lps)
         parts.append(
-            f"TopoFit flat patch {patch.surface} LPS_mm center=({center}) "
-            f"normal=({normal})"
+            f"TopoFit patch {patch_id} {patch.surface} LPS_mm center=({center}) "
+            f"normal=({normal}) area_mm2={patch.area_mm2:.1f} rms_mm={patch.rms_distance_mm:.3f}"
         )
     return "; ".join(parts)
 
@@ -460,14 +458,15 @@ def _format_sulcal_middepth_comment(sulci) -> str:
     return f"TopoFit sulcal mid-depth research voxels: {counts}"
 
 
-def _qc_mrd_images(
-    qc_path: Path,
+def _source_grid_mrd_images(
+    image_path: Path,
     source_images,
     series_index: int,
-    flat_patches=None,
-    sulci=None,
+    description_suffix: str,
+    processing_role: str,
+    details: str,
 ) -> list:
-    image = nib.load(str(qc_path))
+    image = nib.load(str(image_path))
     volume_xyz = np.asarray(image.get_fdata(dtype=np.float32))
     if volume_xyz.shape != (
         source_images[0].data.shape[-1],
@@ -475,15 +474,15 @@ def _qc_mrd_images(
         len(source_images),
     ):
         raise ValueError(
-            "TopoFit QC geometry does not match the source MRD series: "
-            f"qc={volume_xyz.shape} source_yx={source_images[0].data.shape[-2:]} "
+            "TopoFit source-grid output does not match the source MRD series: "
+            f"output={volume_xyz.shape} source_yx={source_images[0].data.shape[-2:]} "
             f"source_z={len(source_images)}"
         )
     volume_yxz = np.rint(volume_xyz.transpose((1, 0, 2))).astype(np.int16)
     series_uid = _new_series_uid()
-    description = f"{_series_description(source_images[0], 'mprage')}_topofit_qc"
-    patch_comment = _format_flat_patch_comment(flat_patches or {})
-    sulcal_comment = _format_sulcal_middepth_comment(sulci or {})
+    description = (
+        f"{_series_description(source_images[0], 'mprage')}{description_suffix}"
+    )
     output = []
     for index, source in enumerate(source_images):
         plane = np.ascontiguousarray(volume_yxz[:, :, index])
@@ -497,12 +496,61 @@ def _qc_mrd_images(
             index,
             series_uid,
             description,
-            ["PYTHON", "BRAINNET", "TOPOFIT", "SURFACE_QC"],
+            ["PYTHON", "BRAINNET", "TOPOFIT", processing_role],
             RESEARCH_WARNING,
-            "; ".join(part for part in (patch_comment, sulcal_comment) if part),
+            details,
         )
         output.append(derived)
     return output
+
+
+def _qc_mrd_images(
+    qc_path: Path,
+    source_images,
+    series_index: int,
+    flat_patches=None,
+    sulci=None,
+    patch_search_enabled: bool = False,
+) -> list:
+    patch_comment = _format_flat_patch_comment(flat_patches or {})
+    if patch_search_enabled:
+        patch_comment = f"Accepted cortical patches: {len(flat_patches or {})}. " + (
+            patch_comment or "No patch met the quality criteria; no prescription coordinates."
+        )
+    sulcal_comment = _format_sulcal_middepth_comment(sulci or {})
+    return _source_grid_mrd_images(
+        qc_path,
+        source_images,
+        series_index,
+        "_topofit_qc",
+        "SURFACE_QC",
+        "; ".join(part for part in (patch_comment, sulcal_comment) if part),
+    )
+
+
+def _patch_qc_mrd_images(
+    patch_qc_path: Path,
+    source_images,
+    series_index: int,
+    flat_patches,
+) -> list:
+    details = "; ".join(
+        part
+        for part in (
+            _format_flat_patch_comment(flat_patches),
+            "TopoFit normal glyph: dot=increasing slice position, "
+            "cross=decreasing slice position",
+        )
+        if part
+    )
+    return _source_grid_mrd_images(
+        patch_qc_path,
+        source_images,
+        series_index,
+        "_topofit_patch_qc",
+        "PATCH_QC",
+        details,
+    )
 
 
 def _send_images(connection, images, label: str) -> None:
@@ -519,6 +567,7 @@ def _send_images(connection, images, label: str) -> None:
 
 
 def _options_from_config(config) -> TopoFitOptions:
+    patch_region = str(_config_value(config, "tfpatchregion", "cortex", "str"))
     options = TopoFitOptions(
         device=str(_config_value(config, "tfdevice", DEFAULTS["tfdevice"], "str"))
         .strip()
@@ -527,6 +576,14 @@ def _options_from_config(config) -> TopoFitOptions:
         .strip()
         .lower(),
         conform=_config_bool(config, "tfconform", DEFAULTS["tfconform"]),
+        patch_roi=(str(_config_value(config, "tfpatchroi", "", "str")).strip() or None)
+        if patch_region == "roi" else None,
+        patch_count=_config_int(config, "tfpatchcount", 3),
+        patch_radius_mm=_config_float(config, "tfpatchradius", 10.0),
+        patch_max_rms_mm=_config_float(config, "tfpatchmaxrms", 0.5),
+        patch_min_area_fraction=_config_float(config, "tfpatchminarea", 0.25),
+        patch_hemisphere=str(_config_value(config, "tfpatchhemisphere", "both", "str")),
+        patch_search_region=patch_region,
         find_flat_patches=_config_bool(
             config, "tfflatpatches", DEFAULTS["tfflatpatches"]
         ),
@@ -607,9 +664,19 @@ def process(connection, config, metadata):
                 next_series_index,
                 result.flat_patches,
                 result.sulci,
+                patch_search_enabled=options.find_flat_patches,
             )
             pending_output.append(("TopoFit QC", qc_images))
             next_series_index += 1
+            if result.patch_qc_image:
+                patch_qc_images = _patch_qc_mrd_images(
+                    Path(result.patch_qc_image),
+                    ordered,
+                    next_series_index,
+                    result.flat_patches,
+                )
+                pending_output.append(("TopoFit patch QC", patch_qc_images))
+                next_series_index += 1
             logging.info(
                 "TOPOFIT_OPENRECON_RESULT status=%s elapsed_seconds=%.3f "
                 "manifest=%s warning=%s",
@@ -658,8 +725,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--find-flat-patches",
         action="store_true",
-        help="Find and draw one flat pial-surface patch per hemisphere",
+        help="Find and draw up to three distinct mid-cortical patches per hemisphere",
     )
+    parser.add_argument(
+        "--patch-roi", type=str,
+        help="Restrict patch selection to a nonzero NIfTI mask on the input grid",
+    )
+    parser.add_argument("--patch-count", type=int, default=3, help="Maximum patches per hemisphere, 1-10")
+    parser.add_argument("--patch-radius", type=float, default=10.0, help="Mesh-edge radius in mm, 5-20")
+    parser.add_argument("--patch-max-rms", type=float, default=0.5, help="Maximum plane-fit error in mm")
+    parser.add_argument("--patch-min-area", type=float, default=0.25, help="Minimum area as a fraction of pi * radius^2")
+    parser.add_argument("--patch-hemisphere", choices=("both", "lh", "rh"), default="both")
+    parser.add_argument("--patch-region", choices=("cortex", "roi"), default="cortex")
     parser.add_argument(
         "--find-sulcal-middepth",
         action="store_true",
@@ -693,6 +770,13 @@ def main() -> int:
         conform=args.conform,
         mock=args.mock,
         find_flat_patches=args.find_flat_patches,
+        patch_roi=args.patch_roi,
+        patch_count=args.patch_count,
+        patch_radius_mm=args.patch_radius,
+        patch_max_rms_mm=args.patch_max_rms,
+        patch_min_area_fraction=args.patch_min_area,
+        patch_hemisphere=args.patch_hemisphere,
+        patch_search_region="roi" if args.patch_roi else args.patch_region,
         find_sulcal_middepth=args.find_sulcal_middepth,
         sulcal_curvature_threshold_mm_inv=args.sulcal_curvature_threshold,
         overlay_thickness=args.overlay_thickness,

--- a/recipes/topofit/topofit_core.py
+++ b/recipes/topofit/topofit_core.py
@@ -10,20 +10,24 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from time import perf_counter
 from typing import Callable, Sequence
 
 import nibabel as nib
 import numpy as np
+from PIL import Image, ImageDraw, ImageFont
 from scipy.spatial import cKDTree
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import dijkstra
 from topofit_geometry import (
     CURVATURE_SIGN_CONVENTION,
     MIDDLE_DEPTH_FRACTION,
     SulcalHemisphere,
     identify_sulcal_middepth,
     triangle_voxel_mask,
+    _outward_vertex_normals,
 )
 
 RESEARCH_WARNING = "RESEARCH ONLY - NOT MOTION-CLEARED - NOT FOR PRESCRIPTION"
@@ -44,7 +48,15 @@ FLAT_PATCH_RADIUS_MM = 10.0
 FLAT_PATCH_NORMAL_LENGTH_MM = 20.0
 MAX_OVERLAY_THICKNESS = 3
 MAX_PATCH_CANDIDATES = 64
+MIN_PATCH_NORMAL_COHERENCE = 0.9
 DEFAULT_SULCAL_CURVATURE_THRESHOLD_MM_INV = 0.1
+PATCH_QC_ANATOMY_MAX = 2000
+PATCH_QC_PATCH_INTENSITY = 3000
+PATCH_QC_NORMAL_INTENSITY = 4095
+PATCH_QC_GLYPH_RADIUS_MM = 4.0
+CORTEX_ATLAS_DIR = Path("/opt/topofit-atlas")
+MIN_RIBBON_SEPARATION_MM = 0.5
+MEDIAL_WALL_MARGIN_MM = 5.0
 
 
 @dataclass(frozen=True)
@@ -61,11 +73,18 @@ class TopoFitOptions:
         DEFAULT_SULCAL_CURVATURE_THRESHOLD_MM_INV
     )
     overlay_thickness: int = 1
+    patch_roi: str | None = None
+    patch_count: int = 3
+    patch_radius_mm: float = FLAT_PATCH_RADIUS_MM
+    patch_max_rms_mm: float = 0.5
+    patch_min_area_fraction: float = 0.25
+    patch_hemisphere: str = "both"
+    patch_search_region: str = "cortex"
 
 
 @dataclass(frozen=True)
 class FlatPatch:
-    """One locally planar pial-surface candidate in NIfTI world RAS."""
+    """One locally planar surface candidate in NIfTI world RAS."""
 
     surface: str
     center_ras_mm: tuple[float, float, float]
@@ -74,6 +93,11 @@ class FlatPatch:
     area_mm2: float
     rms_distance_mm: float
     vertex_count: int
+    depth_fraction: float = MIDDLE_DEPTH_FRACTION
+    median_ribbon_separation_mm: float = 0.0
+    patch_id: str = ""
+    normal_coherence: float = 1.0
+    score: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -81,7 +105,12 @@ class _DetectedFlatPatch:
     """Flat-patch measurements plus private mesh support for the QC renderer."""
 
     patch: FlatPatch
-    vertex_indices: np.ndarray
+    faces: np.ndarray
+    vertices: np.ndarray
+
+    @property
+    def vertex_indices(self) -> np.ndarray:
+        return np.unique(self.faces.reshape(-1))
 
 
 @dataclass(frozen=True)
@@ -92,6 +121,8 @@ class TopoFitResult:
     run_dir: str
     input_image: str
     qc_image: str
+    patch_qc_image: str | None
+    patch_geometry: str | None
     manifest: str
     surfaces: dict[str, str]
     flat_patches: dict[str, FlatPatch]
@@ -121,6 +152,25 @@ def validate_options(options: TopoFitOptions) -> tuple[str, str]:
         or options.sulcal_curvature_threshold_mm_inv <= 0
     ):
         raise ValueError("sulcal curvature threshold must be a positive finite value")
+    if options.patch_roi is not None and not options.find_flat_patches:
+        raise ValueError("patch ROI requires flat-patch analysis")
+    if (isinstance(options.patch_count, bool) or not isinstance(options.patch_count, int)
+            or not 1 <= options.patch_count <= 10):
+        raise ValueError("patch count must be an integer from 1 to 10")
+    for name, value, minimum, maximum in (
+        ("patch radius", options.patch_radius_mm, 5.0, 20.0),
+        ("patch maximum RMS", options.patch_max_rms_mm, 0.01, 2.0),
+        ("patch minimum area fraction", options.patch_min_area_fraction, 0.1, 1.0),
+    ):
+        if (isinstance(value, bool) or not isinstance(value, (int, float))
+                or not np.isfinite(value) or not minimum <= value <= maximum):
+            raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    if options.patch_hemisphere not in {"both", "lh", "rh"}:
+        raise ValueError("patch hemisphere must be both, lh, or rh")
+    if options.patch_search_region not in {"cortex", "roi"}:
+        raise ValueError("patch search region must be cortex or roi")
+    if options.patch_search_region == "roi" and not options.patch_roi:
+        raise ValueError("ROI search requires a native-grid patch ROI file")
     try:
         return MODEL_PRESETS[options.preset]
     except KeyError:
@@ -281,6 +331,21 @@ def _mock_octahedron(
         ],
         dtype=np.int32,
     )
+    # Subdivide the test mesh so a local 10 mm neighborhood contains faces.
+    for _ in range(4):
+        edges, inverse = np.unique(
+            np.sort(faces[:, [[0, 1], [1, 2], [2, 0]]].reshape(-1, 2), axis=1),
+            axis=0, return_inverse=True,
+        )
+        midpoints = unit_vertices[edges].mean(axis=1)
+        midpoints /= np.linalg.norm(midpoints, axis=1, keepdims=True)
+        a, b, c = (inverse.reshape(-1, 3) + len(unit_vertices)).T
+        v0, v1, v2 = faces.T
+        faces = np.concatenate([
+            np.column_stack((v0, a, c)), np.column_stack((a, v1, b)),
+            np.column_stack((c, b, v2)), np.column_stack((a, b, c)),
+        ])
+        unit_vertices = np.vstack((unit_vertices, midpoints))
     voxel_vertices = center + unit_vertices * radii
     world_vertices = nib.affines.apply_affine(image.affine, voxel_vertices)
     return world_vertices.astype(np.float32), faces
@@ -387,7 +452,7 @@ def _fit_face_patch(
     rms_distance = float(np.sqrt(np.average(residuals**2, weights=weights)))
     coherence = float(
         np.average(
-            np.abs(normals[face_indices] @ normal),
+            np.clip(normals[face_indices] @ normal, 0.0, 1.0),
             weights=selected_areas,
         )
     )
@@ -401,6 +466,7 @@ def _candidate_face_indices(
     areas: np.ndarray,
     centers: np.ndarray,
     radius_mm: float,
+    limit: int = MAX_PATCH_CANDIDATES,
 ) -> list[int]:
     vertex_normal_sums = np.zeros_like(vertices, dtype=float)
     weighted_normals = normals * areas[:, np.newaxis]
@@ -412,7 +478,7 @@ def _candidate_face_indices(
     alignment = np.einsum("ij,ikj->ik", normals, vertex_normal_sums[faces])
     local_bending = 1.0 - np.mean(np.clip(alignment, -1.0, 1.0), axis=1)
     ranked = np.lexsort((np.arange(faces.shape[0]), local_bending))
-    if ranked.size <= MAX_PATCH_CANDIDATES:
+    if ranked.size <= limit:
         return [int(index) for index in ranked]
 
     selected: list[int] = []
@@ -424,7 +490,7 @@ def _candidate_face_indices(
             for other in selected
         ):
             selected.append(int(index))
-            if len(selected) == MAX_PATCH_CANDIDATES:
+            if len(selected) == limit:
                 break
     if not selected:
         selected.append(int(ranked[0]))
@@ -436,35 +502,68 @@ def _connected_face_component(
     face_indices: np.ndarray,
     seed_index: int,
 ) -> np.ndarray:
-    """Keep the vertex-connected part of a local neighborhood containing its seed."""
+    """Keep the edge-connected part of a local neighborhood containing its seed."""
 
     face_set = {int(index) for index in face_indices}
     if seed_index not in face_set:
         face_set.add(seed_index)
-    vertex_faces: dict[int, list[int]] = {}
+    edge_faces: dict[tuple[int, int], list[int]] = {}
     for face_index in face_set:
-        for vertex_index in faces[face_index]:
-            vertex_faces.setdefault(int(vertex_index), []).append(face_index)
+        a, b, c = map(int, faces[face_index])
+        for edge in ((a, b), (b, c), (c, a)):
+            edge_faces.setdefault(tuple(sorted(edge)), []).append(face_index)
 
     connected = {seed_index}
     pending = [seed_index]
     while pending:
         face_index = pending.pop()
-        for vertex_index in faces[face_index]:
-            for neighbor in vertex_faces[int(vertex_index)]:
+        a, b, c = map(int, faces[face_index])
+        for edge in ((a, b), (b, c), (c, a)):
+            for neighbor in edge_faces[tuple(sorted(edge))]:
                 if neighbor not in connected:
                     connected.add(neighbor)
                     pending.append(neighbor)
     return np.asarray(sorted(connected), dtype=np.int64)
 
 
-def find_flattest_patch(
+def _surface_edge_graph(vertices: np.ndarray, faces: np.ndarray) -> csr_matrix:
+    edges = np.unique(np.sort(np.concatenate([
+        faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]],
+    ]), axis=1), axis=0)
+    lengths = np.linalg.norm(vertices[edges[:, 0]] - vertices[edges[:, 1]], axis=1)
+    return csr_matrix((np.tile(lengths, 2), (
+        np.concatenate((edges[:, 0], edges[:, 1])),
+        np.concatenate((edges[:, 1], edges[:, 0])),
+    )), shape=(len(vertices), len(vertices)))
+
+
+def erode_cortex_mask(
+    vertices: np.ndarray, faces: np.ndarray, cortex_mask: np.ndarray,
+) -> np.ndarray:
+    """Exclude the uncertain transition bordering the mapped medial wall."""
+
+    noncortex = np.flatnonzero(~cortex_mask)
+    if not len(noncortex):
+        return cortex_mask.copy()
+    distance = dijkstra(
+        _surface_edge_graph(vertices, faces), indices=noncortex,
+        min_only=True, limit=MEDIAL_WALL_MARGIN_MM,
+    )
+    return cortex_mask & (distance > MEDIAL_WALL_MARGIN_MM)
+
+
+def find_ranked_patches(
     vertices: np.ndarray,
     faces: np.ndarray,
     surface: str,
     radius_mm: float = FLAT_PATCH_RADIUS_MM,
-) -> _DetectedFlatPatch:
-    """Find the lowest-residual fixed-radius planar neighborhood on one mesh."""
+    eligible_vertices: np.ndarray | None = None,
+    *,
+    count: int = 3,
+    max_rms_mm: float = 0.5,
+    min_area_fraction: float = 0.25,
+) -> list[_DetectedFlatPatch]:
+    """Rank acceptable cortical neighborhoods and suppress shared mesh vertices."""
 
     vertices = np.asarray(vertices, dtype=float)
     faces = np.asarray(faces, dtype=np.int64)
@@ -475,6 +574,13 @@ def find_flattest_patch(
     if not np.isfinite(radius_mm) or radius_mm <= 0:
         raise ValueError("flat-patch radius must be positive")
 
+    if eligible_vertices is not None:
+        eligible_vertices = np.asarray(eligible_vertices, dtype=bool)
+        if eligible_vertices.shape != (len(vertices),):
+            raise ValueError("cortical mask must have one value per vertex")
+        faces = faces[np.all(eligible_vertices[faces], axis=1)]
+    if not len(faces):
+        raise ValueError(f"{surface}: no eligible cortical faces")
     valid_faces, centers, normals, areas = _face_geometry(vertices, faces)
     candidate_indices = _candidate_face_indices(
         vertices,
@@ -483,63 +589,176 @@ def find_flattest_patch(
         areas,
         centers,
         radius_mm,
+        limit=max(MAX_PATCH_CANDIDATES, count * 32),
     )
-    tree = cKDTree(centers)
-    target_area = np.pi * radius_mm**2 * 0.25
-    best = None
+    graph = _surface_edge_graph(vertices, valid_faces)
+    target_area = np.pi * radius_mm**2 * min_area_fraction
+    candidates = []
     for seed_index in candidate_indices:
-        neighborhood = np.asarray(
-            tree.query_ball_point(centers[seed_index], radius_mm), dtype=np.int64
-        )
-        neighborhood = _connected_face_component(valid_faces, neighborhood, seed_index)
-        if neighborhood.size < 3:
-            neighborhood = np.asarray([seed_index], dtype=np.int64)
+        seed_vertex = valid_faces[seed_index, np.argmin(np.linalg.norm(
+            vertices[valid_faces[seed_index]] - centers[seed_index], axis=1
+        ))]
+        distances = dijkstra(graph, indices=int(seed_vertex), limit=radius_mm)
+        neighborhood = np.flatnonzero(np.all(
+            distances[valid_faces] <= radius_mm, axis=1
+        ))
+        if seed_index not in neighborhood:
+            continue
         center, normal, rms, area, coherence = _fit_face_patch(
             vertices, valid_faces, normals, areas, neighborhood
         )
         aligned = neighborhood[
-            np.abs(normals[neighborhood] @ normal) >= np.cos(np.deg2rad(45.0))
+            (normals[neighborhood] @ normal) >= np.cos(np.deg2rad(45.0))
         ]
-        if aligned.size >= 3 and aligned.size != neighborhood.size:
-            neighborhood = aligned
+        if seed_index not in aligned:
+            continue
+        if aligned.size != neighborhood.size:
+            neighborhood = _connected_face_component(valid_faces, aligned, seed_index)
             center, normal, rms, area, coherence = _fit_face_patch(
                 vertices, valid_faces, normals, areas, neighborhood
             )
-        coverage_penalty = max(0.0, target_area - area) / target_area * radius_mm
-        score = rms + radius_mm * (1.0 - coherence) + coverage_penalty
-        candidate = (score, seed_index, neighborhood, center, normal, rms, area)
-        if best is None or candidate[:2] < best[:2]:
-            best = candidate
+        if rms > max_rms_mm or area < target_area or coherence < MIN_PATCH_NORMAL_COHERENCE:
+            continue
+        score = rms + radius_mm * (1.0 - coherence)
+        candidates.append((score, seed_index, neighborhood, center, normal, rms, area, coherence))
 
-    assert best is not None
-    _, _, support_faces, center, normal, rms, area = best
-    vertex_indices = np.unique(valid_faces[support_faces].reshape(-1))
-    patch = FlatPatch(
-        surface=surface,
-        center_ras_mm=tuple(float(value) for value in center),
-        normal_ras=tuple(float(value) for value in normal),
-        radius_mm=float(radius_mm),
-        area_mm2=area,
-        rms_distance_mm=rms,
-        vertex_count=int(vertex_indices.size),
+    accepted = []
+    used_vertices = np.zeros(len(vertices), dtype=bool)
+    for score, _, support, center, normal, rms, area, coherence in sorted(
+        candidates, key=lambda candidate: candidate[:2]
+    ):
+        selected_faces = valid_faces[support]
+        indices = np.unique(selected_faces)
+        if np.any(used_vertices[indices]):
+            continue
+        used_vertices[indices] = True
+        center = vertices[indices[np.argmin(np.linalg.norm(vertices[indices] - center, axis=1))]]
+        patch = FlatPatch(
+            surface=surface, center_ras_mm=tuple(float(v) for v in center),
+            normal_ras=tuple(float(v) for v in normal), radius_mm=float(radius_mm),
+            area_mm2=area, rms_distance_mm=rms, vertex_count=int(indices.size),
+            normal_coherence=coherence, score=score,
+        )
+        accepted.append(_DetectedFlatPatch(patch=patch, faces=selected_faces, vertices=vertices))
+        if len(accepted) == count:
+            break
+    return accepted
+
+
+def cortical_ribbon_mask(
+    white: np.ndarray, pial: np.ndarray, cortex_mask: np.ndarray,
+) -> np.ndarray:
+    """Exclude atlas non-cortex and near-collapsed white/pial pairs."""
+
+    return np.asarray(cortex_mask, dtype=bool) & (
+        np.linalg.norm(pial - white, axis=1) >= MIN_RIBBON_SEPARATION_MM
     )
-    return _DetectedFlatPatch(patch=patch, vertex_indices=vertex_indices)
+
+
+def mapped_cortex_mask(
+    registration: np.ndarray,
+    hemisphere: str,
+    atlas_dir: Path = CORTEX_ATLAS_DIR,
+) -> np.ndarray:
+    """Transfer fsaverage cortex membership through the registration sphere."""
+
+    reference, _ = nib.freesurfer.read_geometry(
+        str(atlas_dir / f"{hemisphere}.sphere.reg")
+    )
+    indices = nib.freesurfer.read_label(str(atlas_dir / f"{hemisphere}.cortex.label"))
+    if not len(indices) or indices.min() < 0 or indices.max() >= len(reference):
+        raise ValueError("invalid fsaverage cortex label")
+    masks = np.zeros(len(reference), dtype=bool)
+    masks[indices] = True
+    for sphere in (reference, registration):
+        if not np.all(np.isfinite(sphere)) or np.any(
+            np.linalg.norm(sphere, axis=1) < 1e-6
+        ):
+            raise ValueError("invalid cortical registration sphere")
+    reference = reference / np.linalg.norm(reference, axis=1)[:, None]
+    target = registration / np.linalg.norm(registration, axis=1)[:, None]
+    _, nearest = cKDTree(reference).query(target)
+    return masks[nearest]
+
+
+def _roi_membership(
+    vertices: np.ndarray, roi: nib.spatialimages.SpatialImage,
+) -> np.ndarray:
+    voxels = np.rint(nib.affines.apply_affine(
+        np.linalg.inv(roi.affine), vertices
+    )).astype(int)
+    inside = np.all((voxels >= 0) & (voxels < np.asarray(roi.shape)), axis=1)
+    selected = np.zeros(len(vertices), dtype=bool)
+    selected[inside] = np.asarray(roi.dataobj)[tuple(voxels[inside].T)] > 0
+    return selected
 
 
 def find_flat_patches(
     surfaces: dict[str, Path],
+    options: TopoFitOptions = TopoFitOptions(),
+    *,
+    atlas_dir: Path = CORTEX_ATLAS_DIR,
+    roi: nib.spatialimages.SpatialImage | None = None,
+    mock: bool = False,
 ) -> dict[str, _DetectedFlatPatch]:
-    """Find one fixed-radius flat pial candidate per hemisphere."""
+    """Select mid-ribbon cortex, excluding the atlas medial-wall closure."""
 
     detected = {}
+    eligible_face_count = 0
     for hemisphere in ("lh", "rh"):
-        surface = f"{hemisphere}.pial"
-        vertices, faces = nib.freesurfer.read_geometry(str(surfaces[surface]))
-        detected[hemisphere] = find_flattest_patch(vertices, faces, surface)
+        if options.patch_hemisphere not in {"both", hemisphere}:
+            continue
+        pial, faces = nib.freesurfer.read_geometry(str(surfaces[f"{hemisphere}.pial"]))
+        white, white_faces = nib.freesurfer.read_geometry(
+            str(surfaces[f"{hemisphere}.white"])
+        )
+        registration, reg_faces = nib.freesurfer.read_geometry(
+            str(surfaces[f"{hemisphere}.registration"])
+        )
+        if white.shape != pial.shape or registration.shape != pial.shape or not (
+            np.array_equal(faces, white_faces) and np.array_equal(faces, reg_faces)
+        ):
+            raise ValueError("patch analysis requires corresponding surface topology")
+        cortex = np.ones(len(pial), dtype=bool) if mock else mapped_cortex_mask(
+            registration, hemisphere, atlas_dir
+        )
+        middle = white + MIDDLE_DEPTH_FRACTION * (pial - white)
+        cortex = erode_cortex_mask(middle, faces, cortex)
+        eligible = cortical_ribbon_mask(white, pial, cortex)
+        if roi is not None:
+            eligible &= _roi_membership(middle, roi)
+        count = int(np.count_nonzero(np.all(eligible[faces], axis=1)))
+        eligible_face_count += count
+        if not count:
+            continue
+        candidates = find_ranked_patches(
+            middle, faces, f"{hemisphere}.mid", eligible_vertices=eligible,
+            radius_mm=options.patch_radius_mm, count=options.patch_count,
+            max_rms_mm=options.patch_max_rms_mm,
+            min_area_fraction=options.patch_min_area_fraction,
+        )
+        for rank, detection in enumerate(candidates, 1):
+            indices = detection.vertex_indices
+            normal = np.asarray(detection.patch.normal_ras)
+            if np.dot(normal, np.mean(pial[indices] - white[indices], axis=0)) < 0:
+                normal = -normal
+            patch_id = f"{hemisphere.upper()}{rank:02d}"
+            detected[patch_id] = replace(detection, patch=replace(
+                detection.patch, patch_id=patch_id, normal_ras=tuple(float(v) for v in normal),
+                median_ribbon_separation_mm=float(np.median(
+                    np.linalg.norm(pial[indices] - white[indices], axis=1)
+                )),
+            ))
+    if not eligible_face_count:
+        raise ValueError("ROI contains no eligible cortical patch" if roi is not None
+                         else "No eligible cortical faces in the requested hemisphere")
     return detected
 
 
-def _scaled_anatomy(image: nib.spatialimages.SpatialImage) -> np.ndarray:
+def _scaled_anatomy(
+    image: nib.spatialimages.SpatialImage,
+    maximum: int = 3000,
+) -> np.ndarray:
     data = np.asarray(image.get_fdata(dtype=np.float32))
     finite = data[np.isfinite(data)]
     if finite.size == 0:
@@ -551,7 +770,7 @@ def _scaled_anatomy(image: nib.spatialimages.SpatialImage) -> np.ndarray:
     if high <= low:
         return np.zeros(data.shape, dtype=np.int16)
     scaled = np.clip((np.nan_to_num(data, nan=low) - low) / (high - low), 0.0, 1.0)
-    return np.rint(scaled * 3000.0).astype(np.int16)
+    return np.rint(scaled * maximum).astype(np.int16)
 
 
 def _dilate_in_plane(mask: np.ndarray, radius: int) -> np.ndarray:
@@ -611,9 +830,7 @@ def _flat_patch_masks(
     sample_count = int(np.ceil(FLAT_PATCH_NORMAL_LENGTH_MM / sample_step)) + 1
     distances = np.linspace(0.0, FLAT_PATCH_NORMAL_LENGTH_MM, sample_count)
     for detection in detections.values():
-        vertices, _ = nib.freesurfer.read_geometry(
-            str(surfaces[detection.patch.surface])
-        )
+        vertices = detection.vertices
         patch_mask |= _world_points_voxel_mask(
             image,
             vertices[detection.vertex_indices],
@@ -630,10 +847,200 @@ def _flat_patch_masks(
     return patch_mask, normal_mask
 
 
+def _draw_line_in_plane(
+    mask: np.ndarray,
+    slice_index: int,
+    start: np.ndarray,
+    end: np.ndarray,
+) -> None:
+    sample_count = max(int(np.ceil(np.linalg.norm(end - start) * 2.0)) + 1, 2)
+    points = np.rint(
+        np.linspace(start, end, sample_count, dtype=float)
+    ).astype(int)
+    inside = np.all(points >= 0, axis=1) & np.all(
+        points < np.asarray(mask.shape[:2]), axis=1
+    )
+    points = points[inside]
+    if points.size:
+        mask[points[:, 0], points[:, 1], slice_index] = True
+
+
+def _normal_glyph_mask(
+    image: nib.spatialimages.SpatialImage,
+    patch_mask: np.ndarray,
+    patch: FlatPatch,
+) -> np.ndarray:
+    """Draw one slice-native glyph without changing the measured normal."""
+
+    glyph = np.zeros(image.shape, dtype=bool)
+    occupied_slices = np.flatnonzero(np.any(patch_mask, axis=(0, 1)))
+    if occupied_slices.size == 0:
+        return glyph
+
+    inverse_affine = np.linalg.inv(image.affine)
+    center_voxel = nib.affines.apply_affine(
+        inverse_affine, np.asarray(patch.center_ras_mm, dtype=float)
+    )
+    slice_index = int(
+        occupied_slices[np.argmin(np.abs(occupied_slices - center_voxel[2]))]
+    )
+    center = np.rint(center_voxel[:2]).astype(int)
+    center = np.clip(center, 0, np.asarray(image.shape[:2]) - 1)
+
+    zooms = np.asarray(image.header.get_zooms()[:2], dtype=float)
+    bounds = np.ceil(PATCH_QC_GLYPH_RADIUS_MM / zooms).astype(int) + 1
+    axis_0 = np.arange(center[0] - bounds[0], center[0] + bounds[0] + 1)
+    axis_1 = np.arange(center[1] - bounds[1], center[1] + bounds[1] + 1)
+    grid_0, grid_1 = np.meshgrid(axis_0, axis_1, indexing="ij")
+    distance_mm = np.sqrt(
+        ((grid_0 - center[0]) * zooms[0]) ** 2
+        + ((grid_1 - center[1]) * zooms[1]) ** 2
+    )
+    ring = np.abs(distance_mm - PATCH_QC_GLYPH_RADIUS_MM) <= max(zooms) * 0.6
+    inside = (
+        (grid_0 >= 0)
+        & (grid_0 < image.shape[0])
+        & (grid_1 >= 0)
+        & (grid_1 < image.shape[1])
+        & ring
+    )
+    glyph[grid_0[inside], grid_1[inside], slice_index] = True
+
+    voxel_normal = inverse_affine[:3, :3] @ (
+        FLAT_PATCH_NORMAL_LENGTH_MM
+        * np.asarray(patch.normal_ras, dtype=float)
+    )
+    in_plane_endpoint = center.astype(float) + voxel_normal[:2]
+    _draw_line_in_plane(
+        glyph,
+        slice_index,
+        center.astype(float),
+        in_plane_endpoint,
+    )
+
+    in_plane_length = float(np.linalg.norm(voxel_normal[:2]))
+    if in_plane_length >= 3.0:
+        direction = voxel_normal[:2] / in_plane_length
+        perpendicular = np.asarray([-direction[1], direction[0]])
+        arm_length = min(3.0, in_plane_length * 0.4)
+        for side in (-1.0, 1.0):
+            arm_endpoint = (
+                in_plane_endpoint
+                - direction * arm_length
+                + perpendicular * side * arm_length * 0.6
+            )
+            _draw_line_in_plane(
+                glyph,
+                slice_index,
+                in_plane_endpoint,
+                arm_endpoint,
+            )
+
+    if voxel_normal[2] >= 0:
+        glyph[center[0], center[1], slice_index] = True
+    else:
+        for offset in range(-2, 3):
+            for sign in (-1, 1):
+                point = center + (offset, sign * offset)
+                if np.all(point >= 0) and np.all(point < np.asarray(image.shape[:2])):
+                    glyph[point[0], point[1], slice_index] = True
+    if patch.patch_id:
+        label = Image.new("L", (image.shape[0], image.shape[1]))
+        draw = ImageDraw.Draw(label)
+        font = ImageFont.load_default(size=10)
+        width = int(draw.textlength(patch.patch_id, font=font)) + 2
+        x = int(np.clip(center[0] + 8, 0, max(image.shape[0] - width, 0)))
+        y = int(np.clip(center[1] - 14, 0, max(image.shape[1] - 12, 0)))
+        draw.text((x, y), patch.patch_id, font=font, fill=255)
+        glyph[:, :, slice_index] |= np.asarray(label).T > 0
+    return glyph
+
+
+def write_patch_qc(
+    image: nib.spatialimages.SpatialImage,
+    surfaces: dict[str, Path],
+    detections: dict[str, _DetectedFlatPatch],
+    output_path: Path,
+) -> Path:
+    """Write a source-grid illustration of selected patches and normals."""
+
+    output = _scaled_anatomy(image, PATCH_QC_ANATOMY_MAX)
+    patch_mask = np.zeros(image.shape, dtype=bool)
+    normal_mask = np.zeros(image.shape, dtype=bool)
+    for detection in detections.values():
+        vertices = detection.vertices
+        hemisphere = detection.patch.surface.split(".")[0]
+        for boundary, intensity in (("white", 2400), ("pial", 2700)):
+            boundary_vertices, _ = nib.freesurfer.read_geometry(
+                str(surfaces[f"{hemisphere}.{boundary}"])
+            )
+            boundary_mask = triangle_voxel_mask(
+                tuple(image.shape), image.affine, boundary_vertices, detection.faces
+            )
+            output[boundary_mask] = intensity
+        selected_patch = triangle_voxel_mask(
+            tuple(int(value) for value in image.shape),
+            image.affine,
+            vertices,
+            detection.faces,
+        )
+        patch_mask |= selected_patch
+        normal_mask |= _normal_glyph_mask(image, selected_patch, detection.patch)
+
+    output[patch_mask] = PATCH_QC_PATCH_INTENSITY
+    output[normal_mask] = PATCH_QC_NORMAL_INTENSITY
+    header = image.header.copy()
+    header.set_data_dtype(np.int16)
+    header["descrip"] = b"TopoFit selected patch and normal illustration"
+    patch_qc = nib.Nifti1Image(output, image.affine, header=header)
+    patch_qc.set_qform(image.affine, code=1)
+    patch_qc.set_sform(image.affine, code=1)
+    nib.save(patch_qc, str(output_path))
+    return output_path
+
+
+def write_patch_geometry(
+    surfaces: dict[str, Path],
+    detections: dict[str, _DetectedFlatPatch],
+    output_path: Path,
+) -> Path:
+    """Export paired ribbon coordinates and local mid-surface normals for analysis."""
+
+    arrays = {"depth_fraction": np.asarray(MIDDLE_DEPTH_FRACTION)}
+    normal_cache = {}
+    for patch_id, detection in detections.items():
+        hemisphere = detection.patch.surface.split(".")[0]
+        white, faces = nib.freesurfer.read_geometry(str(surfaces[f"{hemisphere}.white"]))
+        pial, _ = nib.freesurfer.read_geometry(str(surfaces[f"{hemisphere}.pial"]))
+        middle = detection.vertices
+        if hemisphere not in normal_cache:
+            normals, _ = _outward_vertex_normals(middle, faces, pial - white)
+            signs = np.einsum("ij,ij->i", normals, pial - white)
+            normals[signs < 0] *= -1
+            normal_cache[hemisphere] = normals
+        normals = normal_cache[hemisphere]
+        indices = detection.vertex_indices
+        arrays.update({
+            f"{patch_id}_vertex_indices": indices,
+            f"{patch_id}_faces": np.searchsorted(indices, detection.faces),
+            f"{patch_id}_white_ras_mm": white[indices],
+            f"{patch_id}_pial_ras_mm": pial[indices],
+            f"{patch_id}_mid_ras_mm": middle[indices],
+            f"{patch_id}_normals_ras": normals[indices],
+            f"{patch_id}_ribbon_separation_mm": np.linalg.norm(
+                pial[indices] - white[indices], axis=1
+            ),
+        })
+    np.savez_compressed(output_path, **arrays)
+    return output_path
+
+
 def _find_sulcal_middepth(
     image: nib.spatialimages.SpatialImage,
     surfaces: dict[str, Path],
     threshold_mm_inv: float,
+    *,
+    mock: bool = False,
 ) -> tuple[dict[str, SulcalHemisphere], dict[str, np.ndarray]]:
     detections = {}
     masks = {}
@@ -644,6 +1051,14 @@ def _find_sulcal_middepth(
         pial_vertices, pial_faces = nib.freesurfer.read_geometry(
             str(surfaces[f"{hemisphere}.pial"])
         )
+        registration, _ = nib.freesurfer.read_geometry(
+            str(surfaces[f"{hemisphere}.registration"])
+        )
+        cortex = np.ones(len(pial_vertices), dtype=bool) if mock else mapped_cortex_mask(
+            registration, hemisphere
+        )
+        cortex = erode_cortex_mask((white_vertices + pial_vertices) / 2, pial_faces, cortex)
+        eligible = cortical_ribbon_mask(white_vertices, pial_vertices, cortex)
         detection = identify_sulcal_middepth(
             hemisphere,
             white_vertices,
@@ -651,6 +1066,7 @@ def _find_sulcal_middepth(
             pial_vertices,
             pial_faces,
             threshold_mm_inv,
+            eligible_vertices=eligible,
         )
         detections[hemisphere] = detection
         masks[hemisphere] = triangle_voxel_mask(
@@ -758,6 +1174,13 @@ def run_topofit_workflow(
     validate_options(options)
     input_path = input_path.resolve()
     image = validate_nifti_input(input_path)
+    roi = validate_nifti_input(Path(options.patch_roi)) if options.patch_roi else None
+    if roi is not None:
+        if roi.shape != image.shape or not np.allclose(roi.affine, image.affine, atol=1e-4):
+            raise ValueError("patch ROI must be registered on the input image grid")
+        roi_data = np.asarray(roi.dataobj)
+        if not np.all(np.isfinite(roi_data)) or np.any(roi_data < 0):
+            raise ValueError("patch ROI must contain finite nonnegative mask values")
     run_dir.mkdir(parents=True, exist_ok=True)
     surface_dir = run_dir / "surf"
     surface_dir.mkdir(parents=True, exist_ok=True)
@@ -772,11 +1195,12 @@ def run_topofit_workflow(
 
     surfaces = validate_surface_outputs(surface_dir)
     detected_flat_patches = (
-        find_flat_patches(surfaces) if options.find_flat_patches else {}
+        find_flat_patches(surfaces, options, roi=roi, mock=options.mock)
+        if options.find_flat_patches else {}
     )
     sulcal_detections, sulcal_masks = (
         _find_sulcal_middepth(
-            image, surfaces, options.sulcal_curvature_threshold_mm_inv
+            image, surfaces, options.sulcal_curvature_threshold_mm_inv, mock=options.mock
         )
         if options.find_sulcal_middepth
         else ({}, {})
@@ -795,6 +1219,20 @@ def run_topofit_workflow(
         overlay_thickness=options.overlay_thickness,
         flat_patches=detected_flat_patches,
         sulcal_middepth_masks=sulcal_masks,
+    )
+    patch_qc_path = (
+        write_patch_qc(
+            image,
+            surfaces,
+            detected_flat_patches,
+            run_dir / "topofit_patch_qc.nii.gz",
+        )
+        if detected_flat_patches
+        else None
+    )
+    patch_geometry_path = (
+        write_patch_geometry(surfaces, detected_flat_patches, run_dir / "topofit_patch_geometry.npz")
+        if detected_flat_patches else None
     )
     elapsed = perf_counter() - started
     manifest_path = run_dir / "topofit_manifest.json"
@@ -819,6 +1257,10 @@ def run_topofit_workflow(
         run_dir=str(run_dir.resolve()),
         input_image=str(input_path),
         qc_image=str(qc_path.resolve()),
+        patch_qc_image=(
+            str(patch_qc_path.resolve()) if patch_qc_path else None
+        ),
+        patch_geometry=str(patch_geometry_path.resolve()) if patch_geometry_path else None,
         manifest=str(manifest_path.resolve()),
         surfaces={name: str(path.resolve()) for name, path in surfaces.items()},
         flat_patches=flat_patches,
@@ -834,13 +1276,39 @@ def run_topofit_workflow(
     manifest["prescription_coordinates"] = None
     manifest["coordinate_status"] = "WITHHELD_UNTIL_VALIDATED_ANALYSIS_STAGE"
     manifest["flat_patch_status"] = (
-        "CANDIDATES_REPORTED_RESEARCH_ONLY" if flat_patches else "DISABLED"
+        "CANDIDATES_REPORTED_RESEARCH_ONLY" if flat_patches else
+        "NO_PATCH_MEETS_CRITERIA" if options.find_flat_patches else "DISABLED"
     )
+    manifest["patch_counts"] = {
+        hemisphere: sum(p.surface.startswith(hemisphere + ".") for p in flat_patches.values())
+        for hemisphere in ("lh", "rh")
+    }
+    if options.find_flat_patches:
+        logging.info("Cortical patches: %s; requested up to %d per hemisphere",
+                     manifest["patch_counts"], options.patch_count)
+    manifest["flat_patch_definition"] = {
+        "surface": "white + 0.5 * (pial - white)",
+        "cortex_mask": "mock_only" if options.mock else "fsaverage_cortex_via_registration",
+        "minimum_ribbon_separation_mm": MIN_RIBBON_SEPARATION_MM,
+        "neighborhood": "mesh_edge_geodesic_radius",
+        "roi": options.patch_roi,
+        "medial_wall_margin_mm": MEDIAL_WALL_MARGIN_MM,
+        "selection": "independent_candidates_not_homologous_controls",
+        "overlap": "no_shared_vertices_within_hemisphere",
+        "minimum_normal_coherence": MIN_PATCH_NORMAL_COHERENCE,
+        "minimum_area_mm2": np.pi * options.patch_radius_mm**2 * options.patch_min_area_fraction,
+        "schema_version": 2,
+        "normal_ras": "representative_patch_plane_normal",
+        "local_normals": "topofit_patch_geometry.npz; outward mid-surface unit normals",
+    }
     manifest["sulcal_middepth_status"] = (
         "VOXELS_REPORTED_RESEARCH_ONLY" if sulcal_mask_path else "DISABLED"
     )
     manifest["sulcal_middepth_definition"] = {
         "depth_fraction": MIDDLE_DEPTH_FRACTION,
+        "cortex_mask": "mock_only" if options.mock else "fsaverage_cortex_via_registration",
+        "medial_wall_margin_mm": MEDIAL_WALL_MARGIN_MM,
+        "minimum_ribbon_separation_mm": MIN_RIBBON_SEPARATION_MM,
         "curvature_surface": "pial",
         "curvature_method": "cotangent_mean_curvature",
         "curvature_units": "mm^-1",

--- a/recipes/topofit/topofit_geometry.py
+++ b/recipes/topofit/topofit_geometry.py
@@ -114,6 +114,7 @@ def identify_sulcal_middepth(
     pial_vertices: np.ndarray,
     pial_faces: np.ndarray,
     threshold_mm_inv: float,
+    eligible_vertices: np.ndarray | None = None,
 ) -> SulcalHemisphere:
     """Select concave pial faces and place them at middle cortical depth."""
 
@@ -123,6 +124,10 @@ def identify_sulcal_middepth(
         white_vertices, white_faces, pial_vertices, pial_faces
     )
     selected_vertices = curvature <= -threshold_mm_inv
+    if eligible_vertices is not None:
+        if eligible_vertices.shape != selected_vertices.shape:
+            raise ValueError("cortical mask must have one value per vertex")
+        selected_vertices &= eligible_vertices
     selected_faces = faces[np.all(selected_vertices[faces], axis=1)]
     values = curvature[selected_vertices]
     return SulcalHemisphere(

--- a/recipes/topofit/verify_dicom.py
+++ b/recipes/topofit/verify_dicom.py
@@ -1,0 +1,132 @@
+"""Exercise OpenRecon on a single Enhanced MR volume and export research QC.
+
+Run inside the container with PYTHONPATH=/opt/code/python-ismrmrd-server.
+This is an offline MRD adapter check, not a scanner/network certification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+from pathlib import Path
+
+import ismrmrd
+import nibabel as nib
+import numpy as np
+import pydicom
+from pydicom.dataset import Dataset
+from pydicom.sequence import Sequence
+from pydicom.uid import EnhancedMRImageStorage, ExplicitVRLittleEndian, generate_uid
+
+import topofit
+from test_topofit_openrecon import RecordingConnection
+
+
+def verify_dicom(input_path: Path, output_dir: Path) -> None:
+    source = pydicom.dcmread(input_path)
+    if source.SOPClassUID != EnhancedMRImageStorage:
+        raise ValueError("This verification harness expects a single Enhanced MR volume")
+    pixels = source.pixel_array
+    if pixels.ndim != 3:
+        raise ValueError("Expected frames, rows, columns")
+    shared = source.SharedFunctionalGroupsSequence[0]
+    images = []
+    for index, frame in enumerate(source.PerFrameFunctionalGroupsSequence):
+        def group(name):
+            return getattr(frame if hasattr(frame, name) else shared, name)[0]
+
+        orientation = np.asarray(group("PlaneOrientationSequence").ImageOrientationPatient, float)
+        spacing = np.asarray(group("PixelMeasuresSequence").PixelSpacing, float)
+        origin = np.asarray(group("PlanePositionSequence").ImagePositionPatient, float)
+        read, phase = orientation[:3], orientation[3:]
+        center = origin + read * spacing[1] * (source.Columns - 1) / 2 + phase * spacing[0] * (source.Rows - 1) / 2
+        image = ismrmrd.Image.from_array(np.ascontiguousarray(pixels[index]), transpose=False)
+        image.field_of_view = (source.Columns * spacing[1], source.Rows * spacing[0], float(group("PixelMeasuresSequence").SliceThickness))
+        image.position = tuple(center)
+        image.read_dir, image.phase_dir = tuple(read), tuple(phase)
+        image.slice_dir = tuple(np.cross(read, phase))
+        image.slice = index
+        image.image_index = index + 1
+        image.image_series_index = 1
+        image.image_type = ismrmrd.IMTYPE_MAGNITUDE
+        meta = ismrmrd.Meta()
+        for name in ("SeriesDescription", "ProtocolName", "FrameOfReferenceUID"):
+            meta[name] = str(getattr(source, name, ""))
+        image.attribute_string = meta.serialize()
+        images.append(image)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    topofit.WORKSPACE = output_dir / "runs"
+    connection = RecordingConnection(images)
+    topofit.process(connection, {"parameters": {
+        "tfdevice": "cpu", "tfflatpatches": True,
+    }}, None)
+    outputs = [image for batch in connection.image_batches for image in batch]
+    assert connection.closed and len(outputs) == 3 * len(images), connection.logs
+    patch_images = [image for image in outputs if
+        "_topofit_patch_qc" in ismrmrd.Meta.deserialize(image.attribute_string)["SeriesDescription"]]
+    assert len(patch_images) == len(images)
+    patch_images.sort(key=lambda image: image.slice)
+    qc_pixels = np.stack([np.squeeze(image.data) for image in patch_images]).astype("<u2")
+    assert np.count_nonzero(qc_pixels == 3000) > 0
+    assert np.count_nonzero(qc_pixels == 4095) > 0
+    for original, derived in zip(images, patch_images):
+        np.testing.assert_allclose(original.position, derived.position)
+        np.testing.assert_allclose(original.read_dir, derived.read_dir)
+        np.testing.assert_allclose(original.phase_dir, derived.phase_dir)
+
+    derived = copy.deepcopy(source)
+    derived.SOPInstanceUID = generate_uid()
+    derived.SeriesInstanceUID = generate_uid()
+    derived.SeriesNumber = int(source.SeriesNumber) + 1000
+    derived.SeriesDescription = "TopoFit multi-patch QC RESEARCH"
+    derived.ImageType = ["DERIVED", "PRIMARY", "M", "NONE"]
+    derived.BurnedInAnnotation = "YES"
+    derived.ContentQualification = "RESEARCH"
+    derived.DerivationDescription = "Offline OpenRecon adapter QC; mid-cortical patch and normal. NOT FOR PRESCRIPTION."
+    derived.ImageComments = ismrmrd.Meta.deserialize(patch_images[0].attribute_string)["ImageComments"]
+    reference = Dataset()
+    reference.ReferencedSOPClassUID = source.SOPClassUID
+    reference.ReferencedSOPInstanceUID = source.SOPInstanceUID
+    derived.SourceImageSequence = Sequence([reference])
+    derived.BitsAllocated, derived.BitsStored, derived.HighBit = 16, 12, 11
+    derived.PixelRepresentation = 0
+    derived.PhotometricInterpretation = "MONOCHROME2"
+    for element in derived.iterall():
+        if element.keyword in ("WindowCenter", "WindowWidth", "RescaleSlope", "RescaleIntercept"):
+            element.value = {"WindowCenter": 2048, "WindowWidth": 4096, "RescaleSlope": 1, "RescaleIntercept": 0}[element.keyword]
+        elif element.keyword == "FrameType":
+            element.value = ["DERIVED", "PRIMARY", "M", "NONE"]
+    derived.WindowCenter, derived.WindowWidth = 2048, 4096
+    derived.PixelData = qc_pixels.tobytes()
+    derived["PixelData"].is_undefined_length = False
+    derived.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    derived.file_meta.MediaStorageSOPInstanceUID = derived.SOPInstanceUID
+    output_path = output_dir / "topofit_cortical_patch_qc.dcm"
+    derived.save_as(output_path, enforce_file_format=True)
+    np.testing.assert_array_equal(pydicom.dcmread(output_path).pixel_array, qc_pixels)
+    run_dir, = topofit.WORKSPACE.iterdir()
+    manifest = json.loads((run_dir / "topofit_manifest.json").read_text())
+    assert manifest["options"]["mock"] is False
+    for key, expected in (("patch_count", 3), ("patch_radius_mm", 10),
+                          ("patch_max_rms_mm", 0.5), ("patch_min_area_fraction", 0.25)):
+        assert manifest["options"][key] == expected
+    assert manifest["flat_patch_definition"]["medial_wall_margin_mm"] == 5
+    # Prove the exported DICOM contains the same pixels returned by the adapter.
+    ordered, volume, affine = topofit._mrd_series_to_nifti(patch_images)
+    qc = nib.load(run_dir / "topofit_patch_qc.nii.gz")
+    np.testing.assert_array_equal(volume, np.asarray(qc.dataobj))
+    np.testing.assert_allclose(affine, qc.affine, atol=1e-5)
+    print(json.dumps({"run_dir": str(run_dir), "dicom": str(output_path),
+                      "mrd_images_returned": len(outputs), "flat_patches": manifest["flat_patches"]}, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    verify_dicom(args.input, args.output_dir)


### PR DESCRIPTION
## Summary

Release TopoFit 0.5.1 with ranked cortical patches and source-grid normal QC.

- Select connected patches at 50% cortical depth, excluding the medial-wall closure and collapsed ribbon.
- Return up to three non-overlapping patches per hemisphere by default when patch analysis is enabled. Apply area, plane-fit RMS, and normal-coherence quality cutoffs without a relaxed fallback.
- Add OpenRecon controls for count, radius, hemisphere, and cortex or native-space ROI search. Keep advanced quality cutoffs available through JSON configuration and the CLI.
- Burn patch IDs and physically projected normal markers into the returned QC pixels. Export paired ribbon geometry and local normals for research analysis.
- Keep PyTorch CUDA at 11.8 for OpenRecon packaging and install the pinned cortical eligibility atlas.

## Verification

- Recipe 0.5.1 validates and its Dockerfile generates.
- All 20 repository OpenRecon labels validate against the supported schema.
- All 30 TopoFit unit and transport tests passed in the local container.
- All 13 additional runtime and artifact checks passed. A fresh CPU inference through the offline DICOM-to-MRD adapter produced six qualifying patches and preserved source geometry. Exported DICOM pixels matched the returned MRD pixels.
- No subject images, medical metadata, supplied papers, or run outputs are included in this PR.

CI must build and test the exact release candidate before promotion. Local verification does not certify a live scanner connection or GPU execution. Outputs remain research-only and are not prescription coordinates.

## Release

After the candidate checks pass, merge this PR to publish the container and synchronize version 0.5.1 into OpenRecon. Merge the generated OpenRecon metadata PR to build the application bundles.
