### PR TITLE
Drop the settled entries from the label drift list

### DIFF
--- a/builder/tests/test_release_artifact.py
+++ b/builder/tests/test_release_artifact.py
@@ -448,15 +448,11 @@ INDEPENDENT_CONTAINER_VERSIONS = {
     "vesselboost": "local pipeline, tracks the model release",
 }
 
-# Same shape as the amico 2.1.0.post2 mislabel fixed in #3137: a single tracked
-# package whose version the label used to follow and no longer does. Relabelling
-# a published container is a per-container decision, so the check tolerates them
-# by name until each one is settled.
+# vina is labelled 1.2.3 while installing the apt package 1.2.5. Its relabel is
+# ready but cannot be released: rebuilding it at any version fails the Dive gate
+# at 85% user-wasted bytes, because the shared neurodocker preamble duplicates
+# more base files than vina's own 8.7 MB payload adds.
 KNOWN_LABEL_DRIFT = {
-    "datalad": "labelled 1.3.1, installs the apt package 1.1.5",
-    "gimp": "labelled 2.10.18, installs the apt package 2.10.36",
-    "lstai": "labelled 1.2.0.post1, installs 1.1",
-    "palmettobug": "labelled 0.0.3.post1, installs 0.2.11",
     "vina": "labelled 1.2.3, installs the apt package 1.2.5",
 }
 


### PR DESCRIPTION
Step 3 of the relabel sequence, after #3150 (mechanism) and #3151 (relabels).

datalad, gimp, lstai and palmettobug now label the release with the software
version they install, so they come out of `KNOWN_LABEL_DRIFT` and are covered by
`test_single_package_recipes_label_the_software_version_they_install` directly.

vina stays, with its reason recorded: the relabel to 1.2.5 is ready, but
rebuilding vina at *any* version fails the Dive gate at 85% user-wasted bytes
against a 30% threshold, reproduced locally on the unchanged 1.2.3 recipe from
main. Its payload is one 8.7 MB apt layer while the shared neurodocker preamble
duplicates ~57 MB of base files, so the recipe has no lever. The entry goes away
with whichever fix you pick for that — see the discussion on #3151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)