### PR TITLE
Bump bidsappmrtrix3connectome from 0.5.3 to 0.6.0

### DIFF
--- a/recipes/bidsappmrtrix3connectome/build.yaml
+++ b/recipes/bidsappmrtrix3connectome/build.yaml
@@ -1,6 +1,6 @@
 name: bidsappmrtrix3connectome
 
-version: 0.5.3
+version: 0.6.0
 
 copyright:
   - license: Apache-2.0

--- a/recipes/bidsappmrtrix3connectome/fulltest.yaml
+++ b/recipes/bidsappmrtrix3connectome/fulltest.yaml
@@ -15,7 +15,7 @@
 # Tests focus on MRtrix3 utilities that can work with available structural/functional data.
 
 name: bidsappmrtrix3connectome
-version: 0.5.3
+version: 0.6.0
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/bidsappmrtrix3connectome/build.yaml`
- Upstream release: https://hub.docker.com/r/bids/mrtrix3_connectome/tags?name=0.6.0

### Changes
- `version`: `0.5.3` → `0.6.0`
- `fulltest.yaml` version: `0.5.3` → `0.6.0`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.