### PR TITLE
Apply source-only policy during promotion verification

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -287,10 +287,12 @@ jobs:
       - name: Verify candidate against merged recipes and checksums
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
         run: |
           python tools/one_pr_release.py verify --bundle promotion-bundle \
-            --head-sha "${HEAD_SHA}" --pr-number "${PR_NUMBER}" \
+            --head-sha "${HEAD_SHA}" --merge-sha "${MERGE_SHA}" \
+            --pr-number "${PR_NUMBER}" \
             --output verified-manifests.json
       - name: Prepare trusted promotion metadata
         env:
@@ -655,6 +657,7 @@ jobs:
       - name: Commit generated release metadata directly to main
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           RELEASE_TOKEN: ${{ steps.metadata-token.outputs.token }}
         run: |
@@ -681,7 +684,8 @@ jobs:
             python tools/one_pr_release.py verify-metadata \
               --bundle promotion-metadata/release-previews \
               --manifests verified-manifests.json \
-              --head-sha "${HEAD_SHA}" --pr-number "${PR_NUMBER}"
+              --head-sha "${HEAD_SHA}" --merge-sha "${MERGE_SHA}" \
+              --pr-number "${PR_NUMBER}"
             if git -c http.https://github.com/.extraheader="${git_auth_header}" \
                 push origin HEAD:main; then
               exit 0

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -293,6 +293,24 @@ def test_verify_candidate_binds_artifacts_to_pr_and_recipe(
     verified = one_pr_release.verify_candidate(candidate_dir, "abc123", 42)
     assert verified["recipe"] == "demo"
 
+    manifest["recipe_fingerprint"] = "0" * 64
+    (candidate_dir / "manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        one_pr_release,
+        "recipe_changes_since_merge_are_source_only",
+        lambda recipe, merge_sha: recipe == "demo" and merge_sha == "merge123",
+    )
+    verified = one_pr_release.verify_candidate(
+        candidate_dir, "abc123", 42, "merge123"
+    )
+    assert verified["recipe"] == "demo"
+    manifest["recipe_fingerprint"] = one_pr_release.recipe_fingerprint("demo")
+    (candidate_dir / "manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
     manifest["image_name"] = "forged_image"
     (candidate_dir / "manifest.json").write_text(
         json.dumps(manifest), encoding="utf-8"

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -121,8 +121,8 @@ def test_candidate_workflow_reports_every_premerge_check_in_one_comment() -> Non
 def test_promotion_finalizer_classifies_changes_since_candidate_merge() -> None:
     workflow = Path(".github/workflows/promote-container-candidate.yml").read_text()
 
-    assert 'MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}' in workflow
-    assert '--merge-sha "${MERGE_SHA}"' in workflow
+    assert workflow.count('MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}') == 3
+    assert workflow.count('--merge-sha "${MERGE_SHA}"') == 3
 
 
 def test_recipe_pr_validation_checks_fulltest_only_changes() -> None:

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -607,7 +607,10 @@ def load_candidate_manifest(candidate_dir: Path) -> dict[str, Any]:
 
 
 def verify_candidate(
-    candidate_dir: Path, expected_head_sha: str, expected_pr_number: int | None = None
+    candidate_dir: Path,
+    expected_head_sha: str,
+    expected_pr_number: int | None = None,
+    expected_merge_sha: str | None = None,
 ) -> dict[str, Any]:
     """Verify a candidate against its PR identity and the merged recipe."""
     manifest = load_candidate_manifest(candidate_dir)
@@ -639,7 +642,12 @@ def verify_candidate(
         raise RuntimeError(f"Candidate head SHA mismatch for {container}")
     if expected_pr_number is not None and manifest["pr_number"] != expected_pr_number:
         raise RuntimeError(f"Candidate PR number mismatch for {container}")
-    if manifest["recipe_fingerprint"] != recipe_fingerprint(recipe):
+    fingerprint_changed = manifest["recipe_fingerprint"] != recipe_fingerprint(recipe)
+    source_only_change = (
+        expected_merge_sha is not None
+        and recipe_changes_since_merge_are_source_only(recipe, expected_merge_sha)
+    )
+    if fingerprint_changed and not source_only_change:
         raise RuntimeError(f"Merged recipe differs from tested candidate: {container}")
 
     expected_release_json = f"{expected_info['version']}.json"
@@ -696,7 +704,7 @@ def verify_candidate(
 def command_verify(args: argparse.Namespace) -> None:
     """Verify all candidate directories and write their trusted manifests."""
     manifests = [
-        verify_candidate(path.parent, args.head_sha, args.pr_number)
+        verify_candidate(path.parent, args.head_sha, args.pr_number, args.merge_sha)
         for path in sorted(Path(args.bundle).glob("*/manifest.json"))
     ]
     if not manifests:
@@ -879,6 +887,7 @@ def parser() -> argparse.ArgumentParser:
     verify = subparsers.add_parser("verify")
     verify.add_argument("--bundle", required=True)
     verify.add_argument("--head-sha", required=True)
+    verify.add_argument("--merge-sha", required=True)
     verify.add_argument("--pr-number", required=True, type=int)
     verify.add_argument("--output", required=True)
     verify.set_defaults(func=command_verify)


### PR DESCRIPTION
Recovery promotion still failed at candidate verification because a fresh publish job checks the candidate against current `main` before finalization. If a concurrent recipe edit only changes release-source metadata such as `auto_update`, the candidate remains valid but its byte-level recipe fingerprint changes.

Extend the merge-SHA/source-only policy to candidate verification and the metadata push retry. All three trusted verification points now accept only changes that the release planner classifies as source-only; runtime-affecting changes continue to invalidate the candidate.

Validation: `pytest -q builder/tests` (696 passed)

Follow-up to #3124. Unblocks recovery of the tested FastSurfer candidate from #3120.
