### PR TITLE
Bump brainlesion from 1.0.0 to 1.0.0.post1

### DIFF
--- a/recipes/brainlesion/build.yaml
+++ b/recipes/brainlesion/build.yaml
@@ -1,5 +1,5 @@
 name: brainlesion
-version: 1.0.0
+version: "1.0.0.post1"
 architectures:
   - x86_64
 structured_readme:
@@ -24,18 +24,18 @@ structured_readme:
 variables:
   atlas_version: 2.0.0
   loguru_version: 0.7.3
-  panoptica_version: 2.1.6
+  panoptica_version: "2.1.7"
   deep_quality_estimation_version: 0.0.3
   petu_version: 0.0.7
   gliomoda_version: 0.0.4
   antspyx_version: 0.6.3
-  auxiliary_version: 0.3.1
+  auxiliary_version: "0.4.2"
   brainles_hd_bet_version: 0.0.11
   ttictoc_version: 0.5.6
-  typer_version: 0.15.4
-  tqdm_version: 4.67.1
+  typer_version: "0.27.2"
+  tqdm_version: "4.70.1"
   brainles_aurora_version: 0.2.7
-  brainles_preprocessing_version: 0.6.10
+  brainles_preprocessing_version: "0.6.13"
 
 auto_update:
   method: sources

--- a/recipes/brainlesion/fulltest.yaml
+++ b/recipes/brainlesion/fulltest.yaml
@@ -1,5 +1,5 @@
 name: brainlesion
-version: 1.0.0
+version: "1.0.0.post1"
 default_timeout: 120
 
 env:


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/brainlesion/build.yaml`
- Upstream release: https://pypi.org/project/auxiliary/0.4.2/, https://pypi.org/project/brainles-preprocessing/0.6.13/, https://pypi.org/project/panoptica/2.1.7/, https://pypi.org/project/tqdm/4.70.1/, https://pypi.org/project/typer/0.27.2/

### Changes
- `variables.panoptica_version`: `2.1.6` → `2.1.7`
- `variables.auxiliary_version`: `0.3.1` → `0.4.2`
- `variables.typer_version`: `0.15.4` → `0.27.2`
- `variables.tqdm_version`: `4.67.1` → `4.70.1`
- `variables.brainles_preprocessing_version`: `0.6.10` → `0.6.13`
- `fulltest.yaml` version: `1.0.0` → `1.0.0.post1`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.