### PR TITLE
Bump blochsiegertb1mapping from 1.0.11 to 1.0.11.post1

### DIFF
--- a/recipes/blochsiegertb1mapping/build.yaml
+++ b/recipes/blochsiegertb1mapping/build.yaml
@@ -1,5 +1,5 @@
 name: blochsiegertb1mapping
-version: 1.0.11
+version: "1.0.11.post1"
 architectures:
   - x86_64
 
@@ -25,8 +25,8 @@ variables:
   openrecon_server_commit: "33362f2139701fbf5ea855808a325eb59b7db2ae"
   openrecon_python_tools_commit: "17fe6fbf1bb645112e2ad0023eb4f42afb36421e"
   openrecon_siemens_commit: "055eefc09dfa77fbf11fff85979dea9ef2879ba5"
-  openrecon_ismrmrd_version: "1.14.2"
-  base_image_digest: sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc
+  openrecon_ismrmrd_version: "1.15.0"
+  base_image_digest: "sha256:829f6df217bcbae2b371026e81711d1a787c61b2967ad09d015063663ebafbf7"
 
 auto_update:
   method: sources

--- a/recipes/blochsiegertb1mapping/fulltest.yaml
+++ b/recipes/blochsiegertb1mapping/fulltest.yaml
@@ -1,5 +1,5 @@
 name: blochsiegertb1mapping
-version: 1.0.11
+version: "1.0.11.post1"
 default_timeout: 120
 tests:
 - name: Bloch-Siegert OpenRecon workflow unit smoke test


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/blochsiegertb1mapping/build.yaml`
- Upstream release: https://github.com/ismrmrd/ismrmrd/releases/tag/v1.15.0, https://registry-1.docker.io/v2/library/ubuntu/manifests/22.04

### Changes
- `variables.base_image_digest`: `sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc` → `sha256:829f6df217bcbae2b371026e81711d1a787c61b2967ad09d015063663ebafbf7`
- `variables.openrecon_ismrmrd_version`: `1.14.2` → `1.15.0`
- `fulltest.yaml` version: `1.0.11` → `1.0.11.post1`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.