### PR TITLE
Skip unpublished Slicer releases instead of failing the update run

### DIFF
--- a/builder/tests/test_update_bundles.py
+++ b/builder/tests/test_update_bundles.py
@@ -38,9 +38,14 @@ class Session:
         return Response(self.data, url)
 
 
-def slicer_lists(monkeypatch, *, extension_revision="34045", extensions=1):
-    package = {"_id": "1" * 24, "meta": {"app_id": "0" * 24, "version": "5.10.0", "pre_release": False,
-               "revision": "34045", "os": "linux", "arch": "amd64"}}
+def slicer_package(version, revision, pre_release=False):
+    return {"_id": "1" * 24, "meta": {"app_id": "0" * 24, "version": version, "pre_release": pre_release,
+            "revision": revision, "os": "linux", "arch": "amd64"}}
+
+
+def slicer_lists(monkeypatch, *, extension_revision="34045", extensions=1, query_revision="34045",
+                 releases=("5.9.0", "5.10.0", "5.11.0rc1", "nightly"), packages=None):
+    packages = packages if packages is not None else {"5.10.0": [slicer_package("5.10.0", "34045")]}
     extension = {"_id": "2" * 24, "meta": {"app_id": "0" * 24, "app_revision": extension_revision,
                  "baseName": "MONAILabel", "os": "linux", "arch": "amd64"}}
     calls = []
@@ -48,11 +53,10 @@ def slicer_lists(monkeypatch, *, extension_revision="34045", extensions=1):
     def listing(session, url, **params):
         calls.append((url, params))
         if url.endswith("/release"):
-            return [{"name": "5.9.0"}, {"name": "5.10.0"}, {"name": "5.11.0rc1"}, {"name": "nightly"}]
+            return [{"name": name} for name in releases]
         if url.endswith("/package"):
-            assert params["release_id_or_name"] == "5.10.0"
-            return [package]
-        assert params["app_revision"] == "34045"
+            return packages[params["release_id_or_name"]]
+        assert params["app_revision"] == query_revision
         return [extension] * extensions
 
     monkeypatch.setattr(bundles, "_json_list", listing)
@@ -70,6 +74,51 @@ def test_slicer_resolves_application_extension_and_abi_together(monkeypatch):
     assert result.metadata["extension_item"] == "2" * 24
     assert result.metadata["extension_sha256"] == "a" * 64
     assert len(downloads) == 2
+
+
+def test_slicer_falls_back_to_the_newest_promoted_release(monkeypatch):
+    # Kitware publishes a stable release name before its Linux package exists and again
+    # before promoting that package, so the newest promoted build has to win rather than
+    # failing the whole update run.
+    calls = slicer_lists(
+        monkeypatch,
+        query_revision="34627",
+        extension_revision="34627",
+        releases=("5.10.0", "5.12.3", "5.12.4", "5.12.5"),
+        packages={"5.12.5": [],
+                  "5.12.4": [slicer_package("5.12.4", "34645", pre_release=True)],
+                  "5.12.3": [slicer_package("5.12.3", "34627")]},
+    )
+    monkeypatch.setattr(bundles, "_download", lambda session, url, **kwargs: ("a" * 64, 42))
+    result = bundles._slicer({"app_id": "0" * 24, "extension": "MONAILabel"}, None)
+    assert result.version == "5.12.3"
+    assert result.metadata["revision"] == "34627"
+    assert result.metadata["abi"] == "5.12"
+    assert [params["release_id_or_name"] for url, params in calls
+            if url.endswith("/package")] == ["5.12.5", "5.12.4", "5.12.3"]
+
+
+def test_slicer_refuses_an_ambiguous_package_listing(monkeypatch):
+    # Skipping empty listings must not also wave through a release publishing two Linux builds.
+    slicer_lists(
+        monkeypatch,
+        releases=("5.12.4",),
+        packages={"5.12.4": [slicer_package("5.12.4", "34645"), slicer_package("5.12.4", "34646")]},
+    )
+    monkeypatch.setattr(bundles, "_download", lambda *args, **kwargs: pytest.fail("ambiguous bundle downloaded"))
+    with pytest.raises(ValueError, match="expected one Slicer Linux package"):
+        bundles._slicer({"app_id": "0" * 24, "extension": "MONAILabel"}, None)
+
+
+def test_slicer_refuses_a_listing_with_no_promoted_release(monkeypatch):
+    slicer_lists(
+        monkeypatch,
+        releases=("5.12.4",),
+        packages={"5.12.4": [slicer_package("5.12.4", "34645", pre_release=True)]},
+    )
+    monkeypatch.setattr(bundles, "_download", lambda *args, **kwargs: pytest.fail("pre-release bundle downloaded"))
+    with pytest.raises(ValueError, match="promoted"):
+        bundles._slicer({"app_id": "0" * 24, "extension": "MONAILabel"}, None)
 
 
 @pytest.mark.parametrize("revision,count", [("99999", 1), ("34045", 0), ("34045", 2)])

--- a/builder/update_bundles.py
+++ b/builder/update_bundles.py
@@ -132,10 +132,20 @@ def _slicer(config: dict, session: requests.Session):
             versions.append((version, name))
     if not versions:
         raise ValueError("Slicer has no published stable release")
-    _, version = max(versions)
-    package = _one(_json_list(session, app_url + "/package", os="linux", arch="amd64",
-                             release_id_or_name=version, limit=0), "Slicer Linux package")
-    meta = package.get("meta", {})
+    # A stable release name can still carry a package Kitware flags as a pre-release while
+    # it finishes promoting that build, so walk down to the newest promoted package instead
+    # of failing the update run on a release upstream has not finished publishing.
+    for _, version in sorted(versions, reverse=True):
+        packages = _json_list(session, app_url + "/package", os="linux", arch="amd64",
+                              release_id_or_name=version, limit=0)
+        if not packages:
+            continue  # Slicer uploads per platform, so a release can predate its Linux build.
+        package = _one(packages, "Slicer Linux package")
+        meta = package.get("meta", {})
+        if meta.get("pre_release") is not True:
+            break
+    else:
+        raise ValueError("Slicer has no promoted stable Linux package")
     revision = str(meta.get("revision", ""))
     if (meta.get("app_id") != config["app_id"] or meta.get("version") != version or meta.get("pre_release") is not False
             or meta.get("os") != "linux" or meta.get("arch") != "amd64" or not revision.isdecimal()):


### PR DESCRIPTION
## Why

The nightly [Auto Update Recipes run](https://github.com/neurodesk/neurocontainers/actions/runs/34432954528) failed. `builder/check_version.py:755` exits non-zero when any recipe row ends in `error`, and 5 of 247 did. Four were transient Zenodo read timeouts (`brainles-preprocessing`, `mrsiproc`, `musclemap`, `rabies`) — those records answer in ~1.2s now and need no code change. The fifth was real and reproducible: `slicer` raised `ValueError: Slicer package release or architecture metadata disagrees`, and would have kept failing every scheduled run.

`_slicer()` picked the newest stable release *name* from Girder and then asserted the package metadata agreed. Kitware published the Slicer 5.12.4 linux/amd64 package the day before the run flagged `pre_release: True`, while the release name `5.12.4` parses as stable — so the two disagreed and the updater aborted:

```
5.12.4  Slicer_linux_amd64_34645  pre_release=True   built 2026-09-09T20:16Z
5.12.3  Slicer_linux_amd64_34627  pre_release=False  built 2026-07-22
```

A release can also exist before its Linux build is uploaded at all — Slicer publishes per platform, and `4.1.1-1` in the current listing already has zero linux/amd64 packages. That variant hits `_one()` with `found 0` and fails the job the same way.

## What

Walk the stable releases newest-first and skip a release whose linux/amd64 listing is empty or whose package is still flagged as a pre-release, settling on the newest promoted build.

The integrity checks are unchanged for the release actually selected. Only `pre_release is True` and an empty listing are skip signals; a missing `pre_release` flag, mismatched `app_id`/`os`/`arch`/`version`, a non-decimal revision, or an ambiguous two-package listing all still raise. If no release is promoted, it still raises rather than picking one.

## Verification

Ran the resolver against the live Kitware API, not just mocks — it downloads both artifacts and verifies them against the published SHA512 and size:

```
OK version= 5.12.3 revision= 34627 abi= 5.12
sha256= 0d7e6f46ad54356d0076362d07377bb4af648b11bf3e4caf1962e4b2b47b3320 size= 498683944
ext_item= 6a6171ff2eb3d967f0326127 ext_sha= a8b7a0594648...
```

Three new tests cover the fallback (asserting it probes 5.12.5, 5.12.4, then 5.12.3), the ambiguous-listing refusal, and the all-prerelease refusal. `builder/tests`: 699 passed. `python -m builder.audit_updates`: 247 automatic, clean. codespell clean on both changed files.

The recipe pins 5.10.0, so the next scheduled run reports `slicer` as an ordinary bump to 5.12.3 instead of `error`; once Kitware promotes 5.12.4 it moves up on its own. No recipe changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)