### PR TITLE
Sync OpenRecon metadata for post-release container versions

### DIFF
--- a/builder/tests/test_sync_openrecon.py
+++ b/builder/tests/test_sync_openrecon.py
@@ -264,3 +264,45 @@ def test_unchanged_metadata_dispatches_openrecon_rebuild(
         "-f",
         'applications=["demo"]',
     ] in commands
+
+
+# Docker rejects "+", so build metadata cannot carry the post-release marker.
+DOCKER_TAG_PATTERN = __import__("re").compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+
+
+@pytest.mark.parametrize("container_version", ["1.6.0.post1", "1.0.0.post1", "2.9.post2"])
+def test_post_release_versions_stay_schema_valid_and_taggable(container_version):
+    # The updater rebuilds a container as X.Y.Z.postN when only its
+    # dependencies moved, and OpenRecon publishes that version both into a
+    # schema-checked label and into a Docker tag.
+    metadata_version = sync_openrecon.openrecon_version(container_version)
+
+    assert sync_openrecon.OPENRECON_SEMVER_PATTERN.fullmatch(metadata_version)
+    assert DOCKER_TAG_PATTERN.fullmatch(f"V{metadata_version}".lower())
+    assert metadata_version != container_version
+
+
+def test_post_release_container_version_is_kept_for_docker_operations(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "neurocontainers"
+    openrecon_root = tmp_path / "openrecon"
+    write_source_recipe(source_root)
+    target = openrecon_root / "recipes" / "demo"
+    target.mkdir(parents=True)
+    (target / "params.sh").write_text(
+        "#!/bin/bash\n"
+        "export toolName=demo\n"
+        "export version=1.6.0\n"
+        "export baseDockerImage=vnmd/${toolName}_${version}\n",
+        encoding="utf-8",
+    )
+
+    prepared = sync_openrecon.prepare_recipe(
+        source_root, openrecon_root, "demo", "1.6.0.post1"
+    )
+
+    assert prepared is not None
+    params = (target / "params.sh").read_text(encoding="utf-8")
+    assert "export version=1.6.0.post1\n" in params
+    assert "export openrecon_version=1.6.0-post1\n" in params

--- a/tools/sync_openrecon.py
+++ b/tools/sync_openrecon.py
@@ -40,6 +40,9 @@ OPENRECON_SEMVER_PATTERN = re.compile(
     r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 )
 TWO_PART_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+POST_RELEASE_VERSION_PATTERN = re.compile(
+    r"^(?P<base>(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){1,2})\.post(?P<post>0|[1-9]\d*)$"
+)
 
 
 @dataclass(frozen=True)
@@ -79,6 +82,16 @@ def openrecon_version(version: str) -> str:
         return version
     if TWO_PART_VERSION_PATTERN.fullmatch(version):
         return f"{version}.0"
+    post_release = POST_RELEASE_VERSION_PATTERN.fullmatch(version)
+    if post_release:
+        # The updater rebuilds a container as X.Y.Z.postN when only its
+        # dependencies moved. Carry that as a semver prerelease rather than
+        # +build metadata, because OpenRecon derives a Docker tag from this
+        # version and tags reject "+".
+        base = post_release.group("base")
+        if TWO_PART_VERSION_PATTERN.fullmatch(base):
+            base = f"{base}.0"
+        return f"{base}-post{post_release.group('post')}"
     raise ValueError(
         f"OpenRecon requires a semantic version; cannot normalize {version!r}"
     )


### PR DESCRIPTION
## Problem

afib1 1.6.0.post1 (#3128) and arfiproc 1.0.0.post1 (#3132) both published their
container releases and then failed promotion in `sync_openrecon`:

```
ValueError: OpenRecon requires a semantic version; cannot normalize '1.6.0.post1'
```

`tools/sync_openrecon.py` normalizes two-part versions (`0.2` → `0.2.0`) but
rejects everything else. The updater assigns `X.Y.Z.postN` whenever a
container is rebuilt because only its dependencies moved, so every OpenRecon
recipe on a `sources` policy hits this on its next dependency bump. The images
and release metadata are fine; only the mirror to `neurodesk/openrecon` fails.

## Fix

Normalize the post-release suffix into a semver prerelease: `1.6.0.post1` →
`1.6.0-post1`, and `2.9.post2` → `2.9.0-post2`.

`+post1` build metadata would also satisfy
`OpenReconSchema_1.1.0.json`'s version pattern (which `OPENRECON_SEMVER_PATTERN`
mirrors exactly), but `neurodesk/openrecon`'s `recipes/build.py` builds a Docker
tag from that version:

```python
return f"OpenRecon_{general['vendor']}_{package_name}:V{general['version']}".lower()
```

Docker tags reject `+`, so the prerelease form is the one that works for both
the label schema and the tag. `params.sh` keeps the unmodified container version
for Docker operations, which is what the existing `openrecon_version` split is
for.

The trade-off worth naming: semver orders a prerelease *before* its base
version, so `1.6.0-post1` sorts below `1.6.0` even though it is a later
rebuild. That only affects ordering of OpenRecon labels, and the alternative
that sorts correctly cannot be tagged.

## Verification

- `pytest builder/tests` passes (except two pre-existing `dpkg`-dependent apt
  tests that cannot run on macOS).
- New tests assert the contract rather than the literal string: the normalized
  version matches the schema's semver pattern *and* is a legal Docker tag, and
  `params.sh` keeps `version=1.6.0.post1` alongside
  `openrecon_version=1.6.0-post1`.

Once this lands I will re-run the failed `sync_openrecon` jobs for #3128 and
#3132 so both mirrors catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)