### PR TITLE
Bump bidsmanager from 1.2.3 to 1.2.6.1

### DIFF
--- a/recipes/bidsmanager/build.yaml
+++ b/recipes/bidsmanager/build.yaml
@@ -1,5 +1,5 @@
 name: bidsmanager
-version: 1.2.3
+version: 1.2.6.1
 
 copyright:
   - license: MIT

--- a/recipes/bidsmanager/fulltest.yaml
+++ b/recipes/bidsmanager/fulltest.yaml
@@ -2,7 +2,7 @@
 # Tests for BIDS Manager v1.2.3 - raw-to-BIDS conversion, curation, metadata editing, and validation.
 
 name: bidsmanager
-version: 1.2.3
+version: 1.2.6.1
 
 setup:
   script: |


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/bidsmanager/build.yaml`
- Upstream release: https://pypi.org/project/bids-manager/1.2.6.1/

### Changes
- `version`: `1.2.3` → `1.2.6.1`
- `fulltest.yaml` version: `1.2.3` → `1.2.6.1`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.