### PR TITLE
Update QSMxT to 9.17.0 and send original series by default

### DIFF
--- a/recipes/qsmxt/OpenReconLabel.json
+++ b/recipes/qsmxt/OpenReconLabel.json
@@ -82,7 +82,7 @@
       "label": { "en": "Send original" },
       "type": "boolean",
       "information": { "en": "Send original magnitude and phase image series before derived QSMxT output." },
-      "default": false
+      "default": true
     },
     {
       "id": "pipelinepreset",

--- a/recipes/qsmxt/OpenReconREADME.md
+++ b/recipes/qsmxt/OpenReconREADME.md
@@ -33,7 +33,9 @@ debugging, but they are not shown in the scanner UI. Voxel geometry comes from
 the MRD image stream.
 
 Default output is the QSM map (`Chimap`). Enable `sendoutputs=all` to return all
-QSMxT derivatives that exist after the run.
+QSMxT derivatives that exist after the run. The original magnitude and phase
+series are sent back before the derived output by default; disable
+`sendoriginal` when only the derived maps should reach the scanner database.
 
 Derived outputs are converted to unsigned 12-bit display values in the valid
 `0..4095` range. Binary masks use `0` and `4095`. QSM storage scaling preserves
@@ -82,9 +84,9 @@ The OpenRecon wrapper also supplies the output directory and resource settings.
 Its custom-pipeline defaults are ROMEO phase unwrapping, iSMV background-field
 removal, HD-QSM inversion, and BET magnitude masking. BET uses a 0.5 fractional
 intensity threshold, closing radius 1, and automatic hole filling. This differs
-from the upstream QSMxT inversion default, which is RTS. Only the QSM map is
-returned by default. Enable `sendoriginal` only when the original magnitude and
-phase series are needed for debugging.
+from the upstream QSMxT inversion default, which is RTS. The QSM map is the only
+derived output returned by default, and `sendoriginal` is on so the source
+magnitude and phase series are stored alongside it.
 
 The default prioritizes speed while retaining good similarity in the QSM-CI
 in silico 2019 benchmark: ROMEO + iSMV + HD-QSM achieved xSIM 0.361 in about
@@ -357,7 +359,7 @@ An [example Siemens 3 T GRE protocol
 is included as a starting point. It acquires five echoes at 5, 10, 15, 20, and
 25 ms. Its saved OpenRecon settings use ROMEO, PDF, and RTS with robust-threshold
 masking, return the QSM map, and also send the original magnitude and phase
-series. These saved settings differ from the current OpenRecon defaults above.
+series. Their algorithm choices differ from the current OpenRecon defaults above.
 Review all acquisition and safety settings on the target scanner before use.
 
 ## UI parameters
@@ -367,7 +369,7 @@ Review all acquisition and safety settings on the target scanner before use.
 | config | `config` | choice | `qsmxt` | Selects the MRD server configuration. |
 | Input images | `inputseries` | choice | `distortion-corrected` | Processes corrected, ND, or both magnitude/phase pairs. |
 | Output maps | `sendoutputs` | choice | `qsm` | Selects which QSMxT derivatives are sent back. |
-| Send original | `sendoriginal` | boolean | `false` | Sends original magnitude and phase image series before derived outputs. |
+| Send original | `sendoriginal` | boolean | `true` | Sends original magnitude and phase image series before derived outputs. |
 | Pipeline preset | `pipelinepreset` | choice | `custom` | Selects a three-stage combination, a complete-method preset, or custom controls. |
 | QSM algorithm | `qsmalgorithm` | choice | `hdqsm` | Inversion algorithm for the custom pipeline. |
 | Unwrap | `unwrappingalgorithm` | choice | `romeo` | Phase-unwrapping algorithm for the custom pipeline. |

--- a/recipes/qsmxt/build.yaml
+++ b/recipes/qsmxt/build.yaml
@@ -1,5 +1,5 @@
 name: qsmxt
-version: 9.16.0
+version: 9.17.0
 copyright:
   - license: GPL-3.0-only
     url: https://github.com/QSMxT/QSMxT/blob/main/LICENSE
@@ -13,7 +13,7 @@ variables:
   openrecon_python_tools_commit: "17fe6fbf1bb645112e2ad0023eb4f42afb36421e"
   openrecon_siemens_commit: "055eefc09dfa77fbf11fff85979dea9ef2879ba5"
   openrecon_ismrmrd_version: "1.14.2"
-  upstream_version: "9.16.0"
+  upstream_version: "9.17.0"
   model_revision: e7c66cece159dc163885afd6165f582769dc5f29
   qsmxt_tarball:
     try:

--- a/recipes/qsmxt/fulltest.yaml
+++ b/recipes/qsmxt/fulltest.yaml
@@ -1,5 +1,5 @@
 name: qsmxt
-version: 9.16.0
+version: 9.17.0
 
 test_data:
   output_dir: test_output
@@ -211,7 +211,7 @@ tests:
           assert parameters["betfractionalintensity"]["default"] == 0.5
           assert parameters["maskcleanup"]["default"] == "close-fill"
       send_original = next(parameter for parameter in data["parameters"] if parameter["id"] == "sendoriginal")
-      assert send_original["default"] is False
+      assert send_original["default"] is True
       assert "minip" not in parameter_ids
       print(label)
       PY
@@ -335,6 +335,7 @@ tests:
                   "echotimesms": "10,20",
                   "maxechoes": "2",
                   "sendoutputs": "qsm",
+                  "sendoriginal": "false",
               }
           },
           FakeMetadata(),
@@ -407,4 +408,4 @@ tests:
       print("sent derived images:", len(connection.sent_batches[0]))
       PY
 
-upstream_version: 9.16.0
+upstream_version: 9.17.0

--- a/recipes/qsmxt/qsmxt.py
+++ b/recipes/qsmxt/qsmxt.py
@@ -151,6 +151,7 @@ INPUT_SERIES_CHOICES = (
     "both",
 )
 DEFAULT_INPUT_SERIES = DISTORTION_CORRECTED
+DEFAULT_SEND_ORIGINAL = True
 MASK_CLEANUP_PRESETS = {
     "none": {"dilate": 0, "close": 0, "fill_holes": False, "erode": 0},
     "fill": {"dilate": 0, "close": 0, "fill_holes": True, "erode": 0},
@@ -1608,7 +1609,11 @@ def _settings_from_config(config, metadata=None):
         ) from error
     return {
         "input_series": input_series,
-        "send_original": _config_bool(params, "sendoriginal", False),
+        "send_original": _config_bool(
+            params,
+            "sendoriginal",
+            DEFAULT_SEND_ORIGINAL,
+        ),
         "send_outputs": str(params.get("sendoutputs", "qsm") or "qsm"),
         "max_echoes": _config_int(params, "maxechoes", 0),
         "echo_times_ms": _config_text(params, "echotimesms", ""),

--- a/recipes/qsmxt/test_qsmxt_openrecon.py
+++ b/recipes/qsmxt/test_qsmxt_openrecon.py
@@ -344,6 +344,7 @@ def test_openrecon_defaults_select_hdqsm_romeo_and_ismv():
     assert settings["mask_fill_holes"] is True
     assert settings["mask_erode"] == 0
     assert settings["input_series"] == "distortion-corrected"
+    assert settings["send_original"] is True
 
 
 def test_openrecon_input_series_rejects_unknown_value():
@@ -600,6 +601,7 @@ def test_openrecon_label_exposes_processing_defaults():
     assert parameters["maskinginput"]["default"] == "magnitude"
     assert parameters["betfractionalintensity"]["default"] == 0.5
     assert parameters["maskcleanup"]["default"] == "close-fill"
+    assert parameters["sendoriginal"]["default"] is True
     assert "voxelsizemm" not in parameters
 
 
@@ -1085,7 +1087,13 @@ def test_process_runs_qsmxt_and_sends_derived_mrd_image(tmp_path, monkeypatch):
 
     qsmxt.process(
         connection,
-        {"parameters": {"qsmxtbinary": str(fake_qsmxt), "echotimesms": "10,20"}},
+        {
+            "parameters": {
+                "qsmxtbinary": str(fake_qsmxt),
+                "echotimesms": "10,20",
+                "sendoriginal": "false",
+            }
+        },
         FakeMetadata(),
     )
 
@@ -1169,6 +1177,7 @@ def test_process_both_input_series_runs_separately_and_returns_unique_outputs(
                 "qsmxtbinary": str(fake_qsmxt),
                 "echotimesms": "10,20",
                 "inputseries": "both",
+                "sendoriginal": "false",
             }
         },
         FakeMetadata(),
@@ -1207,7 +1216,7 @@ def test_process_returns_scanner_packed_volume_as_one_mm_slices(tmp_path, monkey
 
     qsmxt.process(
         connection,
-        {"parameters": {"qsmxtbinary": str(fake_qsmxt)}},
+        {"parameters": {"qsmxtbinary": str(fake_qsmxt), "sendoriginal": "false"}},
         FakeMetadata(),
     )
 
@@ -1434,7 +1443,6 @@ def test_process_sends_restamped_originals_before_derived_output(tmp_path, monke
             "parameters": {
                 "qsmxtbinary": str(fake_qsmxt),
                 "echotimesms": "10,20",
-                "sendoriginal": "true",
             }
         },
         FakeMetadata(),


### PR DESCRIPTION
## Upstream bump

QSMxT released [v9.17.0](https://github.com/QSMxT/QSMxT/releases/tag/v9.17.0) (qsm-core v0.30.0) on 2026-09-08; the recipe was on 9.16.0. Container `version` and `upstream_version` move together, as this recipe keeps them equal.

Upstream behaviour changes:

- AMP-PE no longer diverges on in-vivo data. Non-diverging output is bit-identical to 9.16.0.
- V-SHARP's default deconvolution threshold changes `0.05` → `0.2`. The OpenRecon defaults use iSMV, so the default reconstruction is unaffected, but anyone selecting **V-SHARP** in the UI will get different output than from the 9.16.0 container.

Checked against the packaged 9.17.0 CLI before bumping: the GUI still exposes exactly the algorithms `qsmxt run --help` supports (29 inversions, 2 unwrappers, 10 background-field methods, no additions or removals), and `--mask`, `--mask-preset`, `--masking-input` and `--n-procs` are unchanged, so the label and wrapper need no other adaptation.

## Send original on by default

`sendoriginal` now defaults to `true`, in `OpenReconLabel.json` and in the wrapper fallback (`DEFAULT_SEND_ORIGINAL`), so a config that omits the key also sends originals. The source magnitude and phase series now reach the scanner database alongside the QSM map without the operator enabling it; unchecking the box in the UI still works. The bundled `gre_qsm.pro` protocol already stored this setting, so it is now consistent with the defaults.

Tests that assert derived-output metadata pass `sendoriginal: "false"` explicitly, and the restamped-original test now omits the flag so it exercises the new default. The label default is asserted in both the unit tests and `fulltest.yaml`.

## Validation

- `python3 builder/validation.py recipes/qsmxt/build.yaml` — passes
- `python -m builder generate qsmxt --recreate` — succeeds and resolves the real 9.17.0 x86_64 tarball
- `pytest recipes/qsmxt/test_qsmxt_openrecon.py` — 94 passed
- `pytest builder/tests` — 696 passed
- `codespell recipes/qsmxt` — clean

Not run locally: the container build and `sf-test`, which need Docker and a long build — left to the candidate CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)