### PR TITLE
Test deployed binaries as wrapper command names

### DIFF
--- a/builder/tests/test_deploy_script_contract.py
+++ b/builder/tests/test_deploy_script_contract.py
@@ -22,8 +22,9 @@ def _run_deploy_script(tmp_path: Path, mode: int) -> tuple[int, dict]:
     env = os.environ.copy()
     env.update(
         {
-            "DEPLOY_BINS": "./owner-only-tool",
+            "DEPLOY_BINS": "owner-only-tool",
             "DEPLOY_PATH": "",
+            "PATH": f".:{env.get('PATH', '')}",
         }
     )
     result = subprocess.run(
@@ -63,6 +64,41 @@ def test_deploy_script_accepts_world_accessible_executable(tmp_path: Path) -> No
 
     assert returncode == 0
     assert payload["failed"] == 0
+
+
+def test_deploy_script_rejects_path_as_wrapper_command(tmp_path: Path) -> None:
+    tool = tmp_path / "tool"
+    tool.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+    tool.chmod(
+        stat.S_IRUSR
+        | stat.S_IWUSR
+        | stat.S_IXUSR
+        | stat.S_IRGRP
+        | stat.S_IXGRP
+        | stat.S_IROTH
+        | stat.S_IXOTH
+    )
+    env = os.environ.copy()
+    env.update({"DEPLOY_BINS": str(tool), "DEPLOY_PATH": ""})
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert {
+        "name": f"deploy_bin.name:{tool}",
+        "status": "failed",
+        "message": (
+            f"DEPLOY_BINS entry {tool} must be a command name without '/'. "
+            "Add its directory to PATH or DEPLOY_PATH."
+        ),
+    } in payload["tests"]
 
 
 def test_deploy_script_checks_directory_access_without_find(tmp_path: Path) -> None:

--- a/workflows/test_deploy.sh
+++ b/workflows/test_deploy.sh
@@ -366,16 +366,18 @@ process_deploy_bins() {
     while IFS= read -r entry; do
         [ -z "$entry" ] && continue
 
-        local resolved=""
-        if [[ "$entry" == /* ]] || [[ "$entry" == .* ]]; then
-            if [ -f "$entry" ]; then
-                resolved="$entry"
-            fi
+        # Transparent Singularity uses each DEPLOY_BINS entry as the host-side
+        # wrapper filename and executes that same value through the container's
+        # PATH. Paths can exist in the image while still being impossible to
+        # expose as wrapper commands.
+        if [[ "$entry" == */* ]]; then
+            record_result "deploy_bin.name:$entry" "failed" \
+                "DEPLOY_BINS entry $entry must be a command name without '/'. Add its directory to PATH or DEPLOY_PATH."
+            continue
         fi
 
-        if [ -z "$resolved" ]; then
-            resolved=$(command -v "$entry" 2>/dev/null || true)
-        fi
+        local resolved=""
+        resolved=$(command -v "$entry" 2>/dev/null || true)
 
         if [ -n "$resolved" ]; then
             record_result "deploy_bin:$entry" "passed" "Binary $entry found at $resolved."


### PR DESCRIPTION
`test_deploy.sh` accepted absolute and relative paths in `DEPLOY_BINS` whenever the target existed in the container. Transparent Singularity cannot expose those entries: it uses each value as a host wrapper filename and executes it through the container's `PATH`. This allowed FastSurfer 2.5.4 to pass its release gate with `/fastsurfer/run_fastsurfer.sh` even though `run_fastsurfer.sh` was not exposed correctly after module load.

Require every `DEPLOY_BINS` entry to be a command name without `/`, then resolve it through `PATH` just as the generated wrapper will. The regression test uses an existing executable absolute path to prove that container-level existence is no longer enough.

Validation: `pytest builder/tests` (285 passed), focused deploy contract tests, shell syntax check, and `git diff --check`.
