### PR TITLE
Skip candidate promotion for mixed pull requests

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -117,8 +117,22 @@ jobs:
           MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
         run: |
           base_sha="$(git rev-parse "${MERGE_SHA}^1")"
-          python tools/one_pr_release.py --repo-root . detect \
-            --base "${base_sha}" --head "${MERGE_SHA}"
+          set +e
+          detection="$(python tools/one_pr_release.py --repo-root . detect \
+            --base "${base_sha}" --head "${MERGE_SHA}" 2>&1)"
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            if grep -Fq "Automated releases require a recipe-only PR." <<< "$detection"; then
+              echo "The merged PR changed recipes and other repository code; skipping candidate promotion."
+              echo "recipes=[]" >> "$GITHUB_OUTPUT"
+              echo "release_plan={}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            printf '%s\n' "$detection" >&2
+            exit "$status"
+          fi
+          printf '%s\n' "$detection"
 
   await_candidate:
     needs: resolve

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -54,6 +54,17 @@ def test_candidate_workflow_skips_mixed_prs_without_hiding_other_detection_error
     assert 'exit "$status"' in candidate_workflow
 
 
+def test_promotion_workflow_skips_mixed_prs_without_hiding_other_detection_errors() -> None:
+    promotion_workflow = Path(
+        ".github/workflows/promote-container-candidate.yml"
+    ).read_text()
+
+    assert "Automated releases require a recipe-only PR." in promotion_workflow
+    assert 'echo "recipes=[]" >> "$GITHUB_OUTPUT"' in promotion_workflow
+    assert 'echo "release_plan={}" >> "$GITHUB_OUTPUT"' in promotion_workflow
+    assert 'exit "$status"' in promotion_workflow
+
+
 def test_candidate_workflow_reports_every_premerge_check_in_one_comment() -> None:
     candidate_workflow = Path(".github/workflows/pr-container-candidate.yml").read_text()
     reporter = Path(".github/workflows/report-container-candidate.yml").read_text()

--- a/workflows/AUTO_UPDATE_MIGRATION.md
+++ b/workflows/AUTO_UPDATE_MIGRATION.md
@@ -60,7 +60,7 @@ macro changes select the consuming recipes for candidate builds.
   and aarch64. Its compatibility repair locates the installed `dafne_dl` package
   instead of depending on a versioned Miniconda path, and verifies GUI imports
   and offscreen startup under Python 3.8.
-- All 693 builder tests passed. They cover source selection, update bindings,
+- All 694 builder tests passed. They cover source selection, update bindings,
   metadata/version consistency, checksums, cache behavior, shared-input release
   planning, and PR reuse. An advancing source branch does not create another PR
   while the same container revision already has an open update PR.


### PR DESCRIPTION
The post-merge candidate-promotion workflow failed after PR #3121 because the trusted release planner rejected that mixed code-and-recipe PR. The same rejection was already handled by the pre-merge candidate gate, but the promotion resolver still treated it as an error.

The resolver now converts only the trusted `Automated releases require a recipe-only PR.` result into an empty promotion plan. It still returns every other planner failure. Mixed PRs publish no container artifacts, while recipe-only PRs keep the existing candidate and promotion checks.

Validation:

- Regression test failed before the workflow fix and passes after it
- `pytest -q builder/tests`: 694 passed
- Configured spelling and diff checks passed
