### PR TITLE
Skip builds for non-image recipe metadata

### DIFF
--- a/builder/release_plan.py
+++ b/builder/release_plan.py
@@ -36,8 +36,9 @@ TOP_LEVEL_FIELD_TIERS: dict[str, frozenset[str]] = {
     "epoch": frozenset({"candidate"}),
 }
 
-# Other roles remain candidate-required until their publication paths exist.
-ENABLED_SOURCE_ONLY_FIELDS = frozenset({"auto_update"})
+# Fields outside these proven non-image groups remain candidate-required.
+ENABLED_SOURCE_ONLY_FIELDS = frozenset({"auto_update", "copyright", "draft"})
+ENABLED_CATALOG_FIELDS = frozenset({"icon"})
 DOCUMENTATION_FIELDS = frozenset({"readme", "readme_url", "structured_readme"})
 KNOWN_NON_IMAGE_FILES = frozenset({"fulltest.yaml"})
 
@@ -220,7 +221,9 @@ def plan_recipe_changes(
                 candidate_reasons.append("new-recipe")
             else:
                 changed_fields = _changed_top_level_fields(base, head)
-                non_image_fields = set(ENABLED_SOURCE_ONLY_FIELDS)
+                non_image_fields = set(
+                    ENABLED_SOURCE_ONLY_FIELDS | ENABLED_CATALOG_FIELDS
+                )
                 for field in DOCUMENTATION_FIELDS:
                     if all(
                         _passive_documentation(data.get(field))
@@ -234,8 +237,12 @@ def plan_recipe_changes(
                     candidate_reasons.append("unclassified-field")
                 elif not changed_fields:
                     source_reasons.append("yaml-only-change")
-                elif changed_fields <= ENABLED_SOURCE_ONLY_FIELDS:
+                elif changed_fields == {"auto_update"}:
                     source_reasons.append("auto-update-only")
+                elif changed_fields <= ENABLED_SOURCE_ONLY_FIELDS:
+                    source_reasons.append("source-metadata-only")
+                elif changed_fields <= ENABLED_CATALOG_FIELDS:
+                    source_reasons.append("catalog-only")
                 elif changed_fields <= non_image_fields:
                     source_reasons.append("documentation-or-catalog-only")
                 else:

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -138,7 +138,14 @@ def test_detect_from_git_preserves_metadata_only_release(tmp_path: Path, monkeyp
 
     path = recipe_dir / "build.yaml"
     recipe = yaml.safe_load(path.read_text())
-    recipe.update(readme="Updated help", categories=["workflows"], auto_update={})
+    recipe.update(
+        readme="Updated help",
+        categories=["workflows"],
+        auto_update={},
+        copyright=[{"license": "MIT", "url": "https://example.com/license"}],
+        icon="data:image/png;base64,aGVsbG8=",
+        draft=True,
+    )
     path.write_text(yaml.safe_dump(recipe) + "# Clarified documentation\n")
     git("commit", "-am", "Update documentation and catalog")
     assert one_pr_release.detect_recipes(base, "HEAD") == []

--- a/builder/tests/test_release_plan.py
+++ b/builder/tests/test_release_plan.py
@@ -45,6 +45,27 @@ def test_auto_update_only_change_is_source_only() -> None:
     assert plan.decisions[0].reasons == ("auto-update-only",)
 
 
+@pytest.mark.parametrize(
+    "updates,reason",
+    [
+        (
+            {"copyright": [{"license": "MIT", "url": "https://example.com/license"}]},
+            "source-metadata-only",
+        ),
+        ({"icon": "data:image/png;base64,aGVsbG8="}, "catalog-only"),
+        ({"draft": True}, "source-metadata-only"),
+    ],
+)
+def test_non_image_recipe_metadata_is_source_only(updates, reason) -> None:
+    plan = plan_recipe_changes(
+        ["recipes/demo/build.yaml"], {"demo": recipe()}, {"demo": recipe(**updates)}
+    )
+
+    assert plan.candidate_recipes == []
+    assert plan.source_only_recipes == ["demo"]
+    assert plan.decisions[0].reasons == (reason,)
+
+
 def test_semantically_unchanged_yaml_is_source_only() -> None:
     data = recipe()
 

--- a/workflows/ONE_PR_RELEASES.md
+++ b/workflows/ONE_PR_RELEASES.md
@@ -69,12 +69,13 @@ second build.
 
 The planner reads the base and head `build.yaml` files as YAML data. It does not
 render Jinja or execute any code from the pull request. Changes that affect only
-`auto_update`, documentation (`readme`, `readme_url`, `structured_readme`), literal
-`categories`, semantically unchanged YAML, or `fulltest.yaml` are currently
-classified as source-only: they are validated, but the existing container is
-preserved and no candidate is built or promoted. This is a behavioural release
-projection, not a claim that rebuilding would produce byte-identical images;
-the current image still embeds the raw `build.yaml` and README.
+`auto_update`, `copyright`, `draft`, `icon`, documentation (`readme`, `readme_url`,
+`structured_readme`), literal `categories`, semantically unchanged YAML, or
+`fulltest.yaml` are currently classified as source-only. The workflow validates
+them, but preserves the existing container and builds or promotes no candidate.
+This is a behavioural release projection, not a claim that rebuilding would
+produce byte-identical images; the current image still embeds the raw
+`build.yaml` and README.
 
 Documentation may use simple context substitutions such as
 `{{ context.version }}`. More complex templates remain candidate-required because


### PR DESCRIPTION
## Summary

- classify `copyright` and `draft` changes as source-only
- classify `icon` changes as catalog-only
- keep runtime fields and recipe build inputs candidate-required
- document the expanded release policy

Follow-up to #2994.

## Testing

- `python -m pytest -q builder/tests` (702 passed)
- focused release-planner, detector, catalog, and workflow tests after rebase (88 passed)
- `codespell` on changed files
- `git diff --check`