### PR TITLE
Bump bidsapppymvpa from 2.0.2 to 4.0.4

### DIFF
--- a/recipes/bidsapppymvpa/build.yaml
+++ b/recipes/bidsapppymvpa/build.yaml
@@ -1,5 +1,5 @@
 name: bidsapppymvpa
-version: 2.0.2
+version: 4.0.4
 
 copyright:
   - license: MIT

--- a/recipes/bidsapppymvpa/fulltest.yaml
+++ b/recipes/bidsapppymvpa/fulltest.yaml
@@ -18,7 +18,7 @@
 #   - Events: cash_demean, control_pumps_demean, explode_demean, pumps_demean
 
 name: bidsapppymvpa
-version: 2.0.2
+version: 4.0.4
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/bidsapppymvpa/build.yaml`
- Upstream release: https://hub.docker.com/r/bids/pymvpa/tags?name=v4.0.4

### Changes
- `version`: `2.0.2` → `4.0.4`
- `fulltest.yaml` version: `2.0.2` → `4.0.4`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.