### PR TITLE
Bump blender from 5.0.1 to 5.2.1

### DIFF
--- a/recipes/blender/build.yaml
+++ b/recipes/blender/build.yaml
@@ -1,5 +1,5 @@
 name: blender
-version: 5.0.1
+version: 5.2.1
 
 copyright:
   - license: GPL-3.0-or-later

--- a/recipes/blender/fulltest.yaml
+++ b/recipes/blender/fulltest.yaml
@@ -1,5 +1,5 @@
 name: blender
-version: 5.0.1
+version: 5.2.1
 default_timeout: 120
 tests:
 - name: Check blender version


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/blender/build.yaml`
- Upstream release: https://github.com/blender/blender/tree/v5.2.1

### Changes
- `version`: `5.0.1` → `5.2.1`
- `fulltest.yaml` version: `5.0.1` → `5.2.1`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.