### PR TITLE
Fix candidate setup timeouts installing git-annex

### DIFF
--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -118,17 +118,12 @@ jobs:
           # fulltest suites declare required_files: from OpenNeuro, which
           # builder/run_tests.py fetches with datalad. Without this the runner
           # raises FileNotFoundError: 'datalad' and the candidate fails after a
-          # full image build. Mirrors the install in run-fulltest.yml.
-          uv pip install --system datalad datalad-installer
-          if [ "$(uname -m)" = "x86_64" ]; then
-            datalad-installer --sudo ok git-annex -m datalad/packages
-          else
-            # datalad/packages publishes amd64 .debs only, so dpkg -i fails on
-            # the arm64 runners. The distro package is older but sufficient for
-            # fetching required_files.
-            sudo apt-get update
-            sudo apt-get install -y git-annex
-          fi
+          # full image build.
+          uv pip install --system datalad
+          # Ubuntu provides git-annex for both architectures. Avoid depending
+          # on the external DataLad package server during candidate setup.
+          sudo apt-get update
+          sudo apt-get install -y git-annex
           git-annex version
           datalad --version
       - name: Configure git for DataLad


### PR DESCRIPTION
Candidate jobs time out before building because `datalad-installer -m datalad/packages` cannot reach `http://datasets.datalad.org/datalad/packages/latest-version`. This failed the epirecon candidate in run 34280226769 and is blocking FastSurfer #3114 at the same setup step.

Install git-annex from Ubuntu on both runner architectures, extending the existing ARM installation path to x86_64. Keep DataLad installed through uv and retain both tool version checks.

Validation: 52 workflow contract and one-PR release tests passed; workflow YAML parsing, tooling shell syntax, and diff checks passed. FastSurfer's candidate will exercise the installation after this fix lands.
