### PR TITLE
Add the qris1 scale set as a manual-build runner choice

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -21,6 +21,7 @@ on:
         options:
         - "neurodesk-syd2-arcrunner-neurocontainers"
         - "neurodesk-syd-arcrunner-neurocontainers"
+        - "neurodesk-qris1-arcrunner-neurocontainers"
         - "blacksmith-8vcpu-ubuntu-2404"
         - "blacksmith-8vcpu-ubuntu-2404-arm"
         - "ubuntu-22.04"
@@ -103,6 +104,9 @@ jobs:
             ;;
           "neurodesk-syd2-arcrunner-neurocontainers")
             runner='"neurodesk-syd2-arcrunner-neurocontainers"'
+            ;;
+          "neurodesk-qris1-arcrunner-neurocontainers")
+            runner='"neurodesk-qris1-arcrunner-neurocontainers"'
             ;;
           "blacksmith-8vcpu-ubuntu-2404"|"blacksmith-8vcpu-ubuntu-2404-arm"|"ubuntu-22.04"|"self-hosted")
             runner="\"$CHOICE\""


### PR DESCRIPTION
Adds `neurodesk-qris1-arcrunner-neurocontainers` to the manual-build runner
dropdown so a build can be dispatched to that scale set explicitly. The qris1
standby scale set shares its name with the production one, so a job cannot
otherwise be aimed at a particular cluster.

Two hunks: the choice list and its `case` branch. Both are required — the
option alone falls through to the `*)` arm and fails with "Unknown runner
choice".

Default unchanged; no effect unless selected.
