### PR TITLE
Qualify Docker Hub references for ORAS finalization

### DIFF
--- a/.github/workflows/promote-container-candidate.yml
+++ b/.github/workflows/promote-container-candidate.yml
@@ -371,7 +371,7 @@ jobs:
           push_mandatory_ghcr "${ghcr}"
 
           for destination in \
-            "${DOCKERHUB_ORG}/${legacy}:${staging_tag}" \
+            "docker.io/${DOCKERHUB_ORG}/${legacy}:${staging_tag}" \
             "registry.rc.nectar.org.au/ssdsorg/${legacy}:${staging_tag}"; do
             docker tag "${source}" "${destination}"
             docker push "${destination}" || \
@@ -609,7 +609,7 @@ jobs:
             done
 
             for destination in \
-              "${DOCKERHUB_ORG}/${legacy}" \
+              "docker.io/${DOCKERHUB_ORG}/${legacy}" \
               "registry.rc.nectar.org.au/ssdsorg/${legacy}"; do
               for tag in "${build_date}" latest; do
                 retag_optional "${destination}:${staging_tag}" "${tag}"

--- a/builder/tests/test_workflow_contract.py
+++ b/builder/tests/test_workflow_contract.py
@@ -191,9 +191,11 @@ def test_candidate_promotion_retries_mandatory_ghcr_pushes() -> None:
     assert "Mandatory GHCR publish failed after 3 attempts" in publish_steps
     assert 'push_mandatory_ghcr "${legacy_ghcr}"' in publish_steps
     assert 'push_mandatory_ghcr "${ghcr}"' in publish_steps
+    assert '"docker.io/${DOCKERHUB_ORG}/${legacy}:${staging_tag}"' in publish_steps
     assert "retag_mandatory()" in finalize_steps
     assert 'if oras tag "${source}" "${tag}"; then' in finalize_steps
     assert 'retag_mandatory "${ghcr}:${staging_tag}" "${tag}"' in finalize_steps
+    assert '"docker.io/${DOCKERHUB_ORG}/${legacy}"' in finalize_steps
 
 
 def test_candidate_promotion_syncs_openrecon_from_verified_manifests() -> None:


### PR DESCRIPTION
FastSurfer promotion staged its Docker Hub image successfully, but final public tag creation failed because ORAS interpreted the unqualified `${DOCKERHUB_ORG}/...` reference as a registry hostname.

Qualify Docker Hub image references with `docker.io/` in both staging and finalization, and lock the contract into the workflow tests. This lets the existing tested FastSurfer candidate finish its Docker Hub release tags on recovery.

Validation: `pytest -q builder/tests` (696 passed)

Observed in promotion run 34388445347 for #3120.
