### PR TITLE
Bump bidsappbrainsuite from 21a to 23a

### DIFF
--- a/recipes/bidsappbrainsuite/build.yaml
+++ b/recipes/bidsappbrainsuite/build.yaml
@@ -1,5 +1,5 @@
 name: bidsappbrainsuite
-version: "21a"
+version: "23a"
 # https://hub.docker.com/r/bids/brainsuite/tags
 
 architectures:

--- a/recipes/bidsappbrainsuite/build.yaml
+++ b/recipes/bidsappbrainsuite/build.yaml
@@ -21,6 +21,13 @@ build:
         DEBIAN_FRONTEND: noninteractive
         PATH: $PATH:/BrainSuite/
 
+    # 23a runs its tools on the MATLAB Runtime, and the upstream image sets
+    # BrainSuiteMCR without putting its libraries, including OpenGL, on the
+    # loader path. 21a shipped no runtime at all, so this is new with the bump.
+    - environment:
+        LD_LIBRARY_PATH: "${BrainSuiteMCR}/runtime/glnxa64:${BrainSuiteMCR}/bin/glnxa64:${BrainSuiteMCR}/sys/os/glnxa64:${BrainSuiteMCR}/sys/opengl/lib/glnxa64:$LD_LIBRARY_PATH"
+        XAPPLRESDIR: "${BrainSuiteMCR}/X11/app-defaults"
+
     - run:
         - printf '%s\n' '#!/usr/bin/env bash' 'set -e' '' 'if [ "$#" -eq 0 ]; then' '  exec /usr/bin/env bash' 'fi' '' 'exec "$@"' > /usr/local/bin/bidsappbrainsuite-entrypoint
         - chmod +x /usr/local/bin/bidsappbrainsuite-entrypoint
@@ -30,9 +37,9 @@ build:
 deploy:
   path:
     - /BrainSuite/QC
-    - /opt/BrainSuite21a/bin
-    - /opt/BrainSuite21a/svreg/bin
-    - /opt/BrainSuite21a/bdp
+    - /opt/BrainSuite{{ context.version }}/bin
+    - /opt/BrainSuite{{ context.version }}/svreg/bin
+    - /opt/BrainSuite{{ context.version }}/bdp
     - /usr/local/miniconda/bin
     - /BrainSuite
 

--- a/recipes/bidsappbrainsuite/fulltest.yaml
+++ b/recipes/bidsappbrainsuite/fulltest.yaml
@@ -18,7 +18,7 @@
 #   - BOLD: Functional MRI (task-balloonanalogrisktask)
 
 name: bidsappbrainsuite
-version: 21a
+version: 23a
 
 required_files:
   - dataset: ds000001

--- a/recipes/bidsappbrainsuite/fulltest.yaml
+++ b/recipes/bidsappbrainsuite/fulltest.yaml
@@ -47,6 +47,18 @@ setup:
     mkdir -p ${output_dir}/pipeline
 
 tests:
+  - name: Renderdfs resolves its runtime libraries
+    description: Verify the surface renderer can load the MATLAB Runtime and OpenGL
+    script: |
+      set -eu
+      renderer="/opt/BrainSuite${version}/bin/renderdfs"
+      test -x "$renderer"
+      dependencies="$(ldd "$renderer")"
+      printf '%s\n' "$dependencies"
+      if printf '%s\n' "$dependencies" | grep -q 'not found'; then
+        exit 1
+      fi
+
   # ==========================================================================
   # BASIC FUNCTIONALITY AND VERSION CHECKS
   # ==========================================================================


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/bidsappbrainsuite/build.yaml`
- Upstream release: https://hub.docker.com/r/bids/brainsuite/tags?name=v23a

### Changes
- `version`: `21a` → `23a`
- `fulltest.yaml` version: `21a` → `23a`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.