### PR TITLE
Bump bidstools from 1.0.4.post1 to 1.0.4.post2

### DIFF
--- a/recipes/bidstools/build.yaml
+++ b/recipes/bidstools/build.yaml
@@ -1,5 +1,5 @@
 name: bidstools
-version: 1.0.4.post1
+version: "1.0.4.post2"
 
 architectures:
   - x86_64
@@ -15,7 +15,7 @@ variables:
   heudiconv_version: 1.5.0
   traits_version: 7.1.0
   bru2nii_version: 1.0.20180303
-  dcm2niix_version: 1.0.20250505
+  dcm2niix_version: "1.0.20260724"
 
 auto_update:
   method: sources

--- a/recipes/bidstools/fulltest.yaml
+++ b/recipes/bidstools/fulltest.yaml
@@ -1,7 +1,7 @@
 # Focused verification for the packaged DICOM/BIDS utilities.
 
 name: bidstools
-version: 1.0.4.post1
+version: "1.0.4.post2"
 heudiconv_version: 1.5.0
 traits_version: 7.1.0
 


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/bidstools/build.yaml`
- Upstream release: https://github.com/rordenlab/dcm2niix/releases/tag/v1.0.20260724

### Changes
- `variables.dcm2niix_version`: `1.0.20250505` → `1.0.20260724`
- `fulltest.yaml` version: `1.0.4.post1` → `1.0.4.post2`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.