### PR TITLE
Fix dashboard publication missing PyYAML dependency

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install snapshot dependencies
+        run: python -m pip install pyyaml==6.0.2
+
       - name: Generate apps.json snapshot
         run: python tools/generate_apps_json.py --output dashboard/apps.json
 


### PR DESCRIPTION
Dashboard publication fails at `Generate apps.json snapshot` with `ModuleNotFoundError: No module named 'yaml'`. Install PyYAML before invoking the generator, using the version pinned in requirements.txt.

This fixes the dashboard failure observed after merging #3112; the container candidate passed and its promotion runs separately.

Validation: the snapshot generator completed in a clean Python 3.10 virtual environment with only PyYAML installed (232 containers, 523 apps); 43 apps.json and workflow contract tests passed; `git diff --check` passed.
