### PR TITLE
Detect release labels that stop naming what they install

### DIFF
--- a/builder/tests/test_release_artifact.py
+++ b/builder/tests/test_release_artifact.py
@@ -11,6 +11,7 @@ from builder.release_artifact import (
     resolve_release_artifact,
     resolve_suite_container,
 )
+from builder.openrecon_updates import OPENRECON_PINS
 from builder.validation import resolve_fulltest_version
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -429,4 +430,109 @@ def test_repository_fulltests_do_not_hardcode_release_artifacts() -> None:
         "fulltest.yaml must not hardcode a release artifact; remove 'container:' so it "
         "is resolved from releases/<recipe>/<version>.json, or set 'pin_container: true' "
         "when a historical image is genuinely required:\n" + "\n".join(offenders)
+    )
+
+
+# Containers whose release label is deliberately their own, not the tracked
+# software's version: a wrapper or bundle identity, or a base image pinned by
+# date. Adding a recipe here is a statement that `ml <recipe>/<version>` is not
+# meant to name the installed software's version.
+INDEPENDENT_CONTAINER_VERSIONS = {
+    "dicomtools": "bundles dcm2niix under its own 1.x line",
+    "epirecon": "local reconstruction pipeline, tracks a pypi dependency",
+    "esilpd": "local pipeline, tracks an upstream download",
+    "fatsegnet": "1.0.gpu names the variant, not the tracked package",
+    "flames": "local pipeline, tracks a pypi dependency",
+    "lesymap": "tracks a base image pinned by date",
+    "oshyx": "tracks a base image pinned by date",
+    "vesselboost": "local pipeline, tracks the model release",
+}
+
+# Same shape as the amico 2.1.0.post2 mislabel fixed in #3137: a single tracked
+# package whose version the label used to follow and no longer does. These need
+# a relabel decision per container, so the check tolerates them by name rather
+# than passing silently on the whole class.
+KNOWN_LABEL_DRIFT = {
+    "datalad": "labelled 1.3.1, installs the apt package 1.1.5",
+    "gimp": "labelled 2.10.18, installs the apt package 2.10.36",
+    "lstai": "labelled 1.2.0.post1, installs 1.1",
+    "palmettobug": "labelled 0.0.3.post1, installs 0.2.11",
+    "vina": "labelled 1.2.3, installs the apt package 1.2.5",
+}
+
+SHARED_DEPENDENCY_VARIABLES = frozenset(OPENRECON_PINS)
+
+# A commit, digest or listing pins bytes without naming a software version, so
+# a label can never be expected to agree with one.
+UNVERSIONED_SOURCE_METHODS = frozenset(
+    {
+        "artifact_listing",
+        "git_commit",
+        "github_commit",
+        "github_release_asset",
+        "http_digest",
+        "oci_digest",
+    }
+)
+
+
+def tracked_software_source(recipe: dict) -> dict | None:
+    """Return the lone source that names the installed software's version."""
+    policy = recipe.get("auto_update")
+    if not isinstance(policy, dict) or policy.get("method") != "sources":
+        return None
+    candidates = [
+        source
+        for source in policy.get("sources") or []
+        if isinstance(source, dict)
+        and source.get("method") not in UNVERSIONED_SOURCE_METHODS
+        and (source.get("target") or {}).get("variable")
+        not in SHARED_DEPENDENCY_VARIABLES
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def version_cores_agree(label: str, installed: str) -> bool:
+    """Report whether one version's numeric core prefixes the other's."""
+    label_core = re.findall(r"\d+", re.sub(r"\.post\d+$", "", label))
+    installed_core = re.findall(r"\d+", installed)
+    if not label_core or not installed_core:
+        return False
+    return (
+        label_core == installed_core[: len(label_core)]
+        or installed_core == label_core[: len(installed_core)]
+    )
+
+
+def test_single_package_recipes_label_the_software_version_they_install() -> None:
+    """A label that stops following its one package misnames what users load."""
+    offenders = []
+    for build_yaml in sorted((REPO_ROOT / "recipes").glob("*/build.yaml")):
+        recipe_name = build_yaml.parent.name
+        if recipe_name in INDEPENDENT_CONTAINER_VERSIONS or recipe_name in KNOWN_LABEL_DRIFT:
+            continue
+        recipe = yaml.safe_load(build_yaml.read_text(encoding="utf-8")) or {}
+        if not isinstance(recipe, dict):
+            continue
+        source = tracked_software_source(recipe)
+        if source is None:
+            continue
+        variable = (source.get("target") or {}).get("variable")
+        installed = str((recipe.get("variables") or {}).get(variable, ""))
+        label = str(recipe.get("version", ""))
+        if not installed or not label:
+            continue
+        if not version_cores_agree(label, installed):
+            offenders.append(
+                f"{recipe_name}: labelled {label}, installs {installed} "
+                f"(source {source.get('method')} -> {variable})"
+            )
+
+    assert not offenders, (
+        "a recipe that installs one tracked package must label the release with "
+        "that package's version, so `ml <recipe>/<version>` names what it ships. "
+        "Either track the package directly (auto_update.method: pypi, "
+        "github_release, ...) with {{ context.version }} in the install command, "
+        "or record the independent identity in "
+        "INDEPENDENT_CONTAINER_VERSIONS:\n" + "\n".join(offenders)
     )


### PR DESCRIPTION
## Why

Of the three bugs found while clearing the open PRs today, two shipped with a
test and one did not:

| Fix | Regression test |
| --- | --- |
| #3136 xsdata range follows the pinned ismrmrd | `test_shared_xsdata_requirement_follows_pinned_ismrmrd` |
| #3140 OpenRecon sync accepts `.postN` versions | `test_post_release_versions_stay_schema_valid_and_taggable` |
| #3137 amico labelled 2.1.0.post2 while shipping 2.1.1 | none |

Nothing would have caught the amico case. The recipe was internally consistent
and validation passed; its fulltest even asserted the right software version,
just through a separate `upstream_version` variable. The only visible symptom
was `ml amico/2.1.0.post2` loading amico 2.1.1.

## The check

`test_single_package_recipes_label_the_software_version_they_install` asserts
the one case where the two versions have to agree: a recipe whose
`auto_update.method: sources` policy tracks **exactly one** software version.
It ignores

- shared dependency pins (`OPENRECON_PINS`), so the 11 OpenRecon recipes are not
  compared against the ismrmrd version they happen to track, and
- sources that name bytes rather than a version (`github_commit`, `oci_digest`,
  `artifact_listing`, ...).

Verified by reverting `recipes/amico/build.yaml` to its pre-#3137 state:

```
amico: labelled 2.1.0.post2, installs 2.1.1 (source pypi -> upstream_version)
```

With the fix in place, it passes. Full `pytest builder/tests` is green (bar the
two pre-existing `dpkg`-dependent apt tests that cannot run on macOS).

## Two allowlists, deliberately named apart

`INDEPENDENT_CONTAINER_VERSIONS` (8 recipes) is the legitimate case this policy
exists for — a wrapper or bundle identity, or a base image pinned by date:
dicomtools, epirecon, esilpd, fatsegnet, flames, lesymap, oshyx, vesselboost.
Each carries its reason.

`KNOWN_LABEL_DRIFT` (5 recipes) is the same shape as the amico mislabel and is
listed separately so it reads as a queue, not as intent:

| Recipe | Label | Actually installs |
| --- | --- | --- |
| datalad | 1.3.1 | apt package 1.1.5 |
| gimp | 2.10.18 | apt package 2.10.36 |
| lstai | 1.2.0.post1 | 1.1 |
| palmettobug | 0.0.3.post1 | 0.2.11 |
| vina | 1.2.3 | apt package 1.2.5 |

I did not relabel these here: each one changes the module name users type and
triggers a rebuild and release, which is your call per container rather than
something this check should decide. Point me at the ones you want fixed and I
will do them the same way as amico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)