### PR TITLE
Bump aidamri from 2.0 to 3.0

### DIFF
--- a/recipes/aidamri/build.yaml
+++ b/recipes/aidamri/build.yaml
@@ -1,5 +1,5 @@
 name: aidamri
-version: "2.0"
+version: "3.0"
 
 copyright:
   - license: GPL-3.0-only

--- a/recipes/aidamri/fulltest.yaml
+++ b/recipes/aidamri/fulltest.yaml
@@ -1,5 +1,5 @@
 name: aidamri
-version: "2.0"
+version: "3.0"
 
 test_data:
   output_dir: test_output/aidamri


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/aidamri/build.yaml`
- Upstream release: https://github.com/Aswendt-Lab/AIDAmri/releases/tag/v3.0

### Changes
- `version`: `2.0` → `3.0`
- `fulltest.yaml` version: `2.0` → `3.0`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.