### PR TITLE
Track the amico release in the container version

### DIFF
--- a/recipes/amico/build.yaml
+++ b/recipes/amico/build.yaml
@@ -1,7 +1,5 @@
 name: amico
-version: "2.1.0.post2"
-variables:
-  upstream_version: "2.1.1"
+version: "2.1.1"
 architectures:
   - x86_64
   - aarch64
@@ -52,14 +50,8 @@ structured_readme:
     Neuroimage 215 (2020): 116835.
     https://doi.org/10.1016/j.neuroimage.2020.116835
 auto_update:
-  method: sources
-  sources:
-    - id: amico
-      method: pypi
-      package: dmri-amico
-      target:
-        variable: upstream_version
-        fulltest_variable: upstream_version
+  method: pypi
+  package: dmri-amico
 
 build:
   kind: neurodocker
@@ -73,7 +65,7 @@ build:
         env_name: amico
         env_exists: "false"
         conda_install: python=3.12
-        pip_install: setuptools<81 dmri-amico=={{ context.upstream_version }}
+        pip_install: setuptools<81 dmri-amico=={{ context.version }}
     - environment:
         PATH: /opt/miniconda/envs/amico/bin:/opt/miniconda/bin:$PATH
     - deploy:

--- a/recipes/amico/fulltest.yaml
+++ b/recipes/amico/fulltest.yaml
@@ -1,5 +1,5 @@
 # AMICO container test suite
-# Tests for AMICO v2.1.0 - Accelerated Microstructure Imaging via Convex Optimization
+# Tests for AMICO v2.1.1 - Accelerated Microstructure Imaging via Convex Optimization
 #
 # AMICO is a Python framework for fitting microstructure models to diffusion MRI data.
 # It implements several diffusion models including:
@@ -28,8 +28,7 @@
 # utility functions, and synthetic signal generation.
 
 name: amico
-version: "2.1.0.post2"
-upstream_version: "2.1.1"
+version: "2.1.1"
 
 required_files:
   - dataset: ds000001
@@ -72,7 +71,7 @@ tests:
   - name: AMICO version check
     description: Verify AMICO version
     command: python -c "import amico; print('AMICO version:', amico.__version__)"
-    expected_output_contains: "${upstream_version}"
+    expected_output_contains: "${version}"
 
   - name: AMICO README check
     description: Verify AMICO README contains expected information


### PR DESCRIPTION
## Problem

#3130 released amico as `2.1.0.post2` while the container actually ships
`dmri-amico` 2.1.1, so `ml amico/2.1.0.post2` loads 2.1.1 and the module name
tells users the wrong version.

That is the `sources` policy working as documented, applied to a recipe that
does not need it. #3121 gave amico `method: sources` with a single PyPI source
targeting `variables.upstream_version`, and a source version is never
substituted for a container label, so the updater can only add `.postN`:

- `.post1` when #3121 pinned `dmri-amico=={{ context.upstream_version }}`
  (it was previously unpinned)
- `.post2` when upstream moved 2.1.0 → 2.1.1

## Fix

amico installs exactly one piece of software, so the container version can
track it: `method: pypi` on `dmri-amico`, installed as
`dmri-amico=={{ context.version }}`. The next upstream release now bumps the
recipe to that version instead of inventing a `.post` suffix.

`fulltest.yaml` asserts `${version}` against `amico.__version__`, which is the
assertion that would have caught the drift.

## Verification

- `builder/validation.py recipes/amico/build.yaml` passes.
- `python -m builder generate amico --recreate` renders `dmri-amico==2.1.1`.
- `python -m builder.audit_updates` reports all 247 recipes automatic.
- `pytest builder/tests` passes (except two pre-existing `dpkg`-dependent apt
  tests that cannot run on macOS).

## Same class elsewhere

`palmettobug` is the worse case of this: release `0.0.3.post1` currently ships
palmettobug 0.2.11. Left alone here because relabelling it is a bigger jump than
a bug fix — say the word and I'll do it the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)