### PR TITLE
Expose FastSurfer launchers as wrapper commands

### DIFF
--- a/recipes/fastsurfer/build.yaml
+++ b/recipes/fastsurfer/build.yaml
@@ -93,13 +93,14 @@ build:
         - /opt/license.txt
     - environment:
         FS_LICENSE: /opt/license.txt
+        PATH: /fastsurfer:$PATH
     - install:
         - wget
     - deploy:
         path: []
         bins:
-          - /fastsurfer/run_fastsurfer.sh
-          - /fastsurfer/long_fastsurfer.sh
+          - run_fastsurfer.sh
+          - long_fastsurfer.sh
 categories:
   - structural imaging
 icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAEcklEQVR4AWRTXUieZRi+nufT3GTYIulnNraB2TaXlOaoUPCgDjwJKluxwINpaiDWcEvUg36wcIRpeO6B/bGWlv3RUdQyquXSNjAUZ1IZjmTRsrH593Rd9/c9n9+2j+967/u57v/7eV+f/dnZcMOnZ0L2Jz+H7I8nQvbIeBIf/RSyPzwdsobHQvbQjyHrg1NJnPghZL3/fcg6/p0h8d63IYtIvDsaEu98ExJvnwyJt74OicGvDN6FAP0cHwIFIE7gIXKS5pviaTI/8fKXzXQzbDx8YEAm5JyJsL7OY0iDiiWOMjNWOugfbdK9qqq6SOmS6fosLk4QF6X50GYcZeQtj8gM+NihgtI6u4i6upKubtI6k4bVFYR//4FsQtpOm+nKQd1bMSoQeEh3E/UUz6Otxuzk3IW/gLOngJVlM8VHnEJ+0r0lZoDJ5StY+/w4Vh4vx0rNfsPqgfthePIBrD71INY667D+xQmsPvcE1vpfwvqxVuDP36y4dc5cNmlKJgvE8iRVtbW1lfU2LjYGLC0tMREv/dcpjI2Nmc/T5SUIv58D1tYsS+ycRkj3CrbKqZ0FujknE1BVVYXKyso0KioqgOVl5M7PorS0lDkCWlpaEKbOIFxagu7CwEZBSLe3iDmtmrqXQWdhdHQUmZiYmACuXMbhgwfoFjA4OIiysjLkzE4Ci+dh8QpkcjpIg1cVTZEEuUCk/v39/chEYWEhkLcV9fX1GB8fR1dXF7z3ePaRaoS5KYTVVa6QCWIBSpsguRDYFMj41dXVoaGhIY2SkhJszwrYsWMH+vr6MDMzg8XFRTQ2NgJck/vvYrJAzKEC1jn3b/dAIo4mn9zcXOTk5KQxPDyMF9tekAkDAwO8jmXk5+ejqKgIWxfmEBb+gDZiuZhTuT2U1EL4yNR51N/X1MMfOQZ/6Ahwxy7U1NRgenoabW1thvb2djjncPSZQwizv8ClvgttRUgWUOIIcIfKLOTdBNxZDLe3FMjZjIqdBcjLy0NHRwd6e3sN3d3dWFhYQG1tra0pXPybPadecU5x3ZesvBpNMg29gtxxZ2enrWXoy5PwbW8g8eYQ3EOPYmRkBAUFBdh2YR6Yn4NjYsXaBLYzdq+kUe/p6bGx1/jxhMAP6/w8wuRpVFdX2324PfcCt2xD2LQZ2LUbTU1N5j8/T79zkwiXL8HugXntLeJMcDy4RALYfQ/80ddhe2/qgM+/HS53C/zBZvjDr8E9/yrcw48BW/IAn4C7q4Qc+eZX4JpfhtvDdTKXJlBeH3hIg5flCnbC3V1O7OfuyxBuvhXhtu3AvvsI8vvKAV42HLer2C03WlMoLgP2EoXFwKZcKLngrXMrB5sC1/wcz/KRs3RJUsk/C4gTRERpPrSJS06gSyHiJLa/eE5JBemO5HOVnYnEGxd1SYGxnFN1NmDd8qhuoq7khhRPAbNLYSIJA3Xx8lWsdK/KIgysqA4zYTwDo8y0WecZNvlcZaft+gnYiqrLWR1Ikkr+GSCb8WSiNB/aSG1MxoN8/wcAAP///SCt6wAAAAZJREFUAwAFW1DpgjhdhQAAAABJRU5ErkJggg==

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -38,6 +38,22 @@ tests:
   # ==========================================================================
   # VERSION AND HELP CHECKS
   # ==========================================================================
+  - name: FastSurfer commands are exported as wrapper names
+    description: Verify Transparent Singularity can expose both launchers in the user session
+    command: |
+      for command in run_fastsurfer.sh long_fastsurfer.sh; do
+        echo "${DEPLOY_BINS}" | tr ':' '\n' | grep -qx -- "${command}" || {
+          echo "NOT EXPORTED: ${command}"
+          exit 1
+        }
+        command -v "${command}" > /dev/null || {
+          echo "EXPORTED BUT MISSING: ${command}"
+          exit 1
+        }
+      done
+      echo "FastSurfer wrapper commands are exportable"
+    expected_output_contains: "FastSurfer wrapper commands are exportable"
+
   - name: FastSurfer version check
     description: Verify FastSurfer reports correct version
     command: run_fastsurfer.sh --version


### PR DESCRIPTION
FastSurfer 2.5.4 declared absolute paths in `DEPLOY_BINS`. Those paths exist inside the image, so the old deploy smoke test passed, but Transparent Singularity uses each entry as a host wrapper filename and as a command resolved through the container `PATH`. As a result, `run_fastsurfer.sh` was not exposed correctly after loading the module.

Export `run_fastsurfer.sh` and `long_fastsurfer.sh` as command names and explicitly add `/fastsurfer` to `PATH`. Add a runtime assertion that both wrapper names are exported and resolvable. The prerequisite release-test fix in #3119 now rejects path-valued `DEPLOY_BINS`, so the candidate gate checks the real wrapper contract.

Validation: recipe schema validation, Dockerfile generation, release planning, 25 focused deploy/release-plan tests, and diff checks passed. The generated Dockerfile contains `DEPLOY_BINS="run_fastsurfer.sh:long_fastsurfer.sh"` and `PATH="/fastsurfer:$PATH"`.
