### PR TITLE
Restore FastSurfer recipe to 2.5.4

### DIFF
--- a/recipes/fastsurfer/build.yaml
+++ b/recipes/fastsurfer/build.yaml
@@ -1,5 +1,5 @@
 name: fastsurfer
-version: 2.4.2
+version: 2.5.4
 copyright:
   - license: Apache-2.0
     url: https://github.com/Deep-MI/FastSurfer/blob/dev/LICENSE

--- a/recipes/fastsurfer/fulltest.yaml
+++ b/recipes/fastsurfer/fulltest.yaml
@@ -14,7 +14,7 @@
 # help messages, and basic functionality that can run quickly.
 
 name: fastsurfer
-version: 2.4.2
+version: 2.5.4
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
Restore FastSurfer 2.5.4 as the current recipe after the corrected historical 2.4.2 candidate was tested and published in #3127.

The executable-wrapper fix remains in place: `/fastsurfer` stays on `PATH`, `DEPLOY_BINS` contains command basenames, and the fulltest checks both wrapper exports. The entrypoint check also supports both upstream directory layouts observed in 2.4.2 and 2.5.4.

Validation:
- `python3 builder/validation.py recipes/fastsurfer/build.yaml --verbose`
- `python3 -m builder generate fastsurfer --recreate`
- `python3 -m pytest builder/tests/test_release_plan.py builder/tests/test_one_pr_release.py -q` (39 passed)
