### PR TITLE
Follow the pinned ismrmrd when constraining xsdata

### DIFF
--- a/builder/tests/test_openrecon_updates.py
+++ b/builder/tests/test_openrecon_updates.py
@@ -88,3 +88,28 @@ def test_macro_fallback_matches_migration_baseline(shared_recipe):
     (path / "build.yaml").write_text(yaml.safe_dump(recipe))
     generated = render_dockerfile(compile_recipe(path, architecture="x86_64", include_dirs=default_config().include_dirs).definition)
     assert all(value in generated for value in OPENRECON_PINS.values())
+
+
+@pytest.mark.parametrize(
+    "ismrmrd_version,requirement",
+    [
+        ("1.9.8", '"xsdata>=22.12,<24.4"'),
+        ("1.14.2", '"xsdata>=22.12,<24.4"'),
+        ("1.15.0", '"xsdata>=26.2"'),
+    ],
+)
+def test_shared_xsdata_requirement_follows_pinned_ismrmrd(
+    shared_recipe, ismrmrd_version, requirement
+):
+    # ismrmrd 1.14.x reads xsdata APIs that 24.4 removed while 1.15.0 requires
+    # 26.2+, so a single hardcoded range makes pip resolution impossible for
+    # every recipe on the other side of that boundary.
+    path, recipe = shared_recipe
+    recipe["variables"]["openrecon_ismrmrd_version"] = ismrmrd_version
+    (path / "build.yaml").write_text(yaml.safe_dump(recipe, sort_keys=False))
+    generated = render_dockerfile(
+        compile_recipe(
+            path, architecture="x86_64", include_dirs=default_config().include_dirs
+        ).definition
+    )
+    assert f"ismrmrd=={ismrmrd_version} {requirement}" in generated

--- a/macros/openrecon/neurodocker.yaml
+++ b/macros/openrecon/neurodocker.yaml
@@ -45,8 +45,19 @@ directives:
       - cmake --install build
       - ldconfig
 
+  # ismrmrd 1.14.x breaks against the xsdata 24.4 API, while 1.15.0 onwards
+  # requires xsdata 26.2+. Follow whichever range the pinned ismrmrd resolves
+  # with instead of one hardcoded ceiling.
+  - variables:
+      openrecon_xsdata_spec:
+        try:
+          - value: ">=26.2"
+            condition: (context.openrecon_ismrmrd_version | default("1.14.2")).split(".")[:2] | map("int") | list >= [1, 15]
+          - value: ">=22.12,<24.4"
+            condition: "true"
+
   - run:
-      - python3 -m pip install $(python3 -m pip install --help | grep -q -- "--break-system-packages" && echo "--break-system-packages") --no-cache-dir h5py ismrmrd=={{ context.openrecon_ismrmrd_version | default("1.14.2") }} "xsdata<24.4" matplotlib pydicom==3.0.1 pynetdicom nibabel scipy scikit-image
+      - python3 -m pip install $(python3 -m pip install --help | grep -q -- "--break-system-packages" && echo "--break-system-packages") --no-cache-dir h5py ismrmrd=={{ context.openrecon_ismrmrd_version | default("1.14.2") }} "xsdata{{ context.openrecon_xsdata_spec }}" matplotlib pydicom==3.0.1 pynetdicom nibabel scipy scikit-image
 
   - run:
       - git clone https://github.com/ismrmrd/ismrmrd-python-tools.git


### PR DESCRIPTION
## Problem

The auto-update PRs that move OpenRecon recipes to ismrmrd 1.15.0 cannot build.
Both #3128 (afib1) and #3132 (arfiproc) fail the same layer on both
architectures:

```
ERROR: Cannot install ismrmrd==1.15.0 and xsdata<24.4 because these package
versions have conflicting dependencies.
    The user requested xsdata<24.4
    ismrmrd 1.15.0 depends on xsdata>=26.2
```

`macros/openrecon/neurodocker.yaml` hardcodes `"xsdata<24.4"`. That ceiling was
added in 7a548ce3 because ismrmrd 1.14.x reads xsdata APIs that 24.4 removed, so
it still has to hold for the 19 recipes pinned there — but ismrmrd 1.15.0
declares `xsdata>=26.2`, so no single range works for both. Every one of the 21
recipes that includes this macro hits this as soon as the updater proposes
1.15.0 for it.

## Fix

Derive the requirement from `openrecon_ismrmrd_version` instead of hardcoding
one range: 1.15+ gets `xsdata>=26.2`, anything older keeps
`xsdata>=22.12,<24.4`, which is exactly what pip already resolved for ismrmrd
1.14.2 (`<24.4` plus ismrmrd's own `>=22.12` floor).

## Verification

- Rendered the macro for 1.9.8 / 1.14.2 / 1.15.0 and asserted the pip
  requirement pair in `builder/tests/test_openrecon_updates.py`, so a constraint
  that stops tracking the pinned release fails in the builder suite rather than
  in 21 recipe builds.
- Built afib1 at `openrecon_ismrmrd_version: 1.15.0` locally on aarch64. The
  layer that fails in CI installs, resolving xsdata 26.2, and the runtime stack
  imports: `ismrmrd` 1.15.0, `ismrmrdtools` at the pinned commit, and
  `python-ismrmrd-server`'s `main.py`.
- `pytest builder/tests` passes (except two pre-existing `dpkg`-dependent apt
  tests that cannot run on macOS).

## Why this does not rebuild the 21 consumers

This PR touches `builder/tests/`, so the release planner treats it as a mixed PR
and skips candidate builds. That is the right outcome here: for every recipe
still pinned below ismrmrd 1.15 the install line resolves to the same xsdata
version as before, so their published images are unchanged. afib1 and arfiproc
get real candidate builds in #3128 and #3132 once they pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)