### PR TITLE
Defer unreachable upstreams instead of failing the auto-update run

### DIFF
--- a/builder/check_version.py
+++ b/builder/check_version.py
@@ -554,6 +554,28 @@ def submit_bump(
     return "opened"
 
 
+# Retries are already exhausted by the time these surface, and a request that never reached
+# upstream says nothing about the recipe. Across 247 recipes a brief outage at any one of them
+# would otherwise fail the whole scheduled run, so they defer to the next run instead.
+TRANSIENT_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def unreachable_upstream(exc: BaseException) -> bool:
+    """Report whether the failure is the network rather than the recipe."""
+    if isinstance(exc, requests.exceptions.HTTPError):
+        response = getattr(exc, "response", None)
+        return response is not None and response.status_code in TRANSIENT_HTTP_STATUSES
+    return isinstance(
+        exc,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RetryError,
+            requests.exceptions.ChunkedEncodingError,
+        ),
+    )
+
+
 def write_report(rows, report_path=None):
     if report_path:
         Path(report_path).write_text(json.dumps(rows, indent=2) + "\n")
@@ -690,7 +712,14 @@ def main():
             row["status"] = "available"
             candidates.append((path, data, release, new_version, row, None))
         except Exception as exc:
-            row.update(status="error", detail=f"{type(exc).__name__}: {exc}")
+            detail = f"{type(exc).__name__}: {exc}"
+            if unreachable_upstream(exc):
+                row.update(
+                    status="deferred",
+                    detail=f"Upstream unreachable; retried on the next run. {detail}",
+                )
+            else:
+                row.update(status="error", detail=detail)
         print(f"{row['recipe']}: {row['status']} {row['detail']}", flush=True)
 
     opened = 0
@@ -750,7 +779,14 @@ def main():
             else:
                 row["status"] = f"pr-{result}"
         except Exception as exc:
-            row.update(status="error", detail=f"{type(exc).__name__}: {exc}")
+            detail = f"{type(exc).__name__}: {exc}"
+            if unreachable_upstream(exc):
+                row.update(
+                    status="deferred",
+                    detail=f"Upstream unreachable; retried on the next run. {detail}",
+                )
+            else:
+                row.update(status="error", detail=detail)
     write_report(rows, args.json)
     return int(not rows or any(row["status"] == "error" for row in rows))
 

--- a/builder/tests/test_check_version.py
+++ b/builder/tests/test_check_version.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import requests
 import yaml
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "check_version.py"
@@ -394,3 +395,41 @@ def test_raw_tag_rewrite_rejects_anchors_and_block_scalars(source):
     text = f"variables:\n  upstream_tag: {source}\nauto_update: {{}}\n"
     with pytest.raises(ValueError, match="plain or quoted scalar"):
         check_version.rewrite_upstream_tag(text, "upstream_tag", "v1.9.6")
+
+
+def raise_and_classify(exc):
+    try:
+        raise exc
+    except Exception as caught:
+        return check_version.unreachable_upstream(caught)
+
+
+def test_unreachable_upstream_defers_the_outages_that_failed_scheduled_runs():
+    # The exact failures that turned whole auto-update runs red while every recipe was fine.
+    zenodo = requests.exceptions.ConnectionError(
+        "HTTPSConnectionPool(host='zenodo.org', port=443): Max retries exceeded"
+    )
+    tgvqsm = requests.exceptions.ConnectTimeout(
+        "HTTPSConnectionPool(host='www.neuroimaging.at', port=443): Max retries exceeded"
+    )
+    assert raise_and_classify(zenodo)
+    assert raise_and_classify(tgvqsm)
+    assert raise_and_classify(requests.exceptions.ReadTimeout("read timed out"))
+    assert raise_and_classify(requests.exceptions.RetryError("too many retries"))
+    assert raise_and_classify(requests.exceptions.ChunkedEncodingError("truncated"))
+
+
+@pytest.mark.parametrize("status,deferred", [(429, True), (503, True), (504, True), (404, False), (403, False)])
+def test_unreachable_upstream_separates_server_outages_from_missing_resources(status, deferred):
+    response = requests.Response()
+    response.status_code = status
+    assert check_version.unreachable_upstream(
+        requests.exceptions.HTTPError(response=response)
+    ) is deferred
+
+
+def test_unreachable_upstream_still_fails_the_run_for_recipe_defects():
+    # The Slicer metadata mismatch must stay an error; only the network gets a pass.
+    assert not raise_and_classify(ValueError("Slicer package release or architecture metadata disagrees"))
+    assert not raise_and_classify(KeyError("upstream_version"))
+    assert not raise_and_classify(requests.exceptions.HTTPError("no response attached"))


### PR DESCRIPTION
## Why

`builder/check_version.py` exits non-zero when any recipe row ends in `error`, so one network blip against any one of 247 upstreams turns the whole scheduled run red. That is most of what it actually reports. Across the last two failed runs, 5 of 6 errors were transient connectivity:

| Run | Recipe | Failure |
| --- | --- | --- |
| [34432954528](https://github.com/neurodesk/neurocontainers/actions/runs/34432954528) | brainles-preprocessing, mrsiproc, musclemap, rabies | `ReadTimeout` against `zenodo.org` |
| [34558024887](https://github.com/neurodesk/neurocontainers/actions/runs/34558024887) | tgvqsm | `ConnectTimeout` against `www.neuroimaging.at` |

Every one of those hosts answers normally now (~1.2s). The only genuine defect in either run was `slicer`, fixed in #3141. A red run that usually means "a CDN hiccuped" is a signal nobody can act on, and it masks the runs that do need attention.

## What

Classify failures that never reached upstream as `deferred` rather than `error`, so they retry on the next run:

- `ConnectionError` (includes `ConnectTimeout`, `SSLError`, `ProxyError`)
- `Timeout` (includes `ReadTimeout`)
- `RetryError`, `ChunkedEncodingError`
- `HTTPError` carrying 429, 500, 502, 503, or 504

Requests already exhaust their configured retries before these surface, and a request that never arrived says nothing about the recipe. The exception is preserved verbatim in the detail column (`Upstream unreachable; retried on the next run. ConnectTimeout: ...`), so a persistently dead host is still greppable in the job summary.

Everything else still fails the run — the Slicer-style metadata mismatch, an unsupported `auto_update` method, an unsafe version bump, and an `HTTPError` carrying 404/403 all remain `error`. Both exception handlers (version discovery and PR submission) get the same treatment.

## Verification

End to end with the network blackholed via an unroutable proxy:

```
$ HTTPS_PROXY=http://127.0.0.1:9 python -m builder.check_version tgvqsm rabies --dry-run
rabies: deferred Upstream unreachable; retried on the next run. ProxyError: ...
tgvqsm: deferred Upstream unreachable; retried on the next run. ProxyError: ...
deferred: 2
EXIT=0
```

And the converse, proving the guard did not just become permissive — a recipe with an invalid `auto_update` policy still fails the run even alongside a deferred network failure:

```
$ HTTPS_PROXY=http://127.0.0.1:9 python -m builder.check_version ztmpbroken tgvqsm --dry-run
tgvqsm: deferred Upstream unreachable; retried on the next run. ProxyError: ...
ztmpbroken: error ValueError: unsupported auto_update method: 'bogus_provider'
deferred: 1, error: 1
EXIT=1
```

Unit tests cover the classifier against the exact exception types from both failed runs, the 429/503/504-vs-404/403 split, and the non-network exceptions that must stay errors. `builder/tests`: 706 passed. `audit_updates`: 247 automatic. codespell clean.

## Tradeoff worth knowing

A permanently dead upstream now reports `deferred` forever rather than going red, so a recipe could silently stop updating. The detail column names the host and exception on every run, but nothing escalates on repetition. If you want that covered, the follow-up is to fail when a recipe defers for network reasons on N consecutive runs — happy to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)