### PR TITLE
Skip image builds for documentation-only recipe changes

### DIFF
--- a/.github/workflows/update-apps-json.yml
+++ b/.github/workflows/update-apps-json.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - "releases/**/*.json"
+      - "recipes/**/build.yaml"
   workflow_dispatch:
 
 # Serialize runs so quick release bursts force-push the branch in order; each
@@ -36,7 +37,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install icon conversion dependencies
-        run: python -m pip install cairosvg
+        run: python -m pip install cairosvg pyyaml
 
       - name: Generate apps.json
         run: |

--- a/builder/release_plan.py
+++ b/builder/release_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Mapping
@@ -35,11 +36,41 @@ TOP_LEVEL_FIELD_TIERS: dict[str, frozenset[str]] = {
     "epoch": frozenset({"candidate"}),
 }
 
-# This first release-planner milestone intentionally enables only the proven,
-# hermetic case from #2994. Other roles are recorded above for completeness but
-# remain candidate-required until their post-merge publication paths exist.
+# Other roles remain candidate-required until their publication paths exist.
 ENABLED_SOURCE_ONLY_FIELDS = frozenset({"auto_update"})
+DOCUMENTATION_FIELDS = frozenset({"readme", "readme_url", "structured_readme"})
 KNOWN_NON_IMAGE_FILES = frozenset({"fulltest.yaml"})
+
+
+def literal_categories(recipe: Mapping[str, object]) -> list[str] | None:
+    """Return categories that the catalog can publish without executing Jinja."""
+    value = recipe.get("categories", [])
+    if not isinstance(value, list) or not all(
+        isinstance(item, str)
+        and not any(token in item for token in ("{{", "{%", "{#"))
+        for item in value
+    ):
+        return None
+    return value
+
+
+def _passive_documentation(value: object) -> bool:
+    """Allow prose and simple context substitutions, not template side effects."""
+    if isinstance(value, str):
+        prose = re.sub(
+            r"{{\s*(?:context\.(?:name|version|original_version|arch|variant)|arch)\s*}}",
+            "",
+            value,
+        )
+        return not any(token in prose for token in ("{{", "{%", "{#"))
+    if isinstance(value, Mapping):
+        return all(
+            _passive_documentation(key) and _passive_documentation(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return all(_passive_documentation(item) for item in value)
+    return True
 
 
 @dataclass(frozen=True)
@@ -151,6 +182,15 @@ def plan_recipe_changes(
                 candidate_reasons.append("new-recipe")
             else:
                 changed_fields = _changed_top_level_fields(base, head)
+                non_image_fields = set(ENABLED_SOURCE_ONLY_FIELDS)
+                for field in DOCUMENTATION_FIELDS:
+                    if all(
+                        _passive_documentation(data.get(field))
+                        for data in (base, head)
+                    ):
+                        non_image_fields.add(field)
+                if all(literal_categories(data) is not None for data in (base, head)):
+                    non_image_fields.add("categories")
                 unknown = changed_fields - TOP_LEVEL_FIELD_TIERS.keys()
                 if unknown:
                     candidate_reasons.append("unclassified-field")
@@ -158,6 +198,8 @@ def plan_recipe_changes(
                     source_reasons.append("yaml-only-change")
                 elif changed_fields <= ENABLED_SOURCE_ONLY_FIELDS:
                     source_reasons.append("auto-update-only")
+                elif changed_fields <= non_image_fields:
+                    source_reasons.append("documentation-or-catalog-only")
                 else:
                     candidate_reasons.append("recipe-definition-changed")
 

--- a/builder/tests/test_generate_apps_json.py
+++ b/builder/tests/test_generate_apps_json.py
@@ -3,8 +3,54 @@ from __future__ import annotations
 import json
 
 import pytest
+import yaml
 
 from tools.generate_apps_json import generate_apps_json, merge_container_releases
+
+
+@pytest.mark.parametrize("container,source", [("demo", None), ("demo_gpu_arm64", "demo")])
+def test_catalog_refresh_preserves_published_artifacts(tmp_path, container, source) -> None:
+    release_dir = tmp_path / "releases" / container
+    release_dir.mkdir(parents=True)
+    release = {
+        "apps": {f"{container} 1.0": {"version": "20260101", "exec": "demo"}},
+        "categories": ["programming"],
+    }
+    if source:
+        release.update(recipe=source, variant="gpu_arm64", architecture="aarch64")
+    release_path = release_dir / "1.0.json"
+    original = json.dumps(release)
+    release_path.write_text(original)
+    recipe_dir = tmp_path / "recipes" / (source or container)
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "build.yaml").write_text(yaml.safe_dump({"categories": ["workflows"]}))
+    output = tmp_path / "apps.json"
+
+    generate_apps_json(str(release_dir.parent), str(output))
+
+    catalog = json.loads(output.read_text())[container]
+    assert catalog["categories"] == ["workflows"]
+    assert catalog["apps"] == release["apps"]
+    assert release_path.read_text() == original
+
+
+@pytest.mark.parametrize("recipe", [None, {}, {"categories": ["{{ context.category }}"]}])
+def test_catalog_retains_release_categories_when_recipe_cannot_supply_them(tmp_path, recipe) -> None:
+    release_dir = tmp_path / "releases" / "demo"
+    release_dir.mkdir(parents=True)
+    (release_dir / "1.0.json").write_text(json.dumps({
+        "apps": {"demo 1.0": {"version": "20260101"}},
+        "categories": ["programming"],
+    }))
+    if recipe is not None:
+        recipe_dir = tmp_path / "recipes" / "demo"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "build.yaml").write_text(yaml.safe_dump(recipe))
+    output = tmp_path / "apps.json"
+
+    generate_apps_json(str(release_dir.parent), str(output))
+
+    assert json.loads(output.read_text())["demo"]["categories"] == ["programming"]
 
 
 def test_merge_container_releases_preserves_visibility_flags(tmp_path) -> None:

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -122,6 +122,32 @@ def test_detect_recipes_allows_pr_without_recipes(tmp_path: Path, monkeypatch) -
     assert one_pr_release.detect_recipes("base", "head") == []
 
 
+def test_detect_from_git_preserves_metadata_only_release(tmp_path: Path, monkeypatch) -> None:
+    """PR detection and post-merge promotion use the same non-image verdict."""
+    monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
+    git = one_pr_release.run_git
+    git("init", "-b", "main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "test")
+    recipe_dir = write_recipe(tmp_path)
+    helper = recipe_dir / "config.txt"
+    helper.write_text("original")
+    git("add", ".")
+    git("commit", "-m", "Initial recipe")
+    base = git("rev-parse", "HEAD")
+
+    path = recipe_dir / "build.yaml"
+    recipe = yaml.safe_load(path.read_text())
+    recipe.update(readme="Updated help", categories=["workflows"], auto_update={})
+    path.write_text(yaml.safe_dump(recipe) + "# Clarified documentation\n")
+    git("commit", "-am", "Update documentation and catalog")
+    assert one_pr_release.detect_recipes(base, "HEAD") == []
+
+    helper.write_text("new runtime configuration")
+    git("commit", "-am", "Update staged input")
+    assert one_pr_release.detect_recipes(base, "HEAD") == ["demo"]
+
+
 def test_detect_recipes_rejects_mixed_pr(tmp_path: Path, monkeypatch) -> None:
     """Mixed automation and recipe changes cannot cross the trust boundary."""
     recipe_dir = write_recipe(tmp_path)

--- a/builder/tests/test_release_plan.py
+++ b/builder/tests/test_release_plan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import attrs
+import pytest
 
 from builder.release_plan import TOP_LEVEL_FIELD_TIERS, plan_recipe_changes
 from builder.validation import ContainerRecipe
@@ -53,6 +54,48 @@ def test_semantically_unchanged_yaml_is_source_only() -> None:
 
     assert plan.candidate_recipes == []
     assert plan.decisions[0].reasons == ("yaml-only-change",)
+
+
+@pytest.mark.parametrize("updates", [
+    {"readme": "Updated instructions for {{ context.name }}/{{ context.version }}"},
+    {"readme_url": "https://example.com/guide"},
+    {"structured_readme": {"description": "Updated instructions"}},
+    {"categories": ["workflows"]},
+    {"readme": "New help", "categories": ["workflows"], "auto_update": {}},
+])
+def test_documentation_and_categories_preserve_image(updates) -> None:
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml"], {"demo": recipe()}, {"demo": recipe(**updates)}
+    )
+
+    assert plan.candidate_recipes == []
+    assert plan.source_only_recipes == ["demo"]
+
+
+@pytest.mark.parametrize("updates", [
+    {"readme": '{{ get_file("asset") }}'},
+    {"categories": ["{{ context.category }}"]},
+    {"readme": "Help", "version": "2.0"},
+    {"readme": "Help", "files": [{"name": "config", "contents": "changed"}]},
+    {"readme": "Help", "deploy": {"bins": ["new-command"]}},
+])
+def test_uncertain_templates_and_build_inputs_still_require_candidate(updates) -> None:
+    # Check both directions, including removal of a template with side effects.
+    for base, head in ((recipe(), recipe(**updates)), (recipe(**updates), recipe())):
+        plan = plan_recipe_changes(
+            ["recipes/demo/build.yaml"], {"demo": base}, {"demo": head}
+        )
+        assert plan.candidate_recipes == ["demo"]
+
+
+def test_documentation_with_staged_file_change_requires_candidate() -> None:
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml", "recipes/demo/config.txt"],
+        {"demo": recipe(readme="Old help")},
+        {"demo": recipe(readme="New help")},
+    )
+
+    assert plan.candidate_recipes == ["demo"]
 
 
 def test_runtime_recipe_field_change_requires_candidate() -> None:

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -526,5 +526,6 @@ def test_update_apps_json_runs_for_release_file_pushes() -> None:
     workflow = Path(".github/workflows/update-apps-json.yml").read_text()
 
     assert "  push:\n    branches: [main]\n    paths:\n      - \"releases/**/*.json\"" in workflow
+    assert '      - "recipes/**/build.yaml"' in workflow
     assert "pull_request:" not in workflow
     assert "github.event.pull_request.merged" not in workflow

--- a/tools/generate_apps_json.py
+++ b/tools/generate_apps_json.py
@@ -6,11 +6,20 @@ This tool reads all release files from the releases/ directory and creates
 a consolidated apps.json file that matches the original format.
 """
 
+import argparse
 import json
 import os
-import argparse
+import sys
 from pathlib import Path
 from typing import Dict, Any
+
+import yaml
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(SCRIPT_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_REPO_ROOT))
+
+from builder.release_plan import literal_categories
 
 
 VISIBILITY_FIELDS = ("show_in_menu", "show_in_applist")
@@ -122,18 +131,60 @@ def merge_container_releases(container_name: str, release_files: list) -> Dict[s
     return {**merged_visibility, **container_data}
 
 
-def generate_apps_json(releases_dir: str, output_file: str):
+def current_recipe_categories(
+    container_name: str, release_files: list, recipes_dir: Path
+) -> list[str] | None:
+    """Read current catalog categories, retaining release data as the fallback.
+
+    Named variants record their source recipe in release metadata. Never infer
+    it by splitting container names, which may themselves contain underscores.
+    """
+    sources = {
+        data.get("recipe", container_name)
+        for _, path in release_files
+        if not is_legacy_arm64_release(data := load_release_file(path))
+    }
+    if len(sources) != 1:
+        return None
+    source = sources.pop()
+    if (
+        not isinstance(source, str)
+        or source in {".", ".."}
+        or Path(source).name != source
+    ):
+        return None
+    path = recipes_dir / source / "build.yaml"
+    if not path.is_file():
+        return None
+    try:
+        recipe = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as error:
+        print(f"Warning: retaining release categories for {container_name}: {error}")
+        return None
+    if not isinstance(recipe, dict) or "categories" not in recipe:
+        return None
+    return literal_categories(recipe)
+
+
+def generate_apps_json(
+    releases_dir: str, output_file: str, recipes_dir: str | None = None
+) -> None:
     """
     Generate apps.json from all release files.
     
     Args:
         releases_dir: Directory containing release files
         output_file: Path to write the generated apps.json
+        recipes_dir: Current recipes; defaults to a sibling of releases_dir
     """
     print(f"Collecting release files from: {releases_dir}")
     
     # Collect all release files
     containers = collect_release_files(releases_dir)
+    recipe_root = (
+        Path(recipes_dir) if recipes_dir is not None
+        else Path(releases_dir).parent / "recipes"
+    )
     
     if not containers:
         print("No release files found!")
@@ -157,6 +208,11 @@ def generate_apps_json(releases_dir: str, output_file: str):
         
         # Merge all releases for this container
         container_data = merge_container_releases(container_name, release_files)
+        categories = current_recipe_categories(
+            container_name, release_files, recipe_root
+        )
+        if categories is not None:
+            container_data["categories"] = sorted(set(categories))
         for app_name in container_data["apps"]:
             existing_owner = app_owners.get(app_name)
             if existing_owner is not None:
@@ -191,6 +247,10 @@ def main():
         help="Directory containing release files"
     )
     parser.add_argument(
+        "--recipes-dir",
+        help="Current recipes for catalog categories (defaults to sibling of releases)"
+    )
+    parser.add_argument(
         "--output",
         default="apps.json",
         help="Output path for generated apps.json"
@@ -202,7 +262,7 @@ def main():
     releases_dir = os.path.abspath(args.releases_dir)
     output_file = os.path.abspath(args.output)
     
-    generate_apps_json(releases_dir, output_file)
+    generate_apps_json(releases_dir, output_file, args.recipes_dir)
     
     return 0
 

--- a/workflows/ONE_PR_RELEASES.md
+++ b/workflows/ONE_PR_RELEASES.md
@@ -69,11 +69,25 @@ second build.
 
 The planner reads the base and head `build.yaml` files as YAML data. It does not
 render Jinja or execute any code from the pull request. Changes that affect only
-`auto_update`, semantically unchanged YAML, or `fulltest.yaml` are currently
+`auto_update`, documentation (`readme`, `readme_url`, `structured_readme`), literal
+`categories`, semantically unchanged YAML, or `fulltest.yaml` are currently
 classified as source-only: they are validated, but the existing container is
 preserved and no candidate is built or promoted. This is a behavioural release
 projection, not a claim that rebuilding would produce byte-identical images;
 the current image still embeds the raw `build.yaml` and README.
+
+Documentation may use simple context substitutions such as
+`{{ context.version }}`. More complex templates remain candidate-required because
+rendering can have side effects. Documentation inside an existing image remains
+the version shipped with that image; updated documentation is available in the
+recipe source until the next image release.
+
+The apps.json workflow also runs on recipe definition changes. It reads literal
+categories from the current source recipe (including the source recorded for
+named variants), replacing the historical category union in the catalog. It
+preserves all published app identities and build dates and does not rewrite
+release JSON or publish images. Missing recipes and templated categories retain
+the categories from release metadata.
 
 Every other recipe definition change is deliberately fail-closed and requires
 a candidate. A changed recipe-local file such as `install.sh` also requires a


### PR DESCRIPTION
## Summary

- Classify documentation and literal category updates as source-only changes.
- Preserve published images while refreshing catalog categories from current recipes.
- Extend release planning, catalog generation, workflow coverage, and regression tests.

## Testing

- Not run.