### PR TITLE
Update FastSurfer to 2.5.4

### DIFF
--- a/recipes/fastsurfer/build.yaml
+++ b/recipes/fastsurfer/build.yaml
@@ -1,5 +1,5 @@
 name: fastsurfer
-version: 2.4.2
+version: 2.5.4
 copyright:
   - license: Apache-2.0
     url: https://github.com/Deep-MI/FastSurfer/blob/dev/LICENSE

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -474,18 +474,10 @@ tests:
   # ==========================================================================
   # DOCKER/CONTAINER CONFIGURATION
   # ==========================================================================
-  - name: Docker directory exists
-    description: Verify Docker configuration directory exists
-    command: bash -lc 'test -d /fastsurfer/Docker && echo "Docker dir exists"'
-    expected_output_contains: "Docker dir exists"
-
-  # ==========================================================================
-  # TEST DIRECTORY IN CONTAINER
-  # ==========================================================================
-  - name: Test directory exists
-    description: Verify test directory exists in container
-    command: bash -lc 'test -d /fastsurfer/test && echo "test dir exists"'
-    expected_output_contains: "test dir exists"
+  - name: Container entrypoint available
+    description: Verify the upstream runtime entrypoint is executable
+    command: test -x /fastsurfer/tools/Docker/entrypoint.sh
+    expected_exit_code: 0
 
 cleanup:
   script: |

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -1,5 +1,5 @@
 # FastSurfer container test suite
-# Tests for FastSurfer v2.4.2 - Deep learning neuroimaging pipeline
+# Tests for FastSurfer - Deep learning neuroimaging pipeline
 #
 # FastSurfer provides a fully compatible FreeSurfer alternative for:
 #   - Volumetric analysis (within minutes)
@@ -14,7 +14,7 @@
 # help messages, and basic functionality that can run quickly.
 
 name: fastsurfer
-version: 2.4.2
+version: 2.5.4
 
 required_files:
   - dataset: ds000001
@@ -41,7 +41,7 @@ tests:
   - name: FastSurfer version check
     description: Verify FastSurfer reports correct version
     command: run_fastsurfer.sh --version
-    expected_output_contains: "2.4.2"
+    expected_output_contains: "${version}"
 
   - name: run_fastsurfer.sh help
     description: Verify main pipeline help is accessible


### PR DESCRIPTION
Updates FastSurfer from 2.4.2 to 2.5.4 using the upstream CPU image. Synchronizes the runtime test suite version and uses `${version}` for its version assertion.

Aligns smoke tests with the upstream 2.5.4 image layout: check the executable `tools/Docker/entrypoint.sh`, replacing the old top-level Docker directory assertion, and remove the assertion for the development `test/` directory that upstream explicitly excludes from its image.

Validation: recipe schema validation, Dockerfile generation, and diff checks passed. Candidate run 34316811786 passed the container build, deployment checks, runtime suite, Dive policy check, and required release gate.

Fixes #3113.
