### PR TITLE
Install DataLad from upstream instead of a four-year-old package

### DIFF
--- a/recipes/datalad/build.yaml
+++ b/recipes/datalad/build.yaml
@@ -1,8 +1,10 @@
 variables:
-  package_version: 1.1.5-1~nd120+1
+  venv: /opt/datalad
+  datalad_version: 1.6.2
+  git_annex_version: 10.20230126-3
 
 name: datalad
-version: 1.1.5
+version: 1.6.2
 
 copyright:
   - license: MIT
@@ -21,23 +23,48 @@ auto_update:
   container_version: datalad
   local: []
   sources:
+  # DataLad publishes to PyPI; Debian and NeuroDebian carry 1.1.5, years behind.
   - id: datalad
-    method: apt
+    method: pypi
     package: datalad
+    target:
+      variable: datalad_version
+      value: version
+      fulltest_variable: datalad_version
+  # git-annex is DataLad's storage backend rather than part of DataLad. Track
+  # Debian's build, which is the one published for both architectures this
+  # recipe declares; NeuroDebian's newer git-annex-standalone is amd64 only.
+  - id: git_annex
+    method: apt
+    package: git-annex
     urls:
-    - https://neurodebian.inm7.de/debian/dists/bookworm/main/binary-amd64/Packages.gz
     - https://deb.debian.org/debian/dists/bookworm/main/binary-amd64/Packages.xz
     target:
-      variable: package_version
-      fulltest_variable: package_version
+      variable: git_annex_version
+      fulltest_variable: git_annex_version
 
 build:
   kind: neurodocker
   base-image: neurodebian:bookworm-non-free
   pkg-manager: apt
   directives:
+  - environment:
+      DEBIAN_FRONTEND: noninteractive
+      PATH: "{{ context.venv }}/bin:$PATH"
   - install:
-    - "datalad={{ context.package_version }}"
+    - "git-annex={{ context.git_annex_version }}"
+    - git
+    - python3
+    - python3-pip
+    - python3-venv
+  - run:
+    - python3 -m venv {{ context.venv }}
+    - "{{ context.venv }}/bin/python -m pip install --no-cache-dir --upgrade pip setuptools wheel"
+    - "{{ context.venv }}/bin/python -m pip install --no-cache-dir datalad=={{ context.datalad_version }}"
+    # A Debian login shell resets PATH, and git-annex resolves its special
+    # remote helpers by name, so datalad's own entry points belong on the
+    # default PATH rather than only inside the venv.
+    - ln -s -t /usr/local/bin {{ context.venv }}/bin/datalad {{ context.venv }}/bin/git-annex-remote-datalad {{ context.venv }}/bin/git-annex-remote-datalad-archives {{ context.venv }}/bin/git-annex-remote-ora {{ context.venv }}/bin/git-annex-remote-ria {{ context.venv }}/bin/git-credential-datalad
   - run:
     - git config --global user.email "user@neurodesk.github.io"
     - git config --global user.name "Neurodesk User"
@@ -45,6 +72,8 @@ build:
 deploy:
   bins:
     - datalad
+  path:
+    - "{{ context.venv }}/bin"
 
 readme: |
   ## datalad/{{context.version}} ##

--- a/recipes/datalad/fulltest.yaml
+++ b/recipes/datalad/fulltest.yaml
@@ -1,6 +1,8 @@
-package_version: 1.1.5-1~nd120+1
+datalad_version: 1.6.2
+git_annex_version: 10.20230126-3
+venv: /opt/datalad
 name: datalad
-version: 1.1.5
+version: 1.6.2
 test_data:
   output_dir: test_output
 setup:
@@ -10,13 +12,9 @@ setup:
     $(mktemp -d /tmp/datalad-fulltest-dataset.XXXXXX)\"\nln -sfn \"${fresh_dataset_dir}\" /tmp/datalad-fulltest-dataset\n"
 tests:
 - name: DataLad version check
-  description: Verify the datalad CLI version matches the shipped runtime
-  command: |
-    reported="$(datalad --version)"
-    expected="${package_version}"
-    expected="${expected#*:}"
-    printf '%s\n' "$reported"
-    test "$reported" = "datalad ${expected%-*}"
+  description: Verify the datalad CLI reports the version this container ships
+  command: datalad --version 2>&1
+  expected_output_contains: ${datalad_version}
 - name: DataLad help output
   description: Verify the main help text renders
   command: datalad --help 2>&1 | head -20
@@ -46,5 +44,18 @@ tests:
   depends_on: DataLad save file
   expected_output_contains: nothing to save, working tree clean
 - name: installed distribution version
-  command: dpkg-query -W -f='${Version}\n' datalad
-  expected_output_contains: ${package_version}
+  description: Verify the venv holds the datalad release this container declares
+  command: ${venv}/bin/python -m pip show datalad
+  expected_output_contains: ${datalad_version}
+- name: git-annex backend version
+  description: Verify the pinned git-annex DataLad stores its data with
+  command: dpkg-query -W -f='${Version}\n' git-annex
+  expected_output_contains: ${git_annex_version}
+- name: DataLad entry points resolve outside the venv
+  description: A login shell resets PATH and git-annex resolves helpers by name
+  command: bash -lc 'command -v datalad; command -v git-annex-remote-ora'
+  expected_output_contains: /usr/local/bin/datalad
+- name: git-annex is usable by datalad
+  description: Verify datalad finds a working git-annex
+  command: git annex version 2>&1 | head -1
+  expected_output_contains: git-annex version


### PR DESCRIPTION
## Why

The recipe installed Debian's `datalad` package. Both Debian bookworm and
NeuroDebian still carry **1.1.5**; upstream is **1.6.2**. Relabelling the
container in #3151 exposed this by moving the release backwards to 1.1.5 — the
honest label for what it shipped. This changes what it ships.

## What changes

| | Before | After |
| --- | --- | --- |
| DataLad | apt `datalad=1.1.5-1~nd120+1` | PyPI `datalad==1.6.2` in a venv at `/opt/datalad` |
| git-annex | pulled in as a dependency, unpinned | apt `git-annex=10.20230126-3`, pinned and tracked |
| Container version | follows the Debian package | follows DataLad (`container_version: datalad`) |

git-annex stays an apt package deliberately: it is DataLad's storage backend
rather than part of DataLad, and it now has its own tracked source instead of
arriving as an unpinned dependency. It is pinned from **Debian** rather than
NeuroDebian's much newer `git-annex-standalone`, because that build is published
for amd64 only and this recipe declares both architectures — pinning it would
break every aarch64 build.

DataLad's entry points are symlinked into `/usr/local/bin`. A venv-only install
looked fine until tested: a Debian login shell resets `PATH`, so
`bash -lc datalad` failed, and git-annex resolves `git-annex-remote-ora` and
friends **by name from PATH**, so datalad special remotes would have broken at
runtime. The suite now asserts both.

## Verification

Built on aarch64 locally and exercised in the image:

```
datalad --version                 -> datalad 1.6.2
/opt/datalad/bin/python -m pip show datalad -> Version: 1.6.2
dpkg-query -W git-annex           -> 10.20230126-3
command -v datalad (login shell)  -> /usr/local/bin/datalad
command -v git-annex-remote-ora   -> /usr/local/bin/git-annex-remote-ora
git annex version                 -> git-annex version: 10.20230126
datalad create / save / status    -> create(ok), save (ok: 1), nothing to save, working tree clean
```

Those are the suite's own assertions, so the fulltest is exercising checks I
have already seen pass rather than guesses. `builder/validation.py`,
`python -m builder.audit_updates` (247 automatic) and `pytest builder/tests` are
green.

## Note on the version sequence

datalad went 1.3.1 (mislabelled) → 1.1.5 (honest) → 1.6.2 (current) across three
releases today. 1.6.2 is above both, so the module list ends up ordered
correctly, and every earlier release stays published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)