### PR TITLE
Remove the label drift list now that no recipe drifts

### DIFF
--- a/builder/tests/test_release_artifact.py
+++ b/builder/tests/test_release_artifact.py
@@ -448,14 +448,6 @@ INDEPENDENT_CONTAINER_VERSIONS = {
     "vesselboost": "local pipeline, tracks the model release",
 }
 
-# vina is labelled 1.2.3 while installing the apt package 1.2.5. Its relabel is
-# ready but cannot be released: rebuilding it at any version fails the Dive gate
-# at 85% user-wasted bytes, because the shared neurodocker preamble duplicates
-# more base files than vina's own 8.7 MB payload adds.
-KNOWN_LABEL_DRIFT = {
-    "vina": "labelled 1.2.3, installs the apt package 1.2.5",
-}
-
 SHARED_DEPENDENCY_VARIABLES = frozenset(OPENRECON_PINS)
 
 # A commit, digest or listing pins bytes without naming a software version, so
@@ -522,7 +514,7 @@ def test_single_package_recipes_label_the_software_version_they_install() -> Non
     offenders = []
     for build_yaml in sorted((REPO_ROOT / "recipes").glob("*/build.yaml")):
         recipe_name = build_yaml.parent.name
-        if recipe_name in INDEPENDENT_CONTAINER_VERSIONS or recipe_name in KNOWN_LABEL_DRIFT:
+        if recipe_name in INDEPENDENT_CONTAINER_VERSIONS:
             continue
         recipe = yaml.safe_load(build_yaml.read_text(encoding="utf-8")) or {}
         if not isinstance(recipe, dict):


### PR DESCRIPTION
vina 1.2.5 released, so `KNOWN_LABEL_DRIFT` is empty and comes out.

All five containers #3142 surfaced now name the software they install:

| Container | Was | Now |
| --- | --- | --- |
| gimp | 2.10.18 | 2.10.36 |
| datalad | 1.3.1 | 1.1.5 |
| lstai | 1.2.0.post1 | 1.1.0 |
| palmettobug | 0.0.3.post1 | 0.2.11 |
| vina | 1.2.3 | 1.2.5 |

`test_single_package_recipes_label_the_software_version_they_install` now covers
every single-package recipe with no exceptions. `INDEPENDENT_CONTAINER_VERSIONS`
stays for the eight containers whose label is deliberately their own identity —
a wrapper, a bundle, or a base image pinned by date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)