### PR TITLE
Bump afib1 from 1.6.0 to 1.6.0.post1

### DIFF
--- a/recipes/afib1/build.yaml
+++ b/recipes/afib1/build.yaml
@@ -1,5 +1,5 @@
 name: afib1
-version: 1.6.0
+version: "1.6.0.post1"
 architectures:
     - x86_64
     - aarch64
@@ -12,8 +12,8 @@ variables:
   openrecon_server_commit: "33362f2139701fbf5ea855808a325eb59b7db2ae"
   openrecon_python_tools_commit: "17fe6fbf1bb645112e2ad0023eb4f42afb36421e"
   openrecon_siemens_commit: "055eefc09dfa77fbf11fff85979dea9ef2879ba5"
-  openrecon_ismrmrd_version: "1.14.2"
-  base_image_digest: sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc
+  openrecon_ismrmrd_version: "1.15.0"
+  base_image_digest: "sha256:829f6df217bcbae2b371026e81711d1a787c61b2967ad09d015063663ebafbf7"
   fsl_bet2_commit: d5acd7fe09a34679aaac63f67f20409abf2ed3b9
 
 auto_update:

--- a/recipes/afib1/fulltest.yaml
+++ b/recipes/afib1/fulltest.yaml
@@ -1,5 +1,5 @@
 name: afib1
-version: 1.6.0
+version: "1.6.0.post1"
 
 test_data:
   output_dir: test_output


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/afib1/build.yaml`
- Upstream release: https://github.com/ismrmrd/ismrmrd/releases/tag/v1.15.0, https://registry-1.docker.io/v2/library/ubuntu/manifests/22.04

### Changes
- `variables.base_image_digest`: `sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc` → `sha256:829f6df217bcbae2b371026e81711d1a787c61b2967ad09d015063663ebafbf7`
- `variables.openrecon_ismrmrd_version`: `1.14.2` → `1.15.0`
- `fulltest.yaml` version: `1.6.0` → `1.6.0.post1`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.