### PR TITLE
Fix MetaBody color output modes

### DIFF
--- a/recipes/metabody/OpenReconLabel.json
+++ b/recipes/metabody/OpenReconLabel.json
@@ -58,36 +58,40 @@
     },
     {
       "id": "colormap",
-      "label": { "en": "Colormap name" },
+      "label": { "en": "Output appearance" },
       "type": "choice",
       "values": [
         {
-          "id": "none",
-          "name": { "en": "none" }
+          "id": "scanner_lut",
+          "name": { "en": "Scanner hot metal (most compatible)" }
         },
         {
           "id": "seismic",
-          "name": { "en": "seismic" }
+          "name": { "en": "Seismic (embedded RGB)" }
         },
         {
           "id": "jet",
-          "name": { "en": "jet" }
+          "name": { "en": "Jet (embedded RGB)" }
         },
         {
           "id": "gray",
-          "name": { "en": "gray" }
+          "name": { "en": "Gray (embedded RGB)" }
         },
         {
           "id": "coolwarm",
-          "name": { "en": "coolwarm" }
+          "name": { "en": "Coolwarm (embedded RGB)" }
         },
         {
           "id": "bwr",
-          "name": { "en": "bwr" }
+          "name": { "en": "Blue-white-red (embedded RGB)" }
+        },
+        {
+          "id": "none",
+          "name": { "en": "Grayscale" }
         }
       ],
-      "default": "seismic",
-      "information": { "en": "Matplotlib colormap to use." }
+      "default": "scanner_lut",
+      "information": { "en": "Use the scanner palette, embed a color map in the image, or return grayscale." }
     }
   ]
 }

--- a/recipes/metabody/OpenReconREADME.md
+++ b/recipes/metabody/OpenReconREADME.md
@@ -19,12 +19,20 @@ foot, right foot, left hand, right hand, and tongue contrasts.
 | --- | --- | --- | --- | --- |
 | Configuration | `config` | choice | `metabody` | Run the Metabody MRD server configuration. |
 | Send original images | `sendOriginal` | boolean | `true` | Return copies of the input images as series 99 before the statistical maps. |
-| Colormap name | `colormap` | choice | `seismic` | Apply a Matplotlib colormap to the statistical maps. Select `none` for grayscale output. |
+| Output appearance | `colormap` | choice | `scanner_lut` | Use the scanner hot-metal palette, embed a selected color map as RGB, or return grayscale output. |
+
+The scanner hot-metal option returns one scalar channel and asks the scanner to
+apply `MicroDeltaHotMetal.pal`. This is the recommended and most compatible
+color output. The grayscale option also returns one scalar channel but does not
+request a palette. Named Matplotlib color maps are embedded as three-channel RGB
+data and remain experimental until scanner round-trip behavior is confirmed.
 
 ## Runtime Notes
 
 - AFNI model settings are fixed in the bundled `afni_processing.sh` workflow.
 - Returned statistical maps carry `ImageComments` labels from the AFNI output.
+- Palette and embedded RGB modes are mutually exclusive. Embedded RGB images do
+  not carry scanner palette or windowing metadata.
 - The processor uses the incoming slice and repetition counters to stack images,
   so their arrival order does not affect the 4D NIfTI layout.
 - Runtime work is written under temporary directories such as `/tmp/afni`, not

--- a/recipes/metabody/build.yaml
+++ b/recipes/metabody/build.yaml
@@ -1,5 +1,5 @@
 name: metabody
-version: 1.0.4
+version: 1.0.5
 architectures:
     - x86_64
 

--- a/recipes/metabody/build.yaml
+++ b/recipes/metabody/build.yaml
@@ -193,8 +193,8 @@ build:
               - chmod +x /opt/code/python-ismrmrd-server/mrd2dicom.py
               - chmod +x /opt/code/afni_processing.sh
 deploy:
-    bins:
-        - /opt/code/afni_processing.sh
+    path:
+        - /opt/code
 
 categories:
   - functional imaging

--- a/recipes/metabody/fulltest.yaml
+++ b/recipes/metabody/fulltest.yaml
@@ -1,5 +1,5 @@
 name: metabody
-version: 1.0.4
+version: 1.0.5
 
 tests:
   - name: OpenRecon server help

--- a/recipes/metabody/metabody.py
+++ b/recipes/metabody/metabody.py
@@ -3,6 +3,7 @@ import logging
 import os
 import subprocess
 import traceback
+from dataclasses import dataclass
 
 import ismrmrd
 import matplotlib.pyplot as plt
@@ -18,7 +19,105 @@ debugFolder = "/tmp/share/debug"
 ORIGINAL_SERIES_INDEX = 99
 PROCESSED_SERIES_INDEX = ORIGINAL_SERIES_INDEX + 1
 RGB_IMAGE_TYPE = 6
+SCANNER_LUT_OUTPUT = "scanner_lut"
+GRAYSCALE_OUTPUT = "none"
+SCANNER_LUT_FILENAME = "MicroDeltaHotMetal.pal"
 DEFAULT_REPETITION_TIME_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class EmbeddedRgbOutput:
+    colormap: str
+
+
+@dataclass(frozen=True)
+class ScannerPaletteOutput:
+    pass
+
+
+@dataclass(frozen=True)
+class GrayscaleOutput:
+    pass
+
+
+@dataclass(frozen=True)
+class OutputEncoding:
+    data: np.ndarray
+    image_type: int
+    processing_history: tuple[str, ...]
+    sequence_description: str
+    window_center: str | None = None
+    window_width: str | None = None
+    internal_send: int | None = None
+    lut_file_name: str | None = None
+
+
+def resolve_output_spec(config):
+    value = mrdhelper.get_json_config_param(
+        config,
+        "colormap",
+        default="seismic",
+    )
+    if value == SCANNER_LUT_OUTPUT:
+        return ScannerPaletteOutput()
+    if value == GRAYSCALE_OUTPUT:
+        return GrayscaleOutput()
+    if not isinstance(value, str):
+        raise ValueError("Output appearance must be a string")
+
+    try:
+        plt.get_cmap(value)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported output appearance: {value!r}") from exc
+    return EmbeddedRgbOutput(value)
+
+
+def encode_output_data(data, output_spec, max_value):
+    scalar_data = data.astype(np.float64)
+    scalar_data *= max_value / scalar_data.max()
+    scalar_data = np.around(scalar_data)
+
+    if isinstance(output_spec, EmbeddedRgbOutput):
+        logging.info(
+            'Converting data into embedded RGB using colormap "%s"',
+            output_spec.colormap,
+        )
+        normalized_data = scalar_data.astype(np.float64)
+        normalized_data -= normalized_data.min()
+        normalized_data *= 1 / normalized_data.max()
+        rgb_data = plt.get_cmap(output_spec.colormap)(normalized_data)
+        rgb_data = rgb_data[..., 0:-1]
+        rgb_data = rgb_data.transpose((5, 0, 1, 2, 3, 4))
+        rgb_data *= 255
+        return OutputEncoding(
+            data=rgb_data.astype(np.uint16),
+            image_type=RGB_IMAGE_TYPE,
+            processing_history=("PYTHON", "METABODY", "RGB"),
+            sequence_description="FIRE_RGB",
+            internal_send=1,
+        )
+
+    scalar_data = scalar_data.astype(np.int16)
+    if isinstance(output_spec, ScannerPaletteOutput):
+        logging.info("Using the scanner hot-metal palette")
+        return OutputEncoding(
+            data=scalar_data,
+            image_type=ismrmrd.IMTYPE_MAGNITUDE,
+            processing_history=("PYTHON", "METABODY", "LUT"),
+            sequence_description="FIRE_LUT",
+            window_center=str((max_value + 1) / 2),
+            window_width=str(max_value + 1),
+            lut_file_name=SCANNER_LUT_FILENAME,
+        )
+
+    return OutputEncoding(
+        data=scalar_data,
+        image_type=ismrmrd.IMTYPE_MAGNITUDE,
+        processing_history=("PYTHON", "METABODY"),
+        sequence_description="OpenRecon",
+        window_center=str((max_value + 1) / 2),
+        window_width=str(max_value + 1),
+    )
 
 
 def get_repetition_time_seconds(image_meta):
@@ -193,10 +292,7 @@ def process_image(images, connection, config, metadata):
     send_originals = mrdhelper.get_json_config_param(
         config, 'sendOriginal', default=True
     )
-    colormap = mrdhelper.get_json_config_param(
-        config, 'colormap', default='seismic'
-    )
-    do_rgb = colormap != 'none'
+    output_spec = resolve_output_spec(config)
 
     # Note: The MRD Image class stores data as [cha z y x]
     # Extract image data into a 5D array of size [img cha z y x]
@@ -347,37 +443,8 @@ def process_image(images, connection, config, metadata):
     #     BitsStored = mrdhelper.get_userParameterLong_value(metadata, "BitsStored")
     maxVal = 2**BitsStored - 1
 
-    # Normalize data
-    data = data.astype(np.float64)
-    data *= maxVal/data.max()
-    data = np.around(data)
-
-    if do_rgb:
-        logging.info(f'Converting data into RGB using colormap "{colormap}"')
-
-        # Normalize to (0.0, 1.0) as expected by get_cmap()
-        data = data.astype(np.float64)
-        data -= data.min()
-        data *= 1/data.max()
-
-        # Apply colormap
-        cmap = plt.get_cmap(colormap)
-        rgb = cmap(data)
-
-        # Remove alpha channel. The input shape is
-        # [cha y x rep slice 4] where the last dimension is RGBA.
-        # `cha` can be replaced by RGB and become `z` (see the required
-        # shape when creating the ISMRMRD Image with `cha` below).
-        rgb = rgb[...,0:-1]
-        rgb = rgb.transpose((5, 0, 1, 2, 3, 4))
-        # rgb = rgb.squeeze()
-
-        # MRD RGB images must be uint16 in range (0, 255)
-        rgb *= 255
-        data = rgb.astype(np.uint16)
-        # np.save(debugFolder + "/" + "imgRGB.npy", data)
-    else:
-        data = data.astype(np.int16)
+    output_encoding = encode_output_data(data, output_spec, maxVal)
+    data = output_encoding.data
 
     # Re-slice image data back into 2D images.
     # Preallocate outputs for speed and efficiency.
@@ -406,9 +473,6 @@ def process_image(images, connection, config, metadata):
             # with this option, can take input as: [cha z y x], [z y x], or [y x]
             img_data = data[..., stat, slice_position]
             # logging.debug(f'Output image data shape for slice {slc} and stat {stat}: {img_data.shape}')
-            # if do_rgb:
-            #     # Make sure RGB takes place of 'cha'.
-            #     img_data = np.expand_dims(img_data, axis=1)
             imagesOut[out_idx] = ismrmrd.Image.from_array(img_data, transpose=False)
 
             # Create a copy of the original fixed header and update the data_type
@@ -421,41 +485,43 @@ def process_image(images, connection, config, metadata):
             oldHeader.slice = slice_id
             oldHeader.repetition = stat
             oldHeader.image_index = out_idx + 1
-            if do_rgb:
-                # Set RGB parameters
-                # To be defined as ismrmrd.IMTYPE_RGB
-                oldHeader.image_type = RGB_IMAGE_TYPE
-                # RGB "channels".  This is set by from_array, but need to
-                # be explicit as we're copying the old header instead.
-                # Otherwise the data itself gets amended.
-                oldHeader.channels = 3
+            oldHeader.image_type = output_encoding.image_type
+            # from_array() sets the channel count, but setHead() replaces that
+            # header with this geometry copy.
+            oldHeader.channels = imagesOut[out_idx].channels
             imagesOut[out_idx].setHead(oldHeader)
 
             # Stat maps are first in the output
             img_comment = stat_labels[stat] if stat <= len(stat_labels)-1 else 'fMRI'
             # Create a copy of the original ISMRMRD Meta attributes and update
             tmpMeta = ismrmrd.Meta.deserialize(meta[header_index].serialize())
-            tmpMeta['DataRole']                       = 'Image'
-            tmpMeta['ImageProcessingHistory']         = ['PYTHON', 'METABODY']
-            tmpMeta['WindowCenter']                   = str((maxVal+1)/2)
-            tmpMeta['WindowWidth']                    = str((maxVal+1))
-            tmpMeta['SequenceDescriptionAdditional']  = 'OpenRecon'
-            tmpMeta['Keep_image_geometry']            = 1
-            tmpMeta['ImageComments']                  = img_comment
+            for key in (
+                'InternalSend',
+                'LUTFileName',
+                'WindowCenter',
+                'WindowWidth',
+            ):
+                if tmpMeta.get(key) is not None:
+                    del tmpMeta[key]
 
-            # Example for setting RGB
-            if do_rgb:
-                tmpMeta['SequenceDescriptionAdditional']  = 'FIRE_RGB'
-                tmpMeta['ImageProcessingHistory'].append('RGB')
+            tmpMeta['DataRole'] = 'Image'
+            tmpMeta['ImageProcessingHistory'] = list(
+                output_encoding.processing_history
+            )
+            tmpMeta['SequenceDescriptionAdditional'] = (
+                output_encoding.sequence_description
+            )
+            tmpMeta['Keep_image_geometry'] = 1
+            tmpMeta['ImageComments'] = img_comment
 
-                # RGB images have no windowing
-                del tmpMeta['WindowCenter']
-                del tmpMeta['WindowWidth']
-
-                # RGB images shouldn't undergo further processing, e.g. orientation or distortion correction
-                tmpMeta['InternalSend'] = 1
-
-                tmpMeta['LUTFileName'] = 'MicroDeltaHotMetal.pal'
+            if output_encoding.window_center is not None:
+                tmpMeta['WindowCenter'] = output_encoding.window_center
+            if output_encoding.window_width is not None:
+                tmpMeta['WindowWidth'] = output_encoding.window_width
+            if output_encoding.internal_send is not None:
+                tmpMeta['InternalSend'] = output_encoding.internal_send
+            if output_encoding.lut_file_name is not None:
+                tmpMeta['LUTFileName'] = output_encoding.lut_file_name
 
             # Add image orientation directions to MetaAttributes if not already present
             if tmpMeta.get('ImageRowDir') is None:

--- a/recipes/metabody/test_metabody.py
+++ b/recipes/metabody/test_metabody.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import subprocess
 import sys
 import types
@@ -7,6 +8,7 @@ from pathlib import Path
 import ismrmrd
 import nibabel as nib
 import numpy as np
+import pytest
 
 
 RECIPE_DIR = Path(__file__).parent
@@ -64,6 +66,102 @@ def make_image(
         metadata["RepetitionTime"] = str(repetition_time_ms)
     image.attribute_string = metadata.serialize()
     return image
+
+
+def render_single_stat(monkeypatch, colormap: str):
+    metabody = load_metabody_module()
+    source = make_image(0, 0, 10)
+    monkeypatch.setattr(metabody.nib, "save", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(metabody.subprocess, "run", lambda *_args, **_kwargs: None)
+
+    stat_data = np.arange(6, dtype=np.float32).reshape(2, 3, 1, 1) + 1
+    stat_image = nib.Nifti1Image(stat_data, np.eye(4))
+    monkeypatch.setattr(
+        metabody,
+        "show_stats",
+        lambda *_args, **_kwargs: (["stat-0"], stat_image),
+    )
+
+    output = metabody.process_image(
+        [source],
+        None,
+        {"sendOriginal": False, "colormap": colormap},
+        None,
+    )
+    assert len(output) == 1
+    return output[0], ismrmrd.Meta.deserialize(output[0].attribute_string)
+
+
+def test_openrecon_label_exposes_output_appearance_choices():
+    label = json.loads((RECIPE_DIR / "OpenReconLabel.json").read_text())
+    parameter = next(
+        item for item in label["parameters"] if item["id"] == "colormap"
+    )
+
+    assert parameter["label"]["en"] == "Output appearance"
+    assert parameter["default"] == "scanner_lut"
+    assert [choice["id"] for choice in parameter["values"]] == [
+        "scanner_lut",
+        "seismic",
+        "jet",
+        "gray",
+        "coolwarm",
+        "bwr",
+        "none",
+    ]
+
+
+def test_missing_output_appearance_preserves_legacy_seismic_default():
+    metabody = load_metabody_module()
+
+    output_spec = metabody.resolve_output_spec({})
+
+    assert isinstance(output_spec, metabody.EmbeddedRgbOutput)
+    assert output_spec.colormap == "seismic"
+
+
+@pytest.mark.parametrize("colormap", ["seismic", "jet", "gray", "coolwarm", "bwr"])
+def test_embedded_rgb_has_no_scanner_lut(monkeypatch, colormap):
+    image, metadata = render_single_stat(monkeypatch, colormap)
+
+    assert image.data.shape == (3, 1, 2, 3)
+    assert image.channels == 3
+    assert image.image_type == 6
+    assert image.data.dtype == np.uint16
+    assert 0 <= image.data.min() <= image.data.max() <= 255
+    assert metadata["InternalSend"] == "1"
+    assert "RGB" in metadata["ImageProcessingHistory"]
+    assert "LUTFileName" not in metadata
+    assert "WindowCenter" not in metadata
+    assert "WindowWidth" not in metadata
+
+
+def test_scanner_palette_uses_one_scalar_channel(monkeypatch):
+    image, metadata = render_single_stat(monkeypatch, "scanner_lut")
+
+    assert image.data.shape == (1, 1, 2, 3)
+    assert image.channels == 1
+    assert image.image_type == ismrmrd.IMTYPE_MAGNITUDE
+    assert 0 <= image.data.min() <= image.data.max() <= 4095
+    assert metadata["LUTFileName"] == "MicroDeltaHotMetal.pal"
+    assert "InternalSend" not in metadata
+    assert "RGB" not in metadata["ImageProcessingHistory"]
+    assert metadata["WindowCenter"] == "2048.0"
+    assert metadata["WindowWidth"] == "4096"
+
+
+def test_grayscale_uses_one_scalar_channel_without_lut(monkeypatch):
+    image, metadata = render_single_stat(monkeypatch, "none")
+
+    assert image.data.shape == (1, 1, 2, 3)
+    assert image.channels == 1
+    assert image.image_type == ismrmrd.IMTYPE_MAGNITUDE
+    assert 0 <= image.data.min() <= image.data.max() <= 4095
+    assert "LUTFileName" not in metadata
+    assert "InternalSend" not in metadata
+    assert "RGB" not in metadata["ImageProcessingHistory"]
+    assert metadata["WindowCenter"] == "2048.0"
+    assert metadata["WindowWidth"] == "4096"
 
 
 def test_sparse_counters_use_dense_stacking_and_slice_headers(monkeypatch):


### PR DESCRIPTION
## Summary

- add scanner-palette, embedded RGB, and grayscale output choices
- default new scanner configurations to the single-channel hot-metal palette
- keep existing saved protocols compatible when the parameter is absent
- separate RGB metadata from scanner LUT and windowing metadata
- set channel count and image type from the encoded output
- release MetaBody 1.0.5

## Cause

MetaBody applied a Matplotlib RGB color map and also requested a scanner presentation LUT. The scanner exported the three MRD channels as repeated monochrome frames, producing three DICOM instances per statistical image and a bright third-channel washout.

## Verification

- `pytest -q recipes/metabody/test_metabody.py` (12 passed)
- `python3 workflows/validate_openrecon_labels.py`
- `python3 builder/validation.py recipes/metabody/build.yaml --verbose`
- `python3 -m builder.audit_updates --recipes metabody`
- `python3 -m builder generate metabody --recreate`
- `python3 -m compileall -q recipes/metabody/metabody.py recipes/metabody/test_metabody.py`
- `git diff --check`

Embedded RGB remains marked experimental pending a scanner round-trip test. The recommended scanner-palette path uses one scalar channel and avoids the malformed three-channel DICOM export.
