### PR TITLE
Relabel vina with the software version it installs

### DIFF
--- a/recipes/vina/build.yaml
+++ b/recipes/vina/build.yaml
@@ -2,8 +2,7 @@ variables:
   package_version: 1.2.5-2build1
 
 name: vina
-version: 1.2.3
-
+version: 1.2.5
 copyright:
   - license: Apache-2.0
     url: https://github.com/ccsb-scripps/AutoDock-Vina/blob/develop/LICENSE
@@ -14,6 +13,7 @@ architectures:
 
 auto_update:
   method: sources
+  container_version: autodock-vina
   local: []
   sources:
   - id: autodock-vina

--- a/recipes/vina/fulltest.yaml
+++ b/recipes/vina/fulltest.yaml
@@ -1,6 +1,6 @@
 package_version: 1.2.5-2build1
 name: vina
-version: 1.2.3
+version: 1.2.5
 test_data:
   output_dir: test_output
 setup:


### PR DESCRIPTION
The last of the five containers from #3142, held back from #3151 because vina
could not be rebuilt at all.

| Container | Was | Now | How the label stays put |
| --- | --- | --- | --- |
| vina | 1.2.3 | 1.2.5 | `container_version: autodock-vina` (apt) |

The install pin is unchanged: apt still installs `autodock-vina=1.2.5-2build1`,
while the label names the software.

This is also the first vina candidate since #3153 made the Dive waste ratio
size-aware, so it is the real test of that change. vina's report was 57 MB of
waste at 85% — the rule should be waived with the step printing why, while every
other Dive rule still applies.

`KNOWN_LABEL_DRIFT` is emptied in a follow-up once this has built, keeping main
green in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)