### PR TITLE
Allow source-only recipe changes during promotion

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -523,6 +523,7 @@ jobs:
         env:
           ARTIFACTS: ${{ needs.await_candidate.outputs.artifacts }}
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
         run: |
           jq -s 'add' promotion-metadata/verified-manifest-*.json > verified-manifests.json
@@ -535,7 +536,8 @@ jobs:
           python tools/one_pr_release.py verify-metadata \
             --bundle promotion-metadata/release-previews \
             --manifests verified-manifests.json \
-            --head-sha "${HEAD_SHA}" --pr-number "${PR_NUMBER}"
+            --head-sha "${HEAD_SHA}" --merge-sha "${MERGE_SHA}" \
+            --pr-number "${PR_NUMBER}"
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -459,6 +459,63 @@ def test_verify_published_metadata_rechecks_identity_without_large_artifacts(
         )
 
 
+def test_verify_published_metadata_allows_only_source_changes_since_merge(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Concurrent source metadata must not invalidate a published candidate."""
+    monkeypatch.setattr(one_pr_release, "REPO_ROOT", tmp_path)
+    git = one_pr_release.run_git
+    git("init", "-b", "main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "test")
+    recipe_dir = write_recipe(tmp_path)
+    git("add", ".")
+    git("commit", "-m", "Merge candidate")
+    merge_sha = git("rev-parse", "HEAD")
+
+    recipe = yaml.safe_load((recipe_dir / "build.yaml").read_text(encoding="utf-8"))
+    bundle = tmp_path / "release-previews"
+    candidate_dir = bundle / "demo"
+    candidate_dir.mkdir(parents=True)
+    release = release_data("demo", "1.2.3", recipe, "20260721", "x86_64")
+    (candidate_dir / "1.2.3.json").write_text(json.dumps(release), encoding="utf-8")
+    manifest = {
+        "recipe": "demo",
+        "container": "demo",
+        "variant": "",
+        "architecture": "x86_64",
+        "version": "1.2.3",
+        "build_date": "20260721",
+        "image_name": "demo_1.2.3",
+        "pr_number": 42,
+        "head_sha": "abc123",
+        "candidate_tag": "nd-candidate-demo:abc123",
+        "recipe_fingerprint": one_pr_release.recipe_fingerprint("demo"),
+        "docker_archive": "demo_1.2.3_20260721.docker.tar",
+        "docker_sha256": "1" * 64,
+        "sif": "demo_1.2.3_20260721.simg",
+        "sif_sha256": "2" * 64,
+        "release_json": "1.2.3.json",
+    }
+    manifests_path = tmp_path / "verified-manifests.json"
+    manifests_path.write_text(json.dumps([manifest]), encoding="utf-8")
+
+    recipe["auto_update"] = {"method": "dockerhub", "repo": "example/demo"}
+    (recipe_dir / "build.yaml").write_text(yaml.safe_dump(recipe), encoding="utf-8")
+    git("commit", "-am", "Add update metadata")
+    assert one_pr_release.verify_published_metadata(
+        bundle, manifests_path, "abc123", 42, merge_sha
+    ) == [manifest]
+
+    recipe["build"]["base-image"] = "ubuntu:24.10"
+    (recipe_dir / "build.yaml").write_text(yaml.safe_dump(recipe), encoding="utf-8")
+    git("commit", "-am", "Change image")
+    with pytest.raises(RuntimeError, match="differs from published candidate"):
+        one_pr_release.verify_published_metadata(
+            bundle, manifests_path, "abc123", 42, merge_sha
+        )
+
+
 def test_detect_targets_expands_declared_architectures(tmp_path: Path, monkeypatch) -> None:
     """Every architecture a recipe declares becomes its own build target."""
     recipe_dir = write_recipe(tmp_path)

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -118,6 +118,13 @@ def test_candidate_workflow_reports_every_premerge_check_in_one_comment() -> Non
     assert "pull-requests: write" not in validator
 
 
+def test_promotion_finalizer_classifies_changes_since_candidate_merge() -> None:
+    workflow = Path(".github/workflows/promote-container-candidate.yml").read_text()
+
+    assert 'MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}' in workflow
+    assert '--merge-sha "${MERGE_SHA}"' in workflow
+
+
 def test_recipe_pr_validation_checks_fulltest_only_changes() -> None:
     workflow = Path(".github/workflows/validate-recipes.yml").read_text()
 

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -192,6 +192,29 @@ def detect_recipes(base: str, head: str) -> list[str]:
     return release_plan(base, head).candidate_recipes
 
 
+def recipe_changes_since_merge_are_source_only(recipe: str, merge_sha: str) -> bool:
+    """Allow finalization past concurrent changes that preserve the image."""
+    base_recipe = load_recipe_at(merge_sha, recipe)
+    head_recipe = load_recipe_at("HEAD", recipe)
+    recipe_prefix = f"recipes/{recipe}/"
+    relevant_paths = [
+        path
+        for path in changed_files(merge_sha, "HEAD")
+        if path.startswith(recipe_prefix)
+        or path_is_shared_input(path, base_recipe)
+        or path_is_shared_input(path, head_recipe)
+    ]
+    if not relevant_paths:
+        return False
+
+    plan = plan_recipe_changes(
+        relevant_paths,
+        {recipe: base_recipe},
+        {recipe: head_recipe},
+    )
+    return plan.source_only_recipes == [recipe]
+
+
 def build_date(recipe: str, revision: str = "HEAD") -> str:
     """Return the last build.yaml commit date in release-tag format."""
     data = load_recipe_at(revision, recipe)
@@ -688,6 +711,7 @@ def verify_published_metadata(
     manifests_path: Path,
     expected_head_sha: str,
     expected_pr_number: int,
+    expected_merge_sha: str | None = None,
 ) -> list[dict[str, Any]]:
     """Revalidate small promotion metadata after large artifacts are published."""
     try:
@@ -730,7 +754,14 @@ def verify_published_metadata(
             raise RuntimeError(f"Published head SHA mismatch for {container}")
         if manifest.get("pr_number") != expected_pr_number:
             raise RuntimeError(f"Published PR number mismatch for {container}")
-        if manifest.get("recipe_fingerprint") != recipe_fingerprint(recipe):
+        fingerprint_changed = (
+            manifest.get("recipe_fingerprint") != recipe_fingerprint(recipe)
+        )
+        source_only_change = (
+            expected_merge_sha is not None
+            and recipe_changes_since_merge_are_source_only(recipe, expected_merge_sha)
+        )
+        if fingerprint_changed and not source_only_change:
             raise RuntimeError(
                 f"Merged recipe differs from published candidate: {container}"
             )
@@ -788,6 +819,7 @@ def command_verify_metadata(args: argparse.Namespace) -> None:
         Path(args.manifests),
         args.head_sha,
         args.pr_number,
+        args.merge_sha,
     )
 
 
@@ -855,6 +887,7 @@ def parser() -> argparse.ArgumentParser:
     verify_metadata.add_argument("--bundle", required=True)
     verify_metadata.add_argument("--manifests", required=True)
     verify_metadata.add_argument("--head-sha", required=True)
+    verify_metadata.add_argument("--merge-sha", required=True)
     verify_metadata.add_argument("--pr-number", required=True, type=int)
     verify_metadata.set_defaults(func=command_verify_metadata)
 


### PR DESCRIPTION
Candidate promotion can fail after all artifacts are staged when another PR changes only source metadata in the same recipe. FastSurfer #3120 hit this race: #3121 added `auto_update` after the candidate merge, and finalization rejected the resulting byte-level recipe fingerprint mismatch even though the trusted release planner classifies `auto_update` as source-only.

Pass the candidate merge SHA into finalization. When the current recipe fingerprint differs, use the trusted release planner to classify only that recipe's changes since its merge. Continue only for source-only changes; candidate-required recipe files, build fields, and shared build inputs still fail closed. Release metadata is still recomputed and compared against the staged preview afterward.

The regression test accepts a concurrent `auto_update` addition, then changes the base image and proves the same candidate is rejected.

Validation: `pytest builder/tests` (696 passed), the exact FastSurfer merge-to-main change classifies as source-only, Python compilation, workflow contract checks, and `git diff --check`.

This unblocks retrying the staged, tested candidate from #3120 without rebuilding it.
