### PR TITLE
Bump aslprep from 26.0.2 to 26.0.3

### DIFF
--- a/recipes/aslprep/build.yaml
+++ b/recipes/aslprep/build.yaml
@@ -1,5 +1,5 @@
 name: aslprep
-version: 26.0.2
+version: 26.0.3
 copyright:
   - license: BSD-3-Clause
     url: https://github.com/pennlinc/aslprep/blob/main/LICENSE.md

--- a/recipes/aslprep/fulltest.yaml
+++ b/recipes/aslprep/fulltest.yaml
@@ -13,7 +13,7 @@
 # in ds000001, so we test the bundled tools (FSL, ANTs, FreeSurfer utilities)
 
 name: aslprep
-version: 26.0.2
+version: 26.0.3
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/aslprep/build.yaml`
- Upstream release: https://hub.docker.com/r/pennlinc/aslprep/tags?name=26.0.3

### Changes
- `version`: `26.0.2` → `26.0.3`
- `fulltest.yaml` version: `26.0.2` → `26.0.3`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.