### PR TITLE
Bump amico from 2.1.0.post1 to 2.1.0.post2

### DIFF
--- a/recipes/amico/build.yaml
+++ b/recipes/amico/build.yaml
@@ -1,7 +1,7 @@
 name: amico
-version: 2.1.0.post1
+version: "2.1.0.post2"
 variables:
-  upstream_version: 2.1.0
+  upstream_version: "2.1.1"
 architectures:
   - x86_64
   - aarch64

--- a/recipes/amico/fulltest.yaml
+++ b/recipes/amico/fulltest.yaml
@@ -28,8 +28,8 @@
 # utility functions, and synthetic signal generation.
 
 name: amico
-version: 2.1.0.post1
-upstream_version: 2.1.0
+version: "2.1.0.post2"
+upstream_version: "2.1.1"
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/amico/build.yaml`
- Upstream release: https://pypi.org/project/dmri-amico/2.1.1/

### Changes
- `variables.upstream_version`: `2.1.0` → `2.1.1`
- `fulltest.yaml` version: `2.1.0.post1` → `2.1.0.post2`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.