### PR TITLE
Bump bidsme from 1.9.3.post1 to 1.9.3.post2

### DIFF
--- a/recipes/bidsme/build.yaml
+++ b/recipes/bidsme/build.yaml
@@ -1,5 +1,5 @@
 name: bidsme
-version: 1.9.3.post1
+version: "1.9.3.post2"
 architectures:
   - x86_64
   - aarch64
@@ -31,8 +31,8 @@ auto_update:
         fulltest_variable: dcm2niix_version
 
 variables:
-  upstream_tag: '1.9.3'
-  upstream_version: '1.9.3'
+  upstream_tag: "v1.9.6"
+  upstream_version: "1.9.6"
   dcm2niix_version: '1.0.20260724'
 
 build:

--- a/recipes/bidsme/fulltest.yaml
+++ b/recipes/bidsme/fulltest.yaml
@@ -17,8 +17,8 @@
 # Documentation: https://github.com/CyclotronResearchCentre/bidsme/blob/dev/doc/cli-interface.md
 
 name: bidsme
-version: 1.9.3.post1
-upstream_version: 1.9.3
+version: "1.9.3.post2"
+upstream_version: "1.9.6"
 dcm2niix_version: 1.0.20260724
 
 required_files:


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/bidsme/build.yaml`
- Upstream release: https://github.com/CyclotronResearchCentre/bidsme/releases/tag/v1.9.6

### Changes
- `variables.upstream_tag`: `1.9.3` → `v1.9.6`
- `variables.upstream_version`: `1.9.3` → `1.9.6`
- `fulltest.yaml` version: `1.9.3.post1` → `1.9.3.post2`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.