### PR TITLE
Bump brainvisa from 6.0.38 to 6.0.40

### DIFF
--- a/recipes/brainvisa/build.yaml
+++ b/recipes/brainvisa/build.yaml
@@ -1,5 +1,5 @@
 name: brainvisa
-version: 6.0.38
+version: 6.0.40
 
 copyright:
   - license: CECILL-B

--- a/recipes/brainvisa/fulltest.yaml
+++ b/recipes/brainvisa/fulltest.yaml
@@ -1,5 +1,5 @@
 name: brainvisa
-version: 6.0.38
+version: 6.0.40
 
 tests:
   - name: BrainVISA launchers are available


### PR DESCRIPTION
Automated version bump generated by `builder/check_version.py`.

- Recipe: `recipes/brainvisa/build.yaml`
- Upstream release: https://brainvisa.info/neuro-forge/linux-64/repodata.json

### Changes
- `version`: `6.0.38` → `6.0.40`
- `fulltest.yaml` version: `6.0.38` → `6.0.40`

A maintainer should confirm the container still builds and that the recipe does not need further changes for this release.