### PR TITLE
Republish FastSurfer 2.4.2 with executable wrappers

### DIFF
--- a/recipes/fastsurfer/build.yaml
+++ b/recipes/fastsurfer/build.yaml
@@ -1,5 +1,5 @@
 name: fastsurfer
-version: 2.5.4
+version: 2.4.2
 copyright:
   - license: Apache-2.0
     url: https://github.com/Deep-MI/FastSurfer/blob/dev/LICENSE

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -492,7 +492,7 @@ tests:
   # ==========================================================================
   - name: Container entrypoint available
     description: Verify the upstream runtime entrypoint is executable
-    command: test -x /fastsurfer/tools/Docker/entrypoint.sh
+    command: test -x /fastsurfer/tools/Docker/entrypoint.sh || test -x /fastsurfer/Docker/entrypoint.sh
     expected_exit_code: 0
 
 cleanup:

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -14,7 +14,7 @@
 # help messages, and basic functionality that can run quickly.
 
 name: fastsurfer
-version: 2.5.4
+version: 2.4.2
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
FastSurfer 2.4.2 was published with absolute `DEPLOY_BINS` entries, so Transparent Singularity could not create usable host wrapper commands for `run_fastsurfer.sh` and `long_fastsurfer.sh`.

Rebuild 2.4.2 from its upstream CPU image using the corrected recipe contract: `/fastsurfer` is on `PATH`, both deployment entries are command basenames, and the focused fulltest checks that each command is exported and resolves at runtime.

After this historical release is promoted, the recipe will be restored to the current 2.5.4 version in a follow-up PR.

Validation:
- `python3 builder/validation.py recipes/fastsurfer/build.yaml --verbose`
- `python3 -m builder generate fastsurfer --recreate`
- `python3 -m pytest builder/tests/test_release_plan.py builder/tests/test_one_pr_release.py -q` (39 passed)

Related to #3113.
