### PR TITLE
Bump brainlifecli from 1.7.0 to 1.8.2

### DIFF
--- a/recipes/brainlifecli/build.yaml
+++ b/recipes/brainlifecli/build.yaml
@@ -1,5 +1,5 @@
 name: brainlifecli
-version: 1.7.0
+version: 1.8.2
 
 copyright:
   - license: MIT

--- a/recipes/brainlifecli/fulltest.yaml
+++ b/recipes/brainlifecli/fulltest.yaml
@@ -15,7 +15,7 @@
 #   - BOLD: 64x64x33x300, 3.125x3.125x4mm, TR=2s (4D functional)
 
 name: brainlifecli
-version: 1.7.0
+version: 1.8.2
 
 required_files:
   - dataset: ds000001


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/brainlifecli/build.yaml`
- Upstream release: https://www.npmjs.com/package/brainlife/v/1.8.2

### Changes
- `version`: `1.7.0` → `1.8.2`
- `fulltest.yaml` version: `1.7.0` → `1.8.2`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.