### PR TITLE
Judge the Dive waste ratio only once the waste is worth judging

### DIFF
--- a/.github/.dive-ci.yml
+++ b/.github/.dive-ci.yml
@@ -14,4 +14,11 @@ rules:
   # If the amount of wasted space makes up for X% or more of the image, mark as failed.
   # Note: the base image layer is NOT included in the total image size.
   # Expressed as a ratio between 0-1; fails if the threshold is met or crossed.
+  #
+  # This ratio divides waste by the bytes a recipe's own layers add, so for a
+  # container whose payload is smaller than the shared neurodocker preamble it
+  # measures that preamble instead. dive cannot express a floor, so the
+  # candidate workflow waives this rule alone below the absolute waste in
+  # DIVE_RATIO_FLOOR_BYTES (tools/one_pr_release.py). Every other rule here,
+  # and this one above the floor, still fails the release.
   highestUserWastedPercent: 0.3

--- a/.github/workflows/pr-container-candidate.yml
+++ b/.github/workflows/pr-container-candidate.yml
@@ -230,10 +230,15 @@ jobs:
           CONTAINER: ${{ matrix.container }}
         run: |
           set -o pipefail
+          status=success
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${PWD}/.github/.dive-ci.yml:/.dive-ci.yml:ro" \
             wagoodman/dive:latest "${CANDIDATE_TAG}" --ci --ci-config /.dive-ci.yml \
-            2>&1 | tee "candidate/${CONTAINER}/dive-report.txt"
+            2>&1 | tee "candidate/${CONTAINER}/dive-report.txt" || status=failure
+          # dive cannot express "judge the ratio only once the waste is worth
+          # judging", so the outcome of this step is the size-aware decision.
+          python tools/one_pr_release.py dive-gate \
+            --candidate-dir "candidate/${CONTAINER}" --status "${status}"
       - name: Generate manifest and release preview
         env:
           RECIPE: ${{ matrix.recipe }}

--- a/builder/tests/test_one_pr_release.py
+++ b/builder/tests/test_one_pr_release.py
@@ -806,3 +806,61 @@ def test_one_pr_workflows_preserve_fork_reporting_contract() -> None:
     assert "listPullRequestsAssociatedWithCommit" in reporter
     assert "if (prs.length === 0) return" not in reporter
     assert "].join('\\n');" in reporter
+
+
+def dive_report(tmp_path: Path, wasted_bytes: int, display: str, *failed: str) -> Path:
+    """Write a Dive CI report with the given failing rules."""
+    lines = [
+        "  efficiency: 82.4040 %",
+        f"  wastedBytes: {wasted_bytes} bytes ({display})",
+        "  userWastedPercent: 85.3592 %",
+        "Results:",
+    ]
+    lines += [f"  FAIL: {rule}: policy text (%-x=0.85 > threshold=0.3)" for rule in failed]
+    (tmp_path / "dive-report.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return tmp_path / "dive-report.txt"
+
+
+def test_small_absolute_waste_waives_only_the_ratio_rule(tmp_path: Path) -> None:
+    # vina adds one 8.7 MB layer and inherits the preamble's duplication, so the
+    # ratio describes the base image rather than anything the recipe controls.
+    report = dive_report(tmp_path, 56730634, "57 MB", "highestUserWastedPercent")
+
+    outcome, reason = one_pr_release.dive_gate_outcome(report, "failure")
+
+    assert outcome == "success"
+    assert "below the 200 MB floor" in reason
+
+
+def test_large_absolute_waste_still_fails_the_ratio_rule(tmp_path: Path) -> None:
+    report = dive_report(tmp_path, 943718400, "944 MB", "highestUserWastedPercent")
+
+    outcome, reason = one_pr_release.dive_gate_outcome(report, "failure")
+
+    assert outcome == "failure"
+    assert "944 MB" in reason
+
+
+def test_a_second_failing_rule_is_never_waived(tmp_path: Path) -> None:
+    report = dive_report(
+        tmp_path, 10485760, "10 MB", "highestUserWastedPercent", "lowestEfficiency"
+    )
+
+    outcome, reason = one_pr_release.dive_gate_outcome(report, "failure")
+
+    assert outcome == "failure"
+    assert "lowestEfficiency" in reason
+
+
+def test_a_dive_run_that_never_completed_is_not_waived(tmp_path: Path) -> None:
+    dive_report(tmp_path, 1024, "1 kB", "highestUserWastedPercent")
+
+    outcome, _ = one_pr_release.dive_gate_outcome(tmp_path / "dive-report.txt", "cancelled")
+
+    assert outcome == "failure"
+
+
+def test_a_missing_report_cannot_waive_a_dive_failure(tmp_path: Path) -> None:
+    outcome, _ = one_pr_release.dive_gate_outcome(tmp_path / "absent.txt", "failure")
+
+    assert outcome == "failure"

--- a/tools/one_pr_release.py
+++ b/tools/one_pr_release.py
@@ -71,6 +71,15 @@ DIVE_PERCENT_FAILURE_PATTERN = re.compile(
     r"\([^=]+=([0-9]+(?:\.[0-9]+)?)\s*[<>]\s*"
     r"threshold=([0-9]+(?:\.[0-9]+)?)\)"
 )
+# The wasted-percentage rule divides waste by the bytes a recipe's own layers
+# add, so for a container whose payload is smaller than the shared neurodocker
+# preamble it measures that preamble rather than the recipe. vina adds one
+# 8.7 MB apt layer and inherits ~57 MB of duplicated glibc, locales and dpkg
+# metadata, which no recipe change can reach. Below this floor the ratio says
+# nothing actionable; above it, waste is worth a maintainer's attention.
+DIVE_RATIO_FLOOR_BYTES = 200 * 1024 * 1024
+DIVE_RATIO_RULE = "highestUserWastedPercent"
+DIVE_FAILED_RULE_PATTERN = re.compile(r"^\s*FAIL:\s*([A-Za-z][A-Za-z0-9_]*)", re.MULTILINE)
 DIVE_INEFFICIENT_FILE_PATTERN = re.compile(
     r"^\s*(\d+)\s+([0-9]+(?:\.[0-9]+)?\s+[kKMGT]?B)\s+(/\S.*)$"
 )
@@ -409,6 +418,43 @@ def _result_count(data: dict[str, Any], field: str) -> int:
     if result < 0:
         raise RuntimeError(f"Invalid candidate test result {field}: {value!r}")
     return result
+
+
+def dive_gate_outcome(report_path: Path, status: str) -> tuple[str, str]:
+    """Decide the Dive gate, waiving the ratio rule on small absolute waste."""
+    if status not in DIVE_STATUSES:
+        raise RuntimeError(f"Invalid Dive status: {status!r}")
+    if status == "success":
+        return "success", "Dive reported no policy failures"
+    if status != "failure" or not report_path.is_file():
+        return "failure", f"Dive did not complete: {status}"
+
+    try:
+        text = ANSI_ESCAPE_PATTERN.sub("", report_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError) as error:
+        raise RuntimeError(
+            f"Unable to read Dive report {report_path}: {error}"
+        ) from error
+
+    failed = set(DIVE_FAILED_RULE_PATTERN.findall(text))
+    if failed != {DIVE_RATIO_RULE}:
+        return "failure", f"Dive failed: {', '.join(sorted(failed)) or 'unknown rule'}"
+
+    match = DIVE_WASTED_BYTES_PATTERN.search(text)
+    if match is None:
+        return "failure", f"Dive failed {DIVE_RATIO_RULE} and reported no wasted bytes"
+
+    wasted = int(match.group(1))
+    if wasted >= DIVE_RATIO_FLOOR_BYTES:
+        return "failure", (
+            f"Dive failed {DIVE_RATIO_RULE} on {match.group(2).strip()} of waste, "
+            f"at or above the {DIVE_RATIO_FLOOR_BYTES // (1024 * 1024)} MB floor"
+        )
+    return "success", (
+        f"{DIVE_RATIO_RULE} waived: {match.group(2).strip()} of waste is below the "
+        f"{DIVE_RATIO_FLOOR_BYTES // (1024 * 1024)} MB floor, so the ratio reflects "
+        "base-image churn rather than this recipe"
+    )
 
 
 def build_dive_summary(report_path: Path, status: str) -> dict[str, Any]:
@@ -820,6 +866,16 @@ def verify_published_metadata(
     return manifests
 
 
+def command_dive_gate(args: argparse.Namespace) -> None:
+    """Apply the size-aware Dive policy to one candidate's report."""
+    outcome, reason = dive_gate_outcome(
+        Path(args.candidate_dir) / "dive-report.txt", args.status
+    )
+    print(reason)
+    if outcome != "success":
+        raise SystemExit(1)
+
+
 def command_verify_metadata(args: argparse.Namespace) -> None:
     """Verify staged metadata without downloading Docker or SIF artifacts."""
     verify_published_metadata(
@@ -891,6 +947,11 @@ def parser() -> argparse.ArgumentParser:
     verify.add_argument("--pr-number", required=True, type=int)
     verify.add_argument("--output", required=True)
     verify.set_defaults(func=command_verify)
+
+    dive_gate = subparsers.add_parser("dive-gate")
+    dive_gate.add_argument("--candidate-dir", required=True)
+    dive_gate.add_argument("--status", required=True, choices=sorted(DIVE_STATUSES))
+    dive_gate.set_defaults(func=command_dive_gate)
 
     verify_metadata = subparsers.add_parser("verify-metadata")
     verify_metadata.add_argument("--bundle", required=True)

--- a/workflows/ONE_PR_RELEASES.md
+++ b/workflows/ONE_PR_RELEASES.md
@@ -12,7 +12,12 @@ artifacts after merge. They no longer create a second release-metadata PR.
    runner.
 2. Each candidate builds a Docker archive and SIF, runs the deploy/fulltest and
    Dive checks, generates the release JSON preview, and stores everything for
-   30 days under its own container identity.
+   30 days under its own container identity. Dive's wasted-percentage rule is
+   applied only once the absolute waste is worth judging: below
+   `DIVE_RATIO_FLOOR_BYTES` that ratio measures the shared neurodocker
+   preamble rather than the recipe, so `one_pr_release.py dive-gate` waives
+   that one rule and the step says so. Every other Dive rule, and this one
+   above the floor, still fails the candidate.
 3. A trusted `workflow_run` posts one action-first lifecycle summary on recipe
    PRs. The heading names the exact container, version, and architecture and
    tells the maintainer whether to merge, fix a candidate, wait for promotion,


### PR DESCRIPTION
## Problem

`highestUserWastedPercent` divides waste by the bytes a recipe's **own layers**
add. For a container whose payload is smaller than the shared neurodocker
preamble, that ratio measures the preamble.

vina is the case in hand. Building the unchanged 1.2.3 recipe from `main`
locally:

```
efficiency: 82.4 %
wastedBytes: 56730634 bytes (57 MB)
userWastedPercent: 85.4 %
FAIL: highestUserWastedPercent (0.854 > threshold 0.3)
```

Its payload is one 8.7 MB apt layer. The 57 MB is libc.so.6, ldconfig.real,
libm, the gconv tables, a regenerated `C.utf8` locale, and four rewrites each of
`/var/lib/dpkg/status` and `/var/log/dpkg.log` — all produced by the preamble
every recipe gets. No recipe change reaches it, so **vina cannot be released at
any version**, which is what blocked its relabel in #3151.

## Fix

dive has no way to express "apply this ratio only above N bytes", so the
candidate step now makes that decision:

- Dive passed → success
- Dive failed **only** `highestUserWastedPercent` **and** wasted bytes are below
  `DIVE_RATIO_FLOOR_BYTES` → success, with the step printing why
- anything else → failure

The floor is **200 MB**: several times the largest preamble churn observed
(57 MB on aarch64, 36 MB on x86_64), and far below the existing 4000 MB
`highestWastedBytes` ceiling. A recipe that downloads and deletes a real payload
still fails.

The step's own outcome is the decision, so `steps.dive.outcome` stays the single
source of truth — the release gate and the PR summary keep working unchanged,
and the summary does not report a failure the gate waived.

## Verification

Five unit tests in `builder/tests/test_one_pr_release.py` cover each branch:
small waste waives only the ratio, large waste still fails, a second failing
rule is never waived, a cancelled Dive run is not waived, and a missing report
cannot waive anything. Checked against the real vina report (waived, 57 MB) and
a synthetic 944 MB one (still fails). `pytest builder/tests` green.

Next PR relabels vina to 1.2.5 and empties `KNOWN_LABEL_DRIFT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)