### PR TITLE
Let a sources policy name the software it distributes

### DIFF
--- a/builder/tests/test_release_artifact.py
+++ b/builder/tests/test_release_artifact.py
@@ -449,9 +449,9 @@ INDEPENDENT_CONTAINER_VERSIONS = {
 }
 
 # Same shape as the amico 2.1.0.post2 mislabel fixed in #3137: a single tracked
-# package whose version the label used to follow and no longer does. These need
-# a relabel decision per container, so the check tolerates them by name rather
-# than passing silently on the whole class.
+# package whose version the label used to follow and no longer does. Relabelling
+# a published container is a per-container decision, so the check tolerates them
+# by name until each one is settled.
 KNOWN_LABEL_DRIFT = {
     "datalad": "labelled 1.3.1, installs the apt package 1.1.5",
     "gimp": "labelled 2.10.18, installs the apt package 2.10.36",
@@ -477,19 +477,36 @@ UNVERSIONED_SOURCE_METHODS = frozenset(
 
 
 def tracked_software_source(recipe: dict) -> dict | None:
-    """Return the lone source that names the installed software's version."""
+    """Return the source whose version the container label should name."""
     policy = recipe.get("auto_update")
     if not isinstance(policy, dict) or policy.get("method") != "sources":
         return None
+    sources = [source for source in policy.get("sources") or [] if isinstance(source, dict)]
+    driver = policy.get("container_version")
+    if driver:
+        # The recipe says which software it is a distribution of, so a second
+        # tracked dependency no longer makes the label unattributable.
+        return next((source for source in sources if source.get("id") == driver), None)
     candidates = [
         source
-        for source in policy.get("sources") or []
-        if isinstance(source, dict)
-        and source.get("method") not in UNVERSIONED_SOURCE_METHODS
+        for source in sources
+        if source.get("method") not in UNVERSIONED_SOURCE_METHODS
         and (source.get("target") or {}).get("variable")
         not in SHARED_DEPENDENCY_VARIABLES
     ]
     return candidates[0] if len(candidates) == 1 else None
+
+
+def tracked_version(recipe: dict, source: dict) -> str:
+    """Return the software version the recipe currently records for a source."""
+    target = source.get("target") or {}
+    variables = recipe.get("variables") or {}
+    if "variable" in target:
+        return str(variables.get(target["variable"], ""))
+    for variable, field in (target.get("variables") or {}).items():
+        if field == "version":
+            return str(variables.get(variable, ""))
+    return ""
 
 
 def version_cores_agree(label: str, installed: str) -> bool:
@@ -517,15 +534,14 @@ def test_single_package_recipes_label_the_software_version_they_install() -> Non
         source = tracked_software_source(recipe)
         if source is None:
             continue
-        variable = (source.get("target") or {}).get("variable")
-        installed = str((recipe.get("variables") or {}).get(variable, ""))
+        installed = tracked_version(recipe, source)
         label = str(recipe.get("version", ""))
         if not installed or not label:
             continue
         if not version_cores_agree(label, installed):
             offenders.append(
                 f"{recipe_name}: labelled {label}, installs {installed} "
-                f"(source {source.get('method')} -> {variable})"
+                f"(source {source.get('id')} via {source.get('method')})"
             )
 
     assert not offenders, (
@@ -533,6 +549,7 @@ def test_single_package_recipes_label_the_software_version_they_install() -> Non
         "that package's version, so `ml <recipe>/<version>` names what it ships. "
         "Either track the package directly (auto_update.method: pypi, "
         "github_release, ...) with {{ context.version }} in the install command, "
-        "or record the independent identity in "
+        "nominate it with auto_update.container_version so the updater keeps the "
+        "label on the software, or record the independent identity in "
         "INDEPENDENT_CONTAINER_VERSIONS:\n" + "\n".join(offenders)
     )

--- a/builder/tests/test_update_observations.py
+++ b/builder/tests/test_update_observations.py
@@ -806,7 +806,9 @@ Version: 1:2.0-1ubuntu2
     )
 
     assert observed.value == "1:2.0-1ubuntu2"
-    assert observed.version is None
+    # The install pin needs the epoch and Debian revision; a container label
+    # naming this software does not.
+    assert observed.version == "2.0"
     assert observed.url.endswith("Packages.gz")
     assert observed.metadata == {"package": "demo"}
 

--- a/builder/tests/test_update_plan.py
+++ b/builder/tests/test_update_plan.py
@@ -112,3 +112,101 @@ def test_source_anchor_cannot_change_another_input_through_alias():
     for variable in ('first', 'second'):
         with pytest.raises(ValueError, match='anchors'):
             rewrite_scalar(text, ('variables', variable), '2.0.0')
+
+
+def make_apt_recipe(tmp_path):
+    """A recipe whose label is the software version and whose pin is not."""
+    root = tmp_path / 'apt-demo'
+    root.mkdir()
+    recipe = {
+        'name': 'apt-demo', 'version': '2.10.36',
+        'variables': {'package_version': '2.10.36-3ubuntu0.24.04.1', 'helper_commit': 'a' * 40},
+        'auto_update': {'method': 'sources', 'container_version': 'tool', 'sources': [
+            {'id': 'tool', 'method': 'apt', 'package': 'tool',
+             'urls': ['https://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/Packages.gz'],
+             'target': {'variable': 'package_version', 'fulltest_variable': 'package_version'}},
+            {'id': 'helper', 'method': 'github_commit', 'repo': 'example/helper', 'ref': 'main',
+             'target': {'variable': 'helper_commit'}},
+        ]},
+        'build': {'base-image': 'ubuntu:24.04', 'directives': [
+            {'install': ['tool={{ context.package_version }}']}]},
+        'files': [{'name': 'helper', 'url': 'https://github.com/example/helper/archive/{{ context.helper_commit }}.tar.gz'}],
+    }
+    path = root / 'build.yaml'
+    path.write_text(yaml.safe_dump(recipe, sort_keys=False))
+    (root / 'fulltest.yaml').write_text(yaml.safe_dump(
+        {'name': 'apt-demo', 'version': '2.10.36', 'package_version': '2.10.36-3ubuntu0.24.04.1',
+         'tests': [{'name': 'version', 'command': 'tool --version', 'expected_output_contains': '${version}'}]},
+        sort_keys=False))
+    return path
+
+
+@pytest.fixture
+def debian_ordering(monkeypatch):
+    """Order apt versions without dpkg, which is absent on non-Debian hosts."""
+    from builder import update_observations
+
+    monkeypatch.setattr(
+        update_observations, "_debian_newer", lambda candidate, current: candidate > current
+    )
+
+
+def apt_observation(package_version):
+    from builder.update_observations import debian_upstream_version
+
+    return SourceObservation(package_version, 'https://archive.ubuntu.com/ubuntu',
+                             version=debian_upstream_version(package_version))
+
+
+def test_nominated_source_moves_the_container_label_to_the_software_version(tmp_path, debian_ordering):
+    # The apt pin carries a packaging revision that must not reach the label.
+    path = make_apt_recipe(tmp_path)
+    found = {'tool': apt_observation('2.10.42-1ubuntu2'),
+             'helper': SourceObservation('a' * 40, 'https://github.com/example/helper')}
+
+    plan = plan_sources(path, observations=found)
+
+    assert plan.next_version == '2.10.42'
+    plan.apply()
+    changed = yaml.safe_load(path.read_text())
+    assert changed['version'] == '2.10.42'
+    assert changed['variables']['package_version'] == '2.10.42-1ubuntu2'
+    suite = yaml.safe_load(path.with_name('fulltest.yaml').read_text())
+    assert suite['version'] == '2.10.42'
+
+
+def test_a_dependency_moving_alone_still_rebuilds_the_same_software(tmp_path):
+    path = make_apt_recipe(tmp_path)
+    found = {'tool': apt_observation('2.10.36-3ubuntu0.24.04.1'),
+             'helper': SourceObservation('b' * 40, 'https://github.com/example/helper')}
+
+    plan = plan_sources(path, observations=found)
+
+    assert plan.next_version == '2.10.36.post1'
+
+
+def test_repackaging_the_same_software_does_not_rename_the_container(tmp_path, debian_ordering):
+    # A new Debian revision of the same upstream release is a rebuild, not a
+    # new version of the software the label names.
+    path = make_apt_recipe(tmp_path)
+    found = {'tool': apt_observation('2.10.36-4ubuntu1'),
+             'helper': SourceObservation('a' * 40, 'https://github.com/example/helper')}
+
+    plan = plan_sources(path, observations=found)
+
+    assert plan.next_version == '2.10.36.post1'
+    plan.apply()
+    assert yaml.safe_load(path.read_text())['variables']['package_version'] == '2.10.36-4ubuntu1'
+
+
+def test_container_version_must_name_a_source_that_observes_a_version():
+    policy = {'method': 'sources', 'container_version': 'helper', 'sources': [
+        {'id': 'helper', 'method': 'github_commit', 'repo': 'example/helper', 'ref': 'main',
+         'target': {'variable': 'helper_commit'}}]}
+
+    with pytest.raises(ValueError, match='pins bytes'):
+        validate_sources_config(policy)
+
+    policy['container_version'] = 'absent'
+    with pytest.raises(ValueError, match='must name one of'):
+        validate_sources_config(policy)

--- a/builder/update_observations.py
+++ b/builder/update_observations.py
@@ -618,6 +618,16 @@ def _debian_newer(candidate: str, current: str) -> bool:
     return result.returncode == 0
 
 
+def debian_upstream_version(version: str) -> str:
+    """Return the software's own version, without the epoch or Debian revision.
+
+    A container labelled with the packaging revision would rename itself for a
+    rebuild that ships identical software.
+    """
+    upstream = version.split(":", 1)[-1]
+    return upstream.rsplit("-", 1)[0] if "-" in upstream else upstream
+
+
 def _apt(config: dict, session: requests.Session) -> SourceObservation:
     package = config["package"]
     best: str | None = None
@@ -645,6 +655,7 @@ def _apt(config: dict, session: requests.Session) -> SourceObservation:
     return SourceObservation(
         value=best,
         url=best_url,
+        version=debian_upstream_version(best),
         metadata={"package": package},
     )
 

--- a/builder/update_plan.py
+++ b/builder/update_plan.py
@@ -12,6 +12,29 @@ from typing import Mapping
 import yaml
 from packaging.version import InvalidVersion, Version
 
+# These sources pin exact bytes without naming a software version, so they can
+# never drive the container label.
+VERSIONLESS_METHODS = frozenset({"git_commit", "github_commit", "http_digest", "oci_digest"})
+
+
+def _validate_container_version(config: dict, ids: set[str]) -> None:
+    """Reject a version driver that is missing or cannot observe a version."""
+    driver = config.get("container_version")
+    if driver is None:
+        return
+    if not isinstance(driver, str) or driver not in ids:
+        raise ValueError(
+            f"container_version must name one of this recipe's sources: {sorted(ids)}"
+        )
+    method = next(
+        source["method"] for source in config["sources"] if source.get("id") == driver
+    )
+    if method in VERSIONLESS_METHODS:
+        raise ValueError(
+            f"container_version source {driver} tracks {method}, which pins bytes "
+            "without naming a software version"
+        )
+
 
 def source_config(source: dict) -> dict:
     return {key: value for key, value in source.items() if key not in {"id", "target"}}
@@ -20,8 +43,10 @@ def source_config(source: dict) -> dict:
 def validate_sources_config(config: dict) -> None:
     from .update_observations import validate_source
 
-    if set(config) - {"method", "sources", "local"}:
-        raise ValueError("sources policy accepts only method, sources and local")
+    if set(config) - {"method", "sources", "local", "container_version"}:
+        raise ValueError(
+            "sources policy accepts only method, sources, local and container_version"
+        )
     sources = config.get("sources", [])
     if not isinstance(sources, list) or (not sources and "local" not in config):
         raise ValueError("sources policy requires installed sources or local paths")
@@ -83,6 +108,7 @@ def validate_sources_config(config: dict) -> None:
             r"[A-Za-z_][A-Za-z_0-9]*", str(target["fulltest_variable"])
         ):
             raise ValueError(f"{name}: invalid fulltest variable")
+    _validate_container_version(config, ids)
 
 
 def _acquisition_text(recipe: dict, variable: str) -> str:
@@ -282,6 +308,8 @@ def plan_sources(recipe_path: Path, github_session=None, *, observations: Mappin
     suite_original = suite_path.read_text()
     updated, suite_updated = original, suite_original
     changes, urls = [], []
+    driver = recipe["auto_update"].get("container_version")
+    driver_version = None
     for source in recipe["auto_update"].get("sources", []):
         target = source["target"]
         current = str(recipe["variables"][target["variable"]]) if "variable" in target else None
@@ -329,7 +357,13 @@ def plan_sources(recipe_path: Path, github_session=None, *, observations: Mappin
                                              source.get("version_scheme", "numeric"), source.get("include_prereleases", False))
                 if previous and _is_older(observation.version, previous.version):
                     continue
-            if observation.version and target.get("value", "value") != "tag":
+            # An apt version is ordered by _debian_newer above; its upstream
+            # version is a label, not a comparable release identity here.
+            if (
+                observation.version
+                and source["method"] != "apt"
+                and target.get("value", "value") != "tag"
+            ):
                 try:
                     if Version(selected) <= Version(current):
                         continue
@@ -366,10 +400,18 @@ def plan_sources(recipe_path: Path, github_session=None, *, observations: Mappin
                 changes.append(f"`{'.'.join(map(str, path))}`: `{node}` → `{value}`")
         if updated != previous:
             urls.append(observation.url)
+            if source["id"] == driver:
+                driver_version = observation.version
     if updated == original:
         return None
     current_version = str(recipe["version"])
-    next_version = next_container_version(current_version)
+    # A nominated source names the software this container is a distribution of,
+    # so its release becomes the label. Everything else, including a dependency
+    # moving on its own, still only rebuilds the same software as .postN.
+    if driver_version and _is_older(current_version, driver_version):
+        next_version = driver_version
+    else:
+        next_version = next_container_version(current_version)
     updated = rewrite_scalar(updated, ("version",), next_version)
     suite = yaml.safe_load(suite_updated)
     indirect = re.fullmatch(r"\$\{(\w+)\}", str(suite["version"]))

--- a/builder/validation.py
+++ b/builder/validation.py
@@ -569,6 +569,7 @@ class Template:
 class AutoUpdate:
     method: str = attrs.field()
     sources: Optional[List[Dict[str, Any]]] = attrs.field(default=None)
+    container_version: Optional[str] = attrs.field(default=None)
     local: Optional[List[str]] = attrs.field(default=None)
     repo: Optional[str] = attrs.field(default=None)
     package: Optional[str] = attrs.field(default=None)

--- a/workflows/AUTO_UPDATES.md
+++ b/workflows/AUTO_UPDATES.md
@@ -139,6 +139,43 @@ required. Its `upstream_version` scalar must match the recipe variable; assertio
 use `${upstream_version}` when checking software versions and `${version}` when
 checking the container version.
 
+### Let one source name the container
+
+By default a `sources` policy only ever increments the container revision, which
+is right when the label is the container's own identity. When the container is a
+distribution of one piece of software, and the label should keep naming that
+software's version, nominate its source with `container_version`:
+
+```yaml
+version: 2.10.36
+variables:
+  package_version: 2.10.36-3ubuntu0.24.04.1
+
+auto_update:
+  method: sources
+  container_version: gimp
+  sources:
+    - id: gimp
+      method: apt
+      package: gimp
+      urls:
+        - https://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/Packages.gz
+      target:
+        variable: package_version
+        fulltest_variable: package_version
+```
+
+A release of that software becomes the container version, while the install
+keeps the pin it needs: here the apt package version carries a distribution
+revision the label must not inherit, so the container is `2.10.36` and the
+install is `gimp=2.10.36-3ubuntu0.24.04.1`. Any other source moving on its own,
+or a repackaging of the same software version, still increments the revision as
+`2.10.36.post1`. The nominated source must observe a version, so a commit or
+digest source is rejected.
+
+Without `container_version` the label and the software drift apart the first
+time upstream moves, which `builder/tests/test_release_artifact.py` fails.
+
 All source observations resolve before the updater writes files. One or several
 changed inputs increment the container revision once, such as `1.0.0.post1`.
 Opaque container labels use `.r1`. The plan updates the sibling test version and


### PR DESCRIPTION
## Why

You asked for the five drifting containers to be relabelled to their upstream
versions. A plain relabel does not hold: with `method: sources` the updater
always increments the container revision
(`next_version = next_container_version(current_version)`), so nothing can ever
move the label. gimp relabelled to 2.10.36 today drifts again on the next apt
bump, and then fails the check added in #3142 — turning every future
auto-update PR for these recipes red.

Switching them to a top-level policy is not available either:

- there is no top-level `apt` method, and an apt install genuinely needs two
  versions: the label `2.10.36` and the pin `2.10.36-3ubuntu0.24.04.1`
- lstai needs a `file` target for its release asset, which only `sources` has

## What this adds

`auto_update.container_version` names the source whose release *is* this
container's version:

```yaml
version: 2.10.36
variables:
  package_version: 2.10.36-3ubuntu0.24.04.1

auto_update:
  method: sources
  container_version: gimp
  sources:
    - id: gimp
      method: apt
      package: gimp
      urls: [...]
      target:
        variable: package_version
        fulltest_variable: package_version
```

- that source's new version becomes the container version
- **any other source moving alone still increments the revision** — a dependency
  bump is a rebuild of the same software
- **a repackaging of the same software is also a revision** — `2.10.36-4ubuntu1`
  gives `2.10.36.post1`, because a new Debian revision ships identical software
- the nominated source must be able to observe a version, so a commit or digest
  source is rejected, as is an id that names no source

apt observations now carry `version`: the Debian version without its epoch or
revision. They keep being *ordered* by `dpkg --compare-versions` as before; the
upstream version is used only as a label.

## Verification

New tests in `builder/tests/test_update_plan.py` cover all four behaviours
above. They stub Debian ordering so they run without `dpkg` rather than only on
Linux. `pytest builder/tests` is green (714 passed; the two pre-existing
`dpkg`-dependent apt tests are excluded on macOS).

## Sequencing

This PR is the mechanism only, so main stays green at every step:

1. **this PR** — mechanism, validation, docs; `KNOWN_LABEL_DRIFT` still in place
2. **next** — the five recipe relabels, recipe-only so each one actually builds
   and releases under its new label
3. **last** — delete `KNOWN_LABEL_DRIFT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)