### PR TITLE
Bump apptainer from 1.4.4 to 1.5.3

### DIFF
--- a/recipes/apptainer/build.yaml
+++ b/recipes/apptainer/build.yaml
@@ -1,5 +1,5 @@
 name: apptainer
-version: 1.4.4
+version: 1.5.3
 
 architectures:
   - x86_64

--- a/recipes/apptainer/fulltest.yaml
+++ b/recipes/apptainer/fulltest.yaml
@@ -6,7 +6,7 @@
 # the ARM64 port is complete.
 
 name: apptainer
-version: 1.4.4
+version: 1.5.3
 
 setup:
   script: |


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/apptainer/build.yaml`
- Upstream release: https://github.com/apptainer/apptainer/releases/tag/v1.5.3

### Changes
- `version`: `1.4.4` → `1.5.3`
- `fulltest.yaml` version: `1.4.4` → `1.5.3`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.