### PR TITLE
Sync OpenRecon image tags with the published build date

### DIFF
--- a/builder/tests/test_sync_openrecon.py
+++ b/builder/tests/test_sync_openrecon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -46,6 +47,28 @@ def write_source_recipe(root: Path, recipe: str = "demo") -> None:
         "variants:\n"
         "  gpu:\n"
         "    architecture: x86_64\n",
+        encoding="utf-8",
+    )
+
+
+def write_release_metadata(
+    root: Path, container: str, version: str, build_date: str
+) -> None:
+    release = root / "releases" / container
+    release.mkdir(parents=True, exist_ok=True)
+    (release / f"{version}.json").write_text(
+        json.dumps(
+            {
+                "apps": {
+                    f"{container} {version}": {
+                        "version": build_date,
+                        "exec": "",
+                        "apptainer_args": [],
+                    }
+                },
+                "categories": ["other"],
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -135,6 +158,111 @@ def test_prepare_recipe_separates_two_part_container_and_openrecon_versions(
     assert "export version=0.2\n" in params
     assert "export openrecon_version=0.2.0\n" in params
     assert "export baseDockerImage=vnmd/${toolName}_${version}\n" in params
+
+
+def test_prepare_recipe_points_dated_image_at_the_published_build(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "neurocontainers"
+    openrecon_root = tmp_path / "openrecon"
+    write_source_recipe(source_root)
+    write_release_metadata(source_root, "demo", "0.2.0", "20260910")
+    target = openrecon_root / "recipes" / "demo"
+    target.mkdir(parents=True)
+    (target / "params.sh").write_text(
+        "#!/bin/bash\n"
+        "export toolName=demo\n"
+        "export version=0.1.0\n"
+        "export baseDockerImage=ghcr.io/neurodesk/${toolName}_${version}:20260907\n",
+        encoding="utf-8",
+    )
+
+    prepared = sync_openrecon.prepare_recipe(
+        source_root, openrecon_root, "demo", "0.2.0"
+    )
+
+    assert prepared is not None
+    params = (target / "params.sh").read_text(encoding="utf-8")
+    assert (
+        "export baseDockerImage=ghcr.io/neurodesk/${toolName}_${version}:20260910\n"
+        in params
+    )
+    assert any("20260907" in note and "20260910" in note for note in prepared.notes)
+
+
+def test_prepare_recipe_keeps_an_already_current_image_tag(tmp_path: Path) -> None:
+    source_root = tmp_path / "neurocontainers"
+    openrecon_root = tmp_path / "openrecon"
+    write_source_recipe(source_root)
+    write_release_metadata(source_root, "demo", "0.2.0", "20260910")
+    target = openrecon_root / "recipes" / "demo"
+    target.mkdir(parents=True)
+    (target / "params.sh").write_text(
+        "#!/bin/bash\n"
+        "export version=0.1.0\n"
+        "export baseDockerImage=ghcr.io/neurodesk/demo_0.2.0:20260910\n",
+        encoding="utf-8",
+    )
+
+    prepared = sync_openrecon.prepare_recipe(
+        source_root, openrecon_root, "demo", "0.2.0"
+    )
+
+    assert prepared is not None
+    assert "ghcr.io/neurodesk/demo_0.2.0:20260910" in (
+        target / "params.sh"
+    ).read_text(encoding="utf-8")
+    assert not any("image tag" in note for note in prepared.notes)
+
+
+def test_prepare_recipe_reports_an_unresolved_build_date(tmp_path: Path) -> None:
+    source_root = tmp_path / "neurocontainers"
+    openrecon_root = tmp_path / "openrecon"
+    write_source_recipe(source_root)
+    target = openrecon_root / "recipes" / "demo"
+    target.mkdir(parents=True)
+    (target / "params.sh").write_text(
+        "#!/bin/bash\n"
+        "export version=0.1.0\n"
+        "export baseDockerImage=ghcr.io/neurodesk/${toolName}_${version}:20260907\n",
+        encoding="utf-8",
+    )
+
+    prepared = sync_openrecon.prepare_recipe(
+        source_root, openrecon_root, "demo", "0.2.0"
+    )
+
+    assert prepared is not None
+    assert "${version}:20260907\n" in (target / "params.sh").read_text(
+        encoding="utf-8"
+    )
+    assert any("20260907" in note for note in prepared.notes)
+
+
+def test_prepare_recipe_resolves_the_build_date_of_a_named_variant(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "neurocontainers"
+    openrecon_root = tmp_path / "openrecon"
+    write_source_recipe(source_root)
+    write_release_metadata(source_root, "demo_gpu", "1.2.3", "20260910")
+    target = openrecon_root / "recipes" / "demo_gpu"
+    target.mkdir(parents=True)
+    (target / "params.sh").write_text(
+        "#!/bin/bash\n"
+        "export version=1.2.2\n"
+        "export baseDockerImage=ghcr.io/neurodesk/demo_gpu_1.2.2:20260904\n",
+        encoding="utf-8",
+    )
+
+    prepared = sync_openrecon.prepare_recipe(
+        source_root, openrecon_root, "demo", "1.2.3", variant="gpu"
+    )
+
+    assert prepared is not None
+    assert "ghcr.io/neurodesk/demo_gpu_1.2.2:20260910" in (
+        target / "params.sh"
+    ).read_text(encoding="utf-8")
 
 
 def test_prepare_recipe_resolves_named_variant_to_concrete_container(

--- a/tools/sync_openrecon.py
+++ b/tools/sync_openrecon.py
@@ -43,6 +43,11 @@ TWO_PART_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 POST_RELEASE_VERSION_PATTERN = re.compile(
     r"^(?P<base>(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){1,2})\.post(?P<post>0|[1-9]\d*)$"
 )
+IMAGE_ASSIGNMENT_PATTERN = re.compile(
+    r"^(?P<prefix>[ \t]*(?:export[ \t]+)?baseDockerImage=)(?P<image>\S*)$",
+    re.MULTILINE,
+)
+BUILD_DATE_PATTERN = re.compile(r"^\d{8}$")
 
 
 @dataclass(frozen=True)
@@ -165,6 +170,50 @@ def update_params_version(contents: str, version: str) -> str:
     )
 
 
+def released_build_date(source_root: Path, container: str, version: str) -> str | None:
+    """Return the build date the release metadata published for this version."""
+    validate_version(version)
+    releases = source_root / "releases"
+    release = releases / container / f"{version}.json"
+    if not release.resolve().is_relative_to(releases.resolve()):
+        raise ValueError(f"Invalid container name: {container!r}")
+    if not release.is_file():
+        return None
+    try:
+        apps = json.loads(release.read_text(encoding="utf-8"))["apps"]
+        build_date = str(apps[f"{container} {version}"]["version"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return build_date if BUILD_DATE_PATTERN.fullmatch(build_date) else None
+
+
+def dated_image_tag(contents: str) -> str | None:
+    """Return the build-date tag a params.sh image reference pins, if any."""
+    match = IMAGE_ASSIGNMENT_PATTERN.search(contents)
+    if match is None:
+        return None
+    _, separator, tag = match.group("image").rpartition(":")
+    if not separator or not BUILD_DATE_PATTERN.fullmatch(tag):
+        return None
+    return tag
+
+
+def update_params_image_tag(contents: str, build_date: str) -> str:
+    """Point a dated image reference at the build published for this release."""
+    if not BUILD_DATE_PATTERN.fullmatch(build_date):
+        raise ValueError(f"Invalid build date: {build_date!r}")
+    if dated_image_tag(contents) is None:
+        return contents
+    match = IMAGE_ASSIGNMENT_PATTERN.search(contents)
+    assert match is not None
+    repository = match.group("image").rpartition(":")[0]
+    return (
+        contents[: match.start("image")]
+        + f"{repository}:{build_date}"
+        + contents[match.end("image") :]
+    )
+
+
 def prepare_recipe(
     source_root: Path,
     openrecon_root: Path,
@@ -206,6 +255,25 @@ def prepare_recipe(
 
     params = target_params.read_text(encoding="utf-8")
     updated_params = update_params_version(params, version)
+    pinned_tag = dated_image_tag(updated_params)
+    if pinned_tag is not None:
+        build_date = released_build_date(
+            source_root, openrecon_target.container, version
+        )
+        if build_date is None:
+            notes.append(
+                f"- Leave the `{pinned_tag}` image tag in "
+                f"`{(relative_recipe / 'params.sh').as_posix()}` because no release "
+                f"metadata was found for {openrecon_target.container} {version}; "
+                "confirm that image exists before merging"
+            )
+        else:
+            updated_params = update_params_image_tag(updated_params, build_date)
+            if build_date != pinned_tag:
+                notes.append(
+                    f"- Repoint `{(relative_recipe / 'params.sh').as_posix()}` from "
+                    f"image tag `{pinned_tag}` to the published `{build_date}`"
+                )
     if updated_params != params:
         target_params.write_text(updated_params, encoding="utf-8")
 

--- a/workflows/ONE_PR_RELEASES.md
+++ b/workflows/ONE_PR_RELEASES.md
@@ -44,6 +44,10 @@ artifacts after merge. They no longer create a second release-metadata PR.
    opens or reuses an OpenRecon metadata PR after the release metadata push. If
    the version, label, and README are unchanged, it dispatches the OpenRecon
    build directly so same-version container rebuilds still propagate.
+   An OpenRecon `params.sh` that pins a dated image tag is repointed at the build
+   date this release published, so the OpenRecon build pulls the image the
+   promoter just pushed. When no release metadata resolves that date, the tag is
+   left alone and the PR body says so.
 
 Manual builds remain available as a recovery path. The old push-to-main
 `auto-build` workflow is removed so recipe changes cannot start an untested


### PR DESCRIPTION
## The bug

`tools/sync_openrecon.py` rewrites the `version=` assignment in an OpenRecon `params.sh` but leaves `baseDockerImage` alone. For recipes whose `params.sh` pins a dated GHCR tag, the synced PR keeps the *previous* release's date.

Concretely, the qsmxt 9.17.0 sync PR ([neurodesk/openrecon#282](https://github.com/neurodesk/openrecon/pull/282)) asked OpenRecon to build from:

```
ghcr.io/neurodesk/qsmxt_9.17.0:20260907
```

That tag does not exist. Registry state:

- `qsmxt_9.17.0` → `20260910`, `latest`
- `qsmxt_9.16.0` → `20260907`, `latest`

So the OpenRecon build pulls a missing image and fails until a maintainer repins it by hand — which is what `Pin QSMxT 9.15.0 OpenRecon build image` (neurodesk/openrecon#260) and `Fix EPIRecon packaging with the published GHCR image` (#278) were.

## The fix

Read the build date back from `releases/<container>/<version>.json`, which the promoter commits *before* the `sync_openrecon` job checks out `main`, and repoint the dated tag at it.

- Only tags matching `^\d{8}$` on an `export baseDockerImage=` line are rewritten; the repository part, including `${toolName}_${version}` expansions, is preserved.
- Undated references such as `vnmd/${toolName}_${version}` are left untouched.
- Named variants resolve their own release file, e.g. `releases/demo_gpu/1.2.3.json`.
- When no release metadata resolves the date, the existing tag is kept and the PR body records that it was not verified, rather than publishing a guess.

Verified against the real repository state: running `prepare_recipe` with this checkout as the source and a copy of the current OpenRecon `params.sh` reproduces exactly the manual fix applied to neurodesk/openrecon#282.

```
export version=9.17.0
export baseDockerImage=ghcr.io/neurodesk/${toolName}_${version}:20260910
```

## Tests

Four new cases in `builder/tests/test_sync_openrecon.py`: dated tag repointed with a PR note, already-current tag left alone, missing release metadata reported instead of guessed, and a named variant resolving its own release file. `pytest builder/tests` — 710 passed. `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)